### PR TITLE
Harden transform pricing around a native lowered family IR

### DIFF
--- a/docs/developer/dsl_system_design_review.md
+++ b/docs/developer/dsl_system_design_review.md
@@ -98,6 +98,7 @@ That shared program is emitted once from product semantics and then projected
 into the bounded numerical families. The current family-specific layer is:
 
 - `AnalyticalBlack76IR`
+- `TransformPricingIR`
 - `EventAwarePDEIR`
 - `VanillaEquityPDEIR` as the current compatibility wrapper for the vanilla
   theta-method PDE route
@@ -106,6 +107,19 @@ into the bounded numerical families. The current family-specific layer is:
 
 These lower onto existing checked-in helpers and kernels. The pricing math
 remains in `trellis/models/`.
+
+For transform routes, the dedicated lowered contract now carries:
+
+- one terminal-state transform state spec
+- one characteristic-function family and model family
+- explicit quote semantics and strike semantics
+- a transform-lane control contract (`identity`) plus the upstream semantic
+  control provenance
+- backend capability split (`helper_backed` versus `raw_kernel_only`)
+
+That removes the earlier ambiguity where transform admissibility could fall
+back to raw option-family tags and mistakenly inherit exercise/state facts that
+are irrelevant to terminal-only transform pricing.
 
 For PDE routes, the typed lowering surface now includes explicit contracts for:
 

--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -174,6 +174,20 @@ FFT/COS kernel path under the same route family. That keeps helper reuse
 honest without widening a GBM-oriented helper into unsupported Heston
 authority.
 
+That route family now also has its own lowered contract boundary. Transform
+tasks compile onto ``TransformPricingIR`` before admissibility, so the canaries
+no longer have to rely on the broader upstream ``vanilla_option`` semantics
+when the numerical lane only needs a terminal-only characteristic-function
+contract. In practice this is what keeps transform canaries such as ``T39`` and
+``T40`` from failing on irrelevant option-family tags like ``holder_max`` or
+``recombining_safe``.
+
+For the analytical benchmark side of those canaries, the runtime now also
+materializes a deterministic exact wrapper around the checked Black76 kernels.
+That wrapper binds ``year_fraction(...)``, discounting, and expiry-vol lookup
+through the actual runtime market-state protocols instead of asking the build
+loop to regenerate a tiny analytical adapter for every transform comparison.
+
 Analytical traces also carry a structured instruction-lifecycle payload. The
 ``GenerationPlan`` now includes a resolved instruction set, the trace emits a
 dedicated ``instruction_lifecycle`` step, and the persisted task-run summary

--- a/docs/plans/transform-family-ir-and-admissibility-hardening.md
+++ b/docs/plans/transform-family-ir-and-admissibility-hardening.md
@@ -1,0 +1,72 @@
+# Transform Family IR And Admissibility Hardening
+
+## Objective
+
+Make transform pricing admit on its own lowered family contract instead of
+falling back to raw vanilla-option semantics. The end state is a bounded
+``TransformPricingIR`` with family-first admissibility, explicit backend
+capability splitting, stable `T39`/`T40` canary recovery, and matching docs and
+trace visibility.
+
+## Why Now
+
+`T40` narrowed the bug to a lower-layer contract problem: the semantic layer
+was already correct, but transform admissibility still read upstream
+option-family tags such as ``holder_max`` and ``recombining_safe``. The same
+route family also needed a cleaner helper-vs-kernel split so diffusion
+vanillas and stochastic-volatility transforms could share one family without
+pretending they use the same backend surface.
+
+## Scope
+
+- ``trellis/agent/family_lowering_ir.py``
+- ``trellis/agent/dsl_lowering.py``
+- ``trellis/agent/route_registry.py``
+- ``trellis/agent/lane_obligations.py``
+- ``trellis/agent/platform_traces.py``
+- ``trellis/agent/executor.py``
+- ``trellis/agent/knowledge/canonical/routes.yaml``
+- transform canaries ``T39`` and ``T40``
+- official docs touched by the new transform family contract
+
+## Non-goals
+
+- new transform numerical methods beyond the existing FFT/COS/kernel surface
+- widening the vanilla transform helper to unsupported model families
+- removing all analytical route-local compatibility machinery
+
+## Ticket Mirror
+
+| Ticket | Title | Status |
+| --- | --- | --- |
+| QUA-771 | Transform pricing lowered family IR and admissibility hardening | Done |
+| QUA-772 | Bounded transform family IR and lowering contract | Done |
+| QUA-773 | Family-first transform admissibility | Done |
+| QUA-774 | Backend binding split: helper vs raw kernel by capability | Done |
+| QUA-775 | `T39` / `T40` canary recovery on the lowered family IR | Done |
+| QUA-776 | Docs, observability, and compatibility cleanup | Done |
+
+## Acceptance Criteria
+
+- ``TransformPricingIR`` exists and lowers bounded transform-compatible claims.
+- transform admissibility reads the lowered family contract before raw semantic
+  option tags.
+- transform traces surface transform-specific family summaries.
+- helper-backed diffusion and raw-kernel stochastic-volatility transforms share
+  the same family with explicit backend capability separation.
+- `T39` and `T40` both pass on the migrated path.
+
+## Validation
+
+- ``/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_family_lowering_ir.py tests/test_agent/test_dsl_lowering.py tests/test_agent/test_route_registry.py tests/test_agent/test_lane_obligations.py tests/test_agent/test_platform_traces.py tests/test_agent/test_executor.py tests/test_models/test_transforms/test_single_state_diffusion.py tests/test_models/test_transforms/test_equity_option_transforms.py -q``
+- ``/Users/steveyang/miniforge3/bin/python3 scripts/run_canary.py --task T39 --model gpt-5.4-mini --output task_results_t39_qua771.json``
+- ``/Users/steveyang/miniforge3/bin/python3 scripts/run_canary.py --task T40 --model gpt-5.4-mini --output task_results_t40_qua771.json``
+
+## Closeout Notes
+
+- The transform family now carries its own typed lowering and admissibility
+  surface.
+- `T39` also required a deterministic analytical comparator wrapper that binds
+  the checked Black76 kernels through runtime ``discount(T)`` and
+  ``black_vol(T, K)`` protocols instead of regenerating an ad hoc analytical
+  adapter.

--- a/docs/quant/contract_algebra.rst
+++ b/docs/quant/contract_algebra.rst
@@ -251,6 +251,7 @@ Shipped family IRs:
 - ``AnalyticalBlack76IR``
 - ``EventAwareMonteCarloIR`` as the new bounded single-state Monte Carlo family
   surface
+- ``TransformPricingIR`` as the bounded terminal-only transform family surface
 - ``EventAwarePDEIR``
 - ``VanillaEquityPDEIR`` as the current compatibility wrapper for the vanilla
   theta-method PDE route
@@ -258,6 +259,23 @@ Shipped family IRs:
 - ``CorrelatedBasketMonteCarloIR``
 - ``CreditDefaultSwapIR``
 - ``NthToDefaultIR``
+
+For transform routes, the compiler now also carries an explicit bounded family
+surface on ``TransformPricingIR``. That surface keeps transform admissibility
+restricted to:
+
+- terminal-only payoff semantics
+- numerical-lane ``identity`` control
+- one typed characteristic-function family such as ``gbm_log_spot`` or
+  ``heston_log_spot``
+- explicit quote and strike semantics
+- a backend capability split between helper-backed diffusion execution and
+  raw-kernel stochastic-volatility execution
+
+That means the transform route no longer admits on the full upstream
+``vanilla_option`` contract. Admissibility reads the lowered transform family
+contract first, so upstream semantic tags such as ``holder_max`` or
+``recombining_safe`` stop leaking into transform-only route checks.
 
 For PDE routes, the compiler now carries typed sub-specifications inside
 ``EventAwarePDEIR``:

