### PR TITLE
[codex] Sync QUA-747 status and clear stale active snapshots

### DIFF
--- a/docs/developer/hosting_and_configuration.rst
+++ b/docs/developer/hosting_and_configuration.rst
@@ -137,6 +137,10 @@ container:
   current session binding slots
 - ``trellis.providers.configure`` persists explicit provider bindings and
   rejects unknown provider ids or production-incompatible mock bindings
+- rebinding ``market_data`` through ``trellis.providers.configure`` clears any
+  active imported market snapshot metadata on that session so later pricing
+  runs cannot mix a new ``provider_id`` with a stale imported
+  ``market_snapshot_id``
 - ``trellis.model.generate_candidate`` persists a governed draft candidate plus
   canonical contract, methodology, lineage, validation-plan, and optional code
   sidecars

--- a/docs/plans/semantic-contract-registry-and-short-rate-claim-generalization.md
+++ b/docs/plans/semantic-contract-registry-and-short-rate-claim-generalization.md
@@ -178,9 +178,9 @@ short-rate follow-on:
 | Issue | Title | Status |
 | --- | --- | --- |
 | `QUA-746` | Semantic comparison regimes: short-rate market objects and claim helper generalization | Backlog |
-| `QUA-747` | Task runtime: typed short-rate comparison regime objects | Backlog |
-| `QUA-748` | Helper layers: shared short-rate regime resolver and discount-bond claim kit | Backlog |
-| `QUA-749` | Short-rate wrappers: migrate ZCB analytical and tree helpers onto shared claim kits | Backlog |
+| `QUA-747` | Task runtime: typed short-rate comparison regime objects | Done |
+| `QUA-748` | Helper layers: shared short-rate regime resolver and discount-bond claim kit | Done |
+| `QUA-749` | Short-rate wrappers: migrate ZCB analytical and tree helpers onto shared claim kits | Done |
 | `QUA-751` | Validation and exact binding: recover T01 on typed short-rate regimes | Backlog |
 
 ### New umbrella

--- a/docs/plans/trellis-mcp-implementation.md
+++ b/docs/plans/trellis-mcp-implementation.md
@@ -62,7 +62,7 @@ Rules for coding agents:
 - Keep the first `price.trade` milestone narrow: approved-model-only governed
   execution. Do not widen it to candidate generation in the MVP slice.
 
-Status mirror last synced: `2026-04-04`
+Status mirror last synced: `2026-04-10`
 
 ### MCP Workstream Tickets
 
@@ -96,6 +96,7 @@ Status mirror last synced: `2026-04-04`
 | `QUA-587` MCP model lifecycle: require per-version validation evidence and preserve version audit artifacts | Done |
 | `QUA-588` MCP transport: local streamable HTTP server for Codex and Claude Code | Done |
 | `QUA-622` MCP local demo mode: sandbox mock prompt-flow bootstrap | Done |
+| `QUA-683` Session context: clear active snapshot when market-data bindings change | Done |
 
 ## Preconditions
 

--- a/tests/test_mcp/test_price_trade_tool.py
+++ b/tests/test_mcp/test_price_trade_tool.py
@@ -758,6 +758,61 @@ def test_price_trade_uses_activated_imported_snapshot(tmp_path):
     assert snapshot_payload["snapshot"]["payload"]["manifest"]["as_of"] == "2026-04-04"
 
 
+def test_price_trade_rebinding_market_data_clears_active_imported_snapshot(tmp_path):
+    from trellis.mcp.server import bootstrap_mcp_server
+
+    server = bootstrap_mcp_server(
+        state_root=tmp_path / "mcp_state",
+        provider_registry=_provider_registry(),
+    )
+    _seed_model(server.services.model_registry, approved=True)
+
+    imported = server.call_tool(
+        "trellis.snapshot.import_files",
+        {
+            "session_id": "sess_price_rebind_snapshot",
+            "manifest_path": _file_import_manifest(tmp_path),
+            "activate_session": True,
+            "reference_date": "2026-04-04",
+        },
+    )
+
+    configured = server.call_tool(
+        "trellis.providers.configure",
+        {
+            "session_id": "sess_price_rebind_snapshot",
+            "provider_bindings": {
+                "market_data": {
+                    "primary": {"provider_id": "market_data.test_live"},
+                }
+            },
+        },
+    )
+
+    assert configured["session"]["provider_bindings"]["market_data"]["primary"]["provider_id"] == "market_data.test_live"
+    assert "active_market_snapshot_id" not in configured["session"]["metadata"]
+    assert "active_market_snapshot_provider_id" not in configured["session"]["metadata"]
+
+    payload = server.call_tool(
+        "trellis.price.trade",
+        {
+            "session_id": "sess_price_rebind_snapshot",
+            "structured_trade": _trade_payload(),
+            "output_mode": "structured",
+            "valuation_date": "2026-04-04",
+        },
+    )
+
+    assert payload["status"] == "succeeded"
+    assert payload["provenance"]["provider_id"] == "market_data.test_live"
+    assert payload["provenance"]["market_snapshot_id"] != imported["snapshot"]["snapshot_id"]
+
+    run_payload = server.call_tool("trellis.run.get", {"run_id": payload["run_id"]})
+
+    assert run_payload["run"]["provenance"]["provider_id"] == "market_data.test_live"
+    assert run_payload["run"]["market_snapshot_id"] != imported["snapshot"]["snapshot_id"]
+
+
 def test_price_trade_can_use_later_settlement_with_fixed_imported_market_data(tmp_path):
     from trellis.mcp.server import bootstrap_mcp_server
 

