### PR TITLE
Lower layers: helper cleanup and stale adapter closeout

### DIFF
--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -137,6 +137,20 @@ keeps comparison failures concentrated on real model/regime mismatches instead
 of letting generated adapter drift reintroduce stale imports or route-local
 numerical defaults.
 
+The lower-layer cleanup tranches now apply that same pattern to FX and quanto
+routes as well. ``trellis.models.fx_vanilla`` and
+``trellis.models.quanto_option`` are the semantic-facing helper kits for the
+supported analytical and Monte Carlo slices, and the checked-in adapters under
+``trellis.instruments._agent`` are intentionally thin shells over those
+helpers instead of separate implementations.
+
+Fresh-build proving keeps a stricter boundary than ordinary supported-route
+reuse. When a task or canary is run with ``fresh_build=True``, the executor
+now skips deterministic exact-binding materialization so the run still has to
+exercise live code generation. Ordinary supported-route runs can still reuse
+exact helper wrappers for stability, but fresh-build canaries no longer get a
+free pass from executor-side deterministic module synthesis.
+
 The same rule now applies to tranche-style basket-credit comparison routes.
 Curated copula canaries bind through the semantic-facing
 ``trellis.models.credit_basket_copula`` helper surface instead of asking the
@@ -152,6 +166,13 @@ checked-in helper-backed route for single-exercise European rate-tree
 comparators. That keeps canaries such as ``T65`` on the stable
 ``price_swaption_tree(...)`` surface instead of regenerating inline lattice
 exercise code for the comparison target.
+
+Transform proving now also distinguishes model families explicitly. The thin
+vanilla transform helper surface is only used for ``equity_diffusion`` claims;
+stochastic-volatility tasks such as the Heston smile canary stay on the raw
+FFT/COS kernel path under the same route family. That keeps helper reuse
+honest without widening a GBM-oriented helper into unsupported Heston
+authority.
 
 Analytical traces also carry a structured instruction-lifecycle payload. The
 ``GenerationPlan`` now includes a resolved instruction set, the trace emits a

--- a/docs/plans/lower-layer-cleanup-and-canary-verification.md
+++ b/docs/plans/lower-layer-cleanup-and-canary-verification.md
@@ -1,0 +1,272 @@
+# Lower-Layer Cleanup And Canary Verification Plan
+
+## Purpose
+
+This plan closes the remaining lower-layer cleanup after the recent semantic,
+route, and short-rate workstreams:
+
+1. retire or explicitly bless the remaining stale checked-in FX/quanto adapters
+2. keep extracting reusable family helper kits underneath product wrappers
+3. keep moving lower-layer authority out of executor/route/product-local glue
+   and into family/helper registries
+4. verify every cleanup slice with the corresponding canary or `TASKS.yaml`
+   acceptance task so the result remains good agent code instead of a paper
+   refactor
+
+## Why This Plan Exists
+
+Recent work materially improved the stack:
+
+- curated canaries are currently green
+- semantic family/method authority is registry-backed
+- route identity is thinner than before
+- reusable short-rate fixed-income helpers exist beneath callable-bond wrappers
+
+But several transitional seams remain:
+
+- four checked-in adapters are still marked stale against `_fresh`
+- executor guidance still contains product-shaped exact-binding rules
+- several model/helper entry points remain product-shaped wrappers over logic
+  that should sit lower in reusable family kits
+- the remaining debt is spread across completed umbrellas, open helper-layer
+  tickets, and stale-adapter lifecycle machinery, so the next work needs one
+  durable queue
+
+## Current Repo-Grounded State
+
+### Remaining stale adapter inventory
+
+These checked-in adapters still differ from their validated `_fresh`
+counterparts:
+
+- `trellis/instruments/_agent/fxvanillaanalytical.py`
+- `trellis/instruments/_agent/fxvanillamontecarlo.py`
+- `trellis/instruments/_agent/quantooptionanalytical.py`
+- `trellis/instruments/_agent/quantooptionmontecarlo.py`
+
+The current diffs suggest two distinct possibilities:
+
+- the checked-in shell is the better thin helper-backed adapter and should be
+  explicitly blessed
+- the `_fresh` output is closer to the desired family helper surface and the
+  checked-in shell should be replaced
+
+This workstream resolves that ambiguity explicitly instead of leaving the
+inventory stale indefinitely.
+
+### Existing open tickets to reuse
+
+The following open tickets already cover part of the desired direction and
+should be reused rather than duplicated:
+
+- `QUA-742` helper layers: event-aware Monte Carlo family composition
+- `QUA-743` helper layers: reusable transform assembly surface
+- `QUA-745` helper layers: docs, observability, and canary hardening
+- `QUA-746` semantic comparison regimes: short-rate market objects and claim
+  helper generalization
+- `QUA-748` helper layers: shared short-rate regime resolver and discount-bond
+  claim kit
+- `QUA-749` short-rate wrappers: migrate ZCB analytical and tree helpers onto
+  shared claim kits
+- `QUA-458` full-task canary replay with diagnosis parity
+- `QUA-710` trustworthy canary telemetry and historical baselines
+
+### Acceptance tasks to keep or recover
+
+#### Canary acceptance
+
+- `T01` short-rate comparison regime and helper authority
+- `T17` callable-bond PDE/tree event-aware short-rate path
+- `T25` and `T26` vanilla Monte Carlo helper surface
+- `T39` and `T40` transform-family helper surface
+- `T49` basket-credit helper surface
+- `T73` swaption comparison and event-aware MC path
+- `T105` quanto analytical-vs-MC parity
+
+#### Direct task acceptance
+
+- task `1314` quanto option: quanto-adjusted BS vs MC cross-currency
+- task `1370` FX vanilla option: Garman-Kohlhagen vs MC
+
+The rule for this workstream is simple:
+
+- no cleanup slice is considered done until its corresponding canary or task
+  rerun still passes on the cleaned surface
+
+## Scope
+
+- stale-adapter closure for the remaining FX/quanto checked-in shells
+- reusable helper extraction for FX/quanto family surfaces
+- reuse and completion of the existing open MC/transform and short-rate helper
+  tickets
+- continued removal of product-local exact-binding authority from executor and
+  route-era guidance
+- canary/task reruns that prove the cleaned lower layer still supports good
+  agent-generated code
+
+## Non-Goals
+
+- deleting every product wrapper immediately
+- deleting every checked-in adapter immediately
+- broad new product-family expansion unrelated to the current debt
+- redesigning the canary runner again
+- replacing the public pricing API or all compatibility layers in one step
+
+## Design Principles
+
+### 1. Family helper kits should replace product-local glue gradually
+
+Product wrappers may remain temporarily, but they should become thin
+compositions over reusable helper layers rather than acting as the true lower
+authority.
+
+### 2. Stale-adapter closure must be explicit
+
+If a checked-in adapter remains the preferred thin shell, bless it and tighten
+the freshness policy around it. If a fresh-build adapter is better, replace the
+checked-in shell. Do not leave a stale warning unresolved just because both
+variants happen to work.
+
+### 3. Executor authority should keep shrinking
+
+Executor/binding code should prefer registry-backed helper metadata and family
+capability surfaces. Product-local exact-binding prose in the executor should
+be treated as transitional debt.
+
+### 4. Canary/task acceptance is mandatory
+
+Every slice must name and rerun the canaries or direct tasks it defends.
+
+## Ordered Delivery Queue
+
+### New umbrella
+
+| Issue | Title | Status |
+| --- | --- | --- |
+| `QUA-766` | Lower-layer cleanup: stale adapters, family helper convergence, and canary-backed verification | Backlog |
+
+### Reused prerequisite tickets
+
+1. `QUA-742`
+2. `QUA-743`
+3. `QUA-748`
+4. `QUA-749`
+5. `QUA-745`
+
+These already exist and should be completed as part of this broader cleanup
+program.
+
+### New cleanup tickets
+
+1. `QUA-767` FX/quanto family helper extraction beneath current wrappers
+2. `QUA-768` stale-adapter closure for FX/quanto checked-in shells
+3. `QUA-769` executor/binding cleanup for remaining product-shaped
+   exact-binding rules
+4. `QUA-770` final canary/task verification and closeout for the cleanup
+   program
+
+### Ordered queue mirror
+
+Status mirror last synced: `2026-04-09`
+
+| Ticket | Slice | Status |
+| --- | --- | --- |
+| `QUA-742` | Helper layers: event-aware Monte Carlo family composition | Done |
+| `QUA-743` | Helper layers: reusable transform assembly surface | Done |
+| `QUA-748` | Helper layers: shared short-rate regime resolver and discount-bond claim kit | Done |
+| `QUA-749` | Short-rate wrappers: migrate ZCB analytical and tree helpers onto shared claim kits | Done |
+| `QUA-767` | Helper layers: FX and quanto family helper kits beneath current wrappers | Done |
+| `QUA-768` | Adapter freshness: close remaining FX and quanto stale checked-in shells | Done |
+| `QUA-769` | Backend binding: retire remaining product-shaped exact-binding guidance from executor | Done |
+| `QUA-745` | Helper layers: docs, observability, and canary hardening | Done |
+| `QUA-770` | Lower-layer cleanup: canary and direct-task verification closeout | Done |
+
+Notes:
+
+- `QUA-768` is blocked by `QUA-767`.
+- `QUA-770` is blocked by `QUA-768` and `QUA-769`.
+- `QUA-458` and `QUA-710` are not delivery blockers for the core cleanup, but
+  they should be reused if replay/telemetry work is needed during closeout.
+
+## Acceptance Matrix
+
+| Slice | Primary acceptance | Secondary acceptance |
+| --- | --- | --- |
+| Stale FX/quanto adapter closure | `T105` | task `1370`, task `1314` |
+| FX/quanto helper extraction | `T105` | task `1370`, task `1314` |
+| MC/transform helper reuse (`QUA-742`, `QUA-743`) | `T25`, `T26`, `T39`, `T40` | full curated canary rerun |
+| Short-rate helper reuse (`QUA-748`, `QUA-749`) | `T01` | `T17` |
+| Executor/binding authority reduction | `T01`, `T17`, `T73`, `T49` | full curated canary rerun |
+| Final closeout | full curated canary rerun | task `1314`, task `1370` |
+
+## Validation Posture
+
+### Local
+
+- targeted unit tests for each helper or binding slice
+- direct task reruns for `1314` and `1370` on FX/quanto cleanup slices
+
+### Regional
+
+- canary reruns by family:
+  - `T105` for quanto
+  - `T25`, `T26` for MC helper extraction
+  - `T39`, `T40` for transform helper extraction
+  - `T01`, `T17` for short-rate helper extraction
+  - `T49` for basket-credit/executor authority
+  - `T73` for rates comparison authority
+
+### Global
+
+- full curated canary rerun after the queue stabilizes
+- broader non-integration suite where touched subsystems justify it
+
+## Done State
+
+This plan is complete when:
+
+- the remaining FX/quanto stale adapters are either replaced or explicitly
+  blessed as the intended thin shells
+- the open MC/transform and short-rate helper tickets are complete
+- executor/binding exact-helper authority is materially thinner and more
+  registry-driven than it is today
+- the direct FX/quanto tasks and the relevant curated canaries still pass
+- the final curated canary rerun remains green and the cleanup is reflected in
+  docs and mirrored plan state
+
+## Closeout
+
+Status mirror last validated: `2026-04-09`
+
+Implemented outcome:
+
+- shared single-state Monte Carlo and transform helper kits now sit under the
+  vanilla wrappers
+- FX vanilla and quanto routes now bind through semantic-facing helper kits and
+  the checked-in adapters/_fresh snapshots were refreshed as the intended thin
+  shells
+- executor exact-binding guidance is narrower and fresh-build runs no longer
+  short-circuit through deterministic exact-binding materialization
+- shared short-rate claim helpers remain the authority under ZCB/callable
+  wrappers
+
+Acceptance evidence:
+
+- direct task reruns passed:
+  - ``T105`` in ``task_results_t105_qua766.json``
+  - ``T108`` in ``task_results_t108_qua766.json``
+- final curated canary rerun passed ``14/14`` in
+  ``canary_results_20260409_qua766_closeout_v2.json``
+
+Residual debt kept explicit:
+
+- product wrappers still exist where they are acting as compatibility surfaces
+  over broader helper kits
+- retry counts on several Monte Carlo / transform / PDE canaries are still
+  non-zero, so this umbrella improved correctness and lower-layer authority
+  more than first-pass efficiency
+- the transform lane still wants a true lowered transform-family IR in the
+  future; see
+  ``docs/plans/transform-family-ir-and-admissibility-hardening.md`` for the
+  follow-on tranche that replaces the bounded route-metadata/model-family fix
+  with a real lowered transform family contract

--- a/docs/quant/pricing_stack.rst
+++ b/docs/quant/pricing_stack.rst
@@ -147,9 +147,18 @@ The first migrated vanilla cases now use that boundary directly:
   single-state diffusion resolver/GBM-support layer under
   ``trellis.models.resolution`` for settlement, maturity, spot, dividend,
   discount, vol, and characteristic-function binding
+- the transform route uses that thin vanilla helper only for true
+  ``equity_diffusion`` contracts; stochastic-volatility transform tasks such
+  as Heston smile extraction still lower onto the raw FFT/COS kernel surface
+  instead of being forced through the single-state helper
 - the local-vol vanilla helper remains a checked route-level wrapper, but it
   now assembles and prices through ``trellis.models.monte_carlo.event_aware``
   instead of maintaining a separate Monte Carlo engine/payoff loop
+- FX vanilla and quanto routes now expose semantic-facing helper kits in
+  ``trellis.models.fx_vanilla`` and ``trellis.models.quanto_option`` so the
+  checked analytical and Monte Carlo adapters can stay as thin shells over
+  shared market-binding and execution helpers rather than separate product
+  implementations
 - the copula basket-credit slice now also exposes a semantic-facing helper
   layer in ``trellis.models.credit_basket_copula`` so tranche-style CDO and
   nth-to-default requests can bind discount/credit inputs, tranche bounds, and

--- a/docs/user_guide/pricing.rst
+++ b/docs/user_guide/pricing.rst
@@ -88,6 +88,14 @@ the Black76 basis decomposition explicit inside the helper, so the same pricing
 math can be reused for both valuation and Greeks without rebuilding it in each
 adapter.
 
+The corresponding quanto routes now follow the same shape. The supported
+analytical and Monte Carlo slices bind through
+``trellis.models.quanto_option`` while the FX vanilla analytical slice binds
+through ``trellis.models.fx_vanilla``. The checked-in adapters under
+``trellis.instruments._agent`` are intentionally thin compatibility shells
+over those semantic-facing helpers rather than separate pricing
+implementations.
+
 Rates Calibration
 -----------------
 
@@ -239,6 +247,13 @@ For fully migrated exact-helper families, Trellis can now mark that alias as
 internal-only. In that case, prompts and trace summaries omit the alias
 entirely and rely on the backend binding id instead, while raw validation and
 replay metadata still retain the route id for compatibility.
+
+That family-first rule now also applies inside transform pricing. The thin
+vanilla transform helper is only selected for ``equity_diffusion`` claims. If
+the same European payoff is being priced under a different model family, such
+as Heston stochastic volatility, Trellis keeps the request on the raw FFT/COS
+kernel surface instead of pretending the vanilla helper is a universal
+transform authority.
 
 For the migrated PDE routes, the same trace boundary now also exposes a compact
 `family_ir_summary` alongside the raw lowering metadata. That summary is the

--- a/tests/test_agent/test_build_loop.py
+++ b/tests/test_agent/test_build_loop.py
@@ -82,7 +82,7 @@ UNAPPROVED_IMPORT_MODULE_CODE = MOCK_MODULE_CODE.replace(
 )
 
 GOOD_QUANTO_MODULE_CODE = '''\
-"""Agent-generated payoff: Quanto option."""
+"""Compatibility adapter for the quanto analytical payoff."""
 
 from __future__ import annotations
 
@@ -91,12 +91,25 @@ from datetime import date
 
 from trellis.core.market_state import MarketState
 from trellis.core.types import DayCountConvention
-from trellis.models.analytical.quanto import price_quanto_option_analytical
-from trellis.models.resolution.quanto import resolve_quanto_inputs
+from trellis.models.quanto_option import price_quanto_option_analytical_from_market_state
+
+
+REQUIREMENTS = frozenset(
+    {
+        "black_vol_surface",
+        "discount_curve",
+        "forward_curve",
+        "fx_rates",
+        "model_parameters",
+        "spot",
+    }
+)
 
 
 @dataclass(frozen=True)
 class QuantoOptionSpec:
+    """Specification for the single-name quanto analytical adapter."""
+
     notional: float
     strike: float
     expiry_date: date
@@ -109,6 +122,8 @@ class QuantoOptionSpec:
 
 
 class QuantoOptionAnalyticalPayoff:
+    """Compatibility payoff that delegates through the semantic-facing helper."""
+
     def __init__(self, spec: QuantoOptionSpec):
         self._spec = spec
 
@@ -118,16 +133,15 @@ class QuantoOptionAnalyticalPayoff:
 
     @property
     def requirements(self) -> set[str]:
-        return {"black_vol_surface", "discount_curve", "forward_curve", "fx_rates", "model_parameters", "spot"}
+        return REQUIREMENTS
 
     def evaluate(self, market_state: MarketState) -> float:
-        resolved = resolve_quanto_inputs(market_state, self._spec)
-        return float(price_quanto_option_analytical(self._spec, resolved))
+        return float(price_quanto_option_analytical_from_market_state(market_state, self._spec))
 '''
 
 UNAPPROVED_QUANTO_IMPORT_MODULE_CODE = GOOD_QUANTO_MODULE_CODE.replace(
-    "from trellis.models.analytical.quanto import price_quanto_option_analytical\nfrom trellis.models.resolution.quanto import resolve_quanto_inputs",
-    "from trellis.models.processes.heston import Heston\nfrom trellis.models.resolution.quanto import resolve_quanto_inputs",
+    "from trellis.models.quanto_option import price_quanto_option_analytical_from_market_state",
+    "from trellis.models.processes.heston import Heston",
 )
 
 AMERICAN_SPEC_SCHEMA = SpecSchema(
@@ -356,10 +370,8 @@ def test_generate_quanto_monte_carlo_skeleton_uses_family_helper_surface():
         generation_plan=SimpleNamespace(method="monte_carlo", instrument_type="quanto_option"),
     )
 