--- a/docs/quant/pricing_stack.rst
+++ b/docs/quant/pricing_stack.rst
@@ -95,6 +95,7 @@ The shipped family IRs are:
 - ``AnalyticalBlack76IR``
 - ``EventAwareMonteCarloIR`` as the new bounded single-state Monte Carlo family
   surface
+- ``TransformPricingIR`` as the bounded transform family surface
 - ``VanillaEquityPDEIR``
 - ``ExerciseLatticeIR``
 - ``CorrelatedBasketMonteCarloIR``
@@ -114,9 +115,26 @@ exercise/call control, and same-day phase ordering. Family IRs then project
 that shared program into their bounded numerical forms:
 
 - lattice keeps the semantic schedule/control surface on ``ExerciseLatticeIR``
+- transforms project it into a terminal-only characteristic-function contract
+  on ``TransformPricingIR``
 - PDE projects it into ``PDEEventTimeSpec`` / ``PDEEventTransformSpec``
 - Monte Carlo projects it into ``MCEventTimeSpec`` plus reduced replay
   requirements
+
+For transforms, that now means route admissibility is family-first rather than
+product-first. ``TransformPricingIR`` carries the transform-specific facts that
+matter numerically:
+
+- characteristic-function family
+- terminal payoff kind
+- strike semantics
+- quote semantics
+- backend capability (helper-backed vanilla diffusion versus raw-kernel
+  stochastic volatility)
+
+So a vanilla European payoff can still have holder-side semantic exercise
+meaning upstream while the transform lane itself lowers onto an ``identity``
+control contract with only terminal-state tags.
 
 For Monte Carlo, the new event-aware family is now the typed
 compiler/admissibility surface for bounded single-state schedule semantics as

--- a/docs/user_guide/pricing.rst
+++ b/docs/user_guide/pricing.rst
@@ -255,6 +255,17 @@ as Heston stochastic volatility, Trellis keeps the request on the raw FFT/COS
 kernel surface instead of pretending the vanilla helper is a universal
 transform authority.
 
+Under the hood, that route family now lowers onto a native
+``TransformPricingIR`` contract before admissibility. Operators will therefore
+see transform-specific facts in the trace summary, such as:
+
+- the characteristic-function family
+- the transform backend capability
+- the terminal payoff kind
+- quote and strike semantics
+
+rather than a fallback view of the broader upstream option family.
+
 For the migrated PDE routes, the same trace boundary now also exposes a compact
 `family_ir_summary` alongside the raw lowering metadata. That summary is the
 operator-facing view of the PDE contract: state variable, operator family,

--- a/tests/test_agent/test_dsl_lowering.py
+++ b/tests/test_agent/test_dsl_lowering.py
@@ -11,6 +11,7 @@ from trellis.agent.family_lowering_ir import (
     EventAwarePDEIR,
     ExerciseLatticeIR,
     NthToDefaultIR,
+    TransformPricingIR,
     VanillaEquityPDEIR,
 )
 
@@ -340,6 +341,9 @@ def test_vanilla_option_transform_lowers_to_checked_in_transform_helper():
     assert lowering.route_id == "transform_fft"
     assert lowering.route_family == "fft_pricing"
     assert lowering.admissibility_errors == ()