--- a/tests/test_platform/test_session_service.py
+++ b/tests/test_platform/test_session_service.py
@@ -98,3 +98,58 @@ def test_provider_reconfigure_clears_active_imported_snapshot_metadata(tmp_path)
     persisted = services.session_service.ensure_record("sess_rebind_snapshot")
     assert "active_market_snapshot_id" not in persisted.metadata
     assert "active_market_snapshot_provider_id" not in persisted.metadata
+
+
+def test_provider_reconfigure_keeps_active_snapshot_for_metadata_only_binding_change(tmp_path):
+    from trellis.platform.services import bootstrap_platform_services
+    from trellis.platform.storage import SnapshotRecord
+
+    services = bootstrap_platform_services(state_root=tmp_path / "state")
+    services.snapshot_store.save_snapshot(
+        SnapshotRecord(
+            snapshot_id="snapshot_import_003",
+            provider_id="market_data.file_import",
+            as_of="2026-04-04",
+            source="file_import",
+            payload={"bundle_type": "file_import_bundle"},
+            provenance={"provider_id": "market_data.file_import"},
+        )
+    )
+    services.session_service.activate_market_snapshot(
+        session_id="sess_rebind_snapshot_metadata",
+        snapshot_id="snapshot_import_003",
+    )
+
+    payload = services.provider_service.configure(
+        session_id="sess_rebind_snapshot_metadata",
+        provider_bindings={
+            "market_data": {
+                "primary": {
+                    "provider_id": "market_data.file_import",
+                    "label": "Desk Upload",
+                    "metadata": {"origin": "ops_refresh"},
+                },
+            }
+        },
+    )
+
+    assert (
+        payload["session"]["provider_bindings"]["market_data"]["primary"]["provider_id"]
+        == "market_data.file_import"
+    )
+    assert (
+        payload["session"]["provider_bindings"]["market_data"]["primary"]["label"]
+        == "Desk Upload"
+    )
+    assert payload["session"]["metadata"]["active_market_snapshot_id"] == "snapshot_import_003"
+    assert (
+        payload["session"]["metadata"]["active_market_snapshot_provider_id"]
+        == "market_data.file_import"
+    )
+
+    persisted = services.session_service.ensure_record("sess_rebind_snapshot_metadata")
+    assert persisted.metadata["active_market_snapshot_id"] == "snapshot_import_003"
+    assert (
+        persisted.metadata["active_market_snapshot_provider_id"]
+        == "market_data.file_import"
+    )

--- a/tests/test_platform/test_session_service.py
+++ b/tests/test_platform/test_session_service.py
@@ -57,3 +57,44 @@ def test_activate_market_snapshot_uses_persisted_snapshot_provider_binding(tmp_p
         persisted.provider_bindings.market_data.primary.provider_id
         == "market_data.file_import"
     )