-    assert "from trellis.models.resolution.quanto import resolve_quanto_inputs" in skeleton
-    assert "from trellis.models.monte_carlo.quanto import price_quanto_option_monte_carlo" in skeleton
-    assert "resolved = resolve_quanto_inputs(market_state, spec)" in skeleton
-    assert "return float(price_quanto_option_monte_carlo(spec, resolved))" in skeleton
+    assert "from trellis.models.quanto_option import price_quanto_option_monte_carlo_from_market_state" in skeleton
+    assert "return float(price_quanto_option_monte_carlo_from_market_state(market_state, spec))" in skeleton
 def test_generate_module_reports_syntax_error_context(monkeypatch):
     from types import SimpleNamespace
 
@@ -647,8 +659,7 @@ from datetime import date
 
 from trellis.core.market_state import MarketState
 from trellis.core.types import DayCountConvention
-from trellis.models.analytical.quanto import price_quanto_option_analytical
-from trellis.models.resolution.quanto import resolve_quanto_inputs
+from trellis.models.quanto_option import price_quanto_option_analytical_from_market_state
 
     from importlib import import_module
 
@@ -679,9 +690,7 @@ class QuantoOptionAnalyticalPayoff:
         return {"black_vol_surface", "discount_curve", "forward_curve", "fx_rates", "model_parameters", "spot"}
 
     def evaluate(self, market_state: MarketState) -> float:
-        spec = self._spec
-        resolved = resolve_quanto_inputs(market_state, spec)
-        return float(price_quanto_option_analytical(spec, resolved))
+        return float(price_quanto_option_analytical_from_market_state(market_state, self._spec))
 '''
 
     monkeypatch.setattr(
@@ -691,8 +700,7 @@ class QuantoOptionAnalyticalPayoff:
 
     result = _generate_module(
         skeleton="""from trellis.core.market_state import MarketState
-from trellis.models.analytical.quanto import price_quanto_option_analytical
-from trellis.models.resolution.quanto import resolve_quanto_inputs
+from trellis.models.quanto_option import price_quanto_option_analytical_from_market_state
 
 class QuantoOptionSpec:
     pass
@@ -704,8 +712,7 @@ class QuantoOptionAnalyticalPayoff:
 
     def evaluate(self, market_state: MarketState) -> float:
         spec = self._spec
-        resolved = resolve_quanto_inputs(market_state, spec)
-        # return float(price_quanto_option_analytical(spec, resolved))
+        # return float(price_quanto_option_analytical_from_market_state(market_state, spec))
         raise NotImplementedError("evaluate not yet implemented")
 """,
         spec_schema=SimpleNamespace(
@@ -720,7 +727,7 @@ class QuantoOptionAnalyticalPayoff:
 
     compile(result.code, "<recovered>", "exec")
     assert "class QuantoOptionAnalyticalPayoff" in result.code
-    assert "return float(price_quanto_option_analytical(spec, resolved))" in result.code
+    assert "return float(price_quanto_option_analytical_from_market_state(market_state, spec))" in result.code
 
 
 def test_validate_build_critic_path_uses_stage_helpers_without_nameerror(monkeypatch, caplog):
@@ -1455,14 +1462,34 @@ class TestBuildLoop:
         from trellis.agent.executor import build_payoff
 
         mock_gen_mod.return_value = '''\
+"""Compatibility adapter for the quanto analytical payoff."""
+
+from __future__ import annotations
+
 from dataclasses import dataclass
 from datetime import date
+
 from trellis.core.market_state import MarketState
 from trellis.core.types import DayCountConvention
-from trellis.models.analytical.quanto import price_quanto_option_analytical
+from trellis.models.quanto_option import price_quanto_option_analytical_from_market_state
+
+
+REQUIREMENTS = frozenset(
+    {
+        "black_vol_surface",
+        "discount_curve",
+        "forward_curve",
+        "fx_rates",
+        "model_parameters",
+        "spot",
+    }
+)
+
 
 @dataclass(frozen=True)
 class QuantoOptionSpec:
+    """Specification for the single-name quanto analytical adapter."""
+
     notional: float
     strike: float
     expiry_date: date
@@ -1473,16 +1500,19 @@ class QuantoOptionSpec:
     quanto_correlation_key: str | None = None
     day_count: DayCountConvention = DayCountConvention.ACT_365
 
+
 class QuantoOptionAnalyticalPayoff:
+    """Compatibility payoff that delegates through the semantic-facing helper."""
+
     def __init__(self, spec: QuantoOptionSpec):
         self._spec = spec
 
     @property
     def requirements(self) -> set[str]:
-        return {"discount_curve", "forward_curve", "black_vol_surface", "fx_rates", "spot", "model_parameters"}
+        return REQUIREMENTS
 
     def evaluate(self, market_state: MarketState) -> float:
-        return float(price_quanto_option_analytical(self._spec, market_state))
+        return float(price_quanto_option_analytical_from_market_state(market_state, self._spec))
 '''
         scratch_path = Path("/tmp/quantooptionanalytical_fresh.py")
         mock_write_module.return_value = scratch_path

--- a/tests/test_agent/test_checkpoints.py
+++ b/tests/test_agent/test_checkpoints.py
@@ -105,13 +105,13 @@ def _generation_boundary(
     exact_fit = bool(route_id)
     binding_ids = {
         "analytical_black76": "trellis.models.black.black76_call",
-        "quanto_adjustment_analytical": "trellis.models.analytical.quanto.price_quanto_option_analytical",
-        "analytical_garman_kohlhagen": "trellis.models.analytical.fx.garman_kohlhagen_price_raw",
+        "quanto_adjustment_analytical": "trellis.models.quanto_option.price_quanto_option_analytical_from_market_state",
+        "analytical_garman_kohlhagen": "trellis.models.fx_vanilla.price_fx_vanilla_analytical",
     }
     helper_refs = {
         "analytical_black76": ["trellis.models.black.black76_call"],
-        "quanto_adjustment_analytical": ["trellis.models.analytical.quanto.price_quanto_option_analytical"],
-        "analytical_garman_kohlhagen": ["trellis.models.analytical.fx.garman_kohlhagen_price_raw"],
+        "quanto_adjustment_analytical": ["trellis.models.quanto_option.price_quanto_option_analytical_from_market_state"],
+        "analytical_garman_kohlhagen": ["trellis.models.fx_vanilla.price_fx_vanilla_analytical"],
     }
     binding_id = binding_ids.get(route_id, "trellis.models.black.black76_call")
     return {

--- a/tests/test_agent/test_platform_requests.py
+++ b/tests/test_agent/test_platform_requests.py
@@ -93,7 +93,7 @@ def test_compile_build_request_uses_quanto_semantic_contract_blueprint():
     assert compiled.request.metadata["semantic_contract"]["semantic_id"] == "quanto_option"
     assert compiled.request.metadata["semantic_contract"]["semantic_concept"]["semantic_id"] == "quanto_option"
     assert compiled.request.metadata["semantic_blueprint"]["dsl_route"] == "quanto_adjustment_analytical"
-    assert "trellis.models.analytical.quanto.price_quanto_option_analytical" in (
+    assert "trellis.models.quanto_option.price_quanto_option_analytical_from_market_state" in (
         compiled.request.metadata["semantic_blueprint"]["dsl_helper_refs"]
     )
     assert compiled.request.metadata["semantic_blueprint"]["lane_plan"]["lane_family"] == "analytical"
@@ -108,6 +108,8 @@ def test_compile_build_request_uses_quanto_semantic_contract_blueprint():
     assert compiled.generation_plan is not None
     assert compiled.execution_plan.reason == "semantic_contract_request"
     assert "trellis.models.resolution.quanto" in compiled.semantic_blueprint.target_modules
+    assert "trellis.models.analytical.quanto" in compiled.semantic_blueprint.target_modules
+    assert "trellis.models.quanto_option" in compiled.generation_plan.approved_modules
     assert "trellis.models.resolution.quanto" in compiled.generation_plan.approved_modules
     assert compiled.semantic_blueprint.lane_plan is not None
     assert compiled.semantic_blueprint.lane_plan.lane_family == "analytical"
@@ -134,11 +136,11 @@ def test_compile_build_request_attaches_route_binding_authority_packet():
     assert authority["route_family"] == "analytical"
     assert authority["authority_kind"] == "exact_backend_fit"
     assert authority["compatibility_alias_policy"] == "internal_only"
-    assert backend_binding["binding_id"] == "trellis.models.analytical.quanto.price_quanto_option_analytical"
+    assert backend_binding["binding_id"] == "trellis.models.quanto_option.price_quanto_option_analytical_from_market_state"
     assert backend_binding["engine_family"] == "analytical"
     assert backend_binding["exact_backend_fit"] is True
     assert "trellis.models.resolution.quanto.resolve_quanto_inputs" in backend_binding["primitive_refs"]
-    assert "trellis.models.analytical.quanto.price_quanto_option_analytical" in backend_binding["helper_refs"]
+    assert "trellis.models.quanto_option.price_quanto_option_analytical_from_market_state" in backend_binding["helper_refs"]
     assert authority["validation_bundle_id"] == "analytical:quanto_option"
     assert "check_non_negativity" in authority["validation_check_ids"]
     assert backend_binding["admissibility"]["multicurrency_support"] == "native_payout_with_fx"

--- a/tests/test_agent/test_promotion_candidates.py
+++ b/tests/test_agent/test_promotion_candidates.py
@@ -257,6 +257,24 @@ def test_detect_adapter_lifecycle_records_flags_stale_checked_in_adapter(monkeyp
     assert fresh[0].module_path == "trellis.instruments._agent._fresh.example_adapter"
 
 
+def test_detect_adapter_lifecycle_records_keeps_fx_and_quanto_shells_fresh():
+    from trellis.agent.knowledge.promotion import (
+        AdapterLifecycleStatus,
+        detect_adapter_lifecycle_records,
+    )
+
+    stale_ids = {
+        record.adapter_id
+        for record in detect_adapter_lifecycle_records()
+        if record.status == AdapterLifecycleStatus.STALE
+    }
+
+    assert "trellis.instruments._agent.fxvanillaanalytical" not in stale_ids
+    assert "trellis.instruments._agent.fxvanillamontecarlo" not in stale_ids
+    assert "trellis.instruments._agent.quantooptionanalytical" not in stale_ids
+    assert "trellis.instruments._agent.quantooptionmontecarlo" not in stale_ids
+
+
 def test_review_and_adopt_promotion_candidate_propagate_adapter_lifecycle_state(monkeypatch, tmp_path):
     from trellis.agent.knowledge.promotion import (
         adopt_promotion_candidate,

--- a/tests/test_agent/test_prompts.py
+++ b/tests/test_agent/test_prompts.py
@@ -704,18 +704,20 @@ def test_evaluate_prompt_compact_surface_mentions_fx_route_helper():
     plan = GenerationPlan(
         method="analytical",
         instrument_type="european_option",
-        inspected_modules=("trellis.models.analytical.fx", "trellis.models.black"),
-        approved_modules=("trellis.models.analytical.fx", "trellis.models.black", "trellis.core.date_utils"),
+        inspected_modules=("trellis.models.fx_vanilla", "trellis.models.analytical.fx", "trellis.models.black"),
+        approved_modules=("trellis.models.fx_vanilla", "trellis.models.analytical.fx", "trellis.models.black", "trellis.core.date_utils"),
         symbols_to_reuse=(
             "ResolvedGarmanKohlhagenInputs",
             "garman_kohlhagen_price_raw",
+            "price_fx_vanilla_analytical",
         ),
         proposed_tests=("tests/test_agent/test_build_loop.py",),
         primitive_plan=PrimitivePlan(
             route="analytical_garman_kohlhagen",
             engine_family="analytical",
             primitives=(
-                PrimitiveRef("trellis.models.analytical.fx", "garman_kohlhagen_price_raw", "route_helper"),
+                PrimitiveRef("trellis.models.fx_vanilla", "price_fx_vanilla_analytical", "route_helper"),
+                PrimitiveRef("trellis.models.analytical.fx", "garman_kohlhagen_price_raw", "pricing_kernel"),
             ),
             adapters=("map_fx_spot_and_curves_to_garman_kohlhagen_inputs",),
             blockers=(),
@@ -738,6 +740,7 @@ def test_evaluate_prompt_compact_surface_mentions_fx_route_helper():
         prompt_surface="compact",
     )
 
+    assert "price_fx_vanilla_analytical" in prompt
     assert "garman_kohlhagen_price_raw" in prompt
     assert "ResolvedGarmanKohlhagenInputs" in prompt
     assert "Garman-Kohlhagen" in prompt
@@ -1720,15 +1723,21 @@ def test_evaluate_prompt_quanto_analytical_surface_includes_resolution_guidance(
         instrument_type="quanto_option",
         inspected_modules=(
             "trellis.models.black",
+            "trellis.models.quanto_option",
             "trellis.models.resolution.quanto",
             "trellis.models.analytical.quanto",
         ),
         approved_modules=(
             "trellis.models.black",
+            "trellis.models.quanto_option",
             "trellis.models.resolution.quanto",
             "trellis.models.analytical.quanto",
         ),
-        symbols_to_reuse=("black76_call", "resolve_quanto_inputs", "price_quanto_option_analytical"),
+        symbols_to_reuse=(
+            "black76_call",
+            "resolve_quanto_inputs",
+            "price_quanto_option_analytical_from_market_state",
+        ),
         proposed_tests=("tests/test_agent/test_build_loop.py",),
         primitive_plan=PrimitivePlan(
             route="quanto_adjustment_analytical",
@@ -1741,8 +1750,8 @@ def test_evaluate_prompt_quanto_analytical_surface_includes_resolution_guidance(
                     "market_binding",
                 ),
                 PrimitiveRef(
-                    "trellis.models.analytical.quanto",
-                    "price_quanto_option_analytical",
+                    "trellis.models.quanto_option",
+                    "price_quanto_option_analytical_from_market_state",
                     "route_helper",
                 ),
             ),
@@ -1756,12 +1765,13 @@ def test_evaluate_prompt_quanto_analytical_surface_includes_resolution_guidance(
         spec_schema=SimpleNamespace(class_name="Demo", fields=[]),
         reference_sources={
             "Quanto helper": "def resolve_quanto_inputs(...):\n    pass\n",
-            "Quanto analytical helper": "def price_quanto_option_analytical(...):\n    pass\n",
+            "Quanto analytical helper": "def price_quanto_option_analytical_from_market_state(...):\n    pass\n",
         },
         pricing_plan=PricingPlan(
             method="analytical",
             method_modules=[
                 "trellis.models.black",
+                "trellis.models.quanto_option",
                 "trellis.models.resolution.quanto",
                 "trellis.models.analytical.quanto",
             ],
@@ -1775,7 +1785,7 @@ def test_evaluate_prompt_quanto_analytical_surface_includes_resolution_guidance(
     )
 
     assert "resolve_quanto_inputs" in prompt
-    assert "price_quanto_option_analytical" in prompt
+    assert "price_quanto_option_analytical_from_market_state" in prompt
     assert "Do not reimplement spot / FX / curve / correlation lookup" in prompt
     assert "Do not reimplement the quanto-adjusted analytical pricing body" in prompt
     assert "quanto-adjusted forward" in prompt
@@ -1795,12 +1805,14 @@ def test_evaluate_prompt_quanto_monte_carlo_surface_includes_joint_state_guidanc
         inspected_modules=(
             "trellis.models.monte_carlo.engine",
             "trellis.models.monte_carlo.quanto",
+            "trellis.models.quanto_option",
             "trellis.models.processes.correlated_gbm",
             "trellis.models.resolution.quanto",
         ),
         approved_modules=(
             "trellis.models.monte_carlo.engine",
             "trellis.models.monte_carlo.quanto",
+            "trellis.models.quanto_option",
             "trellis.models.processes.correlated_gbm",
             "trellis.models.resolution.quanto",
         ),
@@ -1808,7 +1820,7 @@ def test_evaluate_prompt_quanto_monte_carlo_surface_includes_joint_state_guidanc
             "MonteCarloEngine",
             "CorrelatedGBM",
             "resolve_quanto_inputs",
-            "price_quanto_option_monte_carlo",
+            "price_quanto_option_monte_carlo_from_market_state",
         ),
         proposed_tests=("tests/test_agent/test_build_loop.py",),
         primitive_plan=PrimitivePlan(
@@ -1823,8 +1835,8 @@ def test_evaluate_prompt_quanto_monte_carlo_surface_includes_joint_state_guidanc
                     "market_binding",
                 ),
                 PrimitiveRef(
-                    "trellis.models.monte_carlo.quanto",
-                    "price_quanto_option_monte_carlo",
+                    "trellis.models.quanto_option",
+                    "price_quanto_option_monte_carlo_from_market_state",
                     "route_helper",
                 ),
             ),
@@ -1838,13 +1850,14 @@ def test_evaluate_prompt_quanto_monte_carlo_surface_includes_joint_state_guidanc
         spec_schema=SimpleNamespace(class_name="Demo", fields=[]),
         reference_sources={
             "Quanto helper": "def resolve_quanto_inputs(...):\n    pass\n",
-            "Quanto MC helper": "def price_quanto_option_monte_carlo(...):\n    pass\n",
+            "Quanto MC helper": "def price_quanto_option_monte_carlo_from_market_state(...):\n    pass\n",
         },
         pricing_plan=PricingPlan(
             method="monte_carlo",
             method_modules=[
                 "trellis.models.monte_carlo.engine",
                 "trellis.models.monte_carlo.quanto",
+                "trellis.models.quanto_option",
                 "trellis.models.processes.correlated_gbm",
                 "trellis.models.resolution.quanto",
             ],
@@ -1857,7 +1870,7 @@ def test_evaluate_prompt_quanto_monte_carlo_surface_includes_joint_state_guidanc
         prompt_surface="compact",
     )
 
-    assert "price_quanto_option_monte_carlo" in prompt
+    assert "price_quanto_option_monte_carlo_from_market_state" in prompt
     assert "np.array([resolved.spot, resolved.fx_spot]" in prompt
     assert "Do not seed a multi-asset correlated GBM" in prompt
     assert "Do not reimplement process / engine / payoff / discount wiring" in prompt

--- a/tests/test_agent/test_route_registry.py
+++ b/tests/test_agent/test_route_registry.py
@@ -299,7 +299,12 @@ class TestQuantoRoutes:
             ("trellis.models.resolution.quanto", "resolve_quanto_inputs", "market_binding"),
             ("trellis.models.black", "black76_call", "pricing_kernel"),
             ("trellis.models.black", "black76_put", "pricing_kernel"),
-            ("trellis.models.analytical.quanto", "price_quanto_option_analytical", "route_helper"),
+            ("trellis.models.analytical.quanto", "price_quanto_option_analytical", "pricing_kernel"),
+            (
+                "trellis.models.quanto_option",
+                "price_quanto_option_analytical_from_market_state",
+                "route_helper",
+            ),
         }
         assert _prim_set(new_prims) == expected_prims
         assert "reuse_shared_quanto_market_binding" in new_adapters
@@ -945,7 +950,8 @@ class TestFXAnalyticalRoutes:
         spec = [r for r in registry.routes if r.id == "analytical_garman_kohlhagen"][0]
         new_prims = resolve_route_primitives(spec, self.FX_IR)
         expected_prims = {
-            ("trellis.models.analytical.fx", "garman_kohlhagen_price_raw", "route_helper"),
+            ("trellis.models.analytical.fx", "garman_kohlhagen_price_raw", "pricing_kernel"),
+            ("trellis.models.fx_vanilla", "price_fx_vanilla_analytical", "route_helper"),
             ("trellis.core.date_utils", "year_fraction", "time_measure"),
         }
         assert _prim_set(new_prims) == expected_prims
@@ -1007,6 +1013,7 @@ class TestFallbackRoutes:
             instrument="european_option",
             payoff_family="vanilla_option",
             exercise_style="european",
+            model_family="equity_diffusion",
         )
         new_prims = resolve_route_primitives(spec, ir)
         expected_prims = {
@@ -1015,6 +1022,21 @@ class TestFallbackRoutes:
                 "price_vanilla_equity_option_transform",
                 "route_helper",
             ),
+        }
+        assert _prim_set(new_prims) == expected_prims
+
+    def test_stochastic_vol_transform_primitives_fall_back_to_raw_kernels(self, registry):
+        spec = [r for r in registry.routes if r.id == "transform_fft"][0]
+        ir = ProductIR(
+            instrument="european_option",
+            payoff_family="vanilla_option",
+            exercise_style="european",
+            model_family="stochastic_volatility",
+        )
+        new_prims = resolve_route_primitives(spec, ir)
+        expected_prims = {
+            ("trellis.models.transforms.fft_pricer", "fft_price", "transform_pricer"),
+            ("trellis.models.transforms.cos_method", "cos_price", "transform_pricer"),
         }
         assert _prim_set(new_prims) == expected_prims
 
@@ -1072,6 +1094,7 @@ class TestFallbackRoutes:
     def test_pde_admissibility_hydrates_operator_and_event_contracts(self, registry):
         vanilla = find_route_by_id("vanilla_equity_theta_pde", registry)
         generic = find_route_by_id("pde_theta_1d", registry)
+        transform = find_route_by_id("transform_fft", registry)
 
         assert vanilla is not None
         assert vanilla.admissibility.supported_operator_families == ("black_scholes_1d",)
@@ -1084,6 +1107,28 @@ class TestFallbackRoutes:
             "project_max",
             "project_min",
         )
+        assert transform is not None
+        assert transform.admissibility.supported_control_styles == ("identity", "holder_max")
+        assert transform.admissibility.supported_state_tags == ("terminal_markov", "recombining_safe")
+
+    def test_transform_route_admissibility_accepts_european_holder_control_surface(self, registry):
+        from trellis.agent.semantic_contract_compiler import compile_semantic_contract
+        from trellis.agent.semantic_contracts import make_vanilla_option_contract
+
+        spec = find_route_by_id("transform_fft", registry)
+        assert spec is not None
+
+        contract = make_vanilla_option_contract(
+            description="European call on SPX priced with transforms",
+            underliers=("SPX",),
+            observation_schedule=("2026-06-20",),
+            preferred_method="fft_pricing",
+        )
+        blueprint = compile_semantic_contract(contract, preferred_method="fft_pricing")
+
+        decision = evaluate_route_admissibility(spec, semantic_blueprint=blueprint)
+
+        assert decision.ok
 
     def test_vanilla_pde_admissibility_rejects_wrong_operator_family(self, registry):
         from dataclasses import replace

--- a/tests/test_agent/test_semantic_validators.py
+++ b/tests/test_agent/test_semantic_validators.py
@@ -187,7 +187,7 @@ def evaluate(self, market_state):
     def test_importing_route_helper_without_calling_it_still_fails(self, registry):
         spec = [r for r in registry.routes if r.id == "quanto_adjustment_analytical"][0]
         source = '''