+    assert isinstance(lowering.family_ir, TransformPricingIR)
+    assert lowering.family_ir.control_spec.control_style == "identity"
+    assert lowering.family_ir.state_spec.state_tags == ("terminal_markov",)
     assert isinstance(lowering.normalized_expr, ContractAtom)
     assert lowering.normalized_expr.atom_id == "transform_fft:route_helper"
     assert lowering.normalized_expr.primitive_ref == (

--- a/tests/test_agent/test_executor.py
+++ b/tests/test_agent/test_executor.py
@@ -568,7 +568,7 @@ def test_deterministic_exact_binding_module_materializes_black_scholes_comparato
     assert "from trellis.core.date_utils import year_fraction" in generated.code
     assert "year_fraction(market_state.settlement, spec.expiry_date, spec.day_count)" in generated.code
     assert "market_state.discount.discount(T)" in generated.code
-    assert "market_state.vol_surface.black_vol(max(T, 1e-6), spec.strike)" in generated.code
+    assert "market_state.vol_surface.black_vol(max(T, 1e-6), strike)" in generated.code
     assert "terminal_vanilla_from_basis(" not in generated.code
     assert EVALUATE_SENTINEL not in generated.code
 

--- a/tests/test_agent/test_executor.py
+++ b/tests/test_agent/test_executor.py
@@ -527,6 +527,123 @@ def test_deterministic_exact_binding_module_materializes_vanilla_equity_transfor
     assert EVALUATE_SENTINEL not in generated.code
 
 
+def test_deterministic_exact_binding_module_materializes_black_scholes_comparator():
+    from trellis.agent.executor import (
+        EVALUATE_SENTINEL,
+        _generate_skeleton,
+        _materialize_deterministic_exact_binding_module,
+    )
+    from trellis.agent.planner import SPECIALIZED_SPECS
+
+    generation_plan = SimpleNamespace(
+        lane_exact_binding_refs=(
+            "trellis.models.black.black76_call",
+            "trellis.models.black.black76_put",
+            "trellis.models.black.black76_asset_or_nothing_call",
+            "trellis.models.black.black76_asset_or_nothing_put",
+            "trellis.models.black.black76_cash_or_nothing_call",
+            "trellis.models.black.black76_cash_or_nothing_put",
+            "trellis.models.analytical.terminal_vanilla_from_basis",
+            "trellis.core.date_utils.year_fraction",
+        ),
+        primitive_plan=None,
+        method="analytical",
+        instrument_type="european_option",
+    )
+
+    skeleton = _generate_skeleton(
+        SPECIALIZED_SPECS["european_option_analytical"],
+        "European option analytical comparator",
+        generation_plan=generation_plan,
+    )
+    generated = _materialize_deterministic_exact_binding_module(
+        skeleton,
+        generation_plan,
+        comparison_target="black_scholes",
+    )
+
+    assert generated is not None
+    assert "black76_call(forward, strike, sigma, T)" in generated.code
+    assert "black76_put(forward, strike, sigma, T)" in generated.code
+    assert "from trellis.core.date_utils import year_fraction" in generated.code
+    assert "year_fraction(market_state.settlement, spec.expiry_date, spec.day_count)" in generated.code
+    assert "market_state.discount.discount(T)" in generated.code
+    assert "market_state.vol_surface.black_vol(max(T, 1e-6), spec.strike)" in generated.code
+    assert "terminal_vanilla_from_basis(" not in generated.code
+    assert EVALUATE_SENTINEL not in generated.code
+
+
+def test_deterministic_black_scholes_comparator_satisfies_required_primitive_validation():
+    from trellis.agent.executor import (
+        _generate_skeleton,
+        _materialize_deterministic_exact_binding_module,
+    )
+    from trellis.agent.planner import SPECIALIZED_SPECS
+    from trellis.agent.semantic_validation import validate_semantics
+
+    generation_plan = SimpleNamespace(
+        lane_exact_binding_refs=(
+            "trellis.models.black.black76_call",
+            "trellis.models.black.black76_put",
+            "trellis.models.black.black76_asset_or_nothing_call",
+            "trellis.models.black.black76_asset_or_nothing_put",
+            "trellis.models.black.black76_cash_or_nothing_call",
+            "trellis.models.black.black76_cash_or_nothing_put",
+        ),
+        primitive_plan=SimpleNamespace(
+            primitives=(
+                SimpleNamespace(
+                    required=True,
+                    role="pricing_kernel",
+                    module="trellis.models.black",
+                    symbol="black76_call",
+                    excluded=False,
+                ),
+                SimpleNamespace(
+                    required=True,
+                    role="pricing_kernel",
+                    module="trellis.models.black",
+                    symbol="black76_put",
+                    excluded=False,
+                ),
+                SimpleNamespace(
+                    required=False,
+                    role="assembly_helper",
+                    module="trellis.models.analytical",
+                    symbol="terminal_vanilla_from_basis",
+                    excluded=False,
+                ),
+                SimpleNamespace(
+                    required=True,
+                    role="time_measure",
+                    module="trellis.core.date_utils",
+                    symbol="year_fraction",
+                    excluded=False,
+                ),
+            ),
+            blockers=(),
+        ),
+        method="analytical",
+        instrument_type="european_option",
+    )
+
+    skeleton = _generate_skeleton(
+        SPECIALIZED_SPECS["european_option_analytical"],
+        "European option analytical comparator",
+        generation_plan=generation_plan,
+    )
+    generated = _materialize_deterministic_exact_binding_module(
+        skeleton,
+        generation_plan,
+        comparison_target="black_scholes",
+    )
+
+    assert generated is not None
+    report = validate_semantics(generated.code, generation_plan=generation_plan)
+
+    assert report.ok, report.errors
+
+
 @pytest.mark.parametrize(
     ("comparison_target", "expected_fragment"),
     [

--- a/tests/test_agent/test_family_lowering_ir.py
+++ b/tests/test_agent/test_family_lowering_ir.py
@@ -234,8 +234,9 @@ def test_vanilla_option_monte_carlo_compiles_to_terminal_only_event_aware_family
 def test_vanilla_option_transform_compiles_to_bounded_transform_family_ir():
     from dataclasses import replace
 
+    from trellis.agent.family_lowering_ir import build_family_lowering_ir
     from trellis.agent.semantic_contract_compiler import compile_semantic_contract
-    from trellis.agent.semantic_contracts import make_vanilla_option_contract
+    from trellis.agent.semantic_contracts import ControllerProtocol, make_vanilla_option_contract
 
     contract = make_vanilla_option_contract(
         description="EUR call on AAPL, K=150, T=1y",
@@ -278,6 +279,27 @@ def test_vanilla_option_transform_compiles_to_bounded_transform_family_ir():
     assert family_ir.market_mapping == "single_state_diffusion_transform_inputs"
     assert family_ir.timeline_roles == blueprint.dsl_lowering.normalized_expr.signature.timeline_roles
     assert family_ir.required_input_ids == blueprint.required_market_data
+
+    unsupported_contract = replace(
+        transform_contract,
+        product=replace(
+            transform_contract.product,
+            controller_protocol=ControllerProtocol(
+                controller_style="issuer_min",
+                controller_role="issuer",
+                decision_phase="decision",
+                schedule_role="decision_dates",
+            ),
+        ),
+    )
+    unsupported_family_ir = build_family_lowering_ir(
+        unsupported_contract,
+        route_id="transform_fft",
+        route_family="fft_pricing",
+        product_ir=blueprint.product_ir,
+    )
+
+    assert unsupported_family_ir is None
 
 
 def test_callable_bond_compiles_to_exercise_lattice_family_ir():

--- a/tests/test_agent/test_family_lowering_ir.py
+++ b/tests/test_agent/test_family_lowering_ir.py
@@ -21,6 +21,7 @@ from trellis.agent.family_lowering_ir import (
     MCProcessSpec,
     MCStateSpec,
     NthToDefaultIR,
+    TransformPricingIR,
     VanillaEquityPDEIR,
 )
 
@@ -228,10 +229,55 @@ def test_vanilla_option_monte_carlo_compiles_to_terminal_only_event_aware_family
     assert family_ir.state_spec.state_variable == "spot"
     assert family_ir.process_spec.process_family == "gbm_1d"
     assert family_ir.path_requirement_spec.requirement_kind == "terminal_only"
-    assert family_ir.path_requirement_spec.replay_mode == "none"
-    assert family_ir.payoff_reducer_spec.reducer_kind == "terminal_payoff"
-    assert family_ir.event_dates == ()
-    assert family_ir.event_kinds == ()
+
+
+def test_vanilla_option_transform_compiles_to_bounded_transform_family_ir():
+    from dataclasses import replace
+
+    from trellis.agent.semantic_contract_compiler import compile_semantic_contract
+    from trellis.agent.semantic_contracts import make_vanilla_option_contract
+
+    contract = make_vanilla_option_contract(
+        description="EUR call on AAPL, K=150, T=1y",
+        underliers=("AAPL",),
+        observation_schedule=("2026-06-20",),
+        preferred_method="analytical",
+    )
+    transform_contract = replace(
+        contract,
+        methods=replace(
+            contract.methods,
+            candidate_methods=contract.methods.candidate_methods + ("fft_pricing",),
+            reference_methods=("fft_pricing",),
+            preferred_method="fft_pricing",
+        ),
+    )
+    blueprint = compile_semantic_contract(transform_contract, preferred_method="fft_pricing")
+
+    family_ir = blueprint.dsl_lowering.family_ir
+    assert isinstance(family_ir, TransformPricingIR)
+    assert family_ir.route_id == "transform_fft"
+    assert family_ir.route_family == "fft_pricing"
+    assert family_ir.product_instrument == "european_option"
+    assert family_ir.payoff_family == "vanilla_option"
+    assert family_ir.state_spec.state_variable == "spot"
+    assert family_ir.state_spec.dimension == 1
+    assert family_ir.state_spec.state_tags == ("terminal_markov",)
+    assert family_ir.characteristic_spec.model_family == "equity_diffusion"
+    assert family_ir.characteristic_spec.characteristic_family == "gbm_log_spot"
+    assert family_ir.characteristic_spec.supported_methods == ("fft", "cos")
+    assert family_ir.control_spec.control_style == "identity"
+    assert family_ir.control_spec.controller_role == "holder"
+    assert family_ir.control_program.control_style == "holder_max"
+    assert family_ir.control_program.controller_role == "holder"
+    assert family_ir.control_program.schedule_role == "decision_dates"
+    assert family_ir.terminal_payoff_kind == "vanilla_terminal_payoff"
+    assert family_ir.strike_semantics == "vanilla_strike"
+    assert family_ir.quote_semantics == "equity_black_vol_surface"
+    assert family_ir.helper_symbol == "price_vanilla_equity_option_transform"
+    assert family_ir.market_mapping == "single_state_diffusion_transform_inputs"
+    assert family_ir.timeline_roles == blueprint.dsl_lowering.normalized_expr.signature.timeline_roles
+    assert family_ir.required_input_ids == blueprint.required_market_data
 
 
 def test_callable_bond_compiles_to_exercise_lattice_family_ir():

--- a/tests/test_agent/test_lane_obligations.py
+++ b/tests/test_agent/test_lane_obligations.py
@@ -17,6 +17,10 @@ from trellis.agent.family_lowering_ir import (
     MCStateSpec,
     SemanticEventSpec,
     SemanticEventTimeSpec,
+    TransformCharacteristicSpec,
+    TransformControlSpec,
+    TransformPricingIR,
+    TransformStateSpec,
 )
 from trellis.agent.lane_obligations import compile_lane_construction_plan
 
@@ -121,3 +125,62 @@ def test_event_aware_monte_carlo_lane_plan_emits_process_path_and_event_contract
     assert "measure_family:risk_neutral" in plan.control_obligations
     assert any("hull_white_1f" in step for step in plan.construction_steps)
     assert any("event_replay" in step for step in plan.construction_steps)
+
+
+def test_transform_lane_plan_emits_terminal_characteristic_contract():
+    family_ir = TransformPricingIR(
+        route_id="transform_fft",
+        route_family="fft_pricing",
+        product_instrument="european_option",
+        payoff_family="vanilla_option",
+        state_spec=TransformStateSpec(
+            state_variable="spot",
+            state_tags=("terminal_markov",),
+        ),
+        characteristic_spec=TransformCharacteristicSpec(
+            model_family="equity_diffusion",
+            characteristic_family="gbm_log_spot",
+            supported_methods=("fft", "cos"),
+            backend_capability="helper_backed",
+        ),
+        control_program=ControlProgramIR(
+            control_style="holder_max",
+            controller_role="holder",
+            decision_phase="decision",
+            schedule_role="decision_dates",
+            exercise_style="european",
+        ),
+        control_spec=TransformControlSpec(
+            control_style="identity",
+            controller_role="holder",
+        ),
+        terminal_payoff_kind="vanilla_terminal_payoff",
+        strike_semantics="vanilla_strike",
+        quote_semantics="equity_black_vol_surface",
+        helper_symbol="price_vanilla_equity_option_transform",
+        market_mapping="single_state_diffusion_transform_inputs",
+    )
+    lowering = SemanticDslLowering(
+        route_id="transform_fft",
+        route_family="fft_pricing",
+        family_ir=family_ir,
+        expr=None,
+        normalized_expr=None,
+    )
+
+    plan = compile_lane_construction_plan(
+        preferred_method="fft_pricing",
+        required_market_data=("discount_curve", "black_vol_surface"),
+        dsl_lowering=lowering,
+    )
+
+    assert plan is not None
+    assert plan.lane_family == "fft_pricing"
+    assert "spot" in plan.state_obligations
+    assert "gbm_log_spot" in plan.state_obligations
+    assert "vanilla_terminal_payoff" in plan.state_obligations
+    assert "control_style:identity" in plan.control_obligations
+    assert "semantic_control_style:holder_max" in plan.control_obligations
+    assert "quote_semantics:equity_black_vol_surface" in plan.control_obligations
+    assert any("terminal-only transform contract" in step for step in plan.construction_steps)
+    assert any("helper_backed" in step for step in plan.construction_steps)

--- a/tests/test_agent/test_platform_traces.py
+++ b/tests/test_agent/test_platform_traces.py
@@ -407,6 +407,36 @@ def test_platform_trace_summarizes_terminal_only_event_aware_monte_carlo_family_
     assert family_ir_summary["compatibility_status"] == "native_event_aware"
 
 
+def test_platform_trace_summarizes_transform_family_ir(tmp_path):
+    from trellis.agent.platform_requests import compile_build_request
+    from trellis.agent.platform_traces import load_platform_trace_boundary, record_platform_trace
+
+    compiled = compile_build_request(
+        "European equity call on AAPL with strike 120 and expiry 2025-11-15",
+        instrument_type="european_option",
+        preferred_method="fft_pricing",
+    )
+
+    trace_path = record_platform_trace(
+        compiled,
+        success=True,
+        outcome="build_completed",
+        root=tmp_path,
+    )
+    boundary = load_platform_trace_boundary(trace_path)
+    lowering = boundary["generation_boundary"]["lowering"]
+    family_ir_summary = lowering["family_ir_summary"]
+
+    assert lowering["family_ir_type"] == "TransformPricingIR"
+    assert family_ir_summary["characteristic_family"] == "gbm_log_spot"
+    assert family_ir_summary["control_style"] == "identity"
+    assert family_ir_summary["semantic_control_style"] == "holder_max"
+    assert family_ir_summary["terminal_payoff_kind"] == "vanilla_terminal_payoff"
+    assert family_ir_summary["quote_semantics"] == "equity_black_vol_surface"
+    assert family_ir_summary["helper_symbol"] == "price_vanilla_equity_option_transform"
+    assert family_ir_summary["compatibility_status"] == "native_transform_family_ir"
+
+
 def test_platform_trace_summary_reads_legacy_top_level_route_binding_fields():
     from trellis.agent.platform_traces import _construction_identity_summary, _generation_boundary_summary
 

--- a/tests/test_agent/test_route_registry.py
+++ b/tests/test_agent/test_route_registry.py
@@ -1108,8 +1108,12 @@ class TestFallbackRoutes:
             "project_min",
         )
         assert transform is not None
-        assert transform.admissibility.supported_control_styles == ("identity", "holder_max")
-        assert transform.admissibility.supported_state_tags == ("terminal_markov", "recombining_safe")
+        assert transform.admissibility.supported_control_styles == ("identity",)
+        assert transform.admissibility.supported_state_tags == ("terminal_markov",)
+        assert transform.admissibility.supported_characteristic_families == (
+            "gbm_log_spot",
+            "heston_log_spot",
+        )
 
     def test_transform_route_admissibility_accepts_european_holder_control_surface(self, registry):
         from trellis.agent.semantic_contract_compiler import compile_semantic_contract
@@ -1129,6 +1133,34 @@ class TestFallbackRoutes:
         decision = evaluate_route_admissibility(spec, semantic_blueprint=blueprint)
 
         assert decision.ok
+
+    def test_transform_route_admissibility_requires_lowered_transform_family_contract(self, registry):
+        from dataclasses import replace
+
+        from trellis.agent.semantic_contract_compiler import compile_semantic_contract
+        from trellis.agent.semantic_contracts import make_vanilla_option_contract
+
+        spec = find_route_by_id("transform_fft", registry)
+        assert spec is not None
+
+        contract = make_vanilla_option_contract(
+            description="European call on SPX priced with transforms",
+            underliers=("SPX",),
+            observation_schedule=("2026-06-20",),
+            preferred_method="fft_pricing",
+        )
+        blueprint = compile_semantic_contract(contract, preferred_method="fft_pricing")
+        lowered_decision = evaluate_route_admissibility(spec, semantic_blueprint=blueprint)
+        assert lowered_decision.ok
+
+        raw_blueprint = replace(
+            blueprint,
+            dsl_lowering=replace(blueprint.dsl_lowering, family_ir=None),
+        )
+        raw_decision = evaluate_route_admissibility(spec, semantic_blueprint=raw_blueprint)
+
+        assert not raw_decision.ok
+        assert "unsupported_control_style:holder_max" in raw_decision.failures
 
     def test_vanilla_pde_admissibility_rejects_wrong_operator_family(self, registry):
         from dataclasses import replace

--- a/trellis/agent/dsl_lowering.py
+++ b/trellis/agent/dsl_lowering.py
@@ -33,6 +33,7 @@ from trellis.agent.family_lowering_ir import (
     EventAwarePDEIR,
     ExerciseLatticeIR,
     NthToDefaultIR,
+    TransformPricingIR,
     VanillaEquityPDEIR,
     build_family_lowering_ir,
 )
@@ -304,6 +305,12 @@ def _build_expr_for_family_ir(
         )
     if isinstance(family_ir, EventAwareMonteCarloIR):
         return _build_event_aware_monte_carlo_expr_from_family_ir(
+            route_id=route_id,
+            family_ir=family_ir,
+            bindings=bindings,
+        )
+    if isinstance(family_ir, TransformPricingIR):
+        return _build_transform_expr_from_family_ir(
             route_id=route_id,
             family_ir=family_ir,
             bindings=bindings,
@@ -714,6 +721,63 @@ def _build_event_aware_monte_carlo_expr_from_family_ir(
         ),
     )
     return ThenExpr(terms=(process_atom, simulation_atom, reducer_atom)), ()
+
+
+def _build_transform_expr_from_family_ir(
+    *,
+    route_id: str,
+    family_ir: TransformPricingIR,
+    bindings: tuple[DslTargetBinding, ...],
+) -> tuple[ContractExpr | None, tuple[str, ...]]:
+    """Build a bounded transform-pricing lowering from typed family IR."""
+    market_signature = _market_signature_from_family_ir(family_ir)
+    if family_ir.helper_symbol:
+        route_helper = next(
+            (
+                binding
+                for binding in bindings
+                if binding.role == "route_helper" and binding.symbol == family_ir.helper_symbol
+            ),
+            None,
+        )
+        if route_helper is None:
+            return None, (
+                f"Route '{route_id}' is missing the required route helper '{family_ir.helper_symbol}'.",
+            )
+        helper_atom = ContractAtom(
+            atom_id=f"{route_id}:route_helper",
+            primitive_ref=route_helper.primitive_ref,
+            description=(
+                f"Typed transform helper for {family_ir.product_instrument or 'compiled'} "
+                f"with characteristic={family_ir.characteristic_spec.characteristic_family or 'generic_cf'}."
+            ),
+            signature=market_signature,
+        )
+        return helper_atom, ()
+
+    transform_pricer = next(
+        (
+            binding
+            for binding in bindings
+            if binding.role == "transform_pricer"
+        ),
+        None,
+    )
+    if transform_pricer is None:
+        return None, (
+            f"Route '{route_id}' is missing the required raw transform pricing primitive.",
+        )
+
+    kernel_atom = ContractAtom(
+        atom_id=f"{route_id}:transform_pricer",
+        primitive_ref=transform_pricer.primitive_ref,
+        description=(
+            f"Typed raw transform pricing kernel for {family_ir.product_instrument or 'compiled'} "
+            f"with characteristic={family_ir.characteristic_spec.characteristic_family or 'generic_cf'}."
+        ),
+        signature=market_signature,
+    )
+    return kernel_atom, ()
 
 
 def _binding_supports_mc_process(binding: DslTargetBinding, process_family: str) -> bool:

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -2671,7 +2671,10 @@ def _skeleton_exact_binding_import_lines(generation_plan) -> tuple[str, ...]:
         refs.extend(
             f"{primitive.module}.{primitive.symbol}"
             for primitive in getattr(primitive_plan, "primitives", ()) or ()
-            if getattr(primitive, "role", "") in {"route_helper", "pricing_kernel", "schedule_builder"}
+            if (
+                getattr(primitive, "required", False)
+                or getattr(primitive, "role", "") in {"route_helper", "pricing_kernel", "schedule_builder"}
+            )
             and getattr(primitive, "module", "")
             and getattr(primitive, "symbol", "")
         )
@@ -2813,6 +2816,37 @@ def _deterministic_exact_binding_evaluate_body(
     vanilla_equity_transform_kwargs = _vanilla_equity_transform_helper_kwargs(comparison_target)
     zcb_option_tree_kwargs = _zcb_option_tree_helper_kwargs(comparison_target)
     credit_basket_tranche_kwargs = _credit_basket_tranche_helper_kwargs(comparison_target)
+    if (
+        comparison_target == "black_scholes"
+        and "trellis.models.black.black76_call" in refs
+        and "trellis.models.black.black76_put" in refs
+    ):
+        return textwrap.dedent(
+            """\
+            spec = self._spec
+            if market_state.discount is None:
+                raise ValueError("market_state.discount is required for Black-Scholes comparison")
+            if market_state.vol_surface is None:
+                raise ValueError("market_state.vol_surface is required for Black-Scholes comparison")
+            T = max(float(year_fraction(market_state.settlement, spec.expiry_date, spec.day_count)), 0.0)
+            spot = float(spec.spot)
+            strike = float(spec.strike)
+            option_type = str(spec.option_type or "call").strip().lower()
+            if T <= 0.0:
+                intrinsic = max(spot - strike, 0.0) if option_type == "call" else max(strike - spot, 0.0)
+                return float(spec.notional) * intrinsic
+            df = float(market_state.discount.discount(T))
+            sigma = float(market_state.vol_surface.black_vol(max(T, 1e-6), spec.strike))
+            forward = spot / max(df, 1e-12)
+            if option_type == "call":
+                undiscounted = black76_call(forward, strike, sigma, T)
+            elif option_type == "put":
+                undiscounted = black76_put(forward, strike, sigma, T)
+            else:
+                raise ValueError(f"Unsupported option_type {spec.option_type!r}")
+            return float(spec.notional) * df * float(undiscounted)
+            """
+        ).rstrip()
     helper_bodies = {
         "trellis.models.quanto_option.price_quanto_option_analytical_from_market_state": (
             "return float(price_quanto_option_analytical_from_market_state(market_state, spec))"

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -2836,7 +2836,7 @@ def _deterministic_exact_binding_evaluate_body(
                 intrinsic = max(spot - strike, 0.0) if option_type == "call" else max(strike - spot, 0.0)
                 return float(spec.notional) * intrinsic
             df = float(market_state.discount.discount(T))
-            sigma = float(market_state.vol_surface.black_vol(max(T, 1e-6), spec.strike))
+            sigma = float(market_state.vol_surface.black_vol(max(T, 1e-6), strike))
             forward = spot / max(df, 1e-12)
             if option_type == "call":
                 undiscounted = black76_call(forward, strike, sigma, T)

--- a/trellis/agent/family_lowering_ir.py
+++ b/trellis/agent/family_lowering_ir.py
@@ -857,6 +857,8 @@ def _build_transform_pricing_ir(
         return None
 
     control_program = _build_control_program(product)
+    if not _transform_supports_control_program(control_program):
+        return None
     controller_role = str(control_program.controller_role or "holder").strip() or "holder"
 
     return TransformPricingIR(
@@ -883,6 +885,15 @@ def _build_transform_pricing_ir(
         market_mapping=_transform_market_mapping_for_product(product, characteristic_spec),
         compatibility_wrapper="",
     )
+
+
+def _transform_supports_control_program(control_program: ControlProgramIR) -> bool:
+    """Return whether the bounded transform lane can safely lower one control program."""
+    control_style = str(control_program.control_style or "identity").strip().lower()
+    controller_role = str(control_program.controller_role or "none").strip().lower()
+    if control_style not in {"identity", "holder_max"}:
+        return False
+    return controller_role in {"", "none", "holder"}
 
 
 def _transform_state_spec_for_product(product) -> TransformStateSpec:

--- a/trellis/agent/family_lowering_ir.py
+++ b/trellis/agent/family_lowering_ir.py
@@ -116,6 +116,52 @@ class AnalyticalBlack76IR(BaseFamilyLoweringIR):
 
 
 @dataclass(frozen=True)
+class TransformStateSpec:
+    """Typed state-space contract for one bounded transform-pricing problem."""
+
+    state_variable: str = ""
+    dimension: int = 1
+    state_tags: tuple[str, ...] = ()
+    coordinate_chart: str = "spot"
+
+
+@dataclass(frozen=True)
+class TransformCharacteristicSpec:
+    """Typed characteristic-function contract for one transform pricing lane."""
+
+    model_family: str = ""
+    characteristic_family: str = ""
+    supported_methods: tuple[str, ...] = ("fft", "cos")
+    backend_capability: str = "raw_kernel_only"
+
+
+@dataclass(frozen=True)
+class TransformControlSpec:
+    """Typed control contract for one bounded transform pricing lane."""
+
+    control_style: str = "identity"
+    controller_role: str = "holder"
+
+
+@dataclass(frozen=True)
+class TransformPricingIR(BaseFamilyLoweringIR):
+    """Typed lowering payload for bounded transform-pricing routes."""
+
+    state_spec: TransformStateSpec = field(default_factory=TransformStateSpec)
+    characteristic_spec: TransformCharacteristicSpec = field(
+        default_factory=TransformCharacteristicSpec
+    )
+    control_program: ControlProgramIR = field(default_factory=ControlProgramIR)
+    control_spec: TransformControlSpec = field(default_factory=TransformControlSpec)
+    terminal_payoff_kind: str = ""
+    strike_semantics: str = ""
+    quote_semantics: str = ""
+    helper_symbol: str = ""
+    market_mapping: str = ""
+    compatibility_wrapper: str = ""
+
+
+@dataclass(frozen=True)
 class MCStateSpec:
     """Typed state-space contract for one event-aware Monte Carlo problem."""
 
@@ -486,6 +532,7 @@ class NthToDefaultIR(BaseFamilyLoweringIR):
 
 FamilyLoweringIR = (
     AnalyticalBlack76IR
+    | TransformPricingIR
     | EventAwareMonteCarloIR
     | EventAwarePDEIR
     | VanillaEquityPDEIR
@@ -521,6 +568,13 @@ def build_family_lowering_ir(
             return AnalyticalBlack76IR(
                 option_type=option_type,
                 kernel_symbol="black76_put" if option_type == "put" else "black76_call",
+                **common_kwargs,
+            )
+
+        if route_id == "transform_fft":
+            return _build_transform_pricing_ir(
+                contract,
+                product_ir=product_ir,
                 **common_kwargs,
             )
 
@@ -779,6 +833,140 @@ def _build_event_program(
             )
         )
     return EventProgramIR(timeline=tuple(timeline))
+
+
+def _build_transform_pricing_ir(
+    contract,
+    *,
+    product_ir,
+    route_id: str,
+    route_family: str,
+    product_instrument: str,
+    payoff_family: str,
+    required_input_ids: tuple[str, ...],
+    market_data_requirements: frozenset[str],
+    timeline_roles: frozenset[TimelineRole],
+    requested_outputs: tuple[str, ...],
+    reporting_currency: str,
+) -> TransformPricingIR | None:
+    """Build a typed transform family IR for bounded single-state terminal claims."""
+    product = contract.product
+    state_spec = _transform_state_spec_for_product(product)
+    characteristic_spec = _transform_characteristic_spec_for_product(product)
+    if not state_spec.state_variable or not characteristic_spec.characteristic_family:
+        return None
+
+    control_program = _build_control_program(product)
+    controller_role = str(control_program.controller_role or "holder").strip() or "holder"
+
+    return TransformPricingIR(
+        route_id=route_id,
+        route_family=route_family,
+        product_instrument=product_instrument,
+        payoff_family=payoff_family,
+        required_input_ids=required_input_ids,
+        market_data_requirements=market_data_requirements,
+        timeline_roles=timeline_roles,
+        requested_outputs=requested_outputs,
+        reporting_currency=reporting_currency,
+        state_spec=state_spec,
+        characteristic_spec=characteristic_spec,
+        control_program=control_program,
+        control_spec=TransformControlSpec(
+            control_style="identity",
+            controller_role=controller_role,
+        ),
+        terminal_payoff_kind=_transform_terminal_payoff_kind_for_product(product),
+        strike_semantics="vanilla_strike",
+        quote_semantics=_transform_quote_semantics_for_product(characteristic_spec),
+        helper_symbol=_transform_helper_symbol_for_product(product, characteristic_spec),
+        market_mapping=_transform_market_mapping_for_product(product, characteristic_spec),
+        compatibility_wrapper="",
+    )
+
+
+def _transform_state_spec_for_product(product) -> TransformStateSpec:
+    """Infer the bounded transform state contract from semantic product metadata."""
+    model_family = str(getattr(product, "model_family", "") or "").strip().lower()
+    if model_family in {"equity", "equity_diffusion", "stochastic_volatility"}:
+        return TransformStateSpec(
+            state_variable="spot",
+            dimension=1,
+            state_tags=("terminal_markov",),
+            coordinate_chart="spot",
+        )
+    return TransformStateSpec()
+
+
+def _transform_characteristic_spec_for_product(
+    product,
+) -> TransformCharacteristicSpec:
+    """Infer the bounded transform characteristic-function contract for one product."""
+    model_family = str(getattr(product, "model_family", "") or "").strip().lower()
+    if model_family in {"equity", "equity_diffusion"}:
+        return TransformCharacteristicSpec(
+            model_family="equity_diffusion",
+            characteristic_family="gbm_log_spot",
+            supported_methods=("fft", "cos"),
+            backend_capability="helper_backed",
+        )
+    if model_family == "stochastic_volatility":
+        return TransformCharacteristicSpec(
+            model_family="stochastic_volatility",
+            characteristic_family="heston_log_spot",
+            supported_methods=("fft", "cos"),
+            backend_capability="raw_kernel_only",
+        )
+    return TransformCharacteristicSpec()
+
+
+def _transform_terminal_payoff_kind_for_product(product) -> str:
+    """Return the bounded terminal payoff kind for one transform family IR."""
+    payoff_family = str(getattr(product, "payoff_family", "") or "").strip().lower()
+    if payoff_family == "vanilla_option":
+        return "vanilla_terminal_payoff"
+    return "compiled_terminal_payoff"
+
+
+def _transform_quote_semantics_for_product(
+    characteristic_spec: TransformCharacteristicSpec,
+) -> str:
+    """Return a readable quote-semantics label for one transform family IR."""
+    if characteristic_spec.model_family == "equity_diffusion":
+        return "equity_black_vol_surface"
+    if characteristic_spec.model_family == "stochastic_volatility":
+        return "stochastic_vol_model_parameters"
+    return "compiled_transform_quote_inputs"
+
+
+def _transform_helper_symbol_for_product(
+    product,
+    characteristic_spec: TransformCharacteristicSpec,
+) -> str:
+    """Return the bounded helper symbol for transform routes when one exists."""
+    payoff_family = str(getattr(product, "payoff_family", "") or "").strip().lower()
+    if (
+        payoff_family == "vanilla_option"
+        and characteristic_spec.model_family == "equity_diffusion"
+    ):
+        return "price_vanilla_equity_option_transform"
+    return ""
+
+
+def _transform_market_mapping_for_product(
+    product,
+    characteristic_spec: TransformCharacteristicSpec,
+) -> str:
+    """Return a readable market-binding label for one transform family IR."""
+    payoff_family = str(getattr(product, "payoff_family", "") or "").strip().lower()
+    if (
+        payoff_family == "vanilla_option"
+        and characteristic_spec.model_family == "equity_diffusion"
+    ):
+        return "single_state_diffusion_transform_inputs"
+    if characteristic_spec.model_family == "stochastic_volatility":
+        return "stochastic_vol_transform_inputs"
+    return "compiled_transform_inputs"
 
 
 def _build_event_aware_monte_carlo_ir(

--- a/trellis/agent/knowledge/canonical/routes.yaml
+++ b/trellis/agent/knowledge/canonical/routes.yaml
@@ -988,13 +988,14 @@ routes:
     match:
       methods: [fft_pricing]
     admissibility:
-      control_styles: [identity, holder_max]
+      control_styles: [identity]
       event_support: none
       phase_sensitivity: default_phase_order_only
       multicurrency_support: single_currency_only
       supported_outputs: [price, scenario_pnl]
       supports_sensitivity_outputs: true
-      supported_state_tags: [terminal_markov, recombining_safe]
+      supported_state_tags: [terminal_markov]
+      supported_characteristic_families: [gbm_log_spot, heston_log_spot]
       supports_calibration: false
     conditional_primitives:
       - when:

--- a/trellis/agent/lane_obligations.py
+++ b/trellis/agent/lane_obligations.py
@@ -13,6 +13,7 @@ from trellis.agent.family_lowering_ir import (
     EventAwarePDEIR,
     ExerciseLatticeIR,
     NthToDefaultIR,
+    TransformPricingIR,
     VanillaEquityPDEIR,
 )
 from trellis.agent.knowledge.methods import normalize_method
@@ -289,6 +290,15 @@ def _state_obligations_for(family_ir) -> tuple[str, ...]:
                 *(f"semantic_event_kind:{kind}" for kind in getattr(getattr(family_ir, "event_program", None), "event_kinds", ()) or ()),
             )
         )
+    if isinstance(family_ir, TransformPricingIR):
+        return _tuple_unique(
+            (
+                family_ir.state_spec.state_variable,
+                *(family_ir.state_spec.state_tags or ()),
+                family_ir.characteristic_spec.characteristic_family,
+                family_ir.terminal_payoff_kind,
+            )
+        )
     if isinstance(family_ir, ExerciseLatticeIR):
         return _tuple_unique(
             (
@@ -367,6 +377,24 @@ def _control_obligations_for(family_ir) -> tuple[str, ...]:
                 *(f"event_transform:{kind}" for kind in family_ir.event_transform_kinds),
             )
         )
+    if isinstance(family_ir, TransformPricingIR):
+        semantic_control = getattr(family_ir, "control_program", None)
+        return _tuple_unique(
+            (
+                f"control_style:{family_ir.control_spec.control_style}",
+                f"controller_role:{family_ir.control_spec.controller_role}",
+                f"quote_semantics:{family_ir.quote_semantics}",
+                f"strike_semantics:{family_ir.strike_semantics}",
+                *(
+                    (
+                        f"semantic_control_style:{semantic_control.control_style}",
+                        f"semantic_controller_role:{semantic_control.controller_role}",
+                    )
+                    if semantic_control is not None
+                    else ()
+                ),
+            )
+        )
     if isinstance(family_ir, ExerciseLatticeIR):
         return _tuple_unique(
             (
@@ -436,6 +464,17 @@ def _construction_steps_for(*, lane_family: str, family_ir) -> tuple[str, ...]:
             f"Assemble a one-dimensional `{operator_family}` rollback state over `{family_ir.state_spec.state_variable or 'state'}`.",
             f"Apply `{terminal_kind}` at maturity and schedule the typed event transforms: {', '.join(family_ir.event_transform_kinds) or 'none'}.",
             f"Enforce `{control_style}` control semantics during backward stepping before reading out the price.",
+        )
+    if isinstance(family_ir, TransformPricingIR):
+        characteristic_family = (
+            family_ir.characteristic_spec.characteristic_family or "generic_transform_characteristic"
+        )
+        backend_capability = family_ir.characteristic_spec.backend_capability or "raw_kernel_only"
+        binding_target = family_ir.helper_symbol or "raw FFT/COS kernels"
+        return (
+            f"Assemble a terminal-only transform contract over `{family_ir.state_spec.state_variable or 'state'}` with `{characteristic_family}`.",
+            f"Normalize the payoff to `{family_ir.terminal_payoff_kind}` with `{family_ir.quote_semantics}` inputs before transform evaluation.",
+            f"Dispatch through `{binding_target}` according to backend capability `{backend_capability}` instead of widening semantic admissibility.",
         )
     if isinstance(family_ir, ExerciseLatticeIR):
         return (

--- a/trellis/agent/platform_traces.py
+++ b/trellis/agent/platform_traces.py
@@ -642,6 +642,7 @@ def _family_ir_trace_summary(family_ir_payload: dict[str, Any]) -> dict[str, Any
         return {}
 
     state_spec = dict(family_ir_payload.get("state_spec") or {})
+    characteristic_spec = dict(family_ir_payload.get("characteristic_spec") or {})
     process_spec = dict(family_ir_payload.get("process_spec") or {})
     operator_spec = dict(family_ir_payload.get("operator_spec") or {})
     control_spec = dict(family_ir_payload.get("control_spec") or {})
@@ -701,6 +702,10 @@ def _family_ir_trace_summary(family_ir_payload: dict[str, Any]) -> dict[str, Any
         "state_variable": state_spec.get("state_variable"),
         "dimension": state_spec.get("dimension"),
         "state_tags": list(state_spec.get("state_tags") or ()),
+        "model_family": characteristic_spec.get("model_family"),
+        "characteristic_family": characteristic_spec.get("characteristic_family"),
+        "supported_transform_methods": list(characteristic_spec.get("supported_methods") or ()),
+        "transform_backend_capability": characteristic_spec.get("backend_capability"),
         "process_family": process_spec.get("process_family"),
         "simulation_scheme": process_spec.get("simulation_scheme"),
         "operator_family": operator_spec.get("operator_family"),
@@ -713,6 +718,9 @@ def _family_ir_trace_summary(family_ir_payload: dict[str, Any]) -> dict[str, Any
         "semantic_schedule_role": control_program.get("schedule_role"),
         "path_requirement_kind": path_requirement_spec.get("requirement_kind"),
         "reducer_kind": payoff_reducer_spec.get("reducer_kind"),
+        "terminal_payoff_kind": family_ir_payload.get("terminal_payoff_kind"),
+        "strike_semantics": family_ir_payload.get("strike_semantics"),
+        "quote_semantics": family_ir_payload.get("quote_semantics"),
         "event_kinds": event_kinds,
         "semantic_event_kinds": semantic_event_kinds,
         "terminal_condition_kind": boundary_spec.get("terminal_condition_kind"),
@@ -721,12 +729,21 @@ def _family_ir_trace_summary(family_ir_payload: dict[str, Any]) -> dict[str, Any
         "event_dates": event_dates,
         "semantic_event_dates": semantic_event_dates,
         "helper_symbol": family_ir_payload.get("helper_symbol"),
+        "market_mapping": family_ir_payload.get("market_mapping"),
         "compatibility_wrapper": compatibility_wrapper or None,
         "compatibility_status": (
-            "transitional_wrapper" if compatibility_wrapper else "native_event_aware"
+            "transitional_wrapper"
+            if compatibility_wrapper
+            else "native_transform_family_ir"
+            if characteristic_spec
+            else "native_event_aware"
         ),
         "end_state": (
-            "migrate_to_plain_EventAwarePDEIR" if compatibility_wrapper else "native_event_aware"
+            "migrate_to_plain_EventAwarePDEIR"
+            if compatibility_wrapper
+            else "native_transform_family_ir"
+            if characteristic_spec
+            else "native_event_aware"
         ),
     }
     return summary

--- a/trellis/agent/route_registry.py
+++ b/trellis/agent/route_registry.py
@@ -23,7 +23,11 @@ from typing import Any
 import yaml
 
 from trellis.agent.codegen_guardrails import PrimitiveRef
-from trellis.agent.family_lowering_ir import EventAwareMonteCarloIR, EventAwarePDEIR
+from trellis.agent.family_lowering_ir import (
+    EventAwareMonteCarloIR,
+    EventAwarePDEIR,
+    TransformPricingIR,
+)
 from trellis.agent.knowledge.import_registry import (
     get_repo_revision,
     is_valid_import,
@@ -96,6 +100,7 @@ class RouteAdmissibilitySpec:
     supported_process_families: tuple[str, ...] = ()
     supported_path_requirement_kinds: tuple[str, ...] = ()
     supported_operator_families: tuple[str, ...] = ()
+    supported_characteristic_families: tuple[str, ...] = ()
     supported_event_transform_kinds: tuple[str, ...] = ()
     supports_calibration: bool = False
 
@@ -314,6 +319,7 @@ def _default_admissibility_for_route(route_id: str, engine_family: str) -> Route
             supported_process_families=(),
             supported_path_requirement_kinds=(),
             supported_operator_families=(),
+            supported_characteristic_families=(),
             supported_event_transform_kinds=(),
             supports_calibration=False,
         ),
@@ -328,6 +334,7 @@ def _default_admissibility_for_route(route_id: str, engine_family: str) -> Route
             supported_process_families=(),
             supported_path_requirement_kinds=(),
             supported_operator_families=("black_scholes_1d",),
+            supported_characteristic_families=(),
             supported_event_transform_kinds=(),
             supports_calibration=False,
         ),
@@ -342,6 +349,7 @@ def _default_admissibility_for_route(route_id: str, engine_family: str) -> Route
             supported_process_families=(),
             supported_path_requirement_kinds=(),
             supported_operator_families=(),
+            supported_characteristic_families=(),
             supported_event_transform_kinds=(),
             supports_calibration=True,
         ),
@@ -363,6 +371,7 @@ def _default_admissibility_for_route(route_id: str, engine_family: str) -> Route
             supported_process_families=(),
             supported_path_requirement_kinds=("terminal_only", "full_path", "event_snapshots", "event_replay", "reducer_state"),
             supported_operator_families=(),
+            supported_characteristic_families=(),
             supported_event_transform_kinds=(),
             supports_calibration=False,
         ),
@@ -377,6 +386,7 @@ def _default_admissibility_for_route(route_id: str, engine_family: str) -> Route
             supported_process_families=(),
             supported_path_requirement_kinds=(),
             supported_operator_families=(),
+            supported_characteristic_families=(),
             supported_event_transform_kinds=(),
             supports_calibration=False,
         ),
@@ -391,6 +401,7 @@ def _default_admissibility_for_route(route_id: str, engine_family: str) -> Route
             supported_process_families=(),
             supported_path_requirement_kinds=("terminal_only", "full_path", "event_snapshots", "event_replay", "reducer_state"),
             supported_operator_families=(),
+            supported_characteristic_families=(),
             supported_event_transform_kinds=(),
             supports_calibration=False,
         ),
@@ -405,6 +416,7 @@ def _default_admissibility_for_route(route_id: str, engine_family: str) -> Route
             supported_process_families=(),
             supported_path_requirement_kinds=(),
             supported_operator_families=(),
+            supported_characteristic_families=("gbm_log_spot", "heston_log_spot"),
             supported_event_transform_kinds=(),
             supports_calibration=False,
         ),
@@ -419,6 +431,7 @@ def _default_admissibility_for_route(route_id: str, engine_family: str) -> Route
             supported_process_families=(),
             supported_path_requirement_kinds=(),
             supported_operator_families=(),
+            supported_characteristic_families=(),
             supported_event_transform_kinds=(),
             supports_calibration=False,
         ),
@@ -433,6 +446,7 @@ def _default_admissibility_for_route(route_id: str, engine_family: str) -> Route
             supported_process_families=(),
             supported_path_requirement_kinds=(),
             supported_operator_families=(),
+            supported_characteristic_families=(),
             supported_event_transform_kinds=(),
             supports_calibration=False,
         ),
@@ -450,6 +464,7 @@ def _default_admissibility_for_route(route_id: str, engine_family: str) -> Route
             supported_process_families=spec.supported_process_families,
             supported_path_requirement_kinds=spec.supported_path_requirement_kinds,
             supported_operator_families=spec.supported_operator_families,
+            supported_characteristic_families=spec.supported_characteristic_families,
             supported_event_transform_kinds=spec.supported_event_transform_kinds,
             supports_calibration=spec.supports_calibration,
         )
@@ -472,6 +487,7 @@ def _parse_admissibility(raw: dict | None, *, route_id: str, engine_family: str)
         supported_process_families=_str_tuple(raw.get("supported_process_families")) or default.supported_process_families,
         supported_path_requirement_kinds=_str_tuple(raw.get("supported_path_requirement_kinds")) or default.supported_path_requirement_kinds,
         supported_operator_families=_str_tuple(raw.get("supported_operator_families")) or default.supported_operator_families,
+        supported_characteristic_families=_str_tuple(raw.get("supported_characteristic_families")) or default.supported_characteristic_families,
         supported_event_transform_kinds=_str_tuple(raw.get("supported_event_transform_kinds")) or default.supported_event_transform_kinds,
         supports_calibration=bool(raw.get("supports_calibration", default.supports_calibration)),
     )
@@ -1093,6 +1109,7 @@ def route_binding_authority_summary(
                 "supported_process_families": list(backend_binding.admissibility.supported_process_families),
                 "supported_path_requirement_kinds": list(backend_binding.admissibility.supported_path_requirement_kinds),
                 "supported_operator_families": list(backend_binding.admissibility.supported_operator_families),
+                "supported_characteristic_families": list(backend_binding.admissibility.supported_characteristic_families),
                 "supported_event_transform_kinds": list(backend_binding.admissibility.supported_event_transform_kinds),
                 "supports_calibration": backend_binding.admissibility.supports_calibration,
             },
@@ -1289,7 +1306,7 @@ def evaluate_route_admissibility(
     failures: list[str] = []
 
     control_style = str(getattr(getattr(product, "controller_protocol", None), "controller_style", "identity")).strip() or "identity"
-    if isinstance(family_ir, (EventAwarePDEIR, EventAwareMonteCarloIR)):
+    if isinstance(family_ir, (EventAwarePDEIR, EventAwareMonteCarloIR, TransformPricingIR)):
         lowered_control_style = str(
             getattr(getattr(family_ir, "control_spec", None), "control_style", "") or ""
         ).strip()
@@ -1349,6 +1366,12 @@ def evaluate_route_admissibility(
                 for tag in getattr(getattr(family_ir, "state_spec", None), "state_tags", ()) or ()
                 if str(tag).strip()
             }
+        elif isinstance(family_ir, TransformPricingIR):
+            state_tags = {
+                str(tag)
+                for tag in getattr(getattr(family_ir, "state_spec", None), "state_tags", ()) or ()
+                if str(tag).strip()
+            }
         elif isinstance(family_ir, EventAwareMonteCarloIR):
             state_tags = {
                 str(tag)
@@ -1382,6 +1405,17 @@ def evaluate_route_admissibility(
             for kind in family_ir.event_transform_kinds:
                 if kind not in supported_transforms:
                     failures.append(f"unsupported_event_transform_kind:{kind}")
+    if isinstance(family_ir, TransformPricingIR):
+        supported_characteristics = set(admissibility.supported_characteristic_families)
+        characteristic_family = str(
+            getattr(getattr(family_ir, "characteristic_spec", None), "characteristic_family", "")
+        ).strip()
+        if (
+            supported_characteristics
+            and characteristic_family
+            and characteristic_family not in supported_characteristics
+        ):
+            failures.append(f"unsupported_characteristic_family:{characteristic_family}")
     if isinstance(family_ir, EventAwareMonteCarloIR):
         supported_processes = set(admissibility.supported_process_families)
         process_family = str(getattr(getattr(family_ir, "process_spec", None), "process_family", "")).strip()


### PR DESCRIPTION
## Summary
- add a dedicated `TransformPricingIR` family surface and lower transform-compatible claims into it
- make transform admissibility family-first and split backend binding between helper-backed diffusion and raw-kernel stochastic-volatility routes
- recover `T39`/`T40` with a deterministic Black-Scholes comparator wrapper and document the new transform-family contract

## Testing
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_family_lowering_ir.py tests/test_agent/test_dsl_lowering.py tests/test_agent/test_route_registry.py tests/test_agent/test_lane_obligations.py tests/test_agent/test_platform_traces.py tests/test_agent/test_executor.py tests/test_models/test_transforms/test_single_state_diffusion.py tests/test_models/test_transforms/test_equity_option_transforms.py -q`
- `/Users/steveyang/miniforge3/bin/python3 scripts/run_canary.py --task T39 --model gpt-5.4-mini --output task_results_t39_qua771.json`
- `/Users/steveyang/miniforge3/bin/python3 scripts/run_canary.py --task T40 --model gpt-5.4-mini --output task_results_t40_qua771.json`