+
+
+def test_provider_reconfigure_clears_active_imported_snapshot_metadata(tmp_path):
+    from trellis.platform.services import bootstrap_platform_services
+    from trellis.platform.storage import SnapshotRecord
+
+    services = bootstrap_platform_services(state_root=tmp_path / "state")
+    services.snapshot_store.save_snapshot(
+        SnapshotRecord(
+            snapshot_id="snapshot_import_002",
+            provider_id="market_data.file_import",
+            as_of="2026-04-04",
+            source="file_import",
+            payload={"bundle_type": "file_import_bundle"},
+            provenance={"provider_id": "market_data.file_import"},
+        )
+    )
+    services.session_service.activate_market_snapshot(
+        session_id="sess_rebind_snapshot",
+        snapshot_id="snapshot_import_002",
+    )
+
+    payload = services.provider_service.configure(
+        session_id="sess_rebind_snapshot",
+        provider_bindings={
+            "market_data": {
+                "primary": {"provider_id": "market_data.treasury_gov"},
+            }
+        },
+    )
+
+    assert (
+        payload["session"]["provider_bindings"]["market_data"]["primary"]["provider_id"]
+        == "market_data.treasury_gov"
+    )
+    assert "active_market_snapshot_id" not in payload["session"]["metadata"]
+    assert "active_market_snapshot_provider_id" not in payload["session"]["metadata"]
+
+    persisted = services.session_service.ensure_record("sess_rebind_snapshot")
+    assert "active_market_snapshot_id" not in persisted.metadata
+    assert "active_market_snapshot_provider_id" not in persisted.metadata

--- a/trellis/platform/services/provider_service.py
+++ b/trellis/platform/services/provider_service.py
@@ -65,7 +65,9 @@ class ProviderService:
             )
 
         metadata = dict(record.metadata)
-        if bindings.market_data != record.provider_bindings.market_data:
+        if self._market_data_provider_ids(bindings) != self._market_data_provider_ids(
+            record.provider_bindings
+        ):
             metadata.pop("active_market_snapshot_id", None)
             metadata.pop("active_market_snapshot_provider_id", None)
 
@@ -114,13 +116,15 @@ class ProviderService:
 
     @staticmethod
     def _uses_mock_market_data(bindings: ProviderBindings) -> bool:
-        binding_set = bindings.market_data
-        provider_ids = [
-            binding.provider_id
-            for binding in (binding_set.primary, binding_set.fallback)
-            if binding is not None and binding.provider_id
-        ]
+        provider_ids = [provider_id for provider_id in ProviderService._market_data_provider_ids(bindings) if provider_id]
         return any(".mock" in provider_id or provider_id.endswith("_mock") for provider_id in provider_ids)
+
+    @staticmethod
+    def _market_data_provider_ids(bindings: ProviderBindings) -> tuple[str, str]:
+        binding_set = bindings.market_data
+        primary = "" if binding_set.primary is None else str(binding_set.primary.provider_id).strip()
+        fallback = "" if binding_set.fallback is None else str(binding_set.fallback.provider_id).strip()
+        return primary, fallback
 
     @staticmethod
     def _bound_slots(bindings: ProviderBindings) -> dict[str, list[str]]:

--- a/trellis/platform/services/provider_service.py
+++ b/trellis/platform/services/provider_service.py
@@ -64,6 +64,11 @@ class ProviderService:
                 details={"session_id": record.session_id},
             )
 
+        metadata = dict(record.metadata)
+        if bindings.market_data != record.provider_bindings.market_data:
+            metadata.pop("active_market_snapshot_id", None)
+            metadata.pop("active_market_snapshot_provider_id", None)
+
         persisted = self.session_service.save(
             replace(
                 record,
@@ -71,6 +76,7 @@ class ProviderService:
                 connected_providers=tuple(
                     provider.provider_id for provider in self.provider_registry.list_providers()
                 ),
+                metadata=metadata,
             )
         )
         return self.session_service.get_context(persisted.session_id)


### PR DESCRIPTION
## Summary
- sync the local short-rate semantic plan mirror with the already-landed `QUA-747` / `QUA-748` / `QUA-749` Linear state
- clear active imported snapshot metadata when `trellis.providers.configure` changes the session `market_data` binding
- add regression coverage for both session/provider rebinding and governed `trellis.price.trade` provenance
- document the new operator contract for market-data rebinding in the developer hosting/configuration guide

## Why
`QUA-747` was already implemented on `main`, but the repo-local semantic plan mirror was stale. Separately, `QUA-683` exposed a governed runtime bug: rebinding market data left `active_market_snapshot_id` in session metadata, so pricing could keep using an old imported snapshot while reporting the new bound `provider_id` in run provenance.

## Impact
After this change, switching a session from an imported snapshot back to a live provider invalidates the old active snapshot automatically. That keeps persisted runs internally consistent and prevents `provider_id` / `market_snapshot_id` provenance mismatches caused by stale session metadata.

## Validation
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_platform/test_session_service.py -q`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_mcp/test_session_tools.py -q`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_platform/test_provider_registry.py -q`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_mcp/test_price_trade_tool.py -q`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_models/test_resolution.py tests/test_models/test_zcb_option_helpers.py -q`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_task_runtime.py -q -k short_rate_comparison_regime`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_tasks/test_t01_zcb_option.py -q`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/ -x -q -m "not integration"`