-from trellis.models.analytical.quanto import price_quanto_option_analytical
+from trellis.models.quanto_option import price_quanto_option_analytical_from_market_state
 
 def evaluate(self, market_state):
     return black76_call(F, K, T, vol, df)

--- a/tests/test_models/test_fx_vanilla.py
+++ b/tests/test_models/test_fx_vanilla.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from trellis.core.market_state import MarketState
+from trellis.curves.yield_curve import YieldCurve
+from trellis.instruments.fx import FXRate
+from trellis.models.vol_surface import FlatVol
+
+
+SETTLE = date(2024, 11, 15)
+
+
+def _market_state() -> MarketState:
+    domestic = YieldCurve.flat(0.05)
+    foreign = YieldCurve.flat(0.03)
+    return MarketState(
+        as_of=SETTLE,
+        settlement=SETTLE,
+        discount=domestic,
+        forecast_curves={"EUR-DISC": foreign},
+        fx_rates={"EURUSD": FXRate(spot=1.10, domestic="USD", foreign="EUR")},
+        vol_surface=FlatVol(0.20),
+    )
+
+
+class _Spec:
+    notional = 100_000
+    strike = 1.05
+    expiry_date = date(2025, 11, 15)
+    fx_pair = "EURUSD"
+    foreign_discount_key = "EUR-DISC"
+    option_type = "call"
+    n_paths = 12_000
+    n_steps = 64
+    seed = 7
+
+
+def test_resolve_fx_vanilla_inputs_reads_spot_curves_and_vol():
+    from trellis.models.fx_vanilla import resolve_fx_vanilla_inputs
+
+    resolved = resolve_fx_vanilla_inputs(_market_state(), _Spec())
+
+    assert resolved.garman_kohlhagen.spot == pytest.approx(1.10)
+    assert resolved.garman_kohlhagen.strike == pytest.approx(1.05)
+    assert resolved.garman_kohlhagen.T == pytest.approx(1.0)
+    assert resolved.garman_kohlhagen.sigma == pytest.approx(0.20)
+    assert resolved.domestic_rate == pytest.approx(0.05)
+    assert resolved.foreign_rate == pytest.approx(0.03)
+
+
+def test_fx_vanilla_helpers_match_adapter_prices():
+    from trellis.instruments._agent.fxvanillaanalytical import (
+        FXVanillaAnalyticalPayoff,
+        FXVanillaOptionSpec as AnalyticalSpec,
+    )
+    from trellis.instruments._agent.fxvanillamontecarlo import (
+        FXVanillaMonteCarloPayoff,
+        FXVanillaOptionSpec as MonteCarloSpec,
+    )
+    from trellis.models.fx_vanilla import (
+        price_fx_vanilla_analytical,
+        price_fx_vanilla_monte_carlo,
+    )
+
+    analytical_spec = AnalyticalSpec(
+        notional=_Spec.notional,
+        strike=_Spec.strike,
+        expiry_date=_Spec.expiry_date,
+        fx_pair=_Spec.fx_pair,
+        foreign_discount_key=_Spec.foreign_discount_key,
+        option_type=_Spec.option_type,
+    )
+    mc_spec = MonteCarloSpec(
+        notional=_Spec.notional,
+        strike=_Spec.strike,
+        expiry_date=_Spec.expiry_date,
+        fx_pair=_Spec.fx_pair,
+        foreign_discount_key=_Spec.foreign_discount_key,
+        option_type=_Spec.option_type,
+        n_paths=_Spec.n_paths,
+        n_steps=_Spec.n_steps,
+        seed=_Spec.seed,
+    )
+    market_state = _market_state()
+
+    assert price_fx_vanilla_analytical(market_state, analytical_spec) == pytest.approx(
+        FXVanillaAnalyticalPayoff(analytical_spec).evaluate(market_state),
+        rel=1e-12,
+    )
+    assert price_fx_vanilla_monte_carlo(market_state, mc_spec) == pytest.approx(
+        FXVanillaMonteCarloPayoff(mc_spec).evaluate(market_state),
+        rel=1e-12,
+    )

--- a/tests/test_models/test_monte_carlo/test_single_state_diffusion.py
+++ b/tests/test_models/test_monte_carlo/test_single_state_diffusion.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from trellis.core.market_state import MarketState
+from trellis.curves.yield_curve import YieldCurve
+from trellis.models.vol_surface import FlatVol
+
+
+SETTLE = date(2024, 11, 15)
+
+
+class _Spec:
+    notional = 100.0
+    spot = 100.0
+    strike = 100.0
+    expiry_date = date(2025, 11, 15)
+    option_type = "call"
+    n_paths = 12_000
+    n_steps = 64
+    seed = 7
+
+
+def _market_state(vol: float = 0.20, rate: float = 0.05) -> MarketState:
+    return MarketState(
+        as_of=SETTLE,
+        settlement=SETTLE,
+        discount=YieldCurve.flat(rate, max_tenor=5.0),
+        vol_surface=FlatVol(vol),
+    )
+
+
+def test_resolve_single_state_terminal_claim_monte_carlo_inputs_reads_market_and_controls():
+    from trellis.models.monte_carlo.single_state_diffusion import (
+        resolve_single_state_terminal_claim_monte_carlo_inputs,
+    )
+
+    resolved = resolve_single_state_terminal_claim_monte_carlo_inputs(
+        _market_state(vol=0.30, rate=0.04),
+        _Spec(),
+        scheme="log_euler",
+        variance_reduction="antithetic",
+        n_paths=8000,
+        n_steps=96,
+        seed=11,
+    )
+
+    assert resolved.spot == pytest.approx(100.0)
+    assert resolved.rate == pytest.approx(0.04)
+    assert resolved.sigma == pytest.approx(0.30)
+    assert resolved.scheme == "log_euler"
+    assert resolved.variance_reduction == "antithetic"
+    assert resolved.n_paths == 8000
+    assert resolved.n_steps == 96
+    assert resolved.seed == 11
+
+
+def test_build_single_state_terminal_claim_monte_carlo_problem_uses_terminal_only_event_aware_shape():
+    from trellis.models.monte_carlo.single_state_diffusion import (
+        build_single_state_terminal_claim_monte_carlo_problem_from_resolved,
+        resolve_single_state_terminal_claim_monte_carlo_inputs,
+    )
+
+    resolved = resolve_single_state_terminal_claim_monte_carlo_inputs(
+        _market_state(),
+        _Spec(),
+    )
+    problem = build_single_state_terminal_claim_monte_carlo_problem_from_resolved(
+        resolved,
+        terminal_payoff=lambda terminal: terminal,
+    )
+
+    assert problem.path_requirement.full_path is False
+    assert problem.path_requirement.snapshot_steps == ()
+    assert problem.maturity == pytest.approx(1.0)
+    assert problem.discount_rate == pytest.approx(resolved.rate)
+    assert problem.simulation_method == "exact"
+
+
+def test_equity_monte_carlo_wrapper_delegates_through_single_state_family_helper(monkeypatch):
+    from trellis.models import equity_option_monte_carlo as module
+
+    calls: list[tuple[object, object]] = []
+
+    class FakeResult:
+        price = 123.45
+
+    def fake_result(market_state, spec, **kwargs):
+        calls.append((market_state, spec))
+        return FakeResult()
+
+    monkeypatch.setattr(
+        module,
+        "price_single_state_terminal_claim_monte_carlo_result",
+        fake_result,
+    )
+
+    price = module.price_vanilla_equity_option_monte_carlo(_market_state(), _Spec())
+
+    assert calls
+    assert price == pytest.approx(123.45)

--- a/tests/test_models/test_monte_carlo/test_single_state_diffusion.py
+++ b/tests/test_models/test_monte_carlo/test_single_state_diffusion.py
@@ -69,7 +69,7 @@ def test_build_single_state_terminal_claim_monte_carlo_problem_uses_terminal_onl
     )
     problem = build_single_state_terminal_claim_monte_carlo_problem_from_resolved(
         resolved,
-        terminal_payoff=lambda terminal: terminal,
+        terminal_payoff=lambda terminal, resolved: terminal,
     )
 
     assert problem.path_requirement.full_path is False
@@ -77,6 +77,37 @@ def test_build_single_state_terminal_claim_monte_carlo_problem_uses_terminal_onl
     assert problem.maturity == pytest.approx(1.0)
     assert problem.discount_rate == pytest.approx(resolved.rate)
     assert problem.simulation_method == "exact"
+
+
+def test_build_single_state_terminal_claim_monte_carlo_problem_downgrades_local_vol_exact_to_euler():
+    from trellis.models.monte_carlo.single_state_diffusion import (
+        build_single_state_terminal_claim_monte_carlo_problem,
+    )
+
+    _, problem = build_single_state_terminal_claim_monte_carlo_problem(
+        _market_state(),
+        _Spec(),
+        terminal_payoff=lambda terminal, resolved: terminal,
+        process_family="local_vol_1d",
+        local_vol_surface=lambda t, s: 0.20,
+    )
+
+    assert problem.simulation_method == "euler"
+
+
+def test_build_single_state_terminal_claim_monte_carlo_problem_preserves_log_euler():
+    from trellis.models.monte_carlo.single_state_diffusion import (
+        build_single_state_terminal_claim_monte_carlo_problem,
+    )
+
+    _, problem = build_single_state_terminal_claim_monte_carlo_problem(
+        _market_state(),
+        _Spec(),
+        terminal_payoff=lambda terminal, resolved: terminal,
+        scheme="log_euler",
+    )
+
+    assert problem.simulation_method == "log_euler"
 
 
 def test_equity_monte_carlo_wrapper_delegates_through_single_state_family_helper(monkeypatch):

--- a/tests/test_models/test_quanto_option_helpers.py
+++ b/tests/test_models/test_quanto_option_helpers.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from trellis.core.market_state import MarketState
+from trellis.curves.yield_curve import YieldCurve
+from trellis.instruments.fx import FXRate
+from trellis.models.vol_surface import FlatVol
+
+
+SETTLE = date(2024, 11, 15)
+
+
+def _market_state() -> MarketState:
+    domestic = YieldCurve.flat(0.05)
+    foreign = YieldCurve.flat(0.03)
+    return MarketState(
+        as_of=SETTLE,
+        settlement=SETTLE,
+        discount=domestic,
+        forecast_curves={"EUR-DISC": foreign},
+        fx_rates={"EURUSD": FXRate(spot=1.10, domestic="USD", foreign="EUR")},
+        spot=100.0,
+        underlier_spots={"EUR": 100.0},
+        vol_surface=FlatVol(0.20),
+        model_parameters={"quanto_correlation": 0.35},
+    )
+
+
+def test_quanto_option_helpers_match_adapter_prices():
+    from trellis.instruments._agent.quantooptionanalytical import (
+        QuantoOptionAnalyticalPayoff,
+        QuantoOptionSpec as AnalyticalSpec,
+    )
+    from trellis.instruments._agent.quantooptionmontecarlo import (
+        QuantoOptionMonteCarloPayoff,
+        QuantoOptionSpec as MonteCarloSpec,
+    )
+    from trellis.models.quanto_option import (
+        price_quanto_option_analytical_from_market_state,
+        price_quanto_option_monte_carlo_from_market_state,
+    )
+
+    analytical_spec = AnalyticalSpec(
+        notional=100_000,
+        strike=100.0,
+        expiry_date=date(2025, 11, 15),
+        fx_pair="EURUSD",
+    )
+    mc_spec = MonteCarloSpec(
+        notional=100_000,
+        strike=100.0,
+        expiry_date=date(2025, 11, 15),
+        fx_pair="EURUSD",
+        n_paths=12_000,
+        n_steps=64,
+        seed=7,
+    )
+    market_state = _market_state()
+
+    assert price_quanto_option_analytical_from_market_state(market_state, analytical_spec) == pytest.approx(
+        QuantoOptionAnalyticalPayoff(analytical_spec).evaluate(market_state),
+        rel=1e-12,
+    )
+    assert price_quanto_option_monte_carlo_from_market_state(market_state, mc_spec) == pytest.approx(
+        QuantoOptionMonteCarloPayoff(mc_spec).evaluate(market_state),
+        rel=1e-12,
+    )

--- a/tests/test_models/test_transforms/test_single_state_diffusion.py
+++ b/tests/test_models/test_transforms/test_single_state_diffusion.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from trellis.core.market_state import MarketState
+from trellis.curves.yield_curve import YieldCurve
+from trellis.models.vol_surface import FlatVol
+
+
+SETTLE = date(2024, 11, 15)
+
+
+class _Spec:
+    notional = 100.0
+    spot = 100.0
+    strike = 100.0
+    expiry_date = date(2025, 11, 15)
+    option_type = "call"
+
+
+def _market_state(vol: float = 0.20, rate: float = 0.05) -> MarketState:
+    return MarketState(
+        as_of=SETTLE,
+        settlement=SETTLE,
+        discount=YieldCurve.flat(rate, max_tenor=5.0),
+        vol_surface=FlatVol(vol),
+    )
+
+
+def test_resolve_single_state_terminal_claim_transform_inputs_reads_market_and_controls():
+    from trellis.models.transforms.single_state_diffusion import (
+        resolve_single_state_terminal_claim_transform_inputs,
+    )
+
+    resolved = resolve_single_state_terminal_claim_transform_inputs(
+        _market_state(vol=0.30, rate=0.04),
+        _Spec(),
+        method="cos",
+        fft_alpha=2.0,
+        fft_points=2048,
+        fft_eta=0.2,
+        cos_points=128,
+        cos_truncation=12.0,
+    )
+
+    assert resolved.spot == pytest.approx(100.0)
+    assert resolved.rate == pytest.approx(0.04)
+    assert resolved.sigma == pytest.approx(0.30)
+    assert resolved.method == "cos"
+    assert resolved.fft_alpha == pytest.approx(2.0)
+    assert resolved.fft_points == 2048
+    assert resolved.fft_eta == pytest.approx(0.2)
+    assert resolved.cos_points == 128
+    assert resolved.cos_truncation == pytest.approx(12.0)
+
+
+def test_price_single_state_terminal_claim_transform_result_prices_intrinsic_at_expiry():
+    from trellis.models.transforms.single_state_diffusion import (
+        price_single_state_terminal_claim_transform_result,
+    )
+
+    spec = _Spec()
+    spec.expiry_date = SETTLE
+    result = price_single_state_terminal_claim_transform_result(
+        _market_state(),
+        spec,
+        intrinsic_fn=lambda terminal, resolved: max(float(terminal) - resolved.strike, 0.0),
+        fft_log_spot_char_fn=lambda resolved: lambda u: 0.0,
+        cos_log_ratio_char_fn=lambda resolved: lambda u: 0.0,
+        put_from_call_parity_fn=lambda call_price, resolved: float(call_price),
+    )
+
+    assert result.price == pytest.approx(0.0)
+    assert result.maturity == pytest.approx(0.0)
+
+
+def test_equity_transform_wrapper_delegates_through_single_state_family_helper(monkeypatch):
+    from trellis.models import equity_option_transforms as module
+
+    calls: list[tuple[object, object]] = []
+
+    class FakeResult:
+        price = 321.0
+
+    def fake_result(market_state, spec, **kwargs):
+        calls.append((market_state, spec))
+        return FakeResult()
+
+    monkeypatch.setattr(
+        module,
+        "price_single_state_terminal_claim_transform_result",
+        fake_result,
+    )
+
+    price = module.price_vanilla_equity_option_transform(_market_state(), _Spec())
+
+    assert calls
+    assert price == pytest.approx(321.0)

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -1266,23 +1266,24 @@ def build_payoff(
         generated_module: GeneratedModuleResult | None = None
         generation_token_usage: dict[str, object] = {}
         try:
-            generated_module = _materialize_deterministic_exact_binding_module(
-                skeleton,
-                generation_plan,
-                semantic_blueprint=(
-                    getattr(compiled_request, "semantic_blueprint", None)
-                    if compiled_request is not None
-                    else None
-                ),
-                comparison_target=(
-                    (
-                        getattr(getattr(compiled_request, "request", None), "metadata", None)
-                        or {}
-                    ).get("comparison_target")
-                    if compiled_request is not None
-                    else None
-                ),
-            )
+            if not fresh_build:
+                generated_module = _materialize_deterministic_exact_binding_module(
+                    skeleton,
+                    generation_plan,
+                    semantic_blueprint=(
+                        getattr(compiled_request, "semantic_blueprint", None)
+                        if compiled_request is not None
+                        else None
+                    ),
+                    comparison_target=(
+                        (
+                            getattr(getattr(compiled_request, "request", None), "metadata", None)
+                            or {}
+                        ).get("comparison_target")
+                        if compiled_request is not None
+                        else None
+                    ),
+                )
             if generated_module is None:
                 with llm_usage_stage(
                     "code_generation",
@@ -2581,34 +2582,12 @@ def _generate_skeleton(
     requirements_str = ", ".join(f'"{r}"' for r in sorted(spec_schema.requirements))
     import_lines = list(_skeleton_type_import_lines(spec_schema))
     import_lines.extend(_skeleton_exact_binding_import_lines(generation_plan))
-    evaluate_preamble_lines = ["        spec = self._spec"]
-
-    if instrument_type == "quanto_option" and method == "analytical":
-        import_lines.extend(
-            [
-                "from trellis.models.analytical.quanto import price_quanto_option_analytical",
-                "from trellis.models.resolution.quanto import resolve_quanto_inputs",
-            ]
-        )
-        evaluate_preamble_lines.extend(
-            [
-                "        resolved = resolve_quanto_inputs(market_state, spec)",
-                "        # return float(price_quanto_option_analytical(spec, resolved))",
-            ]
-        )
-    elif instrument_type == "quanto_option" and method == "monte_carlo":
-        import_lines.extend(
-            [
-                "from trellis.models.monte_carlo.quanto import price_quanto_option_monte_carlo",
-                "from trellis.models.resolution.quanto import resolve_quanto_inputs",
-            ]
-        )
-        evaluate_preamble_lines.extend(
-            [
-                "        resolved = resolve_quanto_inputs(market_state, spec)",
-                "        # return float(price_quanto_option_monte_carlo(spec, resolved))",
-            ]
-        )
+    semantic_helper_imports, semantic_helper_lines = _skeleton_semantic_helper_hints(
+        instrument_type,
+        method,
+    )
+    import_lines.extend(semantic_helper_imports)
+    evaluate_preamble_lines = ["        spec = self._spec", *semantic_helper_lines]
     extra_imports = "\n".join(dict.fromkeys(import_lines))
     if extra_imports:
         extra_imports = f"{extra_imports}\n"
@@ -2663,12 +2642,30 @@ def _skeleton_type_import_lines(spec_schema) -> tuple[str, ...]:
     return (f"from trellis.core.types import {', '.join(names)}",)
 
 
+def _skeleton_semantic_helper_hints(
+    instrument_type: str,
+    method: str,
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """Return semantic-facing helper imports and commented evaluate hints."""
+    helper_hints = {
+        ("quanto_option", "analytical"): (
+            ("from trellis.models.quanto_option import price_quanto_option_analytical_from_market_state",),
+            ("        # return float(price_quanto_option_analytical_from_market_state(market_state, spec))",),
+        ),
+        ("quanto_option", "monte_carlo"): (
+            ("from trellis.models.quanto_option import price_quanto_option_monte_carlo_from_market_state",),
+            ("        # return float(price_quanto_option_monte_carlo_from_market_state(market_state, spec))",),
+        ),
+    }
+    return helper_hints.get((instrument_type, method), ((), ()))
+
+
 def _skeleton_exact_binding_import_lines(generation_plan) -> tuple[str, ...]:
     """Return import lines for compiler-selected exact bindings."""
     if generation_plan is None:
         return ()
 
-    refs: list[str] = list(getattr(generation_plan, "lane_exact_binding_refs", ()) or ())
+    refs: list[str] = list(_exact_binding_refs(generation_plan))
     primitive_plan = getattr(generation_plan, "primitive_plan", None)
     if primitive_plan is not None:
         refs.extend(
@@ -2714,7 +2711,31 @@ def _exact_binding_refs(generation_plan) -> tuple[str, ...]:
         text = str(ref or "").strip()
         if text and text not in normalized:
             normalized.append(text)
+    for ref in _semantic_exact_binding_refs(tuple(normalized)):
+        if ref not in normalized:
+            normalized.append(ref)
     return tuple(normalized)
+
+
+def _semantic_exact_binding_refs(refs: tuple[str, ...]) -> tuple[str, ...]:
+    """Return semantic-facing helper refs that supersede lower-level route helpers."""
+    extra: list[str] = []
+    raw_to_semantic = {
+        "trellis.models.analytical.quanto.price_quanto_option_analytical": (
+            "trellis.models.quanto_option.price_quanto_option_analytical_from_market_state"
+        ),
+        "trellis.models.monte_carlo.quanto.price_quanto_option_monte_carlo": (
+            "trellis.models.quanto_option.price_quanto_option_monte_carlo_from_market_state"
+        ),
+        "trellis.models.analytical.fx.garman_kohlhagen_price_raw": (
+            "trellis.models.fx_vanilla.price_fx_vanilla_analytical"
+        ),
+    }
+    for ref in refs:
+        semantic = raw_to_semantic.get(ref)
+        if semantic and semantic not in extra:
+            extra.append(semantic)
+    return tuple(extra)
 
 
 def _swaption_comparison_helper_kwargs(semantic_blueprint) -> str:
@@ -2793,6 +2814,15 @@ def _deterministic_exact_binding_evaluate_body(
     zcb_option_tree_kwargs = _zcb_option_tree_helper_kwargs(comparison_target)
     credit_basket_tranche_kwargs = _credit_basket_tranche_helper_kwargs(comparison_target)
     helper_bodies = {
+        "trellis.models.quanto_option.price_quanto_option_analytical_from_market_state": (
+            "return float(price_quanto_option_analytical_from_market_state(market_state, spec))"
+        ),
+        "trellis.models.quanto_option.price_quanto_option_monte_carlo_from_market_state": (
+            "return float(price_quanto_option_monte_carlo_from_market_state(market_state, spec))"
+        ),
+        "trellis.models.fx_vanilla.price_fx_vanilla_analytical": (
+            "return float(price_fx_vanilla_analytical(market_state, spec))"
+        ),
         "trellis.models.callable_bond_pde.price_callable_bond_pde": (
             "return float(price_callable_bond_pde(market_state, spec))"
         ),

--- a/trellis/agent/knowledge/canonical/routes.yaml
+++ b/trellis/agent/knowledge/canonical/routes.yaml
@@ -42,6 +42,9 @@ routes:
         role: pricing_kernel
       - module: trellis.models.analytical.quanto
         symbol: price_quanto_option_analytical
+        role: pricing_kernel
+      - module: trellis.models.quanto_option
+        symbol: price_quanto_option_analytical_from_market_state
         role: route_helper
     adapters:
       - reuse_shared_quanto_market_binding
@@ -79,6 +82,9 @@ routes:
         role: market_binding
       - module: trellis.models.monte_carlo.quanto
         symbol: price_quanto_option_monte_carlo
+        role: pricing_kernel
+      - module: trellis.models.quanto_option
+        symbol: price_quanto_option_monte_carlo_from_market_state
         role: route_helper
     adapters:
       - reuse_shared_quanto_market_binding
@@ -951,6 +957,9 @@ routes:
     primitives:
       - module: trellis.models.analytical.fx
         symbol: garman_kohlhagen_price_raw
+        role: pricing_kernel
+      - module: trellis.models.fx_vanilla
+        symbol: price_fx_vanilla_analytical
         role: route_helper
       - module: trellis.core.date_utils
         symbol: year_fraction
@@ -979,18 +988,19 @@ routes:
     match:
       methods: [fft_pricing]
     admissibility:
-      control_styles: [identity]
+      control_styles: [identity, holder_max]
       event_support: none
       phase_sensitivity: default_phase_order_only
       multicurrency_support: single_currency_only
       supported_outputs: [price, scenario_pnl]
       supports_sensitivity_outputs: true
-      supported_state_tags: [terminal_markov]
+      supported_state_tags: [terminal_markov, recombining_safe]
       supports_calibration: false
     conditional_primitives:
       - when:
           payoff_family: vanilla_option
           exercise_style: [european]
+          model_family: [equity_diffusion]
         primitives:
           - module: trellis.models.equity_option_transforms
             symbol: price_vanilla_equity_option_transform

--- a/trellis/instruments/_agent/_fresh/fxvanillaanalytical.py
+++ b/trellis/instruments/_agent/_fresh/fxvanillaanalytical.py
@@ -1,16 +1,4 @@
-"""Agent-generated payoff: Build a pricer for: FX vanilla option: Garman-Kohlhagen vs MC
-
-Construct methods: analytical, monte_carlo
-Comparison targets: gk_analytical (analytical), mc_fx_option (monte_carlo)
-Cross-validation harness:
-  internal targets: gk_analytical, mc_fx_option
-  external targets: quantlib, financepy
-New component: garman_kohlhagen_formula
-
-Implementation target: gk_analytical
-Preferred method family: analytical
-
-Implementation target: gk_analytical."""
+"""Deterministic vanilla FX analytical payoff adapter."""
 
 from __future__ import annotations
 
@@ -19,49 +7,29 @@ from datetime import date
 
 from trellis.core.market_state import MarketState
 from trellis.core.types import DayCountConvention
-from trellis.models.analytical.fx import garman_kohlhagen_price_raw, ResolvedGarmanKohlhagenInputs
-from trellis.core.date_utils import year_fraction
-from trellis.models.black import garman_kohlhagen_call, garman_kohlhagen_put
+from trellis.models.fx_vanilla import price_fx_vanilla_analytical, resolve_fx_vanilla_inputs
 
 
 @dataclass(frozen=True)
 class FXVanillaOptionSpec:
-    """Specification for Build a pricer for: FX vanilla option: Garman-Kohlhagen vs MC
+    """Specification for a vanilla FX option under Garman-Kohlhagen."""
 
-Construct methods: analytical, monte_carlo
-Comparison targets: gk_analytical (analytical), mc_fx_option (monte_carlo)
-Cross-validation harness:
-  internal targets: gk_analytical, mc_fx_option
-  external targets: quantlib, financepy
-New component: garman_kohlhagen_formula
-
-Implementation target: gk_analytical
-Preferred method family: analytical
-
-Implementation target: gk_analytical."""
     notional: float
     strike: float
     expiry_date: date
     fx_pair: str
     foreign_discount_key: str
-    option_type: str = "'call'"
+    option_type: str = "call"
     day_count: DayCountConvention = DayCountConvention.ACT_365
 
 
+def _resolve_fx_inputs(market_state: MarketState, spec: FXVanillaOptionSpec):
+    """Backward-compatible alias for the semantic-facing FX helper resolver."""
+    return resolve_fx_vanilla_inputs(market_state, spec).garman_kohlhagen
+
+
 class FXVanillaAnalyticalPayoff:
-    """Build a pricer for: FX vanilla option: Garman-Kohlhagen vs MC
-
-Construct methods: analytical, monte_carlo
-Comparison targets: gk_analytical (analytical), mc_fx_option (monte_carlo)
-Cross-validation harness:
-  internal targets: gk_analytical, mc_fx_option
-  external targets: quantlib, financepy
-New component: garman_kohlhagen_formula
-
-Implementation target: gk_analytical
-Preferred method family: analytical
-
-Implementation target: gk_analytical."""
+    """Deterministic thin adapter over the semantic-facing FX analytical helper."""
 
     def __init__(self, spec: FXVanillaOptionSpec):
         self._spec = spec
@@ -72,44 +40,7 @@ Implementation target: gk_analytical."""
 
     @property
     def requirements(self) -> set[str]:
-        return {"black_vol_surface", "discount_curve", "forward_curve", "fx_rates"}
+        return {"discount_curve", "forward_curve", "black_vol_surface", "fx_rates"}
 
     def evaluate(self, market_state: MarketState) -> float:
-        spec = self._spec
-
-        # Compute time to expiry
-        as_of = market_state.as_of
-        T = year_fraction(as_of, spec.expiry_date, spec.day_count)
-
-        # Extract scalar spot FX rate (domestic per unit of foreign)
-        fx_rate_wrapper = market_state.fx_rates[spec.fx_pair]
-        spot = fx_rate_wrapper.spot
-
-        # Domestic discount factor to expiry
-        df_domestic = market_state.discount.discount(T)
-
-        # Foreign discount factor to expiry (rf curve identified by foreign_discount_key)
-        foreign_curve = market_state.forecast_curves[spec.foreign_discount_key]
-        df_foreign = foreign_curve.discount(T)
-
-        # Implied vol from vol surface at (T, strike)
-        sigma = market_state.vol_surface.black_vol(T, spec.strike)
-
-        # Normalise option_type: strip surrounding quotes if present
-        raw_type = spec.option_type.strip().strip("'\"").lower()
-
-        # Build resolved inputs for Garman-Kohlhagen
-        resolved = ResolvedGarmanKohlhagenInputs(
-            spot=spot,
-            strike=spec.strike,
-            T=T,
-            sigma=sigma,
-            df_domestic=df_domestic,
-            df_foreign=df_foreign,
-        )
-
-        # Price via Garman-Kohlhagen closed-form kernel (returns undiscounted unit price)
-        unit_price = garman_kohlhagen_price_raw(raw_type, resolved)
-
-        # Scale by notional and return PV (discounting is embedded in GK formula)
-        return spec.notional * unit_price
+        return float(price_fx_vanilla_analytical(market_state, self._spec))

--- a/trellis/instruments/_agent/_fresh/fxvanillamontecarlo.py
+++ b/trellis/instruments/_agent/_fresh/fxvanillamontecarlo.py
@@ -1,16 +1,4 @@
-"""Agent-generated payoff: Build a pricer for: FX vanilla option: Garman-Kohlhagen vs MC
-
-Construct methods: analytical, monte_carlo
-Comparison targets: gk_analytical (analytical), mc_fx_option (monte_carlo)
-Cross-validation harness:
-  internal targets: gk_analytical, mc_fx_option
-  external targets: quantlib, financepy
-New component: garman_kohlhagen_formula
-
-Implementation target: mc_fx_option
-Preferred method family: monte_carlo
-
-Implementation target: mc_fx_option."""
+"""Deterministic vanilla FX Monte Carlo payoff adapter."""
 
 from __future__ import annotations
 
@@ -19,49 +7,27 @@ from datetime import date
 
 from trellis.core.market_state import MarketState
 from trellis.core.types import DayCountConvention
-
+from trellis.models.fx_vanilla import price_fx_vanilla_monte_carlo
 
 
 @dataclass(frozen=True)
 class FXVanillaOptionSpec:
-    """Specification for Build a pricer for: FX vanilla option: Garman-Kohlhagen vs MC
+    """Specification for a vanilla FX option under risk-neutral FX Monte Carlo."""
 
-Construct methods: analytical, monte_carlo
-Comparison targets: gk_analytical (analytical), mc_fx_option (monte_carlo)
-Cross-validation harness:
-  internal targets: gk_analytical, mc_fx_option
-  external targets: quantlib, financepy
-New component: garman_kohlhagen_formula
-
-Implementation target: mc_fx_option
-Preferred method family: monte_carlo
-
-Implementation target: mc_fx_option."""
     notional: float
     strike: float
     expiry_date: date
     fx_pair: str
     foreign_discount_key: str
-    option_type: str = "'call'"
+    option_type: str = "call"
     day_count: DayCountConvention = DayCountConvention.ACT_365
     n_paths: int = 50000
     n_steps: int = 252
+    seed: int = 42
 
 
 class FXVanillaMonteCarloPayoff:
-    """Build a pricer for: FX vanilla option: Garman-Kohlhagen vs MC
-
-Construct methods: analytical, monte_carlo
-Comparison targets: gk_analytical (analytical), mc_fx_option (monte_carlo)
-Cross-validation harness:
-  internal targets: gk_analytical, mc_fx_option
-  external targets: quantlib, financepy
-New component: garman_kohlhagen_formula
-
-Implementation target: mc_fx_option
-Preferred method family: monte_carlo
-
-Implementation target: mc_fx_option."""
+    """Deterministic thin adapter over the semantic-facing FX Monte Carlo helper."""
 
     def __init__(self, spec: FXVanillaOptionSpec):
         self._spec = spec
@@ -72,82 +38,7 @@ Implementation target: mc_fx_option."""
 
     @property
     def requirements(self) -> set[str]:
-        return {"black_vol_surface", "discount_curve", "forward_curve", "fx_rates"}
+        return {"discount_curve", "forward_curve", "black_vol_surface", "fx_rates"}
 
     def evaluate(self, market_state: MarketState) -> float:
-        from trellis.core.date_utils import year_fraction
-        from trellis.core.differentiable import get_numpy
-        from trellis.models.monte_carlo.engine import MonteCarloEngine
-        from trellis.models.processes.gbm import GBM
-
-        np = get_numpy()
-        spec = self._spec
-
-        # Year fraction to expiry
-        T = year_fraction(market_state.settlement, spec.expiry_date, spec.day_count)
-        if T <= 0.0:
-            return 0.0
-
-        # Domestic discount rate (risk-free rate in domestic currency)
-        r_d = float(market_state.discount.zero_rate(T))
-
-        # Foreign discount rate (risk-free rate in foreign currency)
-        # Used as the dividend yield in the Garman-Kohlhagen / FX GBM framework
-        foreign_curve = market_state.forecast_curves.get(spec.foreign_discount_key)
-        if foreign_curve is not None:
-            r_f = float(foreign_curve.zero_rate(T))
-        else:
-            # Fall back: try to get from discount curve keyed by foreign_discount_key
-            r_f = 0.0
-
-        # Spot FX rate — extract scalar from FXRate wrapper
-        fx_rate_obj = market_state.fx_rates[spec.fx_pair]
-        if hasattr(fx_rate_obj, "spot"):
-            S0 = float(fx_rate_obj.spot)
-        else:
-            S0 = float(fx_rate_obj)
-
-        # Implied volatility from vol surface
-        sigma = float(market_state.vol_surface.black_vol(T, spec.strike))
-
-        # GBM drift under domestic risk-neutral measure for FX:
-        # dS = (r_d - r_f) * S * dt + sigma * S * dW
-        mu = r_d - r_f
-
-        # Build GBM process — no 'spot' keyword; initial state is passed to simulate()
-        process = GBM(mu=mu, sigma=sigma)
-
-        # Number of paths and steps
-        n_paths = spec.n_paths
-        n_steps = max(spec.n_steps, int(T * 252), 50)
-
-        engine = MonteCarloEngine(
-            process,
-            n_paths=n_paths,
-            n_steps=n_steps,
-            seed=42,
-            method="exact",
-        )
-
-        # Simulate paths: shape (n_paths, n_steps + 1)
-        paths = engine.simulate(S0, T)
-
-        # Terminal FX spot values
-        S_T = paths[:, -1]
-
-        # Normalise option type — strip surrounding quotes if present
-        opt_type = spec.option_type.strip().strip("'\"").lower()
-
-        # Compute intrinsic payoff at expiry
-        if opt_type == "call":
-            intrinsic = np.maximum(S_T - spec.strike, 0.0)
-        else:
-            intrinsic = np.maximum(spec.strike - S_T, 0.0)
-
-        # Discount back to valuation date under domestic rate
-        df = float(market_state.discount.discount(T))
-
-        # Monte Carlo price estimate
-        price = df * float(np.mean(intrinsic)) * spec.notional
-
-        return price
+        return float(price_fx_vanilla_monte_carlo(market_state, self._spec))

--- a/trellis/instruments/_agent/_fresh/quantooptionanalytical.py
+++ b/trellis/instruments/_agent/_fresh/quantooptionanalytical.py
@@ -1,4 +1,4 @@
-"""Agent-generated payoff: Quanto option."""
+"""Compatibility adapter for the quanto analytical payoff."""
 
 from __future__ import annotations
 
@@ -7,12 +7,25 @@ from datetime import date
 
 from trellis.core.market_state import MarketState
 from trellis.core.types import DayCountConvention
-from trellis.models.analytical.quanto import price_quanto_option_analytical
-from trellis.models.resolution.quanto import resolve_quanto_inputs
+from trellis.models.quanto_option import price_quanto_option_analytical_from_market_state
+
+
+REQUIREMENTS = frozenset(
+    {
+        "black_vol_surface",
+        "discount_curve",
+        "forward_curve",
+        "fx_rates",
+        "model_parameters",
+        "spot",
+    }
+)
 
 
 @dataclass(frozen=True)
 class QuantoOptionSpec:
+    """Specification for the single-name quanto analytical adapter."""
+
     notional: float
     strike: float
     expiry_date: date
@@ -25,6 +38,8 @@ class QuantoOptionSpec:
 
 
 class QuantoOptionAnalyticalPayoff:
+    """Compatibility payoff that delegates through the semantic-facing helper."""
+
     def __init__(self, spec: QuantoOptionSpec):
         self._spec = spec
 
@@ -34,8 +49,7 @@ class QuantoOptionAnalyticalPayoff:
 
     @property
     def requirements(self) -> set[str]:
-        return {"black_vol_surface", "discount_curve", "forward_curve", "fx_rates", "model_parameters", "spot"}
+        return REQUIREMENTS
 
     def evaluate(self, market_state: MarketState) -> float:
-        resolved = resolve_quanto_inputs(market_state, self._spec)
-        return float(price_quanto_option_analytical(self._spec, resolved))
+        return float(price_quanto_option_analytical_from_market_state(market_state, self._spec))

--- a/trellis/instruments/_agent/_fresh/quantooptionmontecarlo.py
+++ b/trellis/instruments/_agent/_fresh/quantooptionmontecarlo.py
@@ -1,74 +1,48 @@
-"""Agent-generated payoff: Build a pricer for: Quanto option: quanto-adjusted BS vs MC cross-currency
-
-Construct methods: analytical, monte_carlo
-Comparison targets: quanto_bs (analytical), mc_quanto (monte_carlo)
-Cross-validation harness:
-  internal targets: quanto_bs, mc_quanto
-  external targets: quantlib
-New component: ['quanto_adjustment', 'cross_currency_mc']
-
-Implementation target: mc_quanto
-Preferred method family: monte_carlo
-
-Implementation target: mc_quanto."""
+"""Deterministic quanto-option Monte Carlo payoff adapter."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import date
 
-from trellis.core.date_utils import generate_schedule, year_fraction
 from trellis.core.market_state import MarketState
-from trellis.core.types import DayCountConvention, Frequency
-from trellis.models.black import black76_call, black76_put
-from trellis.models.monte_carlo.engine import MonteCarloEngine
-from trellis.models.monte_carlo.quanto import price_quanto_option_monte_carlo
-from trellis.models.resolution.quanto import resolve_quanto_inputs
+from trellis.core.types import DayCountConvention
+from trellis.models.quanto_option import price_quanto_option_monte_carlo_from_market_state
 
+
+REQUIREMENTS = frozenset(
+    {
+        "discount_curve",
+        "forward_curve",
+        "black_vol_surface",
+        "fx_rates",
+        "spot",
+        "model_parameters",
+    }
+)
 
 
 @dataclass(frozen=True)
 class QuantoOptionSpec:
-    """Specification for Build a pricer for: Quanto option: quanto-adjusted BS vs MC cross-currency
+    """Specification for a single-underlier quanto option."""
 
-Construct methods: analytical, monte_carlo
-Comparison targets: quanto_bs (analytical), mc_quanto (monte_carlo)
-Cross-validation harness:
-  internal targets: quanto_bs, mc_quanto
-  external targets: quantlib
-New component: ['quanto_adjustment', 'cross_currency_mc']
-
-Implementation target: mc_quanto
-Preferred method family: monte_carlo
-
-Implementation target: mc_quanto."""
     notional: float
     strike: float
     expiry_date: date
     fx_pair: str
-    underlier_currency: str = "'EUR'"
-    domestic_currency: str = "'USD'"
-    option_type: str = "'call'"
+    underlier_currency: str = "EUR"
+    domestic_currency: str = "USD"
+    option_type: str = "call"
     quanto_correlation_key: str | None = None
     day_count: DayCountConvention = DayCountConvention.ACT_365
-    n_paths: int = 50000
+    n_paths: int = 50_000
     n_steps: int = 252
+    seed: int = 42
+    mc_method: str = "exact"
 
 
 class QuantoOptionMonteCarloPayoff:
-    """Build a pricer for: Quanto option: quanto-adjusted BS vs MC cross-currency
-
-Construct methods: analytical, monte_carlo
-Comparison targets: quanto_bs (analytical), mc_quanto (monte_carlo)
-Cross-validation harness:
-  internal targets: quanto_bs, mc_quanto
-  external targets: quantlib
-New component: ['quanto_adjustment', 'cross_currency_mc']
-
-Implementation target: mc_quanto
-Preferred method family: monte_carlo
-
-Implementation target: mc_quanto."""
+    """Deterministic thin adapter over the semantic-facing quanto MC helper."""
 
     def __init__(self, spec: QuantoOptionSpec):
         self._spec = spec
@@ -79,9 +53,7 @@ Implementation target: mc_quanto."""
 
     @property
     def requirements(self) -> set[str]:
-        return {"black_vol_surface", "discount_curve", "forward_curve", "fx_rates", "model_parameters", "spot"}
+        return REQUIREMENTS
 
     def evaluate(self, market_state: MarketState) -> float:
-        spec = self._spec
-        resolved = resolve_quanto_inputs(market_state, spec)
-        return float(price_quanto_option_monte_carlo(spec, resolved))
+        return float(price_quanto_option_monte_carlo_from_market_state(market_state, self._spec))

--- a/trellis/instruments/_agent/fxvanillaanalytical.py
+++ b/trellis/instruments/_agent/fxvanillaanalytical.py
@@ -5,13 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import date
 
-from trellis.core.date_utils import year_fraction
 from trellis.core.market_state import MarketState
 from trellis.core.types import DayCountConvention
-from trellis.models.analytical.fx import (
-    ResolvedGarmanKohlhagenInputs,
-    garman_kohlhagen_price_raw,
-)
+from trellis.models.fx_vanilla import price_fx_vanilla_analytical, resolve_fx_vanilla_inputs
 
 
 @dataclass(frozen=True)
@@ -27,50 +23,13 @@ class FXVanillaOptionSpec:
     day_count: DayCountConvention = DayCountConvention.ACT_365
 
 
-def _resolve_fx_inputs(
-    market_state: MarketState,
-    spec: FXVanillaOptionSpec,
-) -> ResolvedGarmanKohlhagenInputs:
-    """Resolve FX market inputs into the checked analytical helper surface."""
-    if market_state.discount is None:
-        raise ValueError("market_state.discount is required for FX analytical pricing")
-    if not market_state.forecast_curves or spec.foreign_discount_key not in market_state.forecast_curves:
-        raise ValueError(
-            f"market_state.forecast_curves must contain foreign discount key {spec.foreign_discount_key!r}"
-        )
-
-    fx_quote = (market_state.fx_rates or {}).get(spec.fx_pair)
-    if fx_quote is not None:
-        spot = float(fx_quote.spot)
-    elif market_state.spot is not None:
-        spot = float(market_state.spot)
-    elif market_state.underlier_spots and spec.fx_pair in market_state.underlier_spots:
-        spot = float(market_state.underlier_spots[spec.fx_pair])
-    else:
-        raise ValueError(f"FX spot for pair {spec.fx_pair!r} is not available in market_state")
-
-    T = year_fraction(market_state.settlement, spec.expiry_date, spec.day_count)
-    domestic_df = float(market_state.discount.discount(T))
-    foreign_curve = market_state.forecast_curves[spec.foreign_discount_key]
-    foreign_df = float(foreign_curve.discount(T))
-    if T > 0.0:
-        if market_state.vol_surface is None:
-            raise ValueError("market_state.vol_surface is required for FX analytical pricing")
-        sigma = float(market_state.vol_surface.black_vol(T, spec.strike))
-    else:
-        sigma = 0.0
-    return ResolvedGarmanKohlhagenInputs(
-        spot=spot,
-        strike=float(spec.strike),
-        sigma=sigma,
-        T=float(T),
-        df_domestic=domestic_df,
-        df_foreign=foreign_df,
-    )
+def _resolve_fx_inputs(market_state: MarketState, spec: FXVanillaOptionSpec):
+    """Backward-compatible alias for the semantic-facing FX helper resolver."""
+    return resolve_fx_vanilla_inputs(market_state, spec).garman_kohlhagen
 
 
 class FXVanillaAnalyticalPayoff:
-    """Deterministic thin adapter over the checked FX analytical helper."""
+    """Deterministic thin adapter over the semantic-facing FX analytical helper."""
 
     def __init__(self, spec: FXVanillaOptionSpec):
         self._spec = spec
@@ -84,8 +43,4 @@ class FXVanillaAnalyticalPayoff:
         return {"discount_curve", "forward_curve", "black_vol_surface", "fx_rates"}
 
     def evaluate(self, market_state: MarketState) -> float:
-        spec = self._spec
-        resolved = _resolve_fx_inputs(market_state, spec)
-        return float(spec.notional) * float(
-            garman_kohlhagen_price_raw(spec.option_type, resolved)
-        )
+        return float(price_fx_vanilla_analytical(market_state, self._spec))

--- a/trellis/instruments/_agent/fxvanillamontecarlo.py
+++ b/trellis/instruments/_agent/fxvanillamontecarlo.py
@@ -5,11 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import date
 
-from trellis.core.date_utils import year_fraction
-from trellis.core.differentiable import get_numpy
 from trellis.core.market_state import MarketState
 from trellis.core.types import DayCountConvention
-from trellis.instruments._agent.fxvanillaanalytical import _resolve_fx_inputs
+from trellis.models.fx_vanilla import price_fx_vanilla_monte_carlo
 
 
 @dataclass(frozen=True)
@@ -25,10 +23,11 @@ class FXVanillaOptionSpec:
     day_count: DayCountConvention = DayCountConvention.ACT_365
     n_paths: int = 50000
     n_steps: int = 252
+    seed: int = 42
 
 
 class FXVanillaMonteCarloPayoff:
-    """Deterministic thin adapter over the GBM Monte Carlo engine for vanilla FX."""
+    """Deterministic thin adapter over the semantic-facing FX Monte Carlo helper."""
 
     def __init__(self, spec: FXVanillaOptionSpec):
         self._spec = spec
@@ -42,55 +41,4 @@ class FXVanillaMonteCarloPayoff:
         return {"discount_curve", "forward_curve", "black_vol_surface", "fx_rates"}
 
     def evaluate(self, market_state: MarketState) -> float:
-        from trellis.models.monte_carlo.engine import MonteCarloEngine
-        from trellis.models.processes.gbm import GBM
-
-        spec = self._spec
-        np = get_numpy()
-        resolved = _resolve_fx_inputs(market_state, spec)
-        spot = float(resolved.spot)
-        T = float(resolved.T)
-        if T <= 0.0:
-            intrinsic = (
-                max(spot - spec.strike, 0.0)
-                if spec.option_type.lower() == "call"
-                else max(spec.strike - spot, 0.0)
-            )
-            return float(spec.notional) * float(intrinsic)
-
-        sigma = float(resolved.sigma)
-        rd = float(-np.log(resolved.df_domestic) / T)
-        rf = float(-np.log(resolved.df_foreign) / T)
-        process = GBM(mu=rd - rf, sigma=sigma)
-        engine = MonteCarloEngine(
-            process,
-            n_paths=int(spec.n_paths),
-            n_steps=int(spec.n_steps),
-            seed=42,
-            method="exact",
-        )
-
-        option_type = spec.option_type.lower()
-        strike = float(spec.strike)
-        notional = float(spec.notional)
-
-        def payoff_fn(paths):
-            terminal = paths[:, -1]
-            if option_type == "call":
-                payoffs = np.maximum(terminal - strike, 0.0)
-            elif option_type == "put":
-                payoffs = np.maximum(strike - terminal, 0.0)
-            else:
-                raise ValueError(
-                    f"Unsupported option_type {spec.option_type!r}; expected 'call' or 'put'"
-                )
-            return payoffs * notional
-
-        result = engine.price(
-            spot,
-            T,
-            payoff_fn,
-            discount_rate=rd,
-            return_paths=False,
-        )
-        return float(result["price"])
+        return float(price_fx_vanilla_monte_carlo(market_state, self._spec))

--- a/trellis/instruments/_agent/quantooptionanalytical.py
+++ b/trellis/instruments/_agent/quantooptionanalytical.py
@@ -7,8 +7,7 @@ from datetime import date
 
 from trellis.core.market_state import MarketState
 from trellis.core.types import DayCountConvention
-from trellis.models.analytical.quanto import price_quanto_option_raw
-from trellis.models.resolution.quanto import resolve_quanto_inputs
+from trellis.models.quanto_option import price_quanto_option_analytical_from_market_state
 
 
 REQUIREMENTS = frozenset(
@@ -39,7 +38,7 @@ class QuantoOptionSpec:
 
 
 class QuantoOptionAnalyticalPayoff:
-    """Compatibility payoff that delegates through the shared analytical helper."""
+    """Compatibility payoff that delegates through the semantic-facing helper."""
 
     def __init__(self, spec: QuantoOptionSpec):
         self._spec = spec
@@ -53,9 +52,4 @@ class QuantoOptionAnalyticalPayoff:
         return REQUIREMENTS
 
     def evaluate(self, market_state: MarketState) -> float:
-        return float(
-            price_quanto_option_raw(
-                self._spec,
-                resolve_quanto_inputs(market_state, self._spec),
-            )
-        )
+        return float(price_quanto_option_analytical_from_market_state(market_state, self._spec))

--- a/trellis/instruments/_agent/quantooptionmontecarlo.py
+++ b/trellis/instruments/_agent/quantooptionmontecarlo.py
@@ -6,15 +6,8 @@ from dataclasses import dataclass
 from datetime import date
 
 from trellis.core.market_state import MarketState
-from trellis.core.payoff import MonteCarloPathPayoff
 from trellis.core.types import DayCountConvention
-from trellis.models.monte_carlo.quanto import (
-    build_quanto_mc_initial_state,
-    build_quanto_mc_process,
-    recommended_quanto_mc_engine_kwargs,
-    terminal_quanto_option_payoff,
-)
-from trellis.models.resolution.quanto import ResolvedQuantoInputs, resolve_quanto_inputs
+from trellis.models.quanto_option import price_quanto_option_monte_carlo_from_market_state
 
 
 REQUIREMENTS = frozenset(
@@ -48,49 +41,19 @@ class QuantoOptionSpec:
     mc_method: str = "exact"
 
 
-def _intrinsic_value(option_type: str, spot: float, strike: float) -> float:
-    normalized_type = option_type.lower()
-    if normalized_type == "call":
-        return max(float(spot) - float(strike), 0.0)
-    if normalized_type == "put":
-        return max(float(strike) - float(spot), 0.0)
-    raise ValueError(
-        f"Unsupported option_type {option_type!r}; expected 'call' or 'put'"
-    )
+class QuantoOptionMonteCarloPayoff:
+    """Deterministic thin adapter over the semantic-facing quanto MC helper."""
 
+    def __init__(self, spec: QuantoOptionSpec):
+        self._spec = spec
 
-class QuantoOptionMonteCarloPayoff(
-    MonteCarloPathPayoff[QuantoOptionSpec, ResolvedQuantoInputs]
-):
-    """Deterministic thin adapter over the correlated-GBM quanto MC route."""
+    @property
+    def spec(self) -> QuantoOptionSpec:
+        return self._spec
 
     @property
     def requirements(self) -> set[str]:
         return REQUIREMENTS
 
-    def resolve_inputs(self, market_state: MarketState) -> ResolvedQuantoInputs:
-        return resolve_quanto_inputs(market_state, self.spec)
-
-    def evaluate_at_expiry(self, resolved: ResolvedQuantoInputs) -> float:
-        return float(self.spec.notional) * _intrinsic_value(
-            self.spec.option_type,
-            resolved.spot,
-            float(self.spec.strike),
-        )
-
-    def build_process(self, resolved: ResolvedQuantoInputs):
-        return build_quanto_mc_process(resolved)
-
-    def build_initial_state(self, resolved: ResolvedQuantoInputs):
-        return build_quanto_mc_initial_state(resolved)
-
-    def engine_kwargs(self, resolved: ResolvedQuantoInputs) -> dict[str, object]:
-        return recommended_quanto_mc_engine_kwargs(self.spec, resolved)
-
-    def pathwise_payoff(self, paths, resolved: ResolvedQuantoInputs):
-        normalized = self.normalize_paths(paths)
-        if normalized.shape[-1] < 2:
-            raise ValueError(
-                f"Expected joint underlier/FX paths with state_dim >= 2; got {normalized.shape}."
-            )
-        return terminal_quanto_option_payoff(self.spec, normalized)
+    def evaluate(self, market_state: MarketState) -> float:
+        return float(price_quanto_option_monte_carlo_from_market_state(market_state, self._spec))

--- a/trellis/models/equity_option_monte_carlo.py
+++ b/trellis/models/equity_option_monte_carlo.py
@@ -17,6 +17,7 @@ from trellis.models.monte_carlo.single_state_diffusion import (
     price_single_state_terminal_claim_monte_carlo_result,
     resolve_single_state_terminal_claim_monte_carlo_inputs,
 )
+from trellis.models.monte_carlo.event_aware import EventAwareMonteCarloProblem
 from trellis.models.resolution.single_state_diffusion import (
     SingleStateDiffusionMarketStateLike,
     SingleStateDiffusionSpecLike,
@@ -55,7 +56,7 @@ def build_vanilla_equity_monte_carlo_problem(
     n_paths: int | None = None,
     n_steps: int | None = None,
     seed: int | None = None,
-) -> tuple[ResolvedEquityMonteCarloInputs, object]:
+) -> tuple[ResolvedEquityMonteCarloInputs, EventAwareMonteCarloProblem]:
     """Build the bounded event-aware MC problem for a vanilla European option."""
     return build_single_state_terminal_claim_monte_carlo_problem(
         market_state,

--- a/trellis/models/equity_option_monte_carlo.py
+++ b/trellis/models/equity_option_monte_carlo.py
@@ -8,49 +8,20 @@ rebuilding GBM construction, scheme wiring, or variance-reduction glue inline.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-
 import numpy as raw_np
 
-from trellis.models.monte_carlo.engine import MonteCarloEngine
-from trellis.models.monte_carlo.event_aware import (
-    EventAwareMonteCarloProblem,
-    EventAwareMonteCarloProblemSpec,
-    EventAwareMonteCarloProcessSpec,
-    build_event_aware_monte_carlo_problem,
-    price_event_aware_monte_carlo,
+from trellis.models.monte_carlo.single_state_diffusion import (
+    ResolvedSingleStateMonteCarloInputs as ResolvedEquityMonteCarloInputs,
+    SingleStateMonteCarloResult as VanillaEquityMonteCarloResult,
+    build_single_state_terminal_claim_monte_carlo_problem,
+    price_single_state_terminal_claim_monte_carlo_result,
+    resolve_single_state_terminal_claim_monte_carlo_inputs,
 )
-from trellis.models.monte_carlo.schemes import Antithetic, Euler, Exact, LogEuler, Milstein
-from trellis.models.monte_carlo.variance_reduction import control_variate
 from trellis.models.resolution.single_state_diffusion import (
-    ResolvedSingleStateDiffusionInputs,
     SingleStateDiffusionMarketStateLike,
     SingleStateDiffusionSpecLike,
-    resolve_single_state_diffusion_inputs,
     terminal_intrinsic_from_resolved,
 )
-
-
-@dataclass(frozen=True)
-class ResolvedEquityMonteCarloInputs(ResolvedSingleStateDiffusionInputs):
-    """Resolved market inputs and numerical controls for vanilla MC pricing."""
-    n_paths: int
-    n_steps: int
-    seed: int | None
-    scheme: str
-    variance_reduction: str
-
-
-@dataclass(frozen=True)
-class VanillaEquityMonteCarloResult:
-    """Structured vanilla-equity Monte Carlo pricing result."""
-
-    price: float
-    std_error: float
-    n_paths: int
-    scheme: str
-    variance_reduction: str
-    control_variate_beta: float | None = None
 
 
 def resolve_vanilla_equity_monte_carlo_inputs(
@@ -64,23 +35,14 @@ def resolve_vanilla_equity_monte_carlo_inputs(
     seed: int | None = None,
 ) -> ResolvedEquityMonteCarloInputs:
     """Resolve vanilla-equity MC inputs from market state and a product spec."""
-    resolved_base = resolve_single_state_diffusion_inputs(market_state, spec)
-    resolved_scheme = _normalized_scheme(
-        scheme if scheme is not None else getattr(spec, "scheme", "exact")
-    )
-    resolved_variance_reduction = _normalized_variance_reduction(
-        variance_reduction
-        if variance_reduction is not None
-        else getattr(spec, "variance_reduction", "none")
-    )
-
-    return ResolvedEquityMonteCarloInputs(
-        **resolved_base.__dict__,
-        n_paths=max(int(n_paths if n_paths is not None else getattr(spec, "n_paths", 50_000)), 1),
-        n_steps=max(int(n_steps if n_steps is not None else getattr(spec, "n_steps", 252)), 1),
-        seed=seed if seed is not None else getattr(spec, "seed", 42),
-        scheme=resolved_scheme,
-        variance_reduction=resolved_variance_reduction,
+    return resolve_single_state_terminal_claim_monte_carlo_inputs(
+        market_state,
+        spec,
+        scheme=scheme,
+        variance_reduction=variance_reduction,
+        n_paths=n_paths,
+        n_steps=n_steps,
+        seed=seed,
     )
 
 
@@ -93,36 +55,18 @@ def build_vanilla_equity_monte_carlo_problem(
     n_paths: int | None = None,
     n_steps: int | None = None,
     seed: int | None = None,
-) -> tuple[ResolvedEquityMonteCarloInputs, EventAwareMonteCarloProblem]:
+) -> tuple[ResolvedEquityMonteCarloInputs, object]:
     """Build the bounded event-aware MC problem for a vanilla European option."""
-    resolved = resolve_vanilla_equity_monte_carlo_inputs(
+    return build_single_state_terminal_claim_monte_carlo_problem(
         market_state,
         spec,
+        terminal_payoff=_terminal_payoff,
         scheme=scheme,
         variance_reduction=variance_reduction,
         n_paths=n_paths,
         n_steps=n_steps,
         seed=seed,
     )
-    problem = build_event_aware_monte_carlo_problem(
-        EventAwareMonteCarloProblemSpec(
-            process_spec=EventAwareMonteCarloProcessSpec(
-                family="gbm_1d",
-                risk_free_rate=resolved.rate,
-                dividend_yield=resolved.dividend_yield,
-                sigma=resolved.sigma,
-                simulation_method="exact" if resolved.scheme == "log_euler" else resolved.scheme,
-            ),
-            initial_state=resolved.spot,
-            maturity=resolved.maturity,
-            n_steps=resolved.n_steps,
-            discount_rate=resolved.rate,
-            path_requirement_kind="terminal_only",
-            reducer_kind="terminal_payoff",
-            terminal_payoff=lambda terminal: _terminal_payoff(terminal, resolved),
-        )
-    )
-    return resolved, problem
 
 
 def price_vanilla_equity_option_monte_carlo_result(
@@ -136,110 +80,20 @@ def price_vanilla_equity_option_monte_carlo_result(
     seed: int | None = None,
 ) -> VanillaEquityMonteCarloResult:
     """Return a structured vanilla-equity Monte Carlo price result."""
-    resolved, problem = build_vanilla_equity_monte_carlo_problem(
+    return price_single_state_terminal_claim_monte_carlo_result(
         market_state,
         spec,
+        terminal_payoff=_terminal_payoff,
         scheme=scheme,
         variance_reduction=variance_reduction,
         n_paths=n_paths,
         n_steps=n_steps,
         seed=seed,
-    )
-
-    if resolved.maturity <= 0.0:
-        intrinsic = _terminal_payoff(raw_np.asarray([resolved.spot], dtype=float), resolved)[0]
-        return VanillaEquityMonteCarloResult(
-            price=float(resolved.notional) * float(intrinsic),
-            std_error=0.0,
-            n_paths=0,
-            scheme=resolved.scheme,
-            variance_reduction=resolved.variance_reduction,
-        )
-
-    if resolved.variance_reduction == "none" and resolved.scheme in {"exact", "euler"}:
-        result = price_event_aware_monte_carlo(
-            problem,
-            n_paths=resolved.n_paths,
-            seed=resolved.seed,
-            return_paths=False,
-        )
-        return VanillaEquityMonteCarloResult(
-            price=float(resolved.notional) * float(result["price"]),
-            std_error=float(resolved.notional) * float(result["std_error"]),
-            n_paths=int(result["n_paths"]),
-            scheme=resolved.scheme,
-            variance_reduction=resolved.variance_reduction,
-        )
-
-    scheme_obj = _scheme_object(resolved.scheme)
-    if resolved.variance_reduction == "antithetic":
-        if resolved.n_paths % 2 != 0:
-            raise ValueError("antithetic variance reduction requires an even n_paths")
-        scheme_obj = Antithetic(scheme_obj)
-
-    engine = MonteCarloEngine(
-        problem.process,
-        n_paths=resolved.n_paths,
-        n_steps=resolved.n_steps,
-        seed=resolved.seed,
-        scheme=scheme_obj,
-    )
-
-    if resolved.variance_reduction == "control_variate":
-        paths = engine.simulate(problem.initial_state, problem.maturity)
-        terminal = raw_np.asarray(paths[:, -1], dtype=float)
-        discounted_payoffs = (
-            raw_np.exp(-resolved.rate * resolved.maturity)
-            * resolved.notional
-            * _terminal_payoff(terminal, resolved)
-        )
-        control_values = terminal
-        control_expected = resolved.spot * raw_np.exp(
-            (resolved.rate - resolved.dividend_yield) * resolved.maturity
-        )
-        result = control_variate(
-            discounted_payoffs,
-            control_values,
-            float(control_expected),
-        )
-        return VanillaEquityMonteCarloResult(
-            price=float(result["price"]),
-            std_error=float(result["std_error"]),
-            n_paths=resolved.n_paths,
-            scheme=resolved.scheme,
-            variance_reduction=resolved.variance_reduction,
-            control_variate_beta=float(result["beta"]),
-        )
-
-    if resolved.variance_reduction == "antithetic":
-        paths = engine.simulate(problem.initial_state, problem.maturity)
-        terminal = raw_np.asarray(paths[:, -1], dtype=float)
-        payoffs = resolved.notional * _terminal_payoff(terminal, resolved)
-        half = resolved.n_paths // 2
-        averaged = 0.5 * (payoffs[:half] + payoffs[half:])
-        discounted = raw_np.exp(-resolved.rate * resolved.maturity) * averaged
-        return VanillaEquityMonteCarloResult(
-            price=float(raw_np.mean(discounted)),
-            std_error=float(raw_np.std(discounted) / raw_np.sqrt(half)),
-            n_paths=resolved.n_paths,
-            scheme=resolved.scheme,
-            variance_reduction=resolved.variance_reduction,
-        )
-
-    result = engine.price(
-        problem.initial_state,
-        problem.maturity,
-        lambda paths: resolved.notional * _terminal_payoff(paths[:, -1], resolved),
-        discount_rate=problem.discount_rate,
-        storage_policy=problem.path_requirement,
-        return_paths=False,
-    )
-    return VanillaEquityMonteCarloResult(
-        price=float(result["price"]),
-        std_error=float(result["std_error"]),
-        n_paths=int(result["n_paths"]),
-        scheme=resolved.scheme,
-        variance_reduction=resolved.variance_reduction,
+        control_variate_values=lambda terminal, _: raw_np.asarray(terminal, dtype=float),
+        control_variate_expected=lambda resolved: float(
+            resolved.spot
+            * raw_np.exp((resolved.rate - resolved.dividend_yield) * resolved.maturity)
+        ),
     )
 
 
@@ -265,44 +119,6 @@ def price_vanilla_equity_option_monte_carlo(
             seed=seed,
         ).price
     )
-
-def _normalized_scheme(value: object) -> str:
-    scheme = str(value or "exact").strip().lower().replace("-", "_")
-    aliases = {
-        "plain": "exact",
-        "plain_mc": "exact",
-        "antithetic_mc": "exact",
-        "control_variate_mc": "exact",
-    }
-    scheme = aliases.get(scheme, scheme)
-    if scheme not in {"euler", "milstein", "exact", "log_euler"}:
-        raise ValueError(f"Unsupported Monte Carlo scheme {value!r}")
-    return scheme
-
-
-def _normalized_variance_reduction(value: object) -> str:
-    reduction = str(value or "none").strip().lower().replace("-", "_")
-    aliases = {
-        "plain": "none",
-        "plain_mc": "none",
-        "antithetic_mc": "antithetic",
-        "control_variate_mc": "control_variate",
-    }
-    reduction = aliases.get(reduction, reduction)
-    if reduction not in {"none", "antithetic", "control_variate"}:
-        raise ValueError(f"Unsupported variance reduction mode {value!r}")
-    return reduction
-
-
-def _scheme_object(scheme: str):
-    if scheme == "euler":
-        return Euler()
-    if scheme == "milstein":
-        return Milstein()
-    if scheme == "log_euler":
-        return LogEuler()
-    return Exact()
-
 
 def _terminal_payoff(terminal, resolved: ResolvedEquityMonteCarloInputs) -> raw_np.ndarray:
     terminal_arr = raw_np.asarray(terminal, dtype=float)

--- a/trellis/models/equity_option_transforms.py
+++ b/trellis/models/equity_option_transforms.py
@@ -1,48 +1,27 @@
 """Semantic-facing vanilla-equity transform helpers.
 
-This module wraps the raw FFT and COS kernels with a stable helper surface that
-starts from market state and a plain European equity-option spec. Generated
-adapters should bind transform pricing here instead of rebuilding characteristic
-functions, market conventions, or put/call parity glue inline.
+This module is a thin compatibility wrapper over the reusable single-state
+diffusion transform family helper. Generated adapters should bind transform
+pricing here instead of rebuilding characteristic functions, market
+conventions, or put/call parity glue inline.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-
-from trellis.models.transforms.cos_method import cos_price
-from trellis.models.transforms.fft_pricer import fft_price
+from trellis.models.transforms.single_state_diffusion import (
+    ResolvedSingleStateTransformInputs as ResolvedEquityTransformInputs,
+    SingleStateTransformResult as VanillaEquityTransformResult,
+    price_single_state_terminal_claim_transform_result,
+    resolve_single_state_terminal_claim_transform_inputs,
+)
 from trellis.models.resolution.single_state_diffusion import (
-    ResolvedSingleStateDiffusionInputs,
     SingleStateDiffusionMarketStateLike,
     SingleStateDiffusionSpecLike,
     gbm_log_ratio_char_fn,
     gbm_log_spot_char_fn,
     put_from_call_parity,
-    resolve_single_state_diffusion_inputs,
     terminal_intrinsic_from_resolved,
 )
-
-
-@dataclass(frozen=True)
-class ResolvedEquityTransformInputs(ResolvedSingleStateDiffusionInputs):
-    """Resolved market inputs and transform controls."""
-    method: str
-    fft_alpha: float
-    fft_points: int
-    fft_eta: float
-    cos_points: int
-    cos_truncation: float
-
-
-@dataclass(frozen=True)
-class VanillaEquityTransformResult:
-    """Structured transform-pricing result."""
-
-    price: float
-    method: str
-    sigma: float
-    maturity: float
 
 
 def resolve_vanilla_equity_transform_inputs(
@@ -57,31 +36,15 @@ def resolve_vanilla_equity_transform_inputs(
     cos_truncation: float | None = None,
 ) -> ResolvedEquityTransformInputs:
     """Resolve transform inputs from market state and a vanilla option spec."""
-    resolved_base = resolve_single_state_diffusion_inputs(market_state, spec)
-    resolved_method = _normalized_transform_method(
-        method if method is not None else getattr(spec, "transform_method", "fft")
-    )
-
-    return ResolvedEquityTransformInputs(
-        **resolved_base.__dict__,
-        method=resolved_method,
-        fft_alpha=float(
-            fft_alpha if fft_alpha is not None else getattr(spec, "fft_alpha", 1.5)
-        ),
-        fft_points=max(
-            int(fft_points if fft_points is not None else getattr(spec, "fft_points", 4096)),
-            32,
-        ),
-        fft_eta=float(fft_eta if fft_eta is not None else getattr(spec, "fft_eta", 0.25)),
-        cos_points=max(
-            int(cos_points if cos_points is not None else getattr(spec, "cos_points", 256)),
-            16,
-        ),
-        cos_truncation=float(
-            cos_truncation
-            if cos_truncation is not None
-            else getattr(spec, "cos_truncation", 10.0)
-        ),
+    return resolve_single_state_terminal_claim_transform_inputs(
+        market_state,
+        spec,
+        method=method,
+        fft_alpha=fft_alpha,
+        fft_points=fft_points,
+        fft_eta=fft_eta,
+        cos_points=cos_points,
+        cos_truncation=cos_truncation,
     )
 
 
@@ -97,7 +60,7 @@ def price_vanilla_equity_option_transform_result(
     cos_truncation: float | None = None,
 ) -> VanillaEquityTransformResult:
     """Return a structured transform price result for a vanilla European option."""
-    resolved = resolve_vanilla_equity_transform_inputs(
+    return price_single_state_terminal_claim_transform_result(
         market_state,
         spec,
         method=method,
@@ -106,50 +69,10 @@ def price_vanilla_equity_option_transform_result(
         fft_eta=fft_eta,
         cos_points=cos_points,
         cos_truncation=cos_truncation,
-    )
-
-    if resolved.maturity <= 0.0:
-        intrinsic = terminal_intrinsic_from_resolved(resolved.spot, resolved)
-        return VanillaEquityTransformResult(
-            price=float(resolved.notional) * float(intrinsic),
-            method=resolved.method,
-            sigma=resolved.sigma,
-            maturity=resolved.maturity,
-        )
-
-    if resolved.method == "fft":
-        call_price = fft_price(
-            gbm_log_spot_char_fn(resolved),
-            resolved.spot,
-            resolved.strike,
-            resolved.maturity,
-            resolved.rate,
-            alpha=resolved.fft_alpha,
-            N=resolved.fft_points,
-            eta=resolved.fft_eta,
-        )
-        raw_price = (
-            call_price
-            if resolved.option_type == "call"
-            else put_from_call_parity(call_price, resolved)
-        )
-    else:
-        raw_price = cos_price(
-            gbm_log_ratio_char_fn(resolved),
-            resolved.spot,
-            resolved.strike,
-            resolved.maturity,
-            resolved.rate,
-            N=resolved.cos_points,
-            L=resolved.cos_truncation,
-            option_type=resolved.option_type,
-        )
-
-    return VanillaEquityTransformResult(
-        price=float(resolved.notional) * float(raw_price),
-        method=resolved.method,
-        sigma=resolved.sigma,
-        maturity=resolved.maturity,
+        intrinsic_fn=terminal_intrinsic_from_resolved,
+        fft_log_spot_char_fn=gbm_log_spot_char_fn,
+        cos_log_ratio_char_fn=gbm_log_ratio_char_fn,
+        put_from_call_parity_fn=put_from_call_parity,
     )
 
 
@@ -178,13 +101,11 @@ def price_vanilla_equity_option_transform(
         ).price
     )
 
-def _normalized_transform_method(value: object) -> str:
-    method = str(value or "fft").strip().lower().replace("-", "_")
-    aliases = {
-        "carr_madan": "fft",
-        "fang_oosterlee": "cos",
-    }
-    method = aliases.get(method, method)
-    if method not in {"fft", "cos"}:
-        raise ValueError(f"Unsupported transform method {value!r}")
-    return method
+
+__all__ = [
+    "ResolvedEquityTransformInputs",
+    "VanillaEquityTransformResult",
+    "price_vanilla_equity_option_transform",
+    "price_vanilla_equity_option_transform_result",
+    "resolve_vanilla_equity_transform_inputs",
+]

--- a/trellis/models/fx_vanilla.py
+++ b/trellis/models/fx_vanilla.py
@@ -1,0 +1,182 @@
+"""Semantic-facing helper kit for vanilla FX options."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Protocol
+
+from trellis.core.date_utils import year_fraction
+from trellis.core.differentiable import get_numpy
+from trellis.core.market_state import MarketState
+from trellis.core.types import DayCountConvention
+from trellis.models.analytical.fx import (
+    ResolvedGarmanKohlhagenInputs,
+    garman_kohlhagen_price_raw,
+)
+
+np = get_numpy()
+
+
+class FXVanillaSpecLike(Protocol):
+    """Minimal semantic surface consumed by the vanilla FX helper kit."""
+
+    notional: float
+    strike: float
+    expiry_date: date
+    fx_pair: str
+    foreign_discount_key: str
+    option_type: str
+    day_count: DayCountConvention
+
+
+@dataclass(frozen=True)
+class ResolvedFXVanillaInputs:
+    """Resolved market and numerical inputs for one vanilla FX route."""
+
+    notional: float
+    option_type: str
+    garman_kohlhagen: ResolvedGarmanKohlhagenInputs
+    domestic_rate: float
+    foreign_rate: float
+
+
+def resolve_fx_vanilla_inputs(
+    market_state: MarketState,
+    spec: FXVanillaSpecLike,
+) -> ResolvedFXVanillaInputs:
+    """Resolve spot, domestic/foreign curves, and volatility for one FX option."""
+    if market_state.discount is None:
+        raise ValueError("market_state.discount is required for FX pricing")
+    if not market_state.forecast_curves or spec.foreign_discount_key not in market_state.forecast_curves:
+        raise ValueError(
+            f"market_state.forecast_curves must contain foreign discount key {spec.foreign_discount_key!r}"
+        )
+
+    fx_quote = (market_state.fx_rates or {}).get(spec.fx_pair)
+    if fx_quote is not None:
+        spot = float(fx_quote.spot)
+    elif market_state.spot is not None:
+        spot = float(market_state.spot)
+    elif market_state.underlier_spots and spec.fx_pair in market_state.underlier_spots:
+        spot = float(market_state.underlier_spots[spec.fx_pair])
+    else:
+        raise ValueError(f"FX spot for pair {spec.fx_pair!r} is not available in market_state")
+
+    settlement = market_state.settlement or market_state.as_of
+    if settlement is None:
+        raise ValueError("market_state must provide settlement or as_of for FX pricing")
+
+    maturity = max(
+        float(
+            year_fraction(
+                settlement,
+                spec.expiry_date,
+                getattr(spec, "day_count", DayCountConvention.ACT_365),
+            )
+        ),
+        0.0,
+    )
+    domestic_curve = market_state.discount
+    foreign_curve = market_state.forecast_curves[spec.foreign_discount_key]
+    domestic_df = float(domestic_curve.discount(maturity))
+    foreign_df = float(foreign_curve.discount(maturity))
+    domestic_rate = float(domestic_curve.zero_rate(max(maturity, 1e-6))) if maturity > 0.0 else 0.0
+    foreign_rate = float(foreign_curve.zero_rate(max(maturity, 1e-6))) if maturity > 0.0 else 0.0
+    sigma = (
+        float(market_state.vol_surface.black_vol(max(maturity, 1e-6), float(spec.strike)))
+        if maturity > 0.0 and market_state.vol_surface is not None
+        else 0.0
+    )
+    if maturity > 0.0 and market_state.vol_surface is None:
+        raise ValueError("market_state.vol_surface is required for FX pricing")
+
+    return ResolvedFXVanillaInputs(
+        notional=float(spec.notional),
+        option_type=str(spec.option_type).strip().strip("'\"").lower(),
+        garman_kohlhagen=ResolvedGarmanKohlhagenInputs(
+            spot=spot,
+            strike=float(spec.strike),
+            sigma=sigma,
+            T=maturity,
+            df_domestic=domestic_df,
+            df_foreign=foreign_df,
+        ),
+        domestic_rate=domestic_rate,
+        foreign_rate=foreign_rate,
+    )
+
+
+def price_fx_vanilla_analytical(
+    market_state: MarketState,
+    spec: FXVanillaSpecLike,
+) -> float:
+    """Price one vanilla FX option through the checked analytical helper."""
+    resolved = resolve_fx_vanilla_inputs(market_state, spec)
+    return float(resolved.notional) * float(
+        garman_kohlhagen_price_raw(resolved.option_type, resolved.garman_kohlhagen)
+    )
+
+
+def price_fx_vanilla_monte_carlo(
+    market_state: MarketState,
+    spec: FXVanillaSpecLike,
+    *,
+    seed: int = 42,
+) -> float:
+    """Price one vanilla FX option through the bounded FX Monte Carlo helper."""
+    from trellis.models.monte_carlo.engine import MonteCarloEngine
+    from trellis.models.processes.gbm import GBM
+
+    resolved = resolve_fx_vanilla_inputs(market_state, spec)
+    gk = resolved.garman_kohlhagen
+    if gk.T <= 0.0:
+        intrinsic = (
+            max(float(gk.spot) - float(gk.strike), 0.0)
+            if resolved.option_type == "call"
+            else max(float(gk.strike) - float(gk.spot), 0.0)
+        )
+        return float(resolved.notional) * float(intrinsic)
+
+    process = GBM(mu=resolved.domestic_rate - resolved.foreign_rate, sigma=float(gk.sigma))
+    engine = MonteCarloEngine(
+        process,
+        n_paths=max(int(getattr(spec, "n_paths", 50_000)), 1),
+        n_steps=max(int(getattr(spec, "n_steps", 252)), 1),
+        seed=int(getattr(spec, "seed", seed)),
+        method="exact",
+    )
+
+    strike = float(gk.strike)
+    notional = float(resolved.notional)
+    option_type = resolved.option_type
+
+    def payoff_fn(paths):
+        terminal = np.asarray(paths[:, -1], dtype=float)
+        if option_type == "call":
+            payoffs = np.maximum(terminal - strike, 0.0)
+        elif option_type == "put":
+            payoffs = np.maximum(strike - terminal, 0.0)
+        else:
+            raise ValueError(
+                f"Unsupported option_type {spec.option_type!r}; expected 'call' or 'put'"
+            )
+        return payoffs * notional
+
+    result = engine.price(
+        float(gk.spot),
+        float(gk.T),
+        payoff_fn,
+        discount_rate=float(resolved.domestic_rate),
+        return_paths=False,
+    )
+    return float(result["price"])
+
+
+__all__ = [
+    "FXVanillaSpecLike",
+    "ResolvedFXVanillaInputs",
+    "price_fx_vanilla_analytical",
+    "price_fx_vanilla_monte_carlo",
+    "resolve_fx_vanilla_inputs",
+]

--- a/trellis/models/monte_carlo/single_state_diffusion.py
+++ b/trellis/models/monte_carlo/single_state_diffusion.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Callable
 
 import numpy as raw_np
@@ -87,15 +87,20 @@ def build_single_state_terminal_claim_monte_carlo_problem_from_resolved(
     local_vol_surface: Callable | None = None,
 ) -> EventAwareMonteCarloProblem:
     """Build the event-aware runtime problem for one single-state terminal claim."""
+    process_family_name = str(process_family).strip()
+    simulation_method = _normalized_event_aware_simulation_method(
+        resolved.scheme,
+        process_family=process_family_name,
+    )
     return build_event_aware_monte_carlo_problem(
         EventAwareMonteCarloProblemSpec(
             process_spec=EventAwareMonteCarloProcessSpec(
-                family=str(process_family).strip(),
+                family=process_family_name,
                 risk_free_rate=resolved.rate,
                 dividend_yield=resolved.dividend_yield,
                 sigma=resolved.sigma,
                 local_vol_surface=local_vol_surface,
-                simulation_method="exact" if resolved.scheme == "log_euler" else resolved.scheme,
+                simulation_method=simulation_method,
             ),
             initial_state=resolved.spot,
             maturity=resolved.maturity,
@@ -130,6 +135,13 @@ def build_single_state_terminal_claim_monte_carlo_problem(
         n_paths=n_paths,
         n_steps=n_steps,
         seed=seed,
+    )
+    resolved = replace(
+        resolved,
+        scheme=_normalized_event_aware_simulation_method(
+            resolved.scheme,
+            process_family=str(process_family).strip(),
+        ),
     )
     problem = build_single_state_terminal_claim_monte_carlo_problem_from_resolved(
         resolved,
@@ -304,6 +316,18 @@ def _scheme_object(scheme: str):
     if scheme == "log_euler":
         return LogEuler()
     return Exact()
+
+
+def _normalized_event_aware_simulation_method(
+    scheme: str,
+    *,
+    process_family: str,
+) -> str:
+    normalized = _normalized_scheme(scheme)
+    family = str(process_family or "").strip()
+    if family == "local_vol_1d" and normalized == "exact":
+        return "euler"
+    return normalized
 
 
 __all__ = [

--- a/trellis/models/monte_carlo/single_state_diffusion.py
+++ b/trellis/models/monte_carlo/single_state_diffusion.py
@@ -1,0 +1,316 @@
+"""Reusable event-aware Monte Carlo helpers for single-state diffusion claims."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+import numpy as raw_np
+
+from trellis.models.monte_carlo.engine import MonteCarloEngine
+from trellis.models.monte_carlo.event_aware import (
+    EventAwareMonteCarloProblem,
+    EventAwareMonteCarloProblemSpec,
+    EventAwareMonteCarloProcessSpec,
+    build_event_aware_monte_carlo_problem,
+    price_event_aware_monte_carlo,
+)
+from trellis.models.monte_carlo.schemes import Antithetic, Euler, Exact, LogEuler, Milstein
+from trellis.models.monte_carlo.variance_reduction import control_variate
+from trellis.models.resolution.single_state_diffusion import (
+    ResolvedSingleStateDiffusionInputs,
+    SingleStateDiffusionMarketStateLike,
+    SingleStateDiffusionSpecLike,
+    resolve_single_state_diffusion_inputs,
+)
+
+
+@dataclass(frozen=True)
+class ResolvedSingleStateMonteCarloInputs(ResolvedSingleStateDiffusionInputs):
+    """Resolved market inputs and numerical controls for one single-state MC claim."""
+
+    n_paths: int
+    n_steps: int
+    seed: int | None
+    scheme: str
+    variance_reduction: str
+
+
+@dataclass(frozen=True)
+class SingleStateMonteCarloResult:
+    """Structured result for a bounded single-state Monte Carlo claim."""
+
+    price: float
+    std_error: float
+    n_paths: int
+    scheme: str
+    variance_reduction: str
+    control_variate_beta: float | None = None
+
+
+def resolve_single_state_terminal_claim_monte_carlo_inputs(
+    market_state: SingleStateDiffusionMarketStateLike,
+    spec: SingleStateDiffusionSpecLike,
+    *,
+    scheme: str | None = None,
+    variance_reduction: str | None = None,
+    n_paths: int | None = None,
+    n_steps: int | None = None,
+    seed: int | None = None,
+) -> ResolvedSingleStateMonteCarloInputs:
+    """Resolve one bounded single-state Monte Carlo contract from semantics."""
+    resolved_base = resolve_single_state_diffusion_inputs(market_state, spec)
+    resolved_scheme = _normalized_scheme(
+        scheme if scheme is not None else getattr(spec, "scheme", "exact")
+    )
+    resolved_variance_reduction = _normalized_variance_reduction(
+        variance_reduction
+        if variance_reduction is not None
+        else getattr(spec, "variance_reduction", "none")
+    )
+
+    return ResolvedSingleStateMonteCarloInputs(
+        **resolved_base.__dict__,
+        n_paths=max(int(n_paths if n_paths is not None else getattr(spec, "n_paths", 50_000)), 1),
+        n_steps=max(int(n_steps if n_steps is not None else getattr(spec, "n_steps", 252)), 1),
+        seed=seed if seed is not None else getattr(spec, "seed", 42),
+        scheme=resolved_scheme,
+        variance_reduction=resolved_variance_reduction,
+    )
+
+
+def build_single_state_terminal_claim_monte_carlo_problem_from_resolved(
+    resolved: ResolvedSingleStateMonteCarloInputs,
+    *,
+    terminal_payoff: Callable[[raw_np.ndarray, ResolvedSingleStateMonteCarloInputs], raw_np.ndarray],
+    process_family: str = "gbm_1d",
+    local_vol_surface: Callable | None = None,
+) -> EventAwareMonteCarloProblem:
+    """Build the event-aware runtime problem for one single-state terminal claim."""
+    return build_event_aware_monte_carlo_problem(
+        EventAwareMonteCarloProblemSpec(
+            process_spec=EventAwareMonteCarloProcessSpec(
+                family=str(process_family).strip(),
+                risk_free_rate=resolved.rate,
+                dividend_yield=resolved.dividend_yield,
+                sigma=resolved.sigma,
+                local_vol_surface=local_vol_surface,
+                simulation_method="exact" if resolved.scheme == "log_euler" else resolved.scheme,
+            ),
+            initial_state=resolved.spot,
+            maturity=resolved.maturity,
+            n_steps=resolved.n_steps,
+            discount_rate=resolved.rate,
+            path_requirement_kind="terminal_only",
+            reducer_kind="terminal_payoff",
+            terminal_payoff=lambda terminal: terminal_payoff(terminal, resolved),
+        )
+    )
+
+
+def build_single_state_terminal_claim_monte_carlo_problem(
+    market_state: SingleStateDiffusionMarketStateLike,
+    spec: SingleStateDiffusionSpecLike,
+    *,
+    terminal_payoff: Callable[[raw_np.ndarray, ResolvedSingleStateMonteCarloInputs], raw_np.ndarray],
+    scheme: str | None = None,
+    variance_reduction: str | None = None,
+    n_paths: int | None = None,
+    n_steps: int | None = None,
+    seed: int | None = None,
+    process_family: str = "gbm_1d",
+    local_vol_surface: Callable | None = None,
+) -> tuple[ResolvedSingleStateMonteCarloInputs, EventAwareMonteCarloProblem]:
+    """Resolve one single-state terminal claim and build its event-aware MC problem."""
+    resolved = resolve_single_state_terminal_claim_monte_carlo_inputs(
+        market_state,
+        spec,
+        scheme=scheme,
+        variance_reduction=variance_reduction,
+        n_paths=n_paths,
+        n_steps=n_steps,
+        seed=seed,
+    )
+    problem = build_single_state_terminal_claim_monte_carlo_problem_from_resolved(
+        resolved,
+        terminal_payoff=terminal_payoff,
+        process_family=process_family,
+        local_vol_surface=local_vol_surface,
+    )
+    return resolved, problem
+
+
+def price_single_state_terminal_claim_monte_carlo_result(
+    market_state: SingleStateDiffusionMarketStateLike,
+    spec: SingleStateDiffusionSpecLike,
+    *,
+    terminal_payoff: Callable[[raw_np.ndarray, ResolvedSingleStateMonteCarloInputs], raw_np.ndarray],
+    scheme: str | None = None,
+    variance_reduction: str | None = None,
+    n_paths: int | None = None,
+    n_steps: int | None = None,
+    seed: int | None = None,
+    process_family: str = "gbm_1d",
+    local_vol_surface: Callable | None = None,
+    control_variate_values: Callable[[raw_np.ndarray, ResolvedSingleStateMonteCarloInputs], raw_np.ndarray]
+    | None = None,
+    control_variate_expected: Callable[[ResolvedSingleStateMonteCarloInputs], float] | None = None,
+) -> SingleStateMonteCarloResult:
+    """Price one bounded single-state terminal claim through the generic MC family helper."""
+    resolved, problem = build_single_state_terminal_claim_monte_carlo_problem(
+        market_state,
+        spec,
+        terminal_payoff=terminal_payoff,
+        scheme=scheme,
+        variance_reduction=variance_reduction,
+        n_paths=n_paths,
+        n_steps=n_steps,
+        seed=seed,
+        process_family=process_family,
+        local_vol_surface=local_vol_surface,
+    )
+
+    if resolved.maturity <= 0.0:
+        intrinsic = terminal_payoff(raw_np.asarray([resolved.spot], dtype=float), resolved)[0]
+        return SingleStateMonteCarloResult(
+            price=float(resolved.notional) * float(intrinsic),
+            std_error=0.0,
+            n_paths=0,
+            scheme=resolved.scheme,
+            variance_reduction=resolved.variance_reduction,
+        )
+
+    if resolved.variance_reduction == "none" and resolved.scheme in {"exact", "euler"}:
+        result = price_event_aware_monte_carlo(
+            problem,
+            n_paths=resolved.n_paths,
+            seed=resolved.seed,
+            return_paths=False,
+        )
+        return SingleStateMonteCarloResult(
+            price=float(resolved.notional) * float(result["price"]),
+            std_error=float(resolved.notional) * float(result["std_error"]),
+            n_paths=int(result["n_paths"]),
+            scheme=resolved.scheme,
+            variance_reduction=resolved.variance_reduction,
+        )
+
+    scheme_obj = _scheme_object(resolved.scheme)
+    if resolved.variance_reduction == "antithetic":
+        if resolved.n_paths % 2 != 0:
+            raise ValueError("antithetic variance reduction requires an even n_paths")
+        scheme_obj = Antithetic(scheme_obj)
+
+    engine = MonteCarloEngine(
+        problem.process,
+        n_paths=resolved.n_paths,
+        n_steps=resolved.n_steps,
+        seed=resolved.seed,
+        scheme=scheme_obj,
+    )
+
+    if resolved.variance_reduction == "control_variate":
+        if control_variate_values is None or control_variate_expected is None:
+            raise ValueError(
+                "control variate pricing requires control_variate_values and control_variate_expected"
+            )
+        paths = engine.simulate(problem.initial_state, problem.maturity)
+        terminal = raw_np.asarray(paths[:, -1], dtype=float)
+        discounted_payoffs = (
+            raw_np.exp(-resolved.rate * resolved.maturity)
+            * resolved.notional
+            * terminal_payoff(terminal, resolved)
+        )
+        control_values = raw_np.asarray(control_variate_values(terminal, resolved), dtype=float)
+        result = control_variate(
+            discounted_payoffs,
+            control_values,
+            float(control_variate_expected(resolved)),
+        )
+        return SingleStateMonteCarloResult(
+            price=float(result["price"]),
+            std_error=float(result["std_error"]),
+            n_paths=resolved.n_paths,
+            scheme=resolved.scheme,
+            variance_reduction=resolved.variance_reduction,
+            control_variate_beta=float(result["beta"]),
+        )
+
+    if resolved.variance_reduction == "antithetic":
+        paths = engine.simulate(problem.initial_state, problem.maturity)
+        terminal = raw_np.asarray(paths[:, -1], dtype=float)
+        payoffs = resolved.notional * terminal_payoff(terminal, resolved)
+        half = resolved.n_paths // 2
+        averaged = 0.5 * (payoffs[:half] + payoffs[half:])
+        discounted = raw_np.exp(-resolved.rate * resolved.maturity) * averaged
+        return SingleStateMonteCarloResult(
+            price=float(raw_np.mean(discounted)),
+            std_error=float(raw_np.std(discounted) / raw_np.sqrt(half)),
+            n_paths=resolved.n_paths,
+            scheme=resolved.scheme,
+            variance_reduction=resolved.variance_reduction,
+        )
+
+    result = engine.price(
+        problem.initial_state,
+        problem.maturity,
+        lambda paths: resolved.notional * terminal_payoff(paths[:, -1], resolved),
+        discount_rate=problem.discount_rate,
+        storage_policy=problem.path_requirement,
+        return_paths=False,
+    )
+    return SingleStateMonteCarloResult(
+        price=float(result["price"]),
+        std_error=float(result["std_error"]),
+        n_paths=int(result["n_paths"]),
+        scheme=resolved.scheme,
+        variance_reduction=resolved.variance_reduction,
+    )
+
+
+def _normalized_scheme(value: object) -> str:
+    scheme = str(value or "exact").strip().lower().replace("-", "_")
+    aliases = {
+        "plain": "exact",
+        "plain_mc": "exact",
+        "antithetic_mc": "exact",
+        "control_variate_mc": "exact",
+    }
+    scheme = aliases.get(scheme, scheme)
+    if scheme not in {"euler", "milstein", "exact", "log_euler"}:
+        raise ValueError(f"Unsupported Monte Carlo scheme {value!r}")
+    return scheme
+
+
+def _normalized_variance_reduction(value: object) -> str:
+    reduction = str(value or "none").strip().lower().replace("-", "_")
+    aliases = {
+        "plain": "none",
+        "plain_mc": "none",
+        "antithetic_mc": "antithetic",
+        "control_variate_mc": "control_variate",
+    }
+    reduction = aliases.get(reduction, reduction)
+    if reduction not in {"none", "antithetic", "control_variate"}:
+        raise ValueError(f"Unsupported variance reduction mode {value!r}")
+    return reduction
+
+
+def _scheme_object(scheme: str):
+    if scheme == "euler":
+        return Euler()
+    if scheme == "milstein":
+        return Milstein()
+    if scheme == "log_euler":
+        return LogEuler()
+    return Exact()
+
+
+__all__ = [
+    "ResolvedSingleStateMonteCarloInputs",
+    "SingleStateMonteCarloResult",
+    "build_single_state_terminal_claim_monte_carlo_problem",
+    "build_single_state_terminal_claim_monte_carlo_problem_from_resolved",
+    "price_single_state_terminal_claim_monte_carlo_result",
+    "resolve_single_state_terminal_claim_monte_carlo_inputs",
+]

--- a/trellis/models/quanto_option.py
+++ b/trellis/models/quanto_option.py
@@ -14,12 +14,17 @@ from trellis.models.resolution.quanto import (
 )
 
 
-class QuantoOptionSpecLike(QuantoSpecLike, Protocol):
-    """Minimal semantic surface consumed by the semantic-facing quanto helpers."""
+class QuantoOptionAnalyticalSpecLike(QuantoSpecLike, Protocol):
+    """Minimal semantic surface consumed by the analytical quanto helper."""
 
     notional: float
     strike: float
     option_type: str
+
+
+class QuantoOptionMonteCarloSpecLike(QuantoOptionAnalyticalSpecLike, Protocol):
+    """Monte Carlo extension of the semantic-facing quanto option surface."""
+
     n_paths: int
     n_steps: int
     seed: int
@@ -27,7 +32,7 @@ class QuantoOptionSpecLike(QuantoSpecLike, Protocol):
 
 def resolve_quanto_option_inputs(
     market_state: MarketState,
-    spec: QuantoOptionSpecLike,
+    spec: QuantoOptionAnalyticalSpecLike,
 ) -> ResolvedQuantoInputs:
     """Resolve one semantic-facing quanto option into the shared market inputs."""
     return resolve_quanto_inputs(market_state, spec)
@@ -35,7 +40,7 @@ def resolve_quanto_option_inputs(
 
 def price_quanto_option_analytical_from_market_state(
     market_state: MarketState,
-    spec: QuantoOptionSpecLike,
+    spec: QuantoOptionAnalyticalSpecLike,
 ) -> float:
     """Resolve and price one quanto option analytically."""
     resolved = resolve_quanto_option_inputs(market_state, spec)
@@ -44,7 +49,7 @@ def price_quanto_option_analytical_from_market_state(
 
 def price_quanto_option_monte_carlo_from_market_state(
     market_state: MarketState,
-    spec: QuantoOptionSpecLike,
+    spec: QuantoOptionMonteCarloSpecLike,
 ) -> float:
     """Resolve and price one quanto option through the shared MC helper."""
     resolved = resolve_quanto_option_inputs(market_state, spec)
@@ -52,7 +57,8 @@ def price_quanto_option_monte_carlo_from_market_state(
 
 
 __all__ = [
-    "QuantoOptionSpecLike",
+    "QuantoOptionAnalyticalSpecLike",
+    "QuantoOptionMonteCarloSpecLike",
     "price_quanto_option_analytical_from_market_state",
     "price_quanto_option_monte_carlo_from_market_state",
     "resolve_quanto_option_inputs",

--- a/trellis/models/quanto_option.py
+++ b/trellis/models/quanto_option.py
@@ -1,0 +1,59 @@
+"""Semantic-facing helper kit for single-underlier quanto options."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from trellis.core.market_state import MarketState
+from trellis.models.analytical.quanto import price_quanto_option_analytical
+from trellis.models.monte_carlo.quanto import price_quanto_option_monte_carlo
+from trellis.models.resolution.quanto import (
+    QuantoSpecLike,
+    ResolvedQuantoInputs,
+    resolve_quanto_inputs,
+)
+
+
+class QuantoOptionSpecLike(QuantoSpecLike, Protocol):
+    """Minimal semantic surface consumed by the semantic-facing quanto helpers."""
+
+    notional: float
+    strike: float
+    option_type: str
+    n_paths: int
+    n_steps: int
+    seed: int
+
+
+def resolve_quanto_option_inputs(
+    market_state: MarketState,
+    spec: QuantoOptionSpecLike,
+) -> ResolvedQuantoInputs:
+    """Resolve one semantic-facing quanto option into the shared market inputs."""
+    return resolve_quanto_inputs(market_state, spec)
+
+
+def price_quanto_option_analytical_from_market_state(
+    market_state: MarketState,
+    spec: QuantoOptionSpecLike,
+) -> float:
+    """Resolve and price one quanto option analytically."""
+    resolved = resolve_quanto_option_inputs(market_state, spec)
+    return float(price_quanto_option_analytical(spec, resolved))
+
+
+def price_quanto_option_monte_carlo_from_market_state(
+    market_state: MarketState,
+    spec: QuantoOptionSpecLike,
+) -> float:
+    """Resolve and price one quanto option through the shared MC helper."""
+    resolved = resolve_quanto_option_inputs(market_state, spec)
+    return float(price_quanto_option_monte_carlo(spec, resolved))
+
+
+__all__ = [
+    "QuantoOptionSpecLike",
+    "price_quanto_option_analytical_from_market_state",
+    "price_quanto_option_monte_carlo_from_market_state",
+    "resolve_quanto_option_inputs",
+]

--- a/trellis/models/transforms/single_state_diffusion.py
+++ b/trellis/models/transforms/single_state_diffusion.py
@@ -1,0 +1,166 @@
+"""Reusable transform helpers for single-state diffusion claims."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+from trellis.models.transforms.cos_method import cos_price
+from trellis.models.transforms.fft_pricer import fft_price
+from trellis.models.resolution.single_state_diffusion import (
+    ResolvedSingleStateDiffusionInputs,
+    SingleStateDiffusionMarketStateLike,
+    SingleStateDiffusionSpecLike,
+    resolve_single_state_diffusion_inputs,
+)
+
+
+@dataclass(frozen=True)
+class ResolvedSingleStateTransformInputs(ResolvedSingleStateDiffusionInputs):
+    """Resolved market inputs and transform controls."""
+
+    method: str
+    fft_alpha: float
+    fft_points: int
+    fft_eta: float
+    cos_points: int
+    cos_truncation: float
+
+
+@dataclass(frozen=True)
+class SingleStateTransformResult:
+    """Structured transform-pricing result."""
+
+    price: float
+    method: str
+    sigma: float
+    maturity: float
+
+
+def resolve_single_state_terminal_claim_transform_inputs(
+    market_state: SingleStateDiffusionMarketStateLike,
+    spec: SingleStateDiffusionSpecLike,
+    *,
+    method: str | None = None,
+    fft_alpha: float | None = None,
+    fft_points: int | None = None,
+    fft_eta: float | None = None,
+    cos_points: int | None = None,
+    cos_truncation: float | None = None,
+) -> ResolvedSingleStateTransformInputs:
+    """Resolve transform controls and market inputs for one single-state claim."""
+    resolved_base = resolve_single_state_diffusion_inputs(market_state, spec)
+    resolved_method = _normalized_transform_method(
+        method if method is not None else getattr(spec, "transform_method", "fft")
+    )
+
+    return ResolvedSingleStateTransformInputs(
+        **resolved_base.__dict__,
+        method=resolved_method,
+        fft_alpha=float(fft_alpha if fft_alpha is not None else getattr(spec, "fft_alpha", 1.5)),
+        fft_points=max(
+            int(fft_points if fft_points is not None else getattr(spec, "fft_points", 4096)),
+            32,
+        ),
+        fft_eta=float(fft_eta if fft_eta is not None else getattr(spec, "fft_eta", 0.25)),
+        cos_points=max(
+            int(cos_points if cos_points is not None else getattr(spec, "cos_points", 256)),
+            16,
+        ),
+        cos_truncation=float(
+            cos_truncation
+            if cos_truncation is not None
+            else getattr(spec, "cos_truncation", 10.0)
+        ),
+    )
+
+
+def price_single_state_terminal_claim_transform_result(
+    market_state: SingleStateDiffusionMarketStateLike,
+    spec: SingleStateDiffusionSpecLike,
+    *,
+    method: str | None = None,
+    fft_alpha: float | None = None,
+    fft_points: int | None = None,
+    fft_eta: float | None = None,
+    cos_points: int | None = None,
+    cos_truncation: float | None = None,
+    intrinsic_fn: Callable[[float, ResolvedSingleStateTransformInputs], float],
+    fft_log_spot_char_fn: Callable[[ResolvedSingleStateTransformInputs], Callable[[complex], complex]],
+    cos_log_ratio_char_fn: Callable[[ResolvedSingleStateTransformInputs], Callable[[complex], complex]],
+    put_from_call_parity_fn: Callable[[float, ResolvedSingleStateTransformInputs], float],
+) -> SingleStateTransformResult:
+    """Price one bounded single-state terminal claim through the transform family helper."""
+    resolved = resolve_single_state_terminal_claim_transform_inputs(
+        market_state,
+        spec,
+        method=method,
+        fft_alpha=fft_alpha,
+        fft_points=fft_points,
+        fft_eta=fft_eta,
+        cos_points=cos_points,
+        cos_truncation=cos_truncation,
+    )
+
+    if resolved.maturity <= 0.0:
+        return SingleStateTransformResult(
+            price=float(resolved.notional) * float(intrinsic_fn(resolved.spot, resolved)),
+            method=resolved.method,
+            sigma=resolved.sigma,
+            maturity=resolved.maturity,
+        )
+
+    if resolved.method == "fft":
+        call_price = fft_price(
+            fft_log_spot_char_fn(resolved),
+            resolved.spot,
+            resolved.strike,
+            resolved.maturity,
+            resolved.rate,
+            alpha=resolved.fft_alpha,
+            N=resolved.fft_points,
+            eta=resolved.fft_eta,
+        )
+        raw_price = (
+            call_price
+            if resolved.option_type == "call"
+            else put_from_call_parity_fn(call_price, resolved)
+        )
+    else:
+        raw_price = cos_price(
+            cos_log_ratio_char_fn(resolved),
+            resolved.spot,
+            resolved.strike,
+            resolved.maturity,
+            resolved.rate,
+            N=resolved.cos_points,
+            L=resolved.cos_truncation,
+            option_type=resolved.option_type,
+        )
+
+    return SingleStateTransformResult(
+        price=float(resolved.notional) * float(raw_price),
+        method=resolved.method,
+        sigma=resolved.sigma,
+        maturity=resolved.maturity,
+    )
+
+
+def _normalized_transform_method(value: object) -> str:
+    method = str(value or "fft").strip().lower().replace("-", "_")
+    aliases = {
+        "carr_madan": "fft",
+        "fang_oosterlee": "cos",
+    }
+    method = aliases.get(method, method)
+    if method not in {"fft", "cos"}:
+        raise ValueError(f"Unsupported transform method {value!r}")
+    return method
+
+
+__all__ = [
+    "ResolvedSingleStateTransformInputs",
+    "SingleStateTransformResult",
+    "price_single_state_terminal_claim_transform_result",
+    "resolve_single_state_terminal_claim_transform_inputs",
+]


### PR DESCRIPTION
## Summary
- extract reusable single-state MC/transform helper layers and family-shaped FX/quanto helper kits
- bless the intended thin FX/quanto checked-in adapters and shrink executor exact-binding authority
- update docs and plan mirrors for the lower-layer cleanup umbrella

## Validation
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_build_loop.py tests/test_agent/test_checkpoints.py tests/test_agent/test_platform_requests.py tests/test_agent/test_promotion_candidates.py tests/test_agent/test_prompts.py tests/test_agent/test_route_registry.py tests/test_agent/test_semantic_validators.py tests/test_models/test_fx_vanilla.py tests/test_models/test_monte_carlo/test_single_state_diffusion.py tests/test_models/test_quanto_option_helpers.py tests/test_models/test_transforms/test_single_state_diffusion.py -x -q
- git diff --check

## Notes
- Prior umbrella acceptance already included the direct task reruns and full curated canary rerun recorded in docs/plans/lower-layer-cleanup-and-canary-verification.md.
- Fresh live reruns from this rebased branch were blocked locally because OPENAI_API_KEY is not available in this shell environment.