### PR TITLE
QUA-458: add full-task canary replay cassettes

### DIFF
--- a/cassettes/full_task/T13.yaml
+++ b/cassettes/full_task/T13.yaml
@@ -1,0 +1,1137 @@
+meta:
+  recorded_at: '2026-04-10T15:37:09.749483+00:00'
+  provider: openai
+  model: gpt-5.4-mini
+  total_calls: 4
+  name: T13
+calls:
+- seq: 0
+  function: llm_generate
+  stage: code_generation
+  prompt_hash: 869f7788cd5c3e36e463581a65cf54262ef7eb52bb9b95d0cc2731f49b734952
+  response_text: "from __future__ import annotations\n\nfrom dataclasses import dataclass\n\
+    from datetime import date\n\nfrom trellis.core.market_state import MarketState\n\
+    from trellis.core.types import DayCountConvention\nfrom trellis.models.equity_option_pde\
+    \ import price_vanilla_equity_option_pde\n\n\n\n@dataclass(frozen=True)\nclass\
+    \ EuropeanOptionSpec:\n    \"\"\"Specification for Build a pricer for: European\
+    \ call: theta-method convergence order measurement\n\nEuropean call option on\
+    \ a non-dividend-paying stock.\nS0=100, K=105, T=1Y, risk-free rate r=5%, volatility\
+    \ sigma=20%.\nSolve with the Black-Scholes PDE operator using Crank-Nicolson\n\
+    (theta=0.5) and fully implicit (theta=1.0) on a 200-point spot grid\n× 100 time\
+    \ steps.\nMeasure convergence order by doubling the grid: the CN scheme should\n\
+    show O(dt^2 + dS^2) convergence and the implicit scheme O(dt + dS^2).\nCompare\
+    \ both to the Black-Scholes analytical price.\n\nConstruct methods: pde_solver\n\
+    Comparison targets: theta_0.5 (pde_solver), theta_1.0 (pde_solver), black_scholes\
+    \ (analytical)\nCross-validation harness:\n  internal targets: theta_0.5, theta_1.0\n\
+    \  analytical benchmark: black_scholes\n  external targets: quantlib\nNew component:\
+    \ convergence_order_diagnostic\n\nImplementation target: theta_0.5\nPreferred\
+    \ method family: pde_solver\n\nImplementation target: theta_0.5.\"\"\"\n    notional:\
+    \ float\n    spot: float\n    strike: float\n    expiry_date: date\n    option_type:\
+    \ str = \"'call'\"\n    day_count: DayCountConvention = DayCountConvention.ACT_365\n\
+    \n\nclass EuropeanOptionAnalyticalPayoff:\n    \"\"\"Build a pricer for: European\
+    \ call: theta-method convergence order measurement\n\nEuropean call option on\
+    \ a non-dividend-paying stock.\nS0=100, K=105, T=1Y, risk-free rate r=5%, volatility\
+    \ sigma=20%.\nSolve with the Black-Scholes PDE operator using Crank-Nicolson\n\
+    (theta=0.5) and fully implicit (theta=1.0) on a 200-point spot grid\n× 100 time\
+    \ steps.\nMeasure convergence order by doubling the grid: the CN scheme should\n\
+    show O(dt^2 + dS^2) convergence and the implicit scheme O(dt + dS^2).\nCompare\
+    \ both to the Black-Scholes analytical price.\n\nConstruct methods: pde_solver\n\
+    Comparison targets: theta_0.5 (pde_solver), theta_1.0 (pde_solver), black_scholes\
+    \ (analytical)\nCross-validation harness:\n  internal targets: theta_0.5, theta_1.0\n\
+    \  analytical benchmark: black_scholes\n  external targets: quantlib\nNew component:\
+    \ convergence_order_diagnostic\n\nImplementation target: theta_0.5\nPreferred\
+    \ method family: pde_solver\n\nImplementation target: theta_0.5.\"\"\"\n\n   \
+    \ def __init__(self, spec: EuropeanOptionSpec):\n        self._spec = spec\n\n\
+    \    @property\n    def spec(self) -> EuropeanOptionSpec:\n        return self._spec\n\
+    \n    @property\n    def requirements(self) -> set[str]:\n        return {\"black_vol_surface\"\
+    , \"discount_curve\"}\n\n    def evaluate(self, market_state: MarketState) ->\
+    \ float:\n        spec = self._spec\n        theta = 0.5\n        option_type\
+    \ = str(spec.option_type).strip(\"'\\\"\").lower()\n        if option_type not\
+    \ in {\"call\", \"put\"}:\n            raise ValueError(f\"Unsupported option_type:\
+    \ {spec.option_type!r}\")\n        try:\n            return float(\n         \
+    \       price_vanilla_equity_option_pde(\n                    market_state,\n\
+    \                    spec,\n                    theta=theta,\n               \
+    \ )\n            )\n        except TypeError:\n            class _AdapterSpec:\n\
+    \                def __init__(self, src):\n                    self.notional =\
+    \ src.notional\n                    self.spot = src.spot\n                   \
+    \ self.strike = src.strike\n                    self.expiry_date = src.expiry_date\n\
+    \                    self.option_type = option_type\n                    self.day_count\
+    \ = src.day_count\n\n            return float(\n                price_vanilla_equity_option_pde(\n\
+    \                    market_state,\n                    _AdapterSpec(spec),\n\
+    \                    theta=theta,\n                )\n            )"
+  prompt_text: "You are implementing the evaluate() method for `EuropeanOptionAnalyticalPayoff`\
+    \ in the Trellis pricing library.\n\n## Complete module (skeleton — everything\
+    \ is fixed except evaluate)\n```python\n\"\"\"Agent-generated payoff: Build a\
+    \ pricer for: European call: theta-method convergence order measurement\n\nEuropean\
+    \ call option on a non-dividend-paying stock.\nS0=100, K=105, T=1Y, risk-free\
+    \ rate r=5%, volatility sigma=20%.\nSolve with the Black-Scholes PDE operator\
+    \ using Crank-Nicolson\n(theta=0.5) and fully implicit (theta=1.0) on a 200-point\
+    \ spot grid\n× 100 time steps.\nMeasure convergence order by doubling the grid:\
+    \ the CN scheme should\nshow O(dt^2 + dS^2) convergence and the implicit scheme\
+    \ O(dt + dS^2).\nCompare both to the Black-Scholes analytical price.\n\nConstruct\
+    \ methods: pde_solver\nComparison targets: theta_0.5 (pde_solver), theta_1.0 (pde_solver),\
+    \ black_scholes (analytical)\nCross-validation harness:\n  internal targets: theta_0.5,\
+    \ theta_1.0\n  analytical benchmark: black_scholes\n  external targets: quantlib\n\
+    New component: convergence_order_diagnostic\n\nImplementation target: theta_0.5\n\
+    Preferred method family: pde_solver\n\nImplementation target: theta_0.5.\"\"\"\
+    \n\nfrom __future__ import annotations\n\nfrom dataclasses import dataclass\n\
+    from datetime import date\n\nfrom trellis.core.market_state import MarketState\n\
+    from trellis.core.types import DayCountConvention\nfrom trellis.models.equity_option_pde\
+    \ import price_vanilla_equity_option_pde\n\n\n\n@dataclass(frozen=True)\nclass\
+    \ EuropeanOptionSpec:\n    \"\"\"Specification for Build a pricer for: European\
+    \ call: theta-method convergence order measurement\n\nEuropean call option on\
+    \ a non-dividend-paying stock.\nS0=100, K=105, T=1Y, risk-free rate r=5%, volatility\
+    \ sigma=20%.\nSolve with the Black-Scholes PDE operator using Crank-Nicolson\n\
+    (theta=0.5) and fully implicit (theta=1.0) on a 200-point spot grid\n× 100 time\
+    \ steps.\nMeasure convergence order by doubling the grid: the CN scheme should\n\
+    show O(dt^2 + dS^2) convergence and the implicit scheme O(dt + dS^2).\nCompare\
+    \ both to the Black-Scholes analytical price.\n\nConstruct methods: pde_solver\n\
+    Comparison targets: theta_0.5 (pde_solver), theta_1.0 (pde_solver), black_scholes\
+    \ (analytical)\nCross-validation harness:\n  internal targets: theta_0.5, theta_1.0\n\
+    \  analytical benchmark: black_scholes\n  external targets: quantlib\nNew component:\
+    \ convergence_order_diagnostic\n\nImplementation target: theta_0.5\nPreferred\
+    \ method family: pde_solver\n\nImplementation target: theta_0.5.\"\"\"\n    notional:\
+    \ float\n    spot: float\n    strike: float\n    expiry_date: date\n    option_type:\
+    \ str = \"'call'\"\n    day_count: DayCountConvention = DayCountConvention.ACT_365\n\
+    \n\nclass EuropeanOptionAnalyticalPayoff:\n    \"\"\"Build a pricer for: European\
+    \ call: theta-method convergence order measurement\n\nEuropean call option on\
+    \ a non-dividend-paying stock.\nS0=100, K=105, T=1Y, risk-free rate r=5%, volatility\
+    \ sigma=20%.\nSolve with the Black-Scholes PDE operator using Crank-Nicolson\n\
+    (theta=0.5) and fully implicit (theta=1.0) on a 200-point spot grid\n× 100 time\
+    \ steps.\nMeasure convergence order by doubling the grid: the CN scheme should\n\
+    show O(dt^2 + dS^2) convergence and the implicit scheme O(dt + dS^2).\nCompare\
+    \ both to the Black-Scholes analytical price.\n\nConstruct methods: pde_solver\n\
+    Comparison targets: theta_0.5 (pde_solver), theta_1.0 (pde_solver), black_scholes\
+    \ (analytical)\nCross-validation harness:\n  internal targets: theta_0.5, theta_1.0\n\
+    \  analytical benchmark: black_scholes\n  external targets: quantlib\nNew component:\
+    \ convergence_order_diagnostic\n\nImplementation target: theta_0.5\nPreferred\
+    \ method family: pde_solver\n\nImplementation target: theta_0.5.\"\"\"\n\n   \
+    \ def __init__(self, spec: EuropeanOptionSpec):\n        self._spec = spec\n\n\
+    \    @property\n    def spec(self) -> EuropeanOptionSpec:\n        return self._spec\n\
+    \n    @property\n    def requirements(self) -> set[str]:\n        return {\"black_vol_surface\"\
+    , \"discount_curve\"}\n\n    def evaluate(self, market_state: MarketState) ->\
+    \ float:\n        spec = self._spec\n        raise NotImplementedError(\"evaluate\
+    \ not yet implemented\")\n\n```\n\n## Your task\nWrite ONLY the body of the `evaluate()`\
+    \ method. The signature is already defined:\n\n    def evaluate(self, market_state:\
+    \ MarketState) -> float:\n\n## Spec fields available via self._spec\n- `self._spec.notional`\
+    \ (float): Notional / number of shares\n- `self._spec.spot` (float): Current spot\
+    \ price\n- `self._spec.strike` (float): Option strike price\n- `self._spec.expiry_date`\
+    \ (date): Option expiry date\n- `self._spec.option_type` (str): Option type: 'call'\
+    \ or 'put'\n- `self._spec.day_count` (DayCountConvention): Day count convention\n\
+    \n## Pricing Method (selected by the quant agent — you MUST use this)\nMethod:\
+    \ **pde_solver**\nReasoning: product_ir_compiler\nSelection basis and assumptions:\n\
+    - Selection basis: `explicit_preference`\n- Assumptions / defaulted context:\n\
+    \  - `simplest_valid_assumption_set`\n  - `finite_difference_discretization_route`\n\
+    \  - `boundary_conditions_required`\nRoute-bound modules to import and use:\n\
+    - `trellis.models.equity_option_pde`\n\nYou MUST import and use these route-bound\
+    \ modules in your implementation.\nDo not import a generic parent package such\
+    \ as `from trellis.models import ...` just to satisfy the method family.\n\n##\
+    \ API Map — start here before guessing module paths\n\nUse this navigation card\
+    \ to choose the right module family first. Confirm exact symbols with `find_symbol`\
+    \ or `list_exports` before calling `read_module`.\n\n### Core Types\n#### MarketState\n\
+    - Module: `trellis.core.market_state`\n- Class: `MarketState`\n- Frozen: `true`\n\
+    - Fields: `as_of`, `settlement`, `discount`, `forward_curve`, `vol_surface`, `state_space`,\
+    \ `credit_curve`, `forecast_curves`, `fx_rates`\n- Accessors: `discount_factor`,\
+    \ `zero_rate`, `forward_rate`, `forecast_forward`, `black_vol`, `survival_prob`,\
+    \ `hazard_rate`, `risky_discount`\n- Capabilities: `discount_curve → discount\
+    \ is not None`, `forward_curve → forward_curve is not None (auto from discount)`,\
+    \ `black_vol_surface → vol_surface is not None`, `state_space → state_space is\
+    \ not None`, `credit_curve → credit_curve is not None`, `fx_rates → fx_rates is\
+    \ not None`\n#### Payoff\n- Module: `trellis.core.payoff`\n- Protocol: `Payoff`\n\
+    - Required methods: `evaluate`\n- Required properties: `requirements`\n- Runtime\
+    \ checkable: `true`\n- Notes:\n  - Each payoff handles its own discounting internally\n\
+    \  - The returned float is the final PV\n  - DeterministicCashflowPayoff wraps\
+    \ any Instrument into Payoff\n\n### Model Families\n#### equity_tree\n- Module:\
+    \ `trellis.models.equity_option_tree`\n- Key imports:\n  - `from trellis.models.equity_option_tree\
+    \ import price_vanilla_equity_option_tree`\n  - `from trellis.models.trees.lattice\
+    \ import build_spot_lattice, lattice_backward_induction`\n- Notes:\n  - American/Bermudan\
+    \ equity options should prefer the checked-in helper `price_vanilla_equity_option_tree(...)`\n\
+    \  - If you need the lower-level path, import the lattice builder/backward induction\
+    \ submodules directly\n#### rate_lattice\n- Module: `trellis.models.trees.lattice`\n\
+    - Key imports:\n  - `from trellis.models.trees.lattice import build_rate_lattice,\
+    \ lattice_backward_induction`\n  - `from trellis.models.zcb_option_tree import\
+    \ price_zcb_option_tree`\n- Notes:\n  - Callable bonds, puttable bonds, and Bermudan\
+    \ swaptions use a calibrated rate lattice from a TreeModel specification such\
+    \ as Hull-White or Black-Derman-Toy\n  - lattice_backward_induction handles cashflow_at_node\
+    \ and exercise_fn\n#### monte_carlo\n- Module: `trellis.models.monte_carlo`\n\
+    - Key imports:\n  - `from trellis.models.monte_carlo.engine import MonteCarloEngine`\n\
+    \  - `from trellis.models.monte_carlo.lsm import longstaff_schwartz, longstaff_schwartz_result`\n\
+    \  - `from trellis.models.monte_carlo.early_exercise import EarlyExercisePolicyResult,\
+    \ LeastSquaresContinuationEstimator`\n  - `from trellis.models.monte_carlo.schemes\
+    \ import LaguerreBasis`\n  - `from trellis.models.monte_carlo import euler_maruyama,\
+    \ milstein, brownian_bridge`\n  - `from trellis.models.monte_carlo import antithetic,\
+    \ control_variate`\n  - `from trellis.models.processes.gbm import GBM`\n- Notes:\n\
+    \  - For American/Bermudan Monte Carlo, simulate paths then call an approved early-exercise\
+    \ control primitive; Trellis currently implements longstaff_schwartz\n  - If the\
+    \ control primitive uses continuation regression, choose the estimator or basis\
+    \ explicitly; LaguerreBasis is optional, not mandatory\n#### qmc\n- Module: `trellis.models.qmc`\n\
+    - Key imports:\n  - `from trellis.models.qmc import sobol_normals, brownian_bridge`\n\
+    \  - `from trellis.models.processes.gbm import GBM`\n- Notes:\n  - QMC is an accelerator\
+    \ family layered on Monte Carlo-style estimators\n  - Current support is Sobol-based\
+    \ normal draws and Brownian-bridge construction\n#### pde\n- Module: `trellis.models.pde`\n\
+    - Key imports:\n  - `from trellis.models.equity_option_pde import price_vanilla_equity_option_pde`\n\
+    \  - `from trellis.models.pde.grid import Grid`\n  - `from trellis.models.pde.theta_method\
+    \ import theta_method_1d`\n  - `from trellis.models.pde.operator import BlackScholesOperator`\n\
+    \  - `from trellis.models.pde import psor_1d  # American options`\n  - `from trellis.models.pde\
+    \ import HullWhitePDEOperator`\n- Notes:\n  - Vanilla European equity PDE routes\
+    \ should prefer the checked-in helper `price_vanilla_equity_option_pde(...)`\n\
+    \  - Use theta_method_1d, NOT legacy crank_nicolson_1d or implicit_fd_1d\n####\
+    \ fft\n- Module: `trellis.models.transforms`\n- Key imports:\n  - `from trellis.models.transforms\
+    \ import fft_price, cos_price`\n- Notes:\n  - fft_price expects CF of log(S_T)\
+    \ — include log(S0)\n  - cos_price expects CF of log(S_T/S0) — log-return only\n\
+    #### copulas\n- Module: `trellis.models.copulas`\n- Key imports:\n  - `from trellis.models.copulas\
+    \ import GaussianCopula, StudentTCopula, FactorCopula`\n#### analytical\n- Module:\
+    \ `trellis.models.zcb_option`\n- Key imports:\n  - `from trellis.models.zcb_option\
+    \ import resolve_zcb_option_hw_inputs, price_zcb_option_jamshidian`\n  - `from\
+    \ trellis.models.analytical.jamshidian import ResolvedJamshidianInputs, zcb_option_hw_raw`\n\
+    \  - `from trellis.models.analytical import zcb_option_hw`\n  - `from trellis.models.analytical\
+    \ import terminal_vanilla_from_basis`\n  - `from trellis.models.rate_style_swaption\
+    \ import ResolvedSwaptionBlack76Inputs, resolve_swaption_black76_inputs, price_swaption_black76_raw,\
+    \ price_bermudan_swaption_black76_lower_bound`\n#### calibration\n- Module: `trellis.models.calibration`\n\
+    - Key imports:\n  - `from trellis.models.calibration import implied_vol, implied_vol_jaeckel`\n\
+    \  - `from trellis.models.calibration import RatesCalibrationResult, calibrate_cap_floor_black_vol,\
+    \ calibrate_swaption_black_vol, swaption_terms`\n  - `from trellis.models.calibration\
+    \ import calibrate_sabr`\n  - `from trellis.models.calibration import dupire_local_vol`\n\
+    \n### Utilities\n#### black76\n- Module: `trellis.models.black`\n- Imports:\n\
+    \  - `from trellis.models.black import black76_call, black76_put, black76_asset_or_nothing_call,\
+    \ black76_asset_or_nothing_put, black76_cash_or_nothing_call, black76_cash_or_nothing_put`\n\
+    #### garman_kohlhagen\n- Module: `trellis.models.analytical.fx`\n- Imports:\n\
+    \  - `from trellis.models.analytical.fx import ResolvedGarmanKohlhagenInputs,\
+    \ garman_kohlhagen_price_raw`\n  - `from trellis.models.black import garman_kohlhagen_call,\
+    \ garman_kohlhagen_put`\n#### rate_style_swaption\n- Module: `trellis.models.rate_style_swaption`\n\
+    - Imports:\n  - `from trellis.models.rate_style_swaption import ResolvedSwaptionBlack76Inputs,\
+    \ resolve_swaption_black76_inputs, price_swaption_black76_raw, price_swaption_black76`\n\
+    \  - `from trellis.models.rate_style_swaption import price_bermudan_swaption_black76_lower_bound`\n\
+    #### jamshidian_zcb_option\n- Module: `trellis.models.zcb_option`\n- Imports:\n\
+    \  - `from trellis.models.zcb_option import ResolvedZCBOptionInputs, resolve_zcb_option_hw_inputs,\
+    \ price_zcb_option_jamshidian`\n  - `from trellis.models.analytical.jamshidian\
+    \ import ResolvedJamshidianInputs, zcb_option_hw_raw`\n#### schedule\n- Module:\
+    \ `trellis.core.date_utils`\n- Imports:\n  - `from trellis.core.date_utils import\
+    \ generate_schedule`\n#### day_count\n- Module: `trellis.core.date_utils`\n- Imports:\n\
+    \  - `from trellis.core.date_utils import year_fraction`\n#### vol_surface\n-\
+    \ Module: `trellis.models.vol_surface`\n- Imports:\n  - `from trellis.models.vol_surface\
+    \ import VolSurface, FlatVol`\n#### cashflow_engine\n- Module: `trellis.models.cashflow_engine`\n\
+    - Imports:\n  - `from trellis.models.cashflow_engine import Waterfall, Tranche`\n\
+    \  - `from trellis.models.cashflow_engine import PSA, CPR, RateDependent`\n  -\
+    \ `from trellis.models.cashflow_engine import level_pay, scheduled, custom`\n\
+    #### credit_curve\n- Module: `trellis.curves.credit_curve`\n- Imports:\n  - `from\
+    \ trellis.curves.credit_curve import CreditCurve`\n- Notes:\n  - CreditCurve.flat(hazard_rate)\
+    \ is the simplest starting point for CDS or nth-to-default tasks\n## Distilled\
+    \ Build Memory\n\n- Product: `european_option` / `vanilla_option` / `european`\n\
+    - Default method family: `pde_solver`\n- Method intent: One-dimensional finite-difference\
+    \ theta-method pricing with optional obstacle handling\n- Non-negotiable requirements:\n\
+    \  - GRID: Use at least 200 spatial points and 200+ time steps. For barrier options,\
+    \ use non-uniform grid concentrated near the barrier.\n  - BOUNDARY CONDITIONS:\
+    \ Set V(0,t)=0 for calls, V(S_max,t)=S_max-K*exp(-r*(T-t)) for calls. For puts:\
+    \ V(0,t)=K*exp(-r*(T-t)), V(S_max,t)=0.\n  - STABILITY: Crank-Nicolson (theta=0.5)\
+    \ is second-order but may oscillate near discontinuities. Use Rannacher smoothing\
+    \ (2-4 implicit steps at start) for digital/barrier payoffs.\n- Canonical model\
+    \ grammar:\n  - `local_vol_surface_workflow` -> `Dupire local vol`\n  - `sabr_smile_workflow`\
+    \ -> `SABR smile`\n- Repeated fixes to reuse:\n  - `BlackScholesOperator constructor\
+    \ mismatch` -> Import BlackScholesOperator from trellis.models.pde.operator and\
+    \ pass callables, for example BlackScholesOperator(lambda s, t: sigma, lambda\
+    \ t: r). Add a signature smoke test or cookbook template to lock the constructor\
+    \ shape and keep the solver path aligned with the real API.\n  - `PDE price blow-up\
+    \ from unit/scale mismatch` -> Build Grid(x_min=0.0, x_max=S_max, n_x=n_x, T=T,\
+    \ n_t=n_t), construct BlackScholesOperator(lambda s, t: sigma, lambda t: r), call\
+    \ theta_method_1d(grid, op, terminal, theta=0.5, lower_bc_fn=..., upper_bc_fn=...),\
+    \ then interpolate the returned vector with np.interp(spec.spot, grid.x, V) before\
+    \ multiplying by notional.\n\n## Generated Skills\n- [cookbook] fft_pricing: Characteristic-function\
+    \ pricing for European-style options under models such as Heston\n- [lesson] Unit\
+    \ conversion causes huge PV: Enforce and document input conventions (vol as decimal,\
+    \ discount curve vs zero rate semantics, notional scaling), derive r from discount\
+    \ factors via r = -ln(df)/T or use forward/Black76 consistently, add unit/conversi...\n\
+    ## Structured Lane Card\n- Method family: `pde_solver`\n- Instrument type: `european_option`\n\
+    - Lane boundary: family=`pde_solver`, kind=`exact_target_binding`, exact_bindings=`trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
+    - Lane obligations:\n  - Lane family: `pde_solver`\n  - Plan kind: `exact_target_binding`\n\
+    \  - Market bindings: `black_vol_surface`, `discount_curve`\n  - State obligations:\
+    \ `spot`, `strike`, `expiry`, `expiry_black_vol`\n  - Exact backend bindings:\n\
+    \    - `trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n  -\
+    \ Exact binding signatures:\n    - `price_vanilla_equity_option_pde(market_state:\
+    \ 'EquityPDEMarketStateLike', spec: 'VanillaEquityOptionSpecLike', *, theta: 'float'\
+    \ = 0.5, n_x: 'int | None' = None, n_t: 'int | None' = None, s_max_multiplier:\
+    \ 'float' = 4.0) -> 'float'`\n- Route authority:\n  - binding=`trellis.models.equity_option_pde.price_vanilla_equity_option_pde`,\
+    \ engine=`pde_solver`, authority=`exact_backend_fit`\n  - Route alias: `vanilla_equity_theta_pde`\n\
+    \  - Validation bundle: `pde_solver:european_option`\n  - Validation checks: `check_non_negativity`,\
+    \ `check_price_sanity`, `check_vol_sensitivity`, `check_vol_monotonicity`\n  -\
+    \ Exact target bindings: `trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
+    - Backend binding:\n  - Route: `vanilla_equity_theta_pde`\n  - Engine family:\
+    \ `pde_solver`\n  - Route family: `pde_solver`\n  - Selected primitives:\n   \
+    \ - `trellis.models.equity_option_pde.price_vanilla_equity_option_pde` (route_helper)\n\
+    \  - Resolved instructions:\n    - [hard_constraint] Use the route helper directly\
+    \ inside `evaluate()`; do not rebuild the process, engine, or discount glue manually.\n\
+    \    - [historical_note] For vanilla European equity PDE routes, prefer `price_vanilla_equity_option_pde(market_state,\
+    \ spec, theta=...)` so the adapter stays thin.\n    - [historical_note] Map `implementation_target=theta_0.5`\
+    \ to `theta=0.5` and `implementation_target=theta_1.0` to `theta=1.0`.\n    -\
+    \ [historical_note] The checked-in helper already owns grid sizing, terminal payoff\
+    \ assembly, boundary conditions, theta-method solve, and interpolation back to\
+    \ spot.\n    - [historical_note] Use the lower-level `Grid + BlackScholesOperator\
+    \ + theta_method_1d` path only when the payoff or boundary contract genuinely\
+    \ differs from plain vanilla European call/put.\n  - Required adapters:\n    -\
+    \ `reuse_checked_in_vanilla_equity_pde_helper`\n  - Backend notes:\n    - For\
+    \ vanilla European equity PDE routes, prefer `price_vanilla_equity_option_pde(market_state,\
+    \ spec, theta=...)` so the adapter stays thin.\n    - Map `implementation_target=theta_0.5`\
+    \ to `theta=0.5` and `implementation_target=theta_1.0` to `theta=1.0`.\n    -\
+    \ The checked-in helper already owns grid sizing, terminal payoff assembly, boundary\
+    \ conditions, theta-method solve, and interpolation back to spot.\n    - Use the\
+    \ lower-level `Grid + BlackScholesOperator + theta_method_1d` path only when the\
+    \ payoff or boundary contract genuinely differs from plain vanilla European call/put.\n\
+    - Primary modules to inspect/reuse:\n  - `trellis.models.pde.theta_method`\n-\
+    \ Post-build test targets:\n  - `tests/test_agent/test_build_loop.py`\n- Instruction\
+    \ precedence: follow the lane obligations in this card first. Treat backend route/helper\
+    \ details as exact-fit bindings, not as permission to invent a different numerical\
+    \ path.\n- Treat route authority as backend-fit evidence, not as permission to\
+    \ invent a different synthesis plan.\n- Use approved Trellis imports only. Prefer\
+    \ thin adapters when the compiler found an exact backend; otherwise build the\
+    \ smallest lane-consistent kernel the plan requires.\n## Backend Lookup (Secondary\
+    \ To Lane Obligations)\n- Lane family: `pde_solver`\n- Lane plan kind: `exact_target_binding`\n\
+    - Method family: `pde_solver`\n- Route: `vanilla_equity_theta_pde`\n- Engine family:\
+    \ `pde_solver`\n- Required primitive symbols:\n  - `trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
+    - Adapter obligations:\n  - `reuse_checked_in_vanilla_equity_pde_helper`\n## Thin\
+    \ Adapter Plan\n- Target payoff class: `EuropeanOptionAnalyticalPayoff`\n- Required\
+    \ market reads:\n  - `market_state.vol_surface.black_vol(...)`\n  - `market_state.discount`\n\
+    - Required primitive calls:\n  - `trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
+    - Required adapter steps:\n  - `reuse_checked_in_vanilla_equity_pde_helper`\n\
+    - Return contract: Return a Python `float` present value from `evaluate()`.\n\
+    ## Invariant Pack\n- The generated payoff should be compatible with these deterministic\
+    \ validation checks:\n  - `check_non_negativity`\n  - `check_price_sanity`\n \
+    \ - `check_vol_sensitivity`\n  - `check_vol_monotonicity`\n## Family Route Guidance\n\
+    - For vanilla European PDE routes, prefer `price_vanilla_equity_option_pde(market_state,\
+    \ self._spec, theta=...)` from `trellis.models.equity_option_pde`.\n- Map `implementation_target=theta_0.5`\
+    \ to `theta=0.5` and `implementation_target=theta_1.0` to `theta=1.0`.\n- Keep\
+    \ the wrapper thin: delegate grid sizing, boundary conditions, terminal payoff\
+    \ assembly, theta-method solve, and interpolation back to spot to the checked-in\
+    \ helper.\n- Only fall back to direct `Grid + BlackScholesOperator + theta_method_1d`\
+    \ assembly when the payoff or boundary contract genuinely differs from plain vanilla\
+    \ European call/put.\n## Conventions\n- evaluate() returns a FLOAT — the present\
+    \ value (PV) of the instrument\n- You MUST handle all discounting internally —\
+    \ use `market_state.discount.discount(t)`\n- For forward rates: `market_state.forecast_forward_curve(self._spec.rate_index)`\n\
+    - For vol: `market_state.vol_surface.black_vol(T, strike)`\n- For discount factors:\
+    \ `market_state.discount.discount(t)`\n- `market_state.fx_rates[pair]` returns\
+    \ an `FXRate` wrapper; extract `.spot` before scalar arithmetic or process seeding\n\
+    - Schedule generation: prefer `build_payment_timeline(...)`, `build_observation_timeline(...)`,\
+    \ or `build_period_schedule(...)` for accrual/event routes; use `generate_schedule(start,\
+    \ end, freq)` only for plain date lists with no period semantics\n- Year fractions:\
+    \ `year_fraction(date1, date2, day_count)`\n- Never use wall-clock dates such\
+    \ as `date.today()` or `datetime.now()` inside `evaluate()`; derive valuation\
+    \ time from `market_state` or shared resolver outputs.\n- Black76: `black76_call(F,\
+    \ K, sigma, T)`, `black76_put(F, K, sigma, T)` — undiscounted\n- Black76 digital:\
+    \ `black76_cash_or_nothing_call(F, K, sigma, T)`, `black76_cash_or_nothing_put(F,\
+    \ K, sigma, T)` — undiscounted cash-or-nothing digitals\n- For CDS / nth-to-default:\
+    \ use `market_state.credit_curve.survival_probability(t)` and `market_state.credit_curve.hazard_rate(t)`\
+    \ on an explicit payment/default schedule; do not route credit-default pricing\
+    \ through Black76 call/put primitives.\n- For equity trees: prefer `from trellis.models.equity_option_tree\
+    \ import price_vanilla_equity_option_tree`; the lower-level lattice path is `from\
+    \ trellis.models.trees.lattice import build_spot_lattice, lattice_backward_induction`\n\
+    - For vanilla European PDE routes: prefer `from trellis.models.equity_option_pde\
+    \ import price_vanilla_equity_option_pde`; the lower-level fallback is `from trellis.models.pde.grid\
+    \ import Grid`, `from trellis.models.pde.operator import BlackScholesOperator`,\
+    \ and `from trellis.models.pde.theta_method import theta_method_1d`\n- For rate\
+    \ lattices: prefer helper surfaces such as `price_callable_bond_tree(...)`, `price_bermudan_swaption_tree(...)`,\
+    \ or `price_zcb_option_tree(...)`; the lower-level fallback is `from trellis.models.trees.lattice\
+    \ import build_rate_lattice, lattice_backward_induction`\n- For schedule-dependent\
+    \ rate lattices: `from trellis.models.trees.control import lattice_steps_from_timeline,\
+    \ resolve_lattice_exercise_policy`\n- For MC: `from trellis.models.monte_carlo\
+    \ import MonteCarloEngine`\n- For QMC accelerators: `from trellis.models.qmc import\
+    \ sobol_normals, brownian_bridge`\n- For copulas: `from trellis.models.copulas\
+    \ import GaussianCopula, FactorCopula`\n- Do not invent MonteCarloEngine method\
+    \ strings. Valid `method=` values are `euler`, `milstein`, and `exact`.\n- For\
+    \ Monte Carlo early exercise, use an approved control primitive; do not pretend\
+    \ that `MonteCarloEngine.price(...)` or `method=\"lsm\"` implements early exercise.\
+    \ Approved policy classes: `longstaff_schwartz` [implemented], `tsitsiklis_van_roy`\
+    \ [implemented], `primal_dual_mc` [implemented], `stochastic_mesh` [implemented].\
+    \ Currently implemented in Trellis: `longstaff_schwartz`, `tsitsiklis_van_roy`,\
+    \ `primal_dual_mc`, `stochastic_mesh`.\n- If you use `LaguerreBasis`, import it\
+    \ from `trellis.models.monte_carlo.schemes`, not from `trellis.models.monte_carlo.lsm`.\n\
+    - For FFT/COS pricing, characteristic functions must accept vector `u` and use\
+    \ array-safe numerics such as `numpy`, not scalar `math`/`cmath`.\n- Black76 basis:\
+    \ `black76_asset_or_nothing_call(F, K, sigma, T)`, `black76_asset_or_nothing_put(F,\
+    \ K, sigma, T)`, `black76_cash_or_nothing_call(F, K, sigma, T)`, `black76_cash_or_nothing_put(F,\
+    \ K, sigma, T)` — exact terminal basis claims.\n- For terminal vanilla payoffs,\
+    \ prefer exact basis assembly via `terminal_vanilla_from_basis(...)` from `trellis.models.analytical`.\n\
+    - For FX vanilla options, treat the route as Garman-Kohlhagen: map spot FX and\
+    \ domestic/foreign discount factors to `ResolvedGarmanKohlhagenInputs`, then prefer\
+    \ `garman_kohlhagen_price_raw(spec.option_type, resolved)` from `trellis.models.analytical.fx`;\
+    \ use explicit basis-claim assembly only when the request explicitly needs the\
+    \ decomposition.\n- For cash-or-nothing digital options, use the Black76 digital\
+    \ helpers directly; do not approximate them with vanilla call/put prices or divide\
+    \ by spot.\n- You MUST use only real, approved `trellis.*` imports from the structured\
+    \ generation plan and import registry\n- Treat the compiler-emitted lane obligations\
+    \ in the structured generation plan as the backbone of the implementation.\n-\
+    \ Reuse the listed exact backend bindings when present; otherwise build the smallest\
+    \ lane-consistent kernel that satisfies the construction steps.\n- Do not replace\
+    \ selected primitives with bespoke numerical kernels or alternative Trellis routes\
+    \ unless the plan explicitly permits a new lane implementation.\n- Do not add\
+    \ wildcard imports\n- If the approved modules do not contain what you need, reuse\
+    \ the closest existing implementation and keep the gap explicit instead of inventing\
+    \ a path\n\n## Reference implementations\n\n### Payoff protocol + Cashflows/PresentValue\
+    \ return types\n```python\n\"\"\"Payoff protocol and base classes for pricing\
+    \ instruments.\n\nEvery priceable instrument in Trellis implements the Payoff\
+    \ protocol.\nA payoff takes market data (via MarketState) and returns a present\
+    \ value.\nThis module also provides base classes for two common pricing patterns:\n\
+    \n- ResolvedInputPayoff: for analytical or tree-based pricing where market\n \
+    \ data is extracted once, then fed into a pricing formula.\n- MonteCarloPathPayoff:\
+    \ for simulation-based pricing where paths are\n  generated and payoffs are computed\
+    \ per path then averaged.\n\"\"\"\n\nfrom __future__ import annotations\n\nfrom\
+    \ abc import ABC, abstractmethod\nfrom datetime import date\nfrom typing import\
+    \ Generic, Protocol, TypeVar, runtime_checkable\n\nfrom trellis.core.date_utils\
+    \ import year_fraction\nfrom trellis.core.differentiable import get_numpy\nfrom\
+    \ trellis.core.market_state import MarketState\nfrom trellis.core.types import\
+    \ DayCountC\n# [truncated reference]\n```\n\n### Date utilities used by generated\
+    \ payoffs\n```python\n\"\"\"Date utilities: day count conventions, schedule generation,\
+    \ year fractions.\"\"\"\n\nfrom __future__ import annotations\n\nimport calendar\n\
+    from collections.abc import Iterable\nfrom datetime import date, datetime, timedelta\n\
+    from typing import Union\n\nfrom trellis.core.types import (\n    ContractTimeline,\n\
+    \    DayCountConvention,\n    EventSchedule,\n    Frequency,\n    TimelineRole,\n\
+    )\n\nDateLike = Union[date, datetime]\nExplicitDateInput = ContractTimeline |\
+    \ EventSchedule | Iterable[DateLike | str] | str\n\n\ndef _to_date(d: DateLike)\
+    \ -> date:\n    \"\"\"Normalize ``date``/``datetime`` inputs to plain ``date``\
+    \ objects.\"\"\"\n    if isinstance(d, datetime):\n        return d.date()\n \
+    \   return d\n\n\ndef add_months(dt: DateLike, months: int) -> date:\n    \"\"\
+    \"Add *months* calendar months, clamping the day to the new month's max.\"\"\"\
+    \n    d = _to_date(dt)\n    total_months = d.month - 1 + months\n    year = d.year\
+    \ + total\n# [truncated reference]\n```\n\n### MarketState capabilities and access\
+    \ patterns\n```python\n\"\"\"MarketState: immutable container of market data used\
+    \ for pricing.\n\nA MarketState holds everything a payoff needs to compute a price:\n\
+    discount curves, volatility surfaces, spot prices, credit curves, etc.\nIt is\
+    \ frozen (immutable) so that multiple payoffs can safely share the\nsame market\
+    \ snapshot without risk of accidental modification.\n\"\"\"\n\nfrom __future__\
+    \ import annotations\n\nfrom dataclasses import dataclass\nfrom datetime import\
+    \ date\nfrom typing import TYPE_CHECKING\n\nfrom trellis.core.types import DiscountCurve\n\
+    \nif TYPE_CHECKING:\n    from trellis.core.state_space import StateSpace\n   \
+    \ from trellis.curves.credit_curve import CreditCurve\n    from trellis.curves.forward_curve\
+    \ import ForwardCurve\n    from trellis.instruments.fx import FXRate\n    from\
+    \ trellis.models.vol_surface import VolSurface\n\n\nclass MissingCapabilityError(Exception):\n\
+    \    \"\"\"Raised when a MarketState lacks market data r\n# [truncated reference]\n\
+    ```\n\n### Frequency/day-count types\n```python\n\"\"\"Core protocols, enums,\
+    \ and data structures shared across Trellis.\n\nDefines the fundamental types\
+    \ that most other modules depend on:\nfrequency enums, day count conventions,\
+    \ the DiscountCurve and Instrument\nprotocols, and simple data containers like\
+    \ schedules and pricing results.\n\"\"\"\n\nfrom __future__ import annotations\n\
+    \nfrom dataclasses import dataclass, field\nfrom datetime import date\nfrom enum\
+    \ import Enum\nfrom typing import Protocol, runtime_checkable\n\n# ---------------------------------------------------------------------------\n\
+    # Greek specification types\n# ---------------------------------------------------------------------------\n\
+    \n# What risk sensitivities to compute alongside the price.\n#   None       —\
+    \ price only, no sensitivities\n#   \"all\"      — every known sensitivity (dv01,\
+    \ duration, convexity, etc.)\n#   list[str]  — specific sensitivities by name\
+    \ (e.g. [\"dv01\", \"duration\"])\n# [truncated reference]\n```\n\n[omitted 6\
+    \ additional reference modules]\n\n\n## Output\nReturn the COMPLETE Python module\
+    \ — copy the skeleton exactly, but replace the\n`raise NotImplementedError(...)`\
+    \ line with the actual implementation of `evaluate()`.\nDo NOT change imports,\
+    \ class names, spec fields, or the requirements property.\nOnly implement the\
+    \ evaluate() method body. You may add imports at the top.\nNo markdown fences,\
+    \ no explanation — just the Python code."
+  model: gpt-5.4-mini
+- seq: 1
+  function: llm_generate_json
+  stage: critic
+  prompt_hash: 672a1d8e20d5223babb10d7e8424717b496162ab0fc59cf0a95a3dcc1951752f
+  response_text: '{"check_id": "volatility_input_usage", "description": "The adapter
+    hard-codes a plain `spec` object that may not satisfy the backend''s required
+    volatility-bearing market bindings, and it never validates or forwards any explicit
+    volatility input from the instrument spec.", "severity": "warning", "evidence":
+    "`evaluate()` calls `price_vanilla_equity_option_pde(market_state, spec, theta=theta)`
+    directly, and the only fallback is an `_AdapterSpec` that copies notional/spot/strike/expiry/date
+    fields only. The compiled contract says the route requires `black_vol_surface`
+    and `expiry_black_vol`, but this code never constructs or checks a volatility
+    surface binding before pricing.", "remediation": "Ensure the market state provides
+    the required flat/term volatility input expected by `price_vanilla_equity_option_pde`,
+    and validate that the adapter forwards the volatility-bearing state rather than
+    relying on a shape-only spec object.", "status": "suspect"}'
+  prompt_text: "You are a quantitative model validator reviewing agent-generated pricing\
+    \ code.\nYour job is to find deterministic review concerns, not to praise. Be\
+    \ adversarial.\n\n## Code to review\n```python\nfrom __future__ import annotations\n\
+    \nfrom dataclasses import dataclass\nfrom datetime import date\n\nfrom trellis.core.market_state\
+    \ import MarketState\nfrom trellis.core.types import DayCountConvention\nfrom\
+    \ trellis.models.equity_option_pde import price_vanilla_equity_option_pde\n\n\n\
+    \n@dataclass(frozen=True)\nclass EuropeanOptionSpec:\n    \"\"\"Specification\
+    \ for Build a pricer for: European call: theta-method convergence order measurement\n\
+    \nEuropean call option on a non-dividend-paying stock.\nS0=100, K=105, T=1Y, risk-free\
+    \ rate r=5%, volatility sigma=20%.\nSolve with the Black-Scholes PDE operator\
+    \ using Crank-Nicolson\n(theta=0.5) and fully implicit (theta=1.0) on a 200-point\
+    \ spot grid\n× 100 time steps.\nMeasure convergence order by doubling the grid:\
+    \ the CN scheme should\nshow O(dt^2 + dS^2) convergence and the implicit scheme\
+    \ O(dt + dS^2).\nCompare both to the Black-Scholes analytical price.\n\nConstruct\
+    \ methods: pde_solver\nComparison targets: theta_0.5 (pde_solver), theta_1.0 (pde_solver),\
+    \ black_scholes (analytical)\nCross-validation harness:\n  internal targets: theta_0.5,\
+    \ theta_1.0\n  analytical benchmark: black_scholes\n  external targets: quantlib\n\
+    New component: convergence_order_diagnostic\n\nImplementation target: theta_0.5\n\
+    Preferred method family: pde_solver\n\nImplementation target: theta_0.5.\"\"\"\
+    \n    notional: float\n    spot: float\n    strike: float\n    expiry_date: date\n\
+    \    option_type: str = \"'call'\"\n    day_count: DayCountConvention = DayCountConvention.ACT_365\n\
+    \n\nclass EuropeanOptionAnalyticalPayoff:\n    \"\"\"Build a pricer for: European\
+    \ call: theta-method convergence order measurement\n\nEuropean call option on\
+    \ a non-dividend-paying stock.\nS0=100, K=105, T=1Y, risk-free rate r=5%, volatility\
+    \ sigma=20%.\nSolve with the Black-Scholes PDE operator using Crank-Nicolson\n\
+    (theta=0.5) and fully implicit (theta=1.0) on a 200-point spot grid\n× 100 time\
+    \ steps.\nMeasure convergence order by doubling the grid: the CN scheme should\n\
+    show O(dt^2 + dS^2) convergence and the implicit scheme O(dt + dS^2).\nCompare\
+    \ both to the Black-Scholes analytical price.\n\nConstruct methods: pde_solver\n\
+    Comparison targets: theta_0.5 (pde_solver), theta_1.0 (pde_solver), black_scholes\
+    \ (analytical)\nCross-validation harness:\n  internal targets: theta_0.5, theta_1.0\n\
+    \  analytical benchmark: black_scholes\n  external targets: quantlib\nNew component:\
+    \ convergence_order_diagnostic\n\nImplementation target: theta_0.5\nPreferred\
+    \ method family: pde_solver\n\nImplementation target: theta_0.5.\"\"\"\n\n   \
+    \ def __init__(self, spec: EuropeanOptionSpec):\n        self._spec = spec\n\n\
+    \    @property\n    def spec(self) -> EuropeanOptionSpec:\n        return self._spec\n\
+    \n    @property\n    def requirements(self) -> set[str]:\n        return {\"black_vol_surface\"\
+    , \"discount_curve\"}\n\n    def evaluate(self, market_state: MarketState) ->\
+    \ float:\n        spec = self._spec\n        theta = 0.5\n        option_type\
+    \ = str(spec.option_type).strip(\"'\\\"\").lower()\n        if option_type not\
+    \ in {\"call\", \"put\"}:\n            raise ValueError(f\"Unsupported option_type:\
+    \ {spec.option_type!r}\")\n        try:\n            return float(\n         \
+    \       price_vanilla_equity_option_pde(\n                    market_state,\n\
+    \                    spec,\n                    theta=theta,\n               \
+    \ )\n            )\n        except TypeError:\n            class _AdapterSpec:\n\
+    \                def __init__(self, src):\n                    self.notional =\
+    \ src.notional\n                    self.spot = src.spot\n                   \
+    \ self.strike = src.strike\n                    self.expiry_date = src.expiry_date\n\
+    \                    self.option_type = option_type\n                    self.day_count\
+    \ = src.day_count\n\n            return float(\n                price_vanilla_equity_option_pde(\n\
+    \                    market_state,\n                    _AdapterSpec(spec),\n\
+    \                    theta=theta,\n                )\n            )\n```\n\n##\
+    \ Instrument description\nBuild a pricer for: European call: theta-method convergence\
+    \ order measurement\n\nEuropean call option on a non-dividend-paying stock.\n\
+    S0=100, K=105, T=1Y, risk-free rate r=5%, volatility sigma=20%.\nSolve with the\
+    \ Black-Scholes PDE operator using Crank-Nicolson\n(theta=0.5) and fully implicit\
+    \ (theta=1.0) on a 200-point spot grid\n× 100 time steps.\nMeasure convergence\
+    \ order by doubling the grid: the CN scheme should\nshow O(dt^2 + dS^2) convergence\
+    \ and the implicit scheme O(dt + dS^2).\nCompare both to the Black-Scholes analytical\
+    \ price.\n\nConstruct methods: pde_solver\nComparison targets: theta_0.5 (pde_solver),\
+    \ theta_1.0 (pde_solver), black_scholes (analytical)\nCross-validation harness:\n\
+    \  internal targets: theta_0.5, theta_1.0\n  analytical benchmark: black_scholes\n\
+    \  external targets: quantlib\nNew component: convergence_order_diagnostic\n\n\
+    Implementation target: theta_0.5\nPreferred method family: pde_solver\n\nImplementation\
+    \ target: theta_0.5\n\n## Shared Knowledge\n## Distilled Review Memory\n\n- Review\
+    \ principles:\n  - `P1`: Always calibrate rate trees to the discount curve before\
+    \ pricing\n  - `P2`: Callable bonds need issuer_call lattice control, discrete\
+    \ coupons, and exercise=par+coupon\n  - `P3`: Convert vol units at the boundary\
+    \ between market data and model\n- Review checkpoints:\n  - GRID: Use at least\
+    \ 200 spatial points and 200+ time steps. For barrier options, use non-uniform\
+    \ grid concentrated near the barrier.\n  - BOUNDARY CONDITIONS: Set V(0,t)=0 for\
+    \ calls, V(S_max,t)=S_max-K*exp(-r*(T-t)) for calls. For puts: V(0,t)=K*exp(-r*(T-t)),\
+    \ V(S_max,t)=0.\n  - STABILITY: Crank-Nicolson (theta=0.5) is second-order but\
+    \ may oscillate near discontinuities. Use Rannacher smoothing (2-4 implicit steps\
+    \ at start) for digital/barrier payoffs.\n- Canonical model grammar:\n  - `local_vol_surface_workflow`\
+    \ -> `Dupire local vol`\n  - `sabr_smile_workflow` -> `SABR smile`\n- Known failure\
+    \ traps:\n  - `BlackScholesOperator constructor mismatch` -> The generated code\
+    \ treated the PDE operator as if it accepted scalar 'r' and 'sigma' keywords,\
+    \ but trellis.models.pde.operator.BlackScholesOperator actually expects callables\
+    \ '(sigma_fn, r_fn)'. The mismatch caused constructor failure during module build.\n\
+    \  - `PDE price blow-up from unit/scale mismatch` -> The generated PDE branch\
+    \ called theta_method_1d with the obsolete operator/s_grid/t_grid/boundary_conditions\
+    \ signature and then read the wrong element of the result instead of interpolating\
+    \ the returned solution over grid.x. The actual API is theta_method_1d(grid, operator,\
+    \ terminal_condition, theta=..., lower_bc_fn=..., upper_bc_fn=...), and it returns\
+    \ the full solution vector at t=0.\n\n## Generated Skills\n- [lesson] Unit conversion\
+    \ causes huge PV: Enforce and document input conventions (vol as decimal, discount\
+    \ curve vs zero rate semantics, notional scaling), derive r from discount factors\
+    \ via r = -ln(df)/T or use forward/Black76 consistently, add unit/conversi...\n\
+    \n\n## Compiled Route Contract\n- Method family: `pde_solver`\n- Instrument type:\
+    \ `european_option`\n- Lane boundary: family=`pde_solver`, kind=`exact_target_binding`,\
+    \ exact_bindings=`trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
+    - Lane obligations:\n  - Lane family: `pde_solver`\n  - Plan kind: `exact_target_binding`\n\
+    \  - Market bindings: `black_vol_surface`, `discount_curve`\n  - State obligations:\
+    \ `spot`, `strike`, `expiry`, `expiry_black_vol`\n  - Exact backend bindings:\n\
+    \    - `trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n  -\
+    \ Exact binding signatures:\n    - `price_vanilla_equity_option_pde(market_state:\
+    \ 'EquityPDEMarketStateLike', spec: 'VanillaEquityOptionSpecLike', *, theta: 'float'\
+    \ = 0.5, n_x: 'int | None' = None, n_t: 'int | None' = None, s_max_multiplier:\
+    \ 'float' = 4.0) -> 'float'`\n- Route authority:\n  - binding=`trellis.models.equity_option_pde.price_vanilla_equity_option_pde`,\
+    \ engine=`pde_solver`, authority=`exact_backend_fit`\n  - Route alias: `vanilla_equity_theta_pde`\n\
+    \  - Validation bundle: `pde_solver:european_option`\n  - Validation checks: `check_non_negativity`,\
+    \ `check_price_sanity`, `check_vol_sensitivity`, `check_vol_monotonicity`\n  -\
+    \ Exact target bindings: `trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
+    - Backend binding:\n  - Route: `vanilla_equity_theta_pde`\n  - Engine family:\
+    \ `pde_solver`\n  - Route family: `pde_solver`\n  - Selected primitives:\n   \
+    \ - `trellis.models.equity_option_pde.price_vanilla_equity_option_pde` (route_helper)\n\
+    \  - Resolved instructions:\n    - [hard_constraint] Use the route helper directly\
+    \ inside `evaluate()`; do not rebuild the process, engine, or discount glue manually.\n\
+    \    - [historical_note] For vanilla European equity PDE routes, prefer `price_vanilla_equity_option_pde(market_state,\
+    \ spec, theta=...)` so the adapter stays thin.\n    - [historical_note] Map `implementation_target=theta_0.5`\
+    \ to `theta=0.5` and `implementation_target=theta_1.0` to `theta=1.0`.\n    -\
+    \ [historical_note] The checked-in helper already owns grid sizing, terminal payoff\
+    \ assembly, boundary conditions, theta-method solve, and interpolation back to\
+    \ spot.\n    - [historical_note] Use the lower-level `Grid + BlackScholesOperator\
+    \ + theta_method_1d` path only when the payoff or boundary contract genuinely\
+    \ differs from plain vanilla European call/put.\n  - Required adapters:\n    -\
+    \ `reuse_checked_in_vanilla_equity_pde_helper`\n  - Backend notes:\n    - For\
+    \ vanilla European equity PDE routes, prefer `price_vanilla_equity_option_pde(market_state,\
+    \ spec, theta=...)` so the adapter stays thin.\n    - Map `implementation_target=theta_0.5`\
+    \ to `theta=0.5` and `implementation_target=theta_1.0` to `theta=1.0`.\n    -\
+    \ The checked-in helper already owns grid sizing, terminal payoff assembly, boundary\
+    \ conditions, theta-method solve, and interpolation back to spot.\n    - Use the\
+    \ lower-level `Grid + BlackScholesOperator + theta_method_1d` path only when the\
+    \ payoff or boundary contract genuinely differs from plain vanilla European call/put.\n\
+    - Approved modules in scope:\n  - `trellis.core.date_utils`\n  - `trellis.core.differentiable`\n\
+    \  - `trellis.core.market_state`\n  - `trellis.core.payoff`\n  - `trellis.core.types`\n\
+    \  - `trellis.models.black`\n  - `trellis.models.equity_option_pde`\n  - `trellis.models.pde`\n\
+    - Review the generated code against this compiled boundary. Treat route, helper,\
+    \ or validation drift as real findings.\n\n\n## Available deterministic checks\n\
+    You may ONLY select from this bounded menu:\n- `price_non_negative`: Price should\
+    \ remain non-negative. Use when the route prices a long-only vanilla or option-like\
+    \ payoff that should not produce a negative PV under the default review market\
+    \ state. Deterministic contract: Fail when price_payoff(payoff, ms) < -1e-6.\n\
+    - `volatility_input_usage`: Volatility should move the price materially. Use when\
+    \ the instrument or method requires volatility but the code looks volatility-insensitive.\
+    \ Deterministic contract: Fail when changing flat vol from 5% to 40% moves price\
+    \ by less than 0.1%.\n\n\n## Review policy\n- Do not write Python code.\n- Do\
+    \ not invent new checks, formulas, or test procedures.\n- Only emit a finding\
+    \ when the code strongly suggests the selected check is likely to fail.\n- If\
+    \ none of the available checks are justified, return [].\n\n## Output\nReturn\
+    \ a JSON array of concerns. Each concern:\n{\n    \"check_id\": \"one of the available\
+    \ check ids\",\n    \"description\": \"short concern summary\",\n    \"severity\"\
+    : \"error\" or \"warning\",\n    \"evidence\": \"specific code reference or reasoning\"\
+    ,\n    \"remediation\": \"what to change\",\n    \"status\": \"suspect\"\n}\n\n\
+    Focus on pricing errors that the deterministic checks can confirm.\nReturn at\
+    \ most 3 concerns, ordered by severity.\nReturn ONLY the JSON array."
+  model: gpt-5.4-mini
+- seq: 2
+  function: llm_generate
+  stage: code_generation
+  prompt_hash: e81de32bb1cade880e869861c4188e91277416285f60ab91a72b32541a699a01
+  response_text: "spec = self._spec\n        from trellis.models.equity_option_pde\
+    \ import price_vanilla_equity_option_pde\n\n        if not hasattr(market_state,\
+    \ \"vol_surface\") or market_state.vol_surface is None:\n            raise ValueError(\"\
+    market_state.vol_surface is required for PDE pricing\")\n        if not hasattr(market_state,\
+    \ \"discount\") or market_state.discount is None:\n            raise ValueError(\"\
+    market_state.discount is required for PDE pricing\")\n\n        theta = 0.5 if\
+    \ \"0.5\" in type(self).__doc__ or False else 1.0\n        return float(\n   \
+    \         price_vanilla_equity_option_pde(\n                market_state,\n  \
+    \              spec,\n                theta=1.0,\n            )\n        )"
+  prompt_text: "You are implementing the evaluate() method for `EuropeanOptionAnalyticalPayoff`\
+    \ in the Trellis pricing library.\n\n## Complete module (skeleton — everything\
+    \ is fixed except evaluate)\n```python\n\"\"\"Agent-generated payoff: Build a\
+    \ pricer for: European call: theta-method convergence order measurement\n\nEuropean\
+    \ call option on a non-dividend-paying stock.\nS0=100, K=105, T=1Y, risk-free\
+    \ rate r=5%, volatility sigma=20%.\nSolve with the Black-Scholes PDE operator\
+    \ using Crank-Nicolson\n(theta=0.5) and fully implicit (theta=1.0) on a 200-point\
+    \ spot grid\n× 100 time steps.\nMeasure convergence order by doubling the grid:\
+    \ the CN scheme should\nshow O(dt^2 + dS^2) convergence and the implicit scheme\
+    \ O(dt + dS^2).\nCompare both to the Black-Scholes analytical price.\n\nConstruct\
+    \ methods: pde_solver\nComparison targets: theta_0.5 (pde_solver), theta_1.0 (pde_solver),\
+    \ black_scholes (analytical)\nCross-validation harness:\n  internal targets: theta_0.5,\
+    \ theta_1.0\n  analytical benchmark: black_scholes\n  external targets: quantlib\n\
+    New component: convergence_order_diagnostic\n\nImplementation target: theta_1.0\n\
+    Preferred method family: pde_solver\n\nImplementation target: theta_1.0.\"\"\"\
+    \n\nfrom __future__ import annotations\n\nfrom dataclasses import dataclass\n\
+    from datetime import date\n\nfrom trellis.core.market_state import MarketState\n\
+    from trellis.core.types import DayCountConvention\nfrom trellis.models.equity_option_pde\
+    \ import price_vanilla_equity_option_pde\n\n\n\n@dataclass(frozen=True)\nclass\
+    \ EuropeanOptionSpec:\n    \"\"\"Specification for Build a pricer for: European\
+    \ call: theta-method convergence order measurement\n\nEuropean call option on\
+    \ a non-dividend-paying stock.\nS0=100, K=105, T=1Y, risk-free rate r=5%, volatility\
+    \ sigma=20%.\nSolve with the Black-Scholes PDE operator using Crank-Nicolson\n\
+    (theta=0.5) and fully implicit (theta=1.0) on a 200-point spot grid\n× 100 time\
+    \ steps.\nMeasure convergence order by doubling the grid: the CN scheme should\n\
+    show O(dt^2 + dS^2) convergence and the implicit scheme O(dt + dS^2).\nCompare\
+    \ both to the Black-Scholes analytical price.\n\nConstruct methods: pde_solver\n\
+    Comparison targets: theta_0.5 (pde_solver), theta_1.0 (pde_solver), black_scholes\
+    \ (analytical)\nCross-validation harness:\n  internal targets: theta_0.5, theta_1.0\n\
+    \  analytical benchmark: black_scholes\n  external targets: quantlib\nNew component:\
+    \ convergence_order_diagnostic\n\nImplementation target: theta_1.0\nPreferred\
+    \ method family: pde_solver\n\nImplementation target: theta_1.0.\"\"\"\n    notional:\
+    \ float\n    spot: float\n    strike: float\n    expiry_date: date\n    option_type:\
+    \ str = \"'call'\"\n    day_count: DayCountConvention = DayCountConvention.ACT_365\n\
+    \n\nclass EuropeanOptionAnalyticalPayoff:\n    \"\"\"Build a pricer for: European\
+    \ call: theta-method convergence order measurement\n\nEuropean call option on\
+    \ a non-dividend-paying stock.\nS0=100, K=105, T=1Y, risk-free rate r=5%, volatility\
+    \ sigma=20%.\nSolve with the Black-Scholes PDE operator using Crank-Nicolson\n\
+    (theta=0.5) and fully implicit (theta=1.0) on a 200-point spot grid\n× 100 time\
+    \ steps.\nMeasure convergence order by doubling the grid: the CN scheme should\n\
+    show O(dt^2 + dS^2) convergence and the implicit scheme O(dt + dS^2).\nCompare\
+    \ both to the Black-Scholes analytical price.\n\nConstruct methods: pde_solver\n\
+    Comparison targets: theta_0.5 (pde_solver), theta_1.0 (pde_solver), black_scholes\
+    \ (analytical)\nCross-validation harness:\n  internal targets: theta_0.5, theta_1.0\n\
+    \  analytical benchmark: black_scholes\n  external targets: quantlib\nNew component:\
+    \ convergence_order_diagnostic\n\nImplementation target: theta_1.0\nPreferred\
+    \ method family: pde_solver\n\nImplementation target: theta_1.0.\"\"\"\n\n   \
+    \ def __init__(self, spec: EuropeanOptionSpec):\n        self._spec = spec\n\n\
+    \    @property\n    def spec(self) -> EuropeanOptionSpec:\n        return self._spec\n\
+    \n    @property\n    def requirements(self) -> set[str]:\n        return {\"black_vol_surface\"\
+    , \"discount_curve\"}\n\n    def evaluate(self, market_state: MarketState) ->\
+    \ float:\n        spec = self._spec\n        raise NotImplementedError(\"evaluate\
+    \ not yet implemented\")\n\n```\n\n## Your task\nWrite ONLY the body of the `evaluate()`\
+    \ method. The signature is already defined:\n\n    def evaluate(self, market_state:\
+    \ MarketState) -> float:\n\n## Spec fields available via self._spec\n- `self._spec.notional`\
+    \ (float): Notional / number of shares\n- `self._spec.spot` (float): Current spot\
+    \ price\n- `self._spec.strike` (float): Option strike price\n- `self._spec.expiry_date`\
+    \ (date): Option expiry date\n- `self._spec.option_type` (str): Option type: 'call'\
+    \ or 'put'\n- `self._spec.day_count` (DayCountConvention): Day count convention\n\
+    \n## Pricing Method (selected by the quant agent — you MUST use this)\nMethod:\
+    \ **pde_solver**\nReasoning: product_ir_compiler\nSelection basis and assumptions:\n\
+    - Selection basis: `explicit_preference`\n- Assumptions / defaulted context:\n\
+    \  - `simplest_valid_assumption_set`\n  - `finite_difference_discretization_route`\n\
+    \  - `boundary_conditions_required`\nRoute-bound modules to import and use:\n\
+    - `trellis.models.equity_option_pde`\n\nYou MUST import and use these route-bound\
+    \ modules in your implementation.\nDo not import a generic parent package such\
+    \ as `from trellis.models import ...` just to satisfy the method family.\n\n##\
+    \ API Map — start here before guessing module paths\n\nUse this navigation card\
+    \ to choose the right module family first. Confirm exact symbols with `find_symbol`\
+    \ or `list_exports` before calling `read_module`.\n\n### Core Types\n#### MarketState\n\
+    - Module: `trellis.core.market_state`\n- Class: `MarketState`\n- Frozen: `true`\n\
+    - Fields: `as_of`, `settlement`, `discount`, `forward_curve`, `vol_surface`, `state_space`,\
+    \ `credit_curve`, `forecast_curves`, `fx_rates`\n- Accessors: `discount_factor`,\
+    \ `zero_rate`, `forward_rate`, `forecast_forward`, `black_vol`, `survival_prob`,\
+    \ `hazard_rate`, `risky_discount`\n- Capabilities: `discount_curve → discount\
+    \ is not None`, `forward_curve → forward_curve is not None (auto from discount)`,\
+    \ `black_vol_surface → vol_surface is not None`, `state_space → state_space is\
+    \ not None`, `credit_curve → credit_curve is not None`, `fx_rates → fx_rates is\
+    \ not None`\n#### Payoff\n- Module: `trellis.core.payoff`\n- Protocol: `Payoff`\n\
+    - Required methods: `evaluate`\n- Required properties: `requirements`\n- Runtime\
+    \ checkable: `true`\n- Notes:\n  - Each payoff handles its own discounting internally\n\
+    \  - The returned float is the final PV\n  - DeterministicCashflowPayoff wraps\
+    \ any Instrument into Payoff\n\n### Model Families\n#### equity_tree\n- Module:\
+    \ `trellis.models.equity_option_tree`\n- Key imports:\n  - `from trellis.models.equity_option_tree\
+    \ import price_vanilla_equity_option_tree`\n  - `from trellis.models.trees.lattice\
+    \ import build_spot_lattice, lattice_backward_induction`\n- Notes:\n  - American/Bermudan\
+    \ equity options should prefer the checked-in helper `price_vanilla_equity_option_tree(...)`\n\
+    \  - If you need the lower-level path, import the lattice builder/backward induction\
+    \ submodules directly\n#### rate_lattice\n- Module: `trellis.models.trees.lattice`\n\
+    - Key imports:\n  - `from trellis.models.trees.lattice import build_rate_lattice,\
+    \ lattice_backward_induction`\n  - `from trellis.models.zcb_option_tree import\
+    \ price_zcb_option_tree`\n- Notes:\n  - Callable bonds, puttable bonds, and Bermudan\
+    \ swaptions use a calibrated rate lattice from a TreeModel specification such\
+    \ as Hull-White or Black-Derman-Toy\n  - lattice_backward_induction handles cashflow_at_node\
+    \ and exercise_fn\n#### monte_carlo\n- Module: `trellis.models.monte_carlo`\n\
+    - Key imports:\n  - `from trellis.models.monte_carlo.engine import MonteCarloEngine`\n\
+    \  - `from trellis.models.monte_carlo.lsm import longstaff_schwartz, longstaff_schwartz_result`\n\
+    \  - `from trellis.models.monte_carlo.early_exercise import EarlyExercisePolicyResult,\
+    \ LeastSquaresContinuationEstimator`\n  - `from trellis.models.monte_carlo.schemes\
+    \ import LaguerreBasis`\n  - `from trellis.models.monte_carlo import euler_maruyama,\
+    \ milstein, brownian_bridge`\n  - `from trellis.models.monte_carlo import antithetic,\
+    \ control_variate`\n  - `from trellis.models.processes.gbm import GBM`\n- Notes:\n\
+    \  - For American/Bermudan Monte Carlo, simulate paths then call an approved early-exercise\
+    \ control primitive; Trellis currently implements longstaff_schwartz\n  - If the\
+    \ control primitive uses continuation regression, choose the estimator or basis\
+    \ explicitly; LaguerreBasis is optional, not mandatory\n#### qmc\n- Module: `trellis.models.qmc`\n\
+    - Key imports:\n  - `from trellis.models.qmc import sobol_normals, brownian_bridge`\n\
+    \  - `from trellis.models.processes.gbm import GBM`\n- Notes:\n  - QMC is an accelerator\
+    \ family layered on Monte Carlo-style estimators\n  - Current support is Sobol-based\
+    \ normal draws and Brownian-bridge construction\n#### pde\n- Module: `trellis.models.pde`\n\
+    - Key imports:\n  - `from trellis.models.equity_option_pde import price_vanilla_equity_option_pde`\n\
+    \  - `from trellis.models.pde.grid import Grid`\n  - `from trellis.models.pde.theta_method\
+    \ import theta_method_1d`\n  - `from trellis.models.pde.operator import BlackScholesOperator`\n\
+    \  - `from trellis.models.pde import psor_1d  # American options`\n  - `from trellis.models.pde\
+    \ import HullWhitePDEOperator`\n- Notes:\n  - Vanilla European equity PDE routes\
+    \ should prefer the checked-in helper `price_vanilla_equity_option_pde(...)`\n\
+    \  - Use theta_method_1d, NOT legacy crank_nicolson_1d or implicit_fd_1d\n####\
+    \ fft\n- Module: `trellis.models.transforms`\n- Key imports:\n  - `from trellis.models.transforms\
+    \ import fft_price, cos_price`\n- Notes:\n  - fft_price expects CF of log(S_T)\
+    \ — include log(S0)\n  - cos_price expects CF of log(S_T/S0) — log-return only\n\
+    #### copulas\n- Module: `trellis.models.copulas`\n- Key imports:\n  - `from trellis.models.copulas\
+    \ import GaussianCopula, StudentTCopula, FactorCopula`\n#### analytical\n- Module:\
+    \ `trellis.models.zcb_option`\n- Key imports:\n  - `from trellis.models.zcb_option\
+    \ import resolve_zcb_option_hw_inputs, price_zcb_option_jamshidian`\n  - `from\
+    \ trellis.models.analytical.jamshidian import ResolvedJamshidianInputs, zcb_option_hw_raw`\n\
+    \  - `from trellis.models.analytical import zcb_option_hw`\n  - `from trellis.models.analytical\
+    \ import terminal_vanilla_from_basis`\n  - `from trellis.models.rate_style_swaption\
+    \ import ResolvedSwaptionBlack76Inputs, resolve_swaption_black76_inputs, price_swaption_black76_raw,\
+    \ price_bermudan_swaption_black76_lower_bound`\n#### calibration\n- Module: `trellis.models.calibration`\n\
+    - Key imports:\n  - `from trellis.models.calibration import implied_vol, implied_vol_jaeckel`\n\
+    \  - `from trellis.models.calibration import RatesCalibrationResult, calibrate_cap_floor_black_vol,\
+    \ calibrate_swaption_black_vol, swaption_terms`\n  - `from trellis.models.calibration\
+    \ import calibrate_sabr`\n  - `from trellis.models.calibration import dupire_local_vol`\n\
+    \n### Utilities\n#### black76\n- Module: `trellis.models.black`\n- Imports:\n\
+    \  - `from trellis.models.black import black76_call, black76_put, black76_asset_or_nothing_call,\
+    \ black76_asset_or_nothing_put, black76_cash_or_nothing_call, black76_cash_or_nothing_put`\n\
+    #### garman_kohlhagen\n- Module: `trellis.models.analytical.fx`\n- Imports:\n\
+    \  - `from trellis.models.analytical.fx import ResolvedGarmanKohlhagenInputs,\
+    \ garman_kohlhagen_price_raw`\n  - `from trellis.models.black import garman_kohlhagen_call,\
+    \ garman_kohlhagen_put`\n#### rate_style_swaption\n- Module: `trellis.models.rate_style_swaption`\n\
+    - Imports:\n  - `from trellis.models.rate_style_swaption import ResolvedSwaptionBlack76Inputs,\
+    \ resolve_swaption_black76_inputs, price_swaption_black76_raw, price_swaption_black76`\n\
+    \  - `from trellis.models.rate_style_swaption import price_bermudan_swaption_black76_lower_bound`\n\
+    #### jamshidian_zcb_option\n- Module: `trellis.models.zcb_option`\n- Imports:\n\
+    \  - `from trellis.models.zcb_option import ResolvedZCBOptionInputs, resolve_zcb_option_hw_inputs,\
+    \ price_zcb_option_jamshidian`\n  - `from trellis.models.analytical.jamshidian\
+    \ import ResolvedJamshidianInputs, zcb_option_hw_raw`\n#### schedule\n- Module:\
+    \ `trellis.core.date_utils`\n- Imports:\n  - `from trellis.core.date_utils import\
+    \ generate_schedule`\n#### day_count\n- Module: `trellis.core.date_utils`\n- Imports:\n\
+    \  - `from trellis.core.date_utils import year_fraction`\n#### vol_surface\n-\
+    \ Module: `trellis.models.vol_surface`\n- Imports:\n  - `from trellis.models.vol_surface\
+    \ import VolSurface, FlatVol`\n#### cashflow_engine\n- Module: `trellis.models.cashflow_engine`\n\
+    - Imports:\n  - `from trellis.models.cashflow_engine import Waterfall, Tranche`\n\
+    \  - `from trellis.models.cashflow_engine import PSA, CPR, RateDependent`\n  -\
+    \ `from trellis.models.cashflow_engine import level_pay, scheduled, custom`\n\
+    #### credit_curve\n- Module: `trellis.curves.credit_curve`\n- Imports:\n  - `from\
+    \ trellis.curves.credit_curve import CreditCurve`\n- Notes:\n  - CreditCurve.flat(hazard_rate)\
+    \ is the simplest starting point for CDS or nth-to-default tasks\n## Distilled\
+    \ Build Memory\n\n- Product: `european_option` / `vanilla_option` / `european`\n\
+    - Default method family: `pde_solver`\n- Method intent: One-dimensional finite-difference\
+    \ theta-method pricing with optional obstacle handling\n- Non-negotiable requirements:\n\
+    \  - GRID: Use at least 200 spatial points and 200+ time steps. For barrier options,\
+    \ use non-uniform grid concentrated near the barrier.\n  - BOUNDARY CONDITIONS:\
+    \ Set V(0,t)=0 for calls, V(S_max,t)=S_max-K*exp(-r*(T-t)) for calls. For puts:\
+    \ V(0,t)=K*exp(-r*(T-t)), V(S_max,t)=0.\n  - STABILITY: Crank-Nicolson (theta=0.5)\
+    \ is second-order but may oscillate near discontinuities. Use Rannacher smoothing\
+    \ (2-4 implicit steps at start) for digital/barrier payoffs.\n- Canonical model\
+    \ grammar:\n  - `local_vol_surface_workflow` -> `Dupire local vol`\n  - `sabr_smile_workflow`\
+    \ -> `SABR smile`\n- Repeated fixes to reuse:\n  - `BlackScholesOperator constructor\
+    \ mismatch` -> Import BlackScholesOperator from trellis.models.pde.operator and\
+    \ pass callables, for example BlackScholesOperator(lambda s, t: sigma, lambda\
+    \ t: r). Add a signature smoke test or cookbook template to lock the constructor\
+    \ shape and keep the solver path aligned with the real API.\n  - `PDE price blow-up\
+    \ from unit/scale mismatch` -> Build Grid(x_min=0.0, x_max=S_max, n_x=n_x, T=T,\
+    \ n_t=n_t), construct BlackScholesOperator(lambda s, t: sigma, lambda t: r), call\
+    \ theta_method_1d(grid, op, terminal, theta=0.5, lower_bc_fn=..., upper_bc_fn=...),\
+    \ then interpolate the returned vector with np.interp(spec.spot, grid.x, V) before\
+    \ multiplying by notional.\n\n## Generated Skills\n- [cookbook] fft_pricing: Characteristic-function\
+    \ pricing for European-style options under models such as Heston\n- [lesson] Unit\
+    \ conversion causes huge PV: Enforce and document input conventions (vol as decimal,\
+    \ discount curve vs zero rate semantics, notional scaling), derive r from discount\
+    \ factors via r = -ln(df)/T or use forward/Black76 consistently, add unit/conversi...\n\
+    ## Structured Lane Card\n- Method family: `pde_solver`\n- Instrument type: `european_option`\n\
+    - Lane boundary: family=`pde_solver`, kind=`exact_target_binding`, exact_bindings=`trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
+    - Lane obligations:\n  - Lane family: `pde_solver`\n  - Plan kind: `exact_target_binding`\n\
+    \  - Market bindings: `black_vol_surface`, `discount_curve`\n  - State obligations:\
+    \ `spot`, `strike`, `expiry`, `expiry_black_vol`\n  - Exact backend bindings:\n\
+    \    - `trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n  -\
+    \ Exact binding signatures:\n    - `price_vanilla_equity_option_pde(market_state:\
+    \ 'EquityPDEMarketStateLike', spec: 'VanillaEquityOptionSpecLike', *, theta: 'float'\
+    \ = 0.5, n_x: 'int | None' = None, n_t: 'int | None' = None, s_max_multiplier:\
+    \ 'float' = 4.0) -> 'float'`\n- Route authority:\n  - binding=`trellis.models.equity_option_pde.price_vanilla_equity_option_pde`,\
+    \ engine=`pde_solver`, authority=`exact_backend_fit`\n  - Route alias: `vanilla_equity_theta_pde`\n\
+    \  - Validation bundle: `pde_solver:european_option`\n  - Validation checks: `check_non_negativity`,\
+    \ `check_price_sanity`, `check_vol_sensitivity`, `check_vol_monotonicity`\n  -\
+    \ Exact target bindings: `trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
+    - Backend binding:\n  - Route: `vanilla_equity_theta_pde`\n  - Engine family:\
+    \ `pde_solver`\n  - Route family: `pde_solver`\n  - Selected primitives:\n   \
+    \ - `trellis.models.equity_option_pde.price_vanilla_equity_option_pde` (route_helper)\n\
+    \  - Resolved instructions:\n    - [hard_constraint] Use the route helper directly\
+    \ inside `evaluate()`; do not rebuild the process, engine, or discount glue manually.\n\
+    \    - [historical_note] For vanilla European equity PDE routes, prefer `price_vanilla_equity_option_pde(market_state,\
+    \ spec, theta=...)` so the adapter stays thin.\n    - [historical_note] Map `implementation_target=theta_0.5`\
+    \ to `theta=0.5` and `implementation_target=theta_1.0` to `theta=1.0`.\n    -\
+    \ [historical_note] The checked-in helper already owns grid sizing, terminal payoff\
+    \ assembly, boundary conditions, theta-method solve, and interpolation back to\
+    \ spot.\n    - [historical_note] Use the lower-level `Grid + BlackScholesOperator\
+    \ + theta_method_1d` path only when the payoff or boundary contract genuinely\
+    \ differs from plain vanilla European call/put.\n  - Required adapters:\n    -\
+    \ `reuse_checked_in_vanilla_equity_pde_helper`\n  - Backend notes:\n    - For\
+    \ vanilla European equity PDE routes, prefer `price_vanilla_equity_option_pde(market_state,\
+    \ spec, theta=...)` so the adapter stays thin.\n    - Map `implementation_target=theta_0.5`\
+    \ to `theta=0.5` and `implementation_target=theta_1.0` to `theta=1.0`.\n    -\
+    \ The checked-in helper already owns grid sizing, terminal payoff assembly, boundary\
+    \ conditions, theta-method solve, and interpolation back to spot.\n    - Use the\
+    \ lower-level `Grid + BlackScholesOperator + theta_method_1d` path only when the\
+    \ payoff or boundary contract genuinely differs from plain vanilla European call/put.\n\
+    - Primary modules to inspect/reuse:\n  - `trellis.models.pde.theta_method`\n-\
+    \ Post-build test targets:\n  - `tests/test_agent/test_build_loop.py`\n- Instruction\
+    \ precedence: follow the lane obligations in this card first. Treat backend route/helper\
+    \ details as exact-fit bindings, not as permission to invent a different numerical\
+    \ path.\n- Treat route authority as backend-fit evidence, not as permission to\
+    \ invent a different synthesis plan.\n- Use approved Trellis imports only. Prefer\
+    \ thin adapters when the compiler found an exact backend; otherwise build the\
+    \ smallest lane-consistent kernel the plan requires.\n## Backend Lookup (Secondary\
+    \ To Lane Obligations)\n- Lane family: `pde_solver`\n- Lane plan kind: `exact_target_binding`\n\
+    - Method family: `pde_solver`\n- Route: `vanilla_equity_theta_pde`\n- Engine family:\
+    \ `pde_solver`\n- Required primitive symbols:\n  - `trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
+    - Adapter obligations:\n  - `reuse_checked_in_vanilla_equity_pde_helper`\n## Thin\
+    \ Adapter Plan\n- Target payoff class: `EuropeanOptionAnalyticalPayoff`\n- Required\
+    \ market reads:\n  - `market_state.vol_surface.black_vol(...)`\n  - `market_state.discount`\n\
+    - Required primitive calls:\n  - `trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
+    - Required adapter steps:\n  - `reuse_checked_in_vanilla_equity_pde_helper`\n\
+    - Return contract: Return a Python `float` present value from `evaluate()`.\n\
+    ## Invariant Pack\n- The generated payoff should be compatible with these deterministic\
+    \ validation checks:\n  - `check_non_negativity`\n  - `check_price_sanity`\n \
+    \ - `check_vol_sensitivity`\n  - `check_vol_monotonicity`\n## Family Route Guidance\n\
+    - For vanilla European PDE routes, prefer `price_vanilla_equity_option_pde(market_state,\
+    \ self._spec, theta=...)` from `trellis.models.equity_option_pde`.\n- Map `implementation_target=theta_0.5`\
+    \ to `theta=0.5` and `implementation_target=theta_1.0` to `theta=1.0`.\n- Keep\
+    \ the wrapper thin: delegate grid sizing, boundary conditions, terminal payoff\
+    \ assembly, theta-method solve, and interpolation back to spot to the checked-in\
+    \ helper.\n- Only fall back to direct `Grid + BlackScholesOperator + theta_method_1d`\
+    \ assembly when the payoff or boundary contract genuinely differs from plain vanilla\
+    \ European call/put.\n## Conventions\n- evaluate() returns a FLOAT — the present\
+    \ value (PV) of the instrument\n- You MUST handle all discounting internally —\
+    \ use `market_state.discount.discount(t)`\n- For forward rates: `market_state.forecast_forward_curve(self._spec.rate_index)`\n\
+    - For vol: `market_state.vol_surface.black_vol(T, strike)`\n- For discount factors:\
+    \ `market_state.discount.discount(t)`\n- `market_state.fx_rates[pair]` returns\
+    \ an `FXRate` wrapper; extract `.spot` before scalar arithmetic or process seeding\n\
+    - Schedule generation: prefer `build_payment_timeline(...)`, `build_observation_timeline(...)`,\
+    \ or `build_period_schedule(...)` for accrual/event routes; use `generate_schedule(start,\
+    \ end, freq)` only for plain date lists with no period semantics\n- Year fractions:\
+    \ `year_fraction(date1, date2, day_count)`\n- Never use wall-clock dates such\
+    \ as `date.today()` or `datetime.now()` inside `evaluate()`; derive valuation\
+    \ time from `market_state` or shared resolver outputs.\n- Black76: `black76_call(F,\
+    \ K, sigma, T)`, `black76_put(F, K, sigma, T)` — undiscounted\n- Black76 digital:\
+    \ `black76_cash_or_nothing_call(F, K, sigma, T)`, `black76_cash_or_nothing_put(F,\
+    \ K, sigma, T)` — undiscounted cash-or-nothing digitals\n- For CDS / nth-to-default:\
+    \ use `market_state.credit_curve.survival_probability(t)` and `market_state.credit_curve.hazard_rate(t)`\
+    \ on an explicit payment/default schedule; do not route credit-default pricing\
+    \ through Black76 call/put primitives.\n- For equity trees: prefer `from trellis.models.equity_option_tree\
+    \ import price_vanilla_equity_option_tree`; the lower-level lattice path is `from\
+    \ trellis.models.trees.lattice import build_spot_lattice, lattice_backward_induction`\n\
+    - For vanilla European PDE routes: prefer `from trellis.models.equity_option_pde\
+    \ import price_vanilla_equity_option_pde`; the lower-level fallback is `from trellis.models.pde.grid\
+    \ import Grid`, `from trellis.models.pde.operator import BlackScholesOperator`,\
+    \ and `from trellis.models.pde.theta_method import theta_method_1d`\n- For rate\
+    \ lattices: prefer helper surfaces such as `price_callable_bond_tree(...)`, `price_bermudan_swaption_tree(...)`,\
+    \ or `price_zcb_option_tree(...)`; the lower-level fallback is `from trellis.models.trees.lattice\
+    \ import build_rate_lattice, lattice_backward_induction`\n- For schedule-dependent\
+    \ rate lattices: `from trellis.models.trees.control import lattice_steps_from_timeline,\
+    \ resolve_lattice_exercise_policy`\n- For MC: `from trellis.models.monte_carlo\
+    \ import MonteCarloEngine`\n- For QMC accelerators: `from trellis.models.qmc import\
+    \ sobol_normals, brownian_bridge`\n- For copulas: `from trellis.models.copulas\
+    \ import GaussianCopula, FactorCopula`\n- Do not invent MonteCarloEngine method\
+    \ strings. Valid `method=` values are `euler`, `milstein`, and `exact`.\n- For\
+    \ Monte Carlo early exercise, use an approved control primitive; do not pretend\
+    \ that `MonteCarloEngine.price(...)` or `method=\"lsm\"` implements early exercise.\
+    \ Approved policy classes: `longstaff_schwartz` [implemented], `tsitsiklis_van_roy`\
+    \ [implemented], `primal_dual_mc` [implemented], `stochastic_mesh` [implemented].\
+    \ Currently implemented in Trellis: `longstaff_schwartz`, `tsitsiklis_van_roy`,\
+    \ `primal_dual_mc`, `stochastic_mesh`.\n- If you use `LaguerreBasis`, import it\
+    \ from `trellis.models.monte_carlo.schemes`, not from `trellis.models.monte_carlo.lsm`.\n\
+    - For FFT/COS pricing, characteristic functions must accept vector `u` and use\
+    \ array-safe numerics such as `numpy`, not scalar `math`/`cmath`.\n- Black76 basis:\
+    \ `black76_asset_or_nothing_call(F, K, sigma, T)`, `black76_asset_or_nothing_put(F,\
+    \ K, sigma, T)`, `black76_cash_or_nothing_call(F, K, sigma, T)`, `black76_cash_or_nothing_put(F,\
+    \ K, sigma, T)` — exact terminal basis claims.\n- For terminal vanilla payoffs,\
+    \ prefer exact basis assembly via `terminal_vanilla_from_basis(...)` from `trellis.models.analytical`.\n\
+    - For FX vanilla options, treat the route as Garman-Kohlhagen: map spot FX and\
+    \ domestic/foreign discount factors to `ResolvedGarmanKohlhagenInputs`, then prefer\
+    \ `garman_kohlhagen_price_raw(spec.option_type, resolved)` from `trellis.models.analytical.fx`;\
+    \ use explicit basis-claim assembly only when the request explicitly needs the\
+    \ decomposition.\n- For cash-or-nothing digital options, use the Black76 digital\
+    \ helpers directly; do not approximate them with vanilla call/put prices or divide\
+    \ by spot.\n- You MUST use only real, approved `trellis.*` imports from the structured\
+    \ generation plan and import registry\n- Treat the compiler-emitted lane obligations\
+    \ in the structured generation plan as the backbone of the implementation.\n-\
+    \ Reuse the listed exact backend bindings when present; otherwise build the smallest\
+    \ lane-consistent kernel that satisfies the construction steps.\n- Do not replace\
+    \ selected primitives with bespoke numerical kernels or alternative Trellis routes\
+    \ unless the plan explicitly permits a new lane implementation.\n- Do not add\
+    \ wildcard imports\n- If the approved modules do not contain what you need, reuse\
+    \ the closest existing implementation and keep the gap explicit instead of inventing\
+    \ a path\n\n## Reference implementations\n\n### Payoff protocol + Cashflows/PresentValue\
+    \ return types\n```python\n\"\"\"Payoff protocol and base classes for pricing\
+    \ instruments.\n\nEvery priceable instrument in Trellis implements the Payoff\
+    \ protocol.\nA payoff takes market data (via MarketState) and returns a present\
+    \ value.\nThis module also provides base classes for two common pricing patterns:\n\
+    \n- ResolvedInputPayoff: for analytical or tree-based pricing where market\n \
+    \ data is extracted once, then fed into a pricing formula.\n- MonteCarloPathPayoff:\
+    \ for simulation-based pricing where paths are\n  generated and payoffs are computed\
+    \ per path then averaged.\n\"\"\"\n\nfrom __future__ import annotations\n\nfrom\
+    \ abc import ABC, abstractmethod\nfrom datetime import date\nfrom typing import\
+    \ Generic, Protocol, TypeVar, runtime_checkable\n\nfrom trellis.core.date_utils\
+    \ import year_fraction\nfrom trellis.core.differentiable import get_numpy\nfrom\
+    \ trellis.core.market_state import MarketState\nfrom trellis.core.types import\
+    \ DayCountC\n# [truncated reference]\n```\n\n### Date utilities used by generated\
+    \ payoffs\n```python\n\"\"\"Date utilities: day count conventions, schedule generation,\
+    \ year fractions.\"\"\"\n\nfrom __future__ import annotations\n\nimport calendar\n\
+    from collections.abc import Iterable\nfrom datetime import date, datetime, timedelta\n\
+    from typing import Union\n\nfrom trellis.core.types import (\n    ContractTimeline,\n\
+    \    DayCountConvention,\n    EventSchedule,\n    Frequency,\n    TimelineRole,\n\
+    )\n\nDateLike = Union[date, datetime]\nExplicitDateInput = ContractTimeline |\
+    \ EventSchedule | Iterable[DateLike | str] | str\n\n\ndef _to_date(d: DateLike)\
+    \ -> date:\n    \"\"\"Normalize ``date``/``datetime`` inputs to plain ``date``\
+    \ objects.\"\"\"\n    if isinstance(d, datetime):\n        return d.date()\n \
+    \   return d\n\n\ndef add_months(dt: DateLike, months: int) -> date:\n    \"\"\
+    \"Add *months* calendar months, clamping the day to the new month's max.\"\"\"\
+    \n    d = _to_date(dt)\n    total_months = d.month - 1 + months\n    year = d.year\
+    \ + total\n# [truncated reference]\n```\n\n### MarketState capabilities and access\
+    \ patterns\n```python\n\"\"\"MarketState: immutable container of market data used\
+    \ for pricing.\n\nA MarketState holds everything a payoff needs to compute a price:\n\
+    discount curves, volatility surfaces, spot prices, credit curves, etc.\nIt is\
+    \ frozen (immutable) so that multiple payoffs can safely share the\nsame market\
+    \ snapshot without risk of accidental modification.\n\"\"\"\n\nfrom __future__\
+    \ import annotations\n\nfrom dataclasses import dataclass\nfrom datetime import\
+    \ date\nfrom typing import TYPE_CHECKING\n\nfrom trellis.core.types import DiscountCurve\n\
+    \nif TYPE_CHECKING:\n    from trellis.core.state_space import StateSpace\n   \
+    \ from trellis.curves.credit_curve import CreditCurve\n    from trellis.curves.forward_curve\
+    \ import ForwardCurve\n    from trellis.instruments.fx import FXRate\n    from\
+    \ trellis.models.vol_surface import VolSurface\n\n\nclass MissingCapabilityError(Exception):\n\
+    \    \"\"\"Raised when a MarketState lacks market data r\n# [truncated reference]\n\
+    ```\n\n### Frequency/day-count types\n```python\n\"\"\"Core protocols, enums,\
+    \ and data structures shared across Trellis.\n\nDefines the fundamental types\
+    \ that most other modules depend on:\nfrequency enums, day count conventions,\
+    \ the DiscountCurve and Instrument\nprotocols, and simple data containers like\
+    \ schedules and pricing results.\n\"\"\"\n\nfrom __future__ import annotations\n\
+    \nfrom dataclasses import dataclass, field\nfrom datetime import date\nfrom enum\
+    \ import Enum\nfrom typing import Protocol, runtime_checkable\n\n# ---------------------------------------------------------------------------\n\
+    # Greek specification types\n# ---------------------------------------------------------------------------\n\
+    \n# What risk sensitivities to compute alongside the price.\n#   None       —\
+    \ price only, no sensitivities\n#   \"all\"      — every known sensitivity (dv01,\
+    \ duration, convexity, etc.)\n#   list[str]  — specific sensitivities by name\
+    \ (e.g. [\"dv01\", \"duration\"])\n# [truncated reference]\n```\n\n[omitted 6\
+    \ additional reference modules]\n\n\n## Output\nReturn the COMPLETE Python module\
+    \ — copy the skeleton exactly, but replace the\n`raise NotImplementedError(...)`\
+    \ line with the actual implementation of `evaluate()`.\nDo NOT change imports,\
+    \ class names, spec fields, or the requirements property.\nOnly implement the\
+    \ evaluate() method body. You may add imports at the top.\nNo markdown fences,\
+    \ no explanation — just the Python code."
+  model: gpt-5.4-mini
+- seq: 3
+  function: llm_generate_json
+  stage: critic
+  prompt_hash: befa63693598d5f2813571dc1450d69f6b653e043d1f11bde5e50a6fd3848bda
+  response_text: '{"check_id": "volatility_input_usage", "description": "Volatility
+    is likely ignored or effectively bypassed in the PDE call path", "severity": "error",
+    "evidence": "The evaluate() method hard-codes theta=1.0 and never uses the docstring''s
+    theta-method comparison logic; more importantly, it passes only market_state and
+    spec into price_vanilla_equity_option_pde without any visible handling of the
+    market vol input beyond a presence check. The route contract requires the helper
+    to consume expiry_black_vol from market_state, but this implementation does not
+    verify or adapt it, so a flat-vol sensitivity test is likely to show little or
+    no response if the backend is not wired through correctly.", "remediation": "Ensure
+    the evaluated market_state carries the volatility surface in the backend-expected
+    field and that the route helper is called with the correct theta target (0.5 or
+    1.0 as intended). If the helper is not using market_state.vol_surface/expiry_black_vol,
+    fix the adapter to map the vol input explicitly.", "status": "suspect"}'
+  prompt_text: "You are a quantitative model validator reviewing agent-generated pricing\
+    \ code.\nYour job is to find deterministic review concerns, not to praise. Be\
+    \ adversarial.\n\n## Code to review\n```python\n\"\"\"Agent-generated payoff:\
+    \ Build a pricer for: European call: theta-method convergence order measurement\n\
+    \nEuropean call option on a non-dividend-paying stock.\nS0=100, K=105, T=1Y, risk-free\
+    \ rate r=5%, volatility sigma=20%.\nSolve with the Black-Scholes PDE operator\
+    \ using Crank-Nicolson\n(theta=0.5) and fully implicit (theta=1.0) on a 200-point\
+    \ spot grid\n× 100 time steps.\nMeasure convergence order by doubling the grid:\
+    \ the CN scheme should\nshow O(dt^2 + dS^2) convergence and the implicit scheme\
+    \ O(dt + dS^2).\nCompare both to the Black-Scholes analytical price.\n\nConstruct\
+    \ methods: pde_solver\nComparison targets: theta_0.5 (pde_solver), theta_1.0 (pde_solver),\
+    \ black_scholes (analytical)\nCross-validation harness:\n  internal targets: theta_0.5,\
+    \ theta_1.0\n  analytical benchmark: black_scholes\n  external targets: quantlib\n\
+    New component: convergence_order_diagnostic\n\nImplementation target: theta_1.0\n\
+    Preferred method family: pde_solver\n\nImplementation target: theta_1.0.\"\"\"\
+    \n\nfrom __future__ import annotations\n\nfrom dataclasses import dataclass\n\
+    from datetime import date\n\nfrom trellis.core.market_state import MarketState\n\
+    from trellis.core.types import DayCountConvention\nfrom trellis.models.equity_option_pde\
+    \ import price_vanilla_equity_option_pde\n\n\n\n@dataclass(frozen=True)\nclass\
+    \ EuropeanOptionSpec:\n    \"\"\"Specification for Build a pricer for: European\
+    \ call: theta-method convergence order measurement\n\nEuropean call option on\
+    \ a non-dividend-paying stock.\nS0=100, K=105, T=1Y, risk-free rate r=5%, volatility\
+    \ sigma=20%.\nSolve with the Black-Scholes PDE operator using Crank-Nicolson\n\
+    (theta=0.5) and fully implicit (theta=1.0) on a 200-point spot grid\n× 100 time\
+    \ steps.\nMeasure convergence order by doubling the grid: the CN scheme should\n\
+    show O(dt^2 + dS^2) convergence and the implicit scheme O(dt + dS^2).\nCompare\
+    \ both to the Black-Scholes analytical price.\n\nConstruct methods: pde_solver\n\
+    Comparison targets: theta_0.5 (pde_solver), theta_1.0 (pde_solver), black_scholes\
+    \ (analytical)\nCross-validation harness:\n  internal targets: theta_0.5, theta_1.0\n\
+    \  analytical benchmark: black_scholes\n  external targets: quantlib\nNew component:\
+    \ convergence_order_diagnostic\n\nImplementation target: theta_1.0\nPreferred\
+    \ method family: pde_solver\n\nImplementation target: theta_1.0.\"\"\"\n    notional:\
+    \ float\n    spot: float\n    strike: float\n    expiry_date: date\n    option_type:\
+    \ str = \"'call'\"\n    day_count: DayCountConvention = DayCountConvention.ACT_365\n\
+    \n\nclass EuropeanOptionAnalyticalPayoff:\n    \"\"\"Build a pricer for: European\
+    \ call: theta-method convergence order measurement\n\nEuropean call option on\
+    \ a non-dividend-paying stock.\nS0=100, K=105, T=1Y, risk-free rate r=5%, volatility\
+    \ sigma=20%.\nSolve with the Black-Scholes PDE operator using Crank-Nicolson\n\
+    (theta=0.5) and fully implicit (theta=1.0) on a 200-point spot grid\n× 100 time\
+    \ steps.\nMeasure convergence order by doubling the grid: the CN scheme should\n\
+    show O(dt^2 + dS^2) convergence and the implicit scheme O(dt + dS^2).\nCompare\
+    \ both to the Black-Scholes analytical price.\n\nConstruct methods: pde_solver\n\
+    Comparison targets: theta_0.5 (pde_solver), theta_1.0 (pde_solver), black_scholes\
+    \ (analytical)\nCross-validation harness:\n  internal targets: theta_0.5, theta_1.0\n\
+    \  analytical benchmark: black_scholes\n  external targets: quantlib\nNew component:\
+    \ convergence_order_diagnostic\n\nImplementation target: theta_1.0\nPreferred\
+    \ method family: pde_solver\n\nImplementation target: theta_1.0.\"\"\"\n\n   \
+    \ def __init__(self, spec: EuropeanOptionSpec):\n        self._spec = spec\n\n\
+    \    @property\n    def spec(self) -> EuropeanOptionSpec:\n        return self._spec\n\
+    \n    @property\n    def requirements(self) -> set[str]:\n        return {\"black_vol_surface\"\
+    , \"discount_curve\"}\n\n    def evaluate(self, market_state: MarketState) ->\
+    \ float:\n        spec = self._spec\n        spec = self._spec\n        from trellis.models.equity_option_pde\
+    \ import price_vanilla_equity_option_pde\n\n        if not hasattr(market_state,\
+    \ \"vol_surface\") or market_state.vol_surface is None:\n            raise ValueError(\"\
+    market_state.vol_surface is required for PDE pricing\")\n        if not hasattr(market_state,\
+    \ \"discount\") or market_state.discount is None:\n            raise ValueError(\"\
+    market_state.discount is required for PDE pricing\")\n\n        theta = 0.5 if\
+    \ \"0.5\" in type(self).__doc__ or False else 1.0\n        return float(\n   \
+    \         price_vanilla_equity_option_pde(\n                market_state,\n  \
+    \              spec,\n                theta=1.0,\n            )\n        )\n\n\
+    ```\n\n## Instrument description\nBuild a pricer for: European call: theta-method\
+    \ convergence order measurement\n\nEuropean call option on a non-dividend-paying\
+    \ stock.\nS0=100, K=105, T=1Y, risk-free rate r=5%, volatility sigma=20%.\nSolve\
+    \ with the Black-Scholes PDE operator using Crank-Nicolson\n(theta=0.5) and fully\
+    \ implicit (theta=1.0) on a 200-point spot grid\n× 100 time steps.\nMeasure convergence\
+    \ order by doubling the grid: the CN scheme should\nshow O(dt^2 + dS^2) convergence\
+    \ and the implicit scheme O(dt + dS^2).\nCompare both to the Black-Scholes analytical\
+    \ price.\n\nConstruct methods: pde_solver\nComparison targets: theta_0.5 (pde_solver),\
+    \ theta_1.0 (pde_solver), black_scholes (analytical)\nCross-validation harness:\n\
+    \  internal targets: theta_0.5, theta_1.0\n  analytical benchmark: black_scholes\n\
+    \  external targets: quantlib\nNew component: convergence_order_diagnostic\n\n\
+    Implementation target: theta_1.0\nPreferred method family: pde_solver\n\nImplementation\
+    \ target: theta_1.0\n\n## Shared Knowledge\n## Distilled Review Memory\n\n- Review\
+    \ principles:\n  - `P1`: Always calibrate rate trees to the discount curve before\
+    \ pricing\n  - `P2`: Callable bonds need issuer_call lattice control, discrete\
+    \ coupons, and exercise=par+coupon\n  - `P3`: Convert vol units at the boundary\
+    \ between market data and model\n- Review checkpoints:\n  - GRID: Use at least\
+    \ 200 spatial points and 200+ time steps. For barrier options, use non-uniform\
+    \ grid concentrated near the barrier.\n  - BOUNDARY CONDITIONS: Set V(0,t)=0 for\
+    \ calls, V(S_max,t)=S_max-K*exp(-r*(T-t)) for calls. For puts: V(0,t)=K*exp(-r*(T-t)),\
+    \ V(S_max,t)=0.\n  - STABILITY: Crank-Nicolson (theta=0.5) is second-order but\
+    \ may oscillate near discontinuities. Use Rannacher smoothing (2-4 implicit steps\
+    \ at start) for digital/barrier payoffs.\n- Canonical model grammar:\n  - `local_vol_surface_workflow`\
+    \ -> `Dupire local vol`\n  - `sabr_smile_workflow` -> `SABR smile`\n- Known failure\
+    \ traps:\n  - `BlackScholesOperator constructor mismatch` -> The generated code\
+    \ treated the PDE operator as if it accepted scalar 'r' and 'sigma' keywords,\
+    \ but trellis.models.pde.operator.BlackScholesOperator actually expects callables\
+    \ '(sigma_fn, r_fn)'. The mismatch caused constructor failure during module build.\n\
+    \  - `PDE price blow-up from unit/scale mismatch` -> The generated PDE branch\
+    \ called theta_method_1d with the obsolete operator/s_grid/t_grid/boundary_conditions\
+    \ signature and then read the wrong element of the result instead of interpolating\
+    \ the returned solution over grid.x. The actual API is theta_method_1d(grid, operator,\
+    \ terminal_condition, theta=..., lower_bc_fn=..., upper_bc_fn=...), and it returns\
+    \ the full solution vector at t=0.\n\n## Generated Skills\n- [lesson] Unit conversion\
+    \ causes huge PV: Enforce and document input conventions (vol as decimal, discount\
+    \ curve vs zero rate semantics, notional scaling), derive r from discount factors\
+    \ via r = -ln(df)/T or use forward/Black76 consistently, add unit/conversi...\n\
+    \n\n## Compiled Route Contract\n- Method family: `pde_solver`\n- Instrument type:\
+    \ `european_option`\n- Lane boundary: family=`pde_solver`, kind=`exact_target_binding`,\
+    \ exact_bindings=`trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
+    - Lane obligations:\n  - Lane family: `pde_solver`\n  - Plan kind: `exact_target_binding`\n\
+    \  - Market bindings: `black_vol_surface`, `discount_curve`\n  - State obligations:\
+    \ `spot`, `strike`, `expiry`, `expiry_black_vol`\n  - Exact backend bindings:\n\
+    \    - `trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n  -\
+    \ Exact binding signatures:\n    - `price_vanilla_equity_option_pde(market_state:\
+    \ 'EquityPDEMarketStateLike', spec: 'VanillaEquityOptionSpecLike', *, theta: 'float'\
+    \ = 0.5, n_x: 'int | None' = None, n_t: 'int | None' = None, s_max_multiplier:\
+    \ 'float' = 4.0) -> 'float'`\n- Route authority:\n  - binding=`trellis.models.equity_option_pde.price_vanilla_equity_option_pde`,\
+    \ engine=`pde_solver`, authority=`exact_backend_fit`\n  - Route alias: `vanilla_equity_theta_pde`\n\
+    \  - Validation bundle: `pde_solver:european_option`\n  - Validation checks: `check_non_negativity`,\
+    \ `check_price_sanity`, `check_vol_sensitivity`, `check_vol_monotonicity`\n  -\
+    \ Exact target bindings: `trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
+    - Backend binding:\n  - Route: `vanilla_equity_theta_pde`\n  - Engine family:\
+    \ `pde_solver`\n  - Route family: `pde_solver`\n  - Selected primitives:\n   \
+    \ - `trellis.models.equity_option_pde.price_vanilla_equity_option_pde` (route_helper)\n\
+    \  - Resolved instructions:\n    - [hard_constraint] Use the route helper directly\
+    \ inside `evaluate()`; do not rebuild the process, engine, or discount glue manually.\n\
+    \    - [historical_note] For vanilla European equity PDE routes, prefer `price_vanilla_equity_option_pde(market_state,\
+    \ spec, theta=...)` so the adapter stays thin.\n    - [historical_note] Map `implementation_target=theta_0.5`\
+    \ to `theta=0.5` and `implementation_target=theta_1.0` to `theta=1.0`.\n    -\
+    \ [historical_note] The checked-in helper already owns grid sizing, terminal payoff\
+    \ assembly, boundary conditions, theta-method solve, and interpolation back to\
+    \ spot.\n    - [historical_note] Use the lower-level `Grid + BlackScholesOperator\
+    \ + theta_method_1d` path only when the payoff or boundary contract genuinely\
+    \ differs from plain vanilla European call/put.\n  - Required adapters:\n    -\
+    \ `reuse_checked_in_vanilla_equity_pde_helper`\n  - Backend notes:\n    - For\
+    \ vanilla European equity PDE routes, prefer `price_vanilla_equity_option_pde(market_state,\
+    \ spec, theta=...)` so the adapter stays thin.\n    - Map `implementation_target=theta_0.5`\
+    \ to `theta=0.5` and `implementation_target=theta_1.0` to `theta=1.0`.\n    -\
+    \ The checked-in helper already owns grid sizing, terminal payoff assembly, boundary\
+    \ conditions, theta-method solve, and interpolation back to spot.\n    - Use the\
+    \ lower-level `Grid + BlackScholesOperator + theta_method_1d` path only when the\
+    \ payoff or boundary contract genuinely differs from plain vanilla European call/put.\n\
+    - Approved modules in scope:\n  - `trellis.core.date_utils`\n  - `trellis.core.differentiable`\n\
+    \  - `trellis.core.market_state`\n  - `trellis.core.payoff`\n  - `trellis.core.types`\n\
+    \  - `trellis.models.black`\n  - `trellis.models.equity_option_pde`\n  - `trellis.models.pde`\n\
+    - Review the generated code against this compiled boundary. Treat route, helper,\
+    \ or validation drift as real findings.\n\n\n## Available deterministic checks\n\
+    You may ONLY select from this bounded menu:\n- `price_non_negative`: Price should\
+    \ remain non-negative. Use when the route prices a long-only vanilla or option-like\
+    \ payoff that should not produce a negative PV under the default review market\
+    \ state. Deterministic contract: Fail when price_payoff(payoff, ms) < -1e-6.\n\
+    - `volatility_input_usage`: Volatility should move the price materially. Use when\
+    \ the instrument or method requires volatility but the code looks volatility-insensitive.\
+    \ Deterministic contract: Fail when changing flat vol from 5% to 40% moves price\
+    \ by less than 0.1%.\n\n\n## Review policy\n- Do not write Python code.\n- Do\
+    \ not invent new checks, formulas, or test procedures.\n- Only emit a finding\
+    \ when the code strongly suggests the selected check is likely to fail.\n- If\
+    \ none of the available checks are justified, return [].\n\n## Output\nReturn\
+    \ a JSON array of concerns. Each concern:\n{\n    \"check_id\": \"one of the available\
+    \ check ids\",\n    \"description\": \"short concern summary\",\n    \"severity\"\
+    : \"error\" or \"warning\",\n    \"evidence\": \"specific code reference or reasoning\"\
+    ,\n    \"remediation\": \"what to change\",\n    \"status\": \"suspect\"\n}\n\n\
+    Focus on pricing errors that the deterministic checks can confirm.\nReturn at\
+    \ most 3 concerns, ordered by severity.\nReturn ONLY the JSON array."
+  model: gpt-5.4-mini

--- a/cassettes/full_task/T38.yaml
+++ b/cassettes/full_task/T38.yaml
@@ -1,0 +1,1436 @@
+meta:
+  recorded_at: '2026-04-10T15:36:20.163035+00:00'
+  provider: openai
+  model: gpt-5.4-mini
+  total_calls: 4
+  name: T38
+calls:
+- seq: 0
+  function: llm_generate
+  stage: code_generation
+  prompt_hash: f3f7221443896173945940705c2fd41fe6604a580fec1bb1344c7fd4dca60ecf
+  response_text: "from trellis.core.differentiable import get_numpy\n        from\
+    \ trellis.models.credit_default_swap import build_cds_schedule, price_cds_monte_carlo\n\
+    \n        np = get_numpy()\n\n        spec = self._spec\n        spread = float(spec.spread)\n\
+    \        if spread > 1.0:\n            spread *= 1e-4\n\n        schedule = build_cds_schedule(\n\
+    \            spec.start_date,\n            spec.end_date,\n            spec.frequency,\n\
+    \            spec.day_count,\n            time_origin=spec.start_date,\n     \
+    \   )\n\n        return float(\n            price_cds_monte_carlo(\n         \
+    \       notional=float(spec.notional),\n                spread_quote=spread,\n\
+    \                recovery=float(spec.recovery),\n                schedule=schedule,\n\
+    \                credit_curve=market_state.credit_curve,\n                discount_curve=market_state.discount,\n\
+    \                n_paths=int(spec.n_paths),\n                seed=42,\n      \
+    \      )\n        )"
+  prompt_text: "You are implementing the evaluate() method for `CDSPayoff` in the\
+    \ Trellis pricing library.\n\n## Complete module (skeleton — everything is fixed\
+    \ except evaluate)\n```python\n\"\"\"Agent-generated payoff: Build a pricer for:\
+    \ CDS pricing: hazard rate MC vs survival prob analytical\n\nStandard single-name\
+    \ CDS, protection buyer side.\nNotional: $10,000,000.  Maturity: 5Y from settlement.\n\
+    Premium leg: quarterly payments, Act/360 day count.\nRunning CDS spread: 150 bp.\
+    \  Recovery rate: 40%.\nUse the investment-grade (IG) credit curve from the market\
+    \ snapshot\n(as_of 2024-11-15) — this provides term-dependent hazard rates\nbootstrapped\
+    \ from market CDS spreads at 1Y, 3Y, 5Y, and 10Y tenors.\nDo NOT use a flat hazard\
+    \ rate — the model must respect the full\nhazard rate term structure.\nUse the\
+    \ USD OIS curve for risk-free discounting.\nMethod 1: Monte Carlo simulation of\
+    \ default times from the hazard curve.\nMethod 2: Analytical (deterministic) survival-probability\
+    \ integration.\nCompute the mark-to-market PV (protection leg minus premium leg).\n\
+    \nConstruct methods: monte_carlo\nComparison targets: mc_cds (monte_carlo), analytical_cds\
+    \ (analytical)\nCross-validation harness:\n  internal targets: mc_cds, analytical_cds\n\
+    \  external targets: quantlib, financepy\nNew component: cds_pricing\n\nImplementation\
+    \ target: mc_cds\nPreferred method family: monte_carlo\n\nImplementation target:\
+    \ mc_cds.\"\"\"\n\nfrom __future__ import annotations\n\nfrom dataclasses import\
+    \ dataclass\nfrom datetime import date\n\nfrom trellis.core.market_state import\
+    \ MarketState\nfrom trellis.core.types import DayCountConvention, Frequency\n\
+    from trellis.core.differentiable import get_numpy\nfrom trellis.models.credit_default_swap\
+    \ import build_cds_schedule, price_cds_monte_carlo, interval_default_probability\n\
+    \n\n\n@dataclass(frozen=True)\nclass CDSSpec:\n    \"\"\"Specification for Build\
+    \ a pricer for: CDS pricing: hazard rate MC vs survival prob analytical\n\nStandard\
+    \ single-name CDS, protection buyer side.\nNotional: $10,000,000.  Maturity: 5Y\
+    \ from settlement.\nPremium leg: quarterly payments, Act/360 day count.\nRunning\
+    \ CDS spread: 150 bp.  Recovery rate: 40%.\nUse the investment-grade (IG) credit\
+    \ curve from the market snapshot\n(as_of 2024-11-15) — this provides term-dependent\
+    \ hazard rates\nbootstrapped from market CDS spreads at 1Y, 3Y, 5Y, and 10Y tenors.\n\
+    Do NOT use a flat hazard rate — the model must respect the full\nhazard rate term\
+    \ structure.\nUse the USD OIS curve for risk-free discounting.\nMethod 1: Monte\
+    \ Carlo simulation of default times from the hazard curve.\nMethod 2: Analytical\
+    \ (deterministic) survival-probability integration.\nCompute the mark-to-market\
+    \ PV (protection leg minus premium leg).\n\nConstruct methods: monte_carlo\nComparison\
+    \ targets: mc_cds (monte_carlo), analytical_cds (analytical)\nCross-validation\
+    \ harness:\n  internal targets: mc_cds, analytical_cds\n  external targets: quantlib,\
+    \ financepy\nNew component: cds_pricing\n\nImplementation target: mc_cds\nPreferred\
+    \ method family: monte_carlo\n\nImplementation target: mc_cds.\"\"\"\n    notional:\
+    \ float\n    spread: float\n    start_date: date\n    end_date: date\n    recovery:\
+    \ float = 0.4\n    frequency: Frequency = Frequency.QUARTERLY\n    day_count:\
+    \ DayCountConvention = DayCountConvention.ACT_360\n    n_paths: int = 250000\n\
+    \n\nclass CDSPayoff:\n    \"\"\"Build a pricer for: CDS pricing: hazard rate MC\
+    \ vs survival prob analytical\n\nStandard single-name CDS, protection buyer side.\n\
+    Notional: $10,000,000.  Maturity: 5Y from settlement.\nPremium leg: quarterly\
+    \ payments, Act/360 day count.\nRunning CDS spread: 150 bp.  Recovery rate: 40%.\n\
+    Use the investment-grade (IG) credit curve from the market snapshot\n(as_of 2024-11-15)\
+    \ — this provides term-dependent hazard rates\nbootstrapped from market CDS spreads\
+    \ at 1Y, 3Y, 5Y, and 10Y tenors.\nDo NOT use a flat hazard rate — the model must\
+    \ respect the full\nhazard rate term structure.\nUse the USD OIS curve for risk-free\
+    \ discounting.\nMethod 1: Monte Carlo simulation of default times from the hazard\
+    \ curve.\nMethod 2: Analytical (deterministic) survival-probability integration.\n\
+    Compute the mark-to-market PV (protection leg minus premium leg).\n\nConstruct\
+    \ methods: monte_carlo\nComparison targets: mc_cds (monte_carlo), analytical_cds\
+    \ (analytical)\nCross-validation harness:\n  internal targets: mc_cds, analytical_cds\n\
+    \  external targets: quantlib, financepy\nNew component: cds_pricing\n\nImplementation\
+    \ target: mc_cds\nPreferred method family: monte_carlo\n\nImplementation target:\
+    \ mc_cds.\"\"\"\n\n    def __init__(self, spec: CDSSpec):\n        self._spec\
+    \ = spec\n\n    @property\n    def spec(self) -> CDSSpec:\n        return self._spec\n\
+    \n    @property\n    def requirements(self) -> set[str]:\n        return {\"credit_curve\"\
+    , \"discount_curve\"}\n\n    def evaluate(self, market_state: MarketState) ->\
+    \ float:\n        spec = self._spec\n        raise NotImplementedError(\"evaluate\
+    \ not yet implemented\")\n\n```\n\n## Your task\nWrite ONLY the body of the `evaluate()`\
+    \ method. The signature is already defined:\n\n    def evaluate(self, market_state:\
+    \ MarketState) -> float:\n\n## Spec fields available via self._spec\n- `self._spec.notional`\
+    \ (float): Protection notional\n- `self._spec.spread` (float): CDS running spread\
+    \ in decimal form (e.g. 0.015 = 150bps, not 150.0)\n- `self._spec.recovery` (float):\
+    \ Recovery rate\n- `self._spec.start_date` (date): Protection start date\n- `self._spec.end_date`\
+    \ (date): Protection end date\n- `self._spec.frequency` (Frequency): Premium payment\
+    \ frequency\n- `self._spec.day_count` (DayCountConvention): Day count convention\n\
+    - `self._spec.n_paths` (int): Number of Monte Carlo paths for comparison-quality\
+    \ CDS pricing\n\n## Pricing Method (selected by the quant agent — you MUST use\
+    \ this)\nMethod: **monte_carlo**\nReasoning: product_ir_compiler\nSelection basis\
+    \ and assumptions:\n- Selection basis: `explicit_preference`\n- Assumptions /\
+    \ defaulted context:\n  - `simplest_valid_assumption_set`\n  - `simulation_based_valuation_route`\n\
+    \  - `path_sampling_required`\n  - `multiple_valid_methods_available`\n  - `schedule_dependent_product`\n\
+    Route-bound modules to import and use:\n- `trellis.models.credit_default_swap`\n\
+    - `trellis.core.differentiable`\n\nYou MUST import and use these route-bound modules\
+    \ in your implementation.\nDo not import a generic parent package such as `from\
+    \ trellis.models import ...` just to satisfy the method family.\n\n## API Map\
+    \ — start here before guessing module paths\n\nUse this navigation card to choose\
+    \ the right module family first. Confirm exact symbols with `find_symbol` or `list_exports`\
+    \ before calling `read_module`.\n\n### Core Types\n#### MarketState\n- Module:\
+    \ `trellis.core.market_state`\n- Class: `MarketState`\n- Frozen: `true`\n- Fields:\
+    \ `as_of`, `settlement`, `discount`, `forward_curve`, `vol_surface`, `state_space`,\
+    \ `credit_curve`, `forecast_curves`, `fx_rates`\n- Accessors: `discount_factor`,\
+    \ `zero_rate`, `forward_rate`, `forecast_forward`, `black_vol`, `survival_prob`,\
+    \ `hazard_rate`, `risky_discount`\n- Capabilities: `discount_curve → discount\
+    \ is not None`, `forward_curve → forward_curve is not None (auto from discount)`,\
+    \ `black_vol_surface → vol_surface is not None`, `state_space → state_space is\
+    \ not None`, `credit_curve → credit_curve is not None`, `fx_rates → fx_rates is\
+    \ not None`\n#### Payoff\n- Module: `trellis.core.payoff`\n- Protocol: `Payoff`\n\
+    - Required methods: `evaluate`\n- Required properties: `requirements`\n- Runtime\
+    \ checkable: `true`\n- Notes:\n  - Each payoff handles its own discounting internally\n\
+    \  - The returned float is the final PV\n  - DeterministicCashflowPayoff wraps\
+    \ any Instrument into Payoff\n\n### Model Families\n#### equity_tree\n- Module:\
+    \ `trellis.models.equity_option_tree`\n- Key imports:\n  - `from trellis.models.equity_option_tree\
+    \ import price_vanilla_equity_option_tree`\n  - `from trellis.models.trees.lattice\
+    \ import build_spot_lattice, lattice_backward_induction`\n- Notes:\n  - American/Bermudan\
+    \ equity options should prefer the checked-in helper `price_vanilla_equity_option_tree(...)`\n\
+    \  - If you need the lower-level path, import the lattice builder/backward induction\
+    \ submodules directly\n#### rate_lattice\n- Module: `trellis.models.trees.lattice`\n\
+    - Key imports:\n  - `from trellis.models.trees.lattice import build_rate_lattice,\
+    \ lattice_backward_induction`\n  - `from trellis.models.zcb_option_tree import\
+    \ price_zcb_option_tree`\n- Notes:\n  - Callable bonds, puttable bonds, and Bermudan\
+    \ swaptions use a calibrated rate lattice from a TreeModel specification such\
+    \ as Hull-White or Black-Derman-Toy\n  - lattice_backward_induction handles cashflow_at_node\
+    \ and exercise_fn\n#### monte_carlo\n- Module: `trellis.models.monte_carlo`\n\
+    - Key imports:\n  - `from trellis.models.monte_carlo.engine import MonteCarloEngine`\n\
+    \  - `from trellis.models.monte_carlo.lsm import longstaff_schwartz, longstaff_schwartz_result`\n\
+    \  - `from trellis.models.monte_carlo.early_exercise import EarlyExercisePolicyResult,\
+    \ LeastSquaresContinuationEstimator`\n  - `from trellis.models.monte_carlo.schemes\
+    \ import LaguerreBasis`\n  - `from trellis.models.monte_carlo import euler_maruyama,\
+    \ milstein, brownian_bridge`\n  - `from trellis.models.monte_carlo import antithetic,\
+    \ control_variate`\n  - `from trellis.models.processes.gbm import GBM`\n- Notes:\n\
+    \  - For American/Bermudan Monte Carlo, simulate paths then call an approved early-exercise\
+    \ control primitive; Trellis currently implements longstaff_schwartz\n  - If the\
+    \ control primitive uses continuation regression, choose the estimator or basis\
+    \ explicitly; LaguerreBasis is optional, not mandatory\n#### qmc\n- Module: `trellis.models.qmc`\n\
+    - Key imports:\n  - `from trellis.models.qmc import sobol_normals, brownian_bridge`\n\
+    \  - `from trellis.models.processes.gbm import GBM`\n- Notes:\n  - QMC is an accelerator\
+    \ family layered on Monte Carlo-style estimators\n  - Current support is Sobol-based\
+    \ normal draws and Brownian-bridge construction\n#### pde\n- Module: `trellis.models.pde`\n\
+    - Key imports:\n  - `from trellis.models.equity_option_pde import price_vanilla_equity_option_pde`\n\
+    \  - `from trellis.models.pde.grid import Grid`\n  - `from trellis.models.pde.theta_method\
+    \ import theta_method_1d`\n  - `from trellis.models.pde.operator import BlackScholesOperator`\n\
+    \  - `from trellis.models.pde import psor_1d  # American options`\n  - `from trellis.models.pde\
+    \ import HullWhitePDEOperator`\n- Notes:\n  - Vanilla European equity PDE routes\
+    \ should prefer the checked-in helper `price_vanilla_equity_option_pde(...)`\n\
+    \  - Use theta_method_1d, NOT legacy crank_nicolson_1d or implicit_fd_1d\n####\
+    \ fft\n- Module: `trellis.models.transforms`\n- Key imports:\n  - `from trellis.models.transforms\
+    \ import fft_price, cos_price`\n- Notes:\n  - fft_price expects CF of log(S_T)\
+    \ — include log(S0)\n  - cos_price expects CF of log(S_T/S0) — log-return only\n\
+    #### copulas\n- Module: `trellis.models.copulas`\n- Key imports:\n  - `from trellis.models.copulas\
+    \ import GaussianCopula, StudentTCopula, FactorCopula`\n#### analytical\n- Module:\
+    \ `trellis.models.zcb_option`\n- Key imports:\n  - `from trellis.models.zcb_option\
+    \ import resolve_zcb_option_hw_inputs, price_zcb_option_jamshidian`\n  - `from\
+    \ trellis.models.analytical.jamshidian import ResolvedJamshidianInputs, zcb_option_hw_raw`\n\
+    \  - `from trellis.models.analytical import zcb_option_hw`\n  - `from trellis.models.analytical\
+    \ import terminal_vanilla_from_basis`\n  - `from trellis.models.rate_style_swaption\
+    \ import ResolvedSwaptionBlack76Inputs, resolve_swaption_black76_inputs, price_swaption_black76_raw,\
+    \ price_bermudan_swaption_black76_lower_bound`\n#### calibration\n- Module: `trellis.models.calibration`\n\
+    - Key imports:\n  - `from trellis.models.calibration import implied_vol, implied_vol_jaeckel`\n\
+    \  - `from trellis.models.calibration import RatesCalibrationResult, calibrate_cap_floor_black_vol,\
+    \ calibrate_swaption_black_vol, swaption_terms`\n  - `from trellis.models.calibration\
+    \ import calibrate_sabr`\n  - `from trellis.models.calibration import dupire_local_vol`\n\
+    \n### Utilities\n#### black76\n- Module: `trellis.models.black`\n- Imports:\n\
+    \  - `from trellis.models.black import black76_call, black76_put, black76_asset_or_nothing_call,\
+    \ black76_asset_or_nothing_put, black76_cash_or_nothing_call, black76_cash_or_nothing_put`\n\
+    #### garman_kohlhagen\n- Module: `trellis.models.analytical.fx`\n- Imports:\n\
+    \  - `from trellis.models.analytical.fx import ResolvedGarmanKohlhagenInputs,\
+    \ garman_kohlhagen_price_raw`\n  - `from trellis.models.black import garman_kohlhagen_call,\
+    \ garman_kohlhagen_put`\n#### rate_style_swaption\n- Module: `trellis.models.rate_style_swaption`\n\
+    - Imports:\n  - `from trellis.models.rate_style_swaption import ResolvedSwaptionBlack76Inputs,\
+    \ resolve_swaption_black76_inputs, price_swaption_black76_raw, price_swaption_black76`\n\
+    \  - `from trellis.models.rate_style_swaption import price_bermudan_swaption_black76_lower_bound`\n\
+    #### jamshidian_zcb_option\n- Module: `trellis.models.zcb_option`\n- Imports:\n\
+    \  - `from trellis.models.zcb_option import ResolvedZCBOptionInputs, resolve_zcb_option_hw_inputs,\
+    \ price_zcb_option_jamshidian`\n  - `from trellis.models.analytical.jamshidian\
+    \ import ResolvedJamshidianInputs, zcb_option_hw_raw`\n#### schedule\n- Module:\
+    \ `trellis.core.date_utils`\n- Imports:\n  - `from trellis.core.date_utils import\
+    \ generate_schedule`\n#### day_count\n- Module: `trellis.core.date_utils`\n- Imports:\n\
+    \  - `from trellis.core.date_utils import year_fraction`\n#### vol_surface\n-\
+    \ Module: `trellis.models.vol_surface`\n- Imports:\n  - `from trellis.models.vol_surface\
+    \ import VolSurface, FlatVol`\n#### cashflow_engine\n- Module: `trellis.models.cashflow_engine`\n\
+    - Imports:\n  - `from trellis.models.cashflow_engine import Waterfall, Tranche`\n\
+    \  - `from trellis.models.cashflow_engine import PSA, CPR, RateDependent`\n  -\
+    \ `from trellis.models.cashflow_engine import level_pay, scheduled, custom`\n\
+    #### credit_curve\n- Module: `trellis.curves.credit_curve`\n- Imports:\n  - `from\
+    \ trellis.curves.credit_curve import CreditCurve`\n- Notes:\n  - CreditCurve.flat(hazard_rate)\
+    \ is the simplest starting point for CDS or nth-to-default tasks\n## Distilled\
+    \ Build Memory\n\n- Product: `cds` / `cds` / `none`\n- Default method family:\
+    \ `monte_carlo`\n- Method intent: Path simulation for path-dependent or high-dimensional\
+    \ claims, including LSM-based exercise when needed\n- Non-negotiable requirements:\n\
+    \  - CONVERGENCE: Use at least 10,000 paths. Verify that the standard error is\
+    \ <1% of the price. If path-dependent, use at least 100 time steps per year.\n\
+    \  - DISCRETE OBSERVATIONS: For instruments with discrete fixing/observation dates\
+    \ (Asian options, barriers), simulate paths that pass through those exact dates.\
+    \ Do not interpolate between steps.\n  - EARLY EXERCISE: For American or Bermudan\
+    \ exercise in Monte Carlo, use an approved optimal-stopping control primitive\
+    \ instead of inventing method=\"lsm\" or treating engine.price(...) as a substitute\
+    \ for early-exercise control. Trellis currently implements longstaff_schwartz.\
+    \ Planned policy classes include tsitsiklis_van_roy, primal_dual_mc, and stochastic_mesh.\
+    \ If the control primitive uses continuation regression, the basis or estimator\
+    \ choice is explicit; LaguerreBasis is a common option, not a mandatory route\
+    \ primitive.\n- Canonical model grammar:\n  - `credit_single_name_reduced_form`\
+    \ -> `Reduced-form single-name credit`\n  - `heston_smile_workflow` -> `Heston`\n\
+    - Repeated fixes to reuse:\n  - `MC payoff must use market_state.discount` ->\
+    \ Implement the MC payoff to explicitly call market_state.discount.discount(time)\
+    \ for all discounting and return a 1D numpy array of per-path present values.\
+    \ Run a quick syntax/lint pass on generated code to eliminate indentation/SyntaxError\
+    \ issues before submission.\n  - `MC payoff must use required primitives` -> Rebuild\
+    \ the payoff as a thin adapter that calls trellis.core.differentiable.get_numpy\
+    \ to obtain numpy arrays, perform all pathwise computations in numpy, and ensure\
+    \ the payoff returns a 1D array of shape (n_paths,). Follow other assembly constraints\
+    \ (no banned imports, correct output shape).\n\n## Generated Skills\n- [lesson]\
+    \ NthToDefaultPayoff analytical must use Gaussian copula integration, not independent\
+    \ binomial: Use the Gaussian copula conditional independence formula (integrate\
+    \ over common factor Z). This is the analytical counterpart of the GaussianCopula\
+    \ MC. from math import comb from scipy import integrate from scipy.stat...\n\n\
+    ## Instrument Disambiguation\n- Treat this request as a single-name CDS / credit_default_swap\
+    \ contract.\n- Do not reinterpret CDS here as nth_to_default, basket CDS, first-to-default,\
+    \ or any multi-name credit product.\n- Do not import copula or Gaussian-copula\
+    \ machinery unless the request explicitly says nth-to-default, first-to-default,\
+    \ basket CDS, or multiple reference names.\n## Structured Lane Card\n- Method\
+    \ family: `monte_carlo`\n- Instrument type: `cds`\n- Semantic contract: `credit_default_swap`,\
+    \ request=`credit_default_swap`, bridge=`canonical_semantic`, instrument=`cds`,\
+    \ payoff=`credit_default_swap`, structure=`single_reference_entity`\n- Valuation\
+    \ context: market_source=`unbound_market_snapshot`\n- Lane boundary: family=`monte_carlo`,\
+    \ kind=`exact_target_binding`, timeline_roles=`settlement`, `payment`, `observation`,\
+    \ exact_bindings=`trellis.models.credit_default_swap.build_cds_schedule`, `trellis.models.credit_default_swap.price_cds_monte_carlo`\n\
+    - Lowering boundary: family_ir=`CreditDefaultSwapIR`, expr=`ThenExpr`, helpers=`trellis.models.credit_default_swap.build_cds_schedule`,\
+    \ `trellis.models.credit_default_swap.interval_default_probability`, route_alias=`credit_default_swap_monte_carlo`\n\
+    - Validation contract: bundle=`monte_carlo:credit_default_swap`, checks=`check_cds_spread_quote_normalization`,\
+    \ `check_cds_credit_curve_sensitivity`, `premium_leg_accrues_on_schedule`, `protection_leg_triggers_on_default`,\
+    \ residual_risks=`comparison_relations_unspecified`\n- Lane obligations:\n  -\
+    \ Lane family: `monte_carlo`\n  - Plan kind: `exact_target_binding`\n  - Timeline\
+    \ roles: `settlement`, `payment`, `observation`\n  - Market bindings: `discount_curve`,\
+    \ `credit_curve`\n  - Control semantics: `pricing_mode:monte_carlo`, `schedule_role:payment_dates`\n\
+    \  - State obligations: `survival_state`, `premium_leg_schedule`, `default_indicator`\n\
+    \  - Construction steps:\n    - Build the CDS schedule with `build_cds_schedule`\
+    \ and keep the leg semantics explicit: premium_leg, protection_leg.\n    - Bind\
+    \ discount and credit-curve inputs to the `monte_carlo` lane without routing through\
+    \ equity-option kernels.\n    - Price the schedule-driven contract through `price_cds_monte_carlo`\
+    \ unless the request introduces a genuinely new credit kernel.\n  - Exact backend\
+    \ bindings:\n    - `trellis.models.credit_default_swap.build_cds_schedule`\n \
+    \   - `trellis.models.credit_default_swap.interval_default_probability`\n    -\
+    \ `trellis.models.credit_default_swap.price_cds_monte_carlo`\n    - `trellis.core.differentiable.get_numpy`\n\
+    \  - Exact binding signatures:\n    - `build_cds_schedule(start_date: 'date',\
+    \ end_date: 'date', frequency: 'Frequency', day_count: 'DayCountConvention', *,\
+    \ time_origin: 'date | None' = None) -> 'EventSchedule'`\n    - `price_cds_monte_carlo(*,\
+    \ notional: 'float', spread_quote: 'float', recovery: 'float', schedule: 'EventSchedule',\
+    \ credit_curve: 'CreditCurveLike', discount_curve: 'DiscountCurveLike', n_paths:\
+    \ 'int' = 50000, seed: 'int' = 42) -> 'float'`\n- Route authority:\n  - binding=`trellis.models.credit_default_swap.price_cds_monte_carlo`,\
+    \ engine=`monte_carlo`, authority=`exact_backend_fit`\n  - Route alias: `credit_default_swap_monte_carlo`\n\
+    \  - Validation bundle: `monte_carlo:credit_default_swap`\n  - Validation checks:\
+    \ `check_cds_spread_quote_normalization`, `check_cds_credit_curve_sensitivity`,\
+    \ `check_non_negativity`, `check_price_sanity`\n  - Canary coverage: canaries=`T38`\n\
+    \  - Helper authority: `trellis.models.credit_default_swap.build_cds_schedule`,\
+    \ `trellis.models.credit_default_swap.interval_default_probability`\n  - Exact\
+    \ target bindings: `trellis.models.credit_default_swap.build_cds_schedule`, `trellis.models.credit_default_swap.price_cds_monte_carlo`\n\
+    - Backend binding:\n  - Route: `credit_default_swap_monte_carlo`\n  - Engine family:\
+    \ `monte_carlo`\n  - Route family: `credit_default_swap`\n  - Selected primitives:\n\
+    \    - `trellis.models.credit_default_swap.build_cds_schedule` (schedule_builder)\n\
+    \    - `trellis.models.credit_default_swap.interval_default_probability` (event_probability)\n\
+    \    - `trellis.models.credit_default_swap.price_cds_monte_carlo` (route_helper)\n\
+    \    - `trellis.core.differentiable.get_numpy` (array_backend)\n  - Resolved instructions:\n\
+    \    - [hard_constraint] Use the route helper directly inside `evaluate()`; do\
+    \ not rebuild the process, engine, or discount glue manually.\n    - [route_hint]\
+    \ Use `trellis.models.credit_default_swap.build_cds_schedule` to build the route\
+    \ schedule before pricing.\n    - [route_hint] Do not hard-code observation or\
+    \ payment grids inside the payoff body.\n    - [route_hint] Do not hard-code n_paths=50000\
+    \ for comparison-quality single-name CDS. Use spec.n_paths when available; otherwise\
+    \ choose a comparison-stable count such as 250000.\n    - [route_hint] Do not\
+    \ import or instantiate `MonteCarloEngine` for a single-name CDS route. Here Monte\
+    \ Carlo means direct random default-time draws on the explicit payment schedule,\
+    \ not a generic diffusion-engine wrapper.\n    - [route_hint] Do not collapse\
+    \ the Monte Carlo CDS leg to scalar alive state, a single RNG draw per payment\
+    \ date, or a one-scenario loop that breaks after default.\n    - [route_hint]\
+    \ Use hazard_rate only for within-interval default-time interpolation after an\
+    \ interval default is selected. Do not replace interval default probability with\
+    \ a midpoint-hazard approximation when survival probabilities are available.\n\
+    \    - [route_hint] Do not discount protection at sampled default times tau in\
+    \ the comparison build.\n  - Schedule construction:\n    - [route_hint] Use `trellis.models.credit_default_swap.build_cds_schedule`\
+    \ to build the route schedule before pricing.\n    - [route_hint] Do not hard-code\
+    \ observation or payment grids inside the payoff body.\n    - [route_hint] Do\
+    \ not import or instantiate `MonteCarloEngine` for a single-name CDS route. Here\
+    \ Monte Carlo means direct random default-time draws on the explicit payment schedule,\
+    \ not a generic diffusion-engine wrapper.\n    - [route_hint] Carry a persistent\
+    \ `alive` indicator across the schedule and update it after each interval. Do\
+    \ not overwrite the default state from scratch inside the loop.\n    - [historical_note]\
+    \ For single-name CDS Monte Carlo pricing, prefer the checked-in build_cds_schedule(...)\
+    \ and price_cds_monte_carlo(...) helpers so the adapter stays thin.\n    - [historical_note]\
+    \ If the helper cannot be reused, fall back to build_period_schedule(...) so the\
+    \ adapter iterates over explicit periods with accrual fractions and model times\
+    \ instead of rebuilding payment_dates and prev_date logic by hand.\n    - [historical_note]\
+    \ For comparison tasks, keep protection-leg discounting aligned with the analytical\
+    \ schedule loop and use the payment-date discount factor discount(t_pay) for interval\
+    \ default mass.\n    - [historical_note] Use spec.start_date as the time origin\
+    \ for Monte Carlo schedule times so the MC and analytical CDS comparators share\
+    \ the same t convention.\n  - Required adapters:\n    - `use_credit_curve_hazard_rate_or_survival_probability`\n\
+    \    - `declare_credit_curve_and_discount_curve_requirements`\n  - Backend notes:\n\
+    \    - For single-name CDS Monte Carlo pricing, prefer the checked-in build_cds_schedule(...)\
+    \ and price_cds_monte_carlo(...) helpers so the adapter stays thin.\n    - If\
+    \ the spec exposes n_paths, pass spec.n_paths through to price_cds_monte_carlo(...)\
+    \ instead of hard-coding a smaller comparison-path count in the adapter.\n   \
+    \ - Do not hard-code n_paths=50000 for comparison-quality single-name CDS. Use\
+    \ spec.n_paths when available; otherwise choose a comparison-stable count such\
+    \ as 250000.\n    - Keep comparison-task randomness reproducible with seed=42\
+    \ unless the spec explicitly carries a different seed input.\n- Primary modules\
+    \ to inspect/reuse:\n  - `trellis.core.differentiable`\n  - `trellis.models.credit_default_swap`\n\
+    \  - `trellis.models.monte_carlo.engine`\n- Post-build test targets:\n  - `tests/test_agent/test_build_loop.py`\n\
+    - Instruction precedence: follow the lane obligations in this card first. Treat\
+    \ backend route/helper details as exact-fit bindings, not as permission to invent\
+    \ a different numerical path.\n- Treat route authority as backend-fit evidence,\
+    \ not as permission to invent a different synthesis plan.\n- Use approved Trellis\
+    \ imports only. Prefer thin adapters when the compiler found an exact backend;\
+    \ otherwise build the smallest lane-consistent kernel the plan requires.\n## Backend\
+    \ Lookup (Secondary To Lane Obligations)\n- Lane family: `monte_carlo`\n- Lane\
+    \ plan kind: `exact_target_binding`\n- Method family: `monte_carlo`\n- Route:\
+    \ `credit_default_swap_monte_carlo`\n- Engine family: `monte_carlo`\n- Required\
+    \ primitive symbols:\n  - `trellis.models.credit_default_swap.build_cds_schedule`\n\
+    \  - `trellis.models.credit_default_swap.interval_default_probability`\n  - `trellis.models.credit_default_swap.price_cds_monte_carlo`\n\
+    \  - `trellis.core.differentiable.get_numpy`\n- Adapter obligations:\n  - `use_credit_curve_hazard_rate_or_survival_probability`\n\
+    \  - `declare_credit_curve_and_discount_curve_requirements`\n## Thin Adapter Plan\n\
+    - Target payoff class: `CDSPayoff`\n- Required market reads:\n  - `market_state.credit_curve`\n\
+    \  - `market_state.discount`\n- Required primitive calls:\n  - `trellis.models.credit_default_swap.interval_default_probability`\n\
+    \  - `trellis.models.credit_default_swap.price_cds_monte_carlo`\n  - `trellis.core.differentiable.get_numpy`\n\
+    - Required adapter steps:\n  - `use_credit_curve_hazard_rate_or_survival_probability`\n\
+    \  - `declare_credit_curve_and_discount_curve_requirements`\n- Return contract:\
+    \ Return a Python `float` present value from `evaluate()`.\n## Invariant Pack\n\
+    - The generated payoff should be compatible with these deterministic validation\
+    \ checks:\n  - `check_cds_spread_quote_normalization`\n  - `check_cds_credit_curve_sensitivity`\n\
+    \  - `check_non_negativity`\n  - `check_price_sanity`\n## Family Route Guidance\n\
+    - For single-name CDS Monte Carlo routes, keep the premium leg and protection\
+    \ leg on an explicit payment/default schedule for one reference entity.\n- Prefer\
+    \ `build_cds_schedule` and `price_cds_monte_carlo` from `trellis.models.credit_default_swap`\
+    \ so the adapter delegates to checked-in CDS helpers instead of open-coding the\
+    \ leg loop.\n- If the spec exposes `n_paths`, pass `spec.n_paths` through to `price_cds_monte_carlo(...)`\
+    \ instead of hard-coding a smaller path count in the adapter.\n- Do not hard-code\
+    \ `n_paths=50000` for a comparison-quality CDS route. Use `spec.n_paths` when\
+    \ available; otherwise pick a comparison-stable path count such as `250000`.\n\
+    - Keep comparison-task randomness reproducible with `seed=42` unless the spec\
+    \ explicitly carries a different seed input.\n- Do not import or instantiate `MonteCarloEngine`\
+    \ for this route. Here Monte Carlo means direct random default-time draws, not\
+    \ a generic diffusion-engine wrapper.\n- CDS running spreads are often quoted\
+    \ in basis points in task text. Normalize them at the top of `evaluate()` with\
+    \ `spread = float(spec.spread)` and `if spread > 1.0: spread *= 1e-4`, for example\
+    \ `150 bp -> 0.015`.\n- After that normalization step, use only the local `spread`\
+    \ variable in the premium leg. Do not read raw `spec.spread` again later in the\
+    \ body.\n- Treat `100` and `0.01` as semantically equivalent CDS running spreads.\
+    \ The route should price them the same up to numerical tolerance.\n- Start the\
+    \ body with `from trellis.core.differentiable import get_numpy` and `np = get_numpy()`\
+    \ so the route uses the approved array backend.\n- Use `rng = np.random.default_rng(...)`\
+    \ or equivalent direct RNG draws to sample default times from the credit curve\
+    \ hazard structure.\n- Use `market_state.credit_curve.hazard_rate(t)` or `market_state.credit_curve.survival_probability(t)`\
+    \ directly on the schedule; do not hide the credit curve behind an alias.\n- Use\
+    \ `market_state.discount.discount(t)` directly for each payment-date discount\
+    \ factor.\n- Build the explicit schedule with `build_period_schedule(spec.start_date,\
+    \ spec.end_date, spec.frequency, day_count=spec.day_count, time_origin=spec.start_date)`\
+    \ and iterate over `period.payment_date`, `period.accrual_fraction`, and `period.t_payment`.\n\
+    - This route must price a Monte Carlo expectation over many paths. Use `n_paths\
+    \ = ...`, `alive = np.ones(n_paths, dtype=bool)`, vectorized `default_in_interval`,\
+    \ and return a path average such as `float(np.mean(protection_pv - premium_pv))`.\n\
+    - Do not collapse the Monte Carlo leg to scalar `alive`, a single `rng.random()`\
+    \ draw per coupon date, or a one-scenario loop with `break` after default.\n-\
+    \ Compute interval default probability from `survival_probability(prev_t)` and\
+    \ `survival_probability(t_pay)` as `1.0 - s_pay / s_prev` when `s_prev > 0.0`.\n\
+    - Use `hazard_rate` only for within-interval default-time interpolation after\
+    \ an interval default is sampled; do not replace the interval default probability\
+    \ with `1.0 - exp(-hazard * dt)` when survival probabilities are available.\n\
+    - For this comparison route, keep protection-leg discounting aligned with the\
+    \ analytical schedule loop: use the payment-date discount factor `discount(t_pay)`\
+    \ for interval default mass.\n- Do not discount protection at sampled default\
+    \ times `tau` or replace interval default mass with sampled settlement-time discounting\
+    \ in the comparison build.\n- Use `spec.start_date` as the time origin for Monte\
+    \ Carlo schedule times so the MC and analytical CDS legs share the same `t` convention.\n\
+    - If you track both accrual dates and survival/default times, keep `prev_date`\
+    \ and `prev_t` as separate variables. Do not compare float year-fractions to `date`\
+    \ objects or pass floats into `year_fraction(...)` date slots.\n- Keep a persistent\
+    \ `alive` indicator across the schedule. Sample `default_in_interval` once per\
+    \ accrual interval, add protection only on that interval, then update `alive`\
+    \ before the next payment date.\n- Update `alive` immediately after drawing `default_in_interval`,\
+    \ then use the updated `alive` state for premium accrual at the payment date.\n\
+    - Premium accrual should use the fraction of paths still alive through the payment\
+    \ date, not the start-of-interval alive state. Do not overwrite or reinitialize\
+    \ the default state inside each loop iteration.\n- Keep the body as a single explicit\
+    \ schedule loop plus a final `premium_leg` / `protection_leg` PV aggregation;\
+    \ do not invent helper names or route credit-default pricing through Black76.\n\
+    - Do not import copulas or reinterpret a single-name CDS as nth-to-default, basket\
+    \ CDS, or first-to-default.\n- A good shape is: initialize `premium_leg = 0.0`,\
+    \ `protection_leg = 0.0`, loop over the payment dates, update both legs, then\
+    \ `return protection_leg - premium_leg`.\n## Conventions\n- evaluate() returns\
+    \ a FLOAT — the present value (PV) of the instrument\n- You MUST handle all discounting\
+    \ internally — use `market_state.discount.discount(t)`\n- For forward rates: `market_state.forecast_forward_curve(self._spec.rate_index)`\n\
+    - For vol: `market_state.vol_surface.black_vol(T, strike)`\n- For discount factors:\
+    \ `market_state.discount.discount(t)`\n- `market_state.fx_rates[pair]` returns\
+    \ an `FXRate` wrapper; extract `.spot` before scalar arithmetic or process seeding\n\
+    - Schedule generation: prefer `build_payment_timeline(...)`, `build_observation_timeline(...)`,\
+    \ or `build_period_schedule(...)` for accrual/event routes; use `generate_schedule(start,\
+    \ end, freq)` only for plain date lists with no period semantics\n- Year fractions:\
+    \ `year_fraction(date1, date2, day_count)`\n- Never use wall-clock dates such\
+    \ as `date.today()` or `datetime.now()` inside `evaluate()`; derive valuation\
+    \ time from `market_state` or shared resolver outputs.\n- Black76: `black76_call(F,\
+    \ K, sigma, T)`, `black76_put(F, K, sigma, T)` — undiscounted\n- Black76 digital:\
+    \ `black76_cash_or_nothing_call(F, K, sigma, T)`, `black76_cash_or_nothing_put(F,\
+    \ K, sigma, T)` — undiscounted cash-or-nothing digitals\n- For CDS / nth-to-default:\
+    \ use `market_state.credit_curve.survival_probability(t)` and `market_state.credit_curve.hazard_rate(t)`\
+    \ on an explicit payment/default schedule; do not route credit-default pricing\
+    \ through Black76 call/put primitives.\n- For equity trees: prefer `from trellis.models.equity_option_tree\
+    \ import price_vanilla_equity_option_tree`; the lower-level lattice path is `from\
+    \ trellis.models.trees.lattice import build_spot_lattice, lattice_backward_induction`\n\
+    - For vanilla European PDE routes: prefer `from trellis.models.equity_option_pde\
+    \ import price_vanilla_equity_option_pde`; the lower-level fallback is `from trellis.models.pde.grid\
+    \ import Grid`, `from trellis.models.pde.operator import BlackScholesOperator`,\
+    \ and `from trellis.models.pde.theta_method import theta_method_1d`\n- For rate\
+    \ lattices: prefer helper surfaces such as `price_callable_bond_tree(...)`, `price_bermudan_swaption_tree(...)`,\
+    \ or `price_zcb_option_tree(...)`; the lower-level fallback is `from trellis.models.trees.lattice\
+    \ import build_rate_lattice, lattice_backward_induction`\n- For schedule-dependent\
+    \ rate lattices: `from trellis.models.trees.control import lattice_steps_from_timeline,\
+    \ resolve_lattice_exercise_policy`\n- For MC: `from trellis.models.monte_carlo\
+    \ import MonteCarloEngine`\n- For QMC accelerators: `from trellis.models.qmc import\
+    \ sobol_normals, brownian_bridge`\n- For copulas: `from trellis.models.copulas\
+    \ import GaussianCopula, FactorCopula`\n- Do not invent MonteCarloEngine method\
+    \ strings. Valid `method=` values are `euler`, `milstein`, and `exact`.\n- For\
+    \ Monte Carlo early exercise, use an approved control primitive; do not pretend\
+    \ that `MonteCarloEngine.price(...)` or `method=\"lsm\"` implements early exercise.\
+    \ Approved policy classes: `longstaff_schwartz` [implemented], `tsitsiklis_van_roy`\
+    \ [implemented], `primal_dual_mc` [implemented], `stochastic_mesh` [implemented].\
+    \ Currently implemented in Trellis: `longstaff_schwartz`, `tsitsiklis_van_roy`,\
+    \ `primal_dual_mc`, `stochastic_mesh`.\n- If you use `LaguerreBasis`, import it\
+    \ from `trellis.models.monte_carlo.schemes`, not from `trellis.models.monte_carlo.lsm`.\n\
+    - For FFT/COS pricing, characteristic functions must accept vector `u` and use\
+    \ array-safe numerics such as `numpy`, not scalar `math`/`cmath`.\n- Black76 basis:\
+    \ `black76_asset_or_nothing_call(F, K, sigma, T)`, `black76_asset_or_nothing_put(F,\
+    \ K, sigma, T)`, `black76_cash_or_nothing_call(F, K, sigma, T)`, `black76_cash_or_nothing_put(F,\
+    \ K, sigma, T)` — exact terminal basis claims.\n- For terminal vanilla payoffs,\
+    \ prefer exact basis assembly via `terminal_vanilla_from_basis(...)` from `trellis.models.analytical`.\n\
+    - For FX vanilla options, treat the route as Garman-Kohlhagen: map spot FX and\
+    \ domestic/foreign discount factors to `ResolvedGarmanKohlhagenInputs`, then prefer\
+    \ `garman_kohlhagen_price_raw(spec.option_type, resolved)` from `trellis.models.analytical.fx`;\
+    \ use explicit basis-claim assembly only when the request explicitly needs the\
+    \ decomposition.\n- For cash-or-nothing digital options, use the Black76 digital\
+    \ helpers directly; do not approximate them with vanilla call/put prices or divide\
+    \ by spot.\n- You MUST use only real, approved `trellis.*` imports from the structured\
+    \ generation plan and import registry\n- Treat the compiler-emitted lane obligations\
+    \ in the structured generation plan as the backbone of the implementation.\n-\
+    \ Reuse the listed exact backend bindings when present; otherwise build the smallest\
+    \ lane-consistent kernel that satisfies the construction steps.\n- Do not replace\
+    \ selected primitives with bespoke numerical kernels or alternative Trellis routes\
+    \ unless the plan explicitly permits a new lane implementation.\n- Do not add\
+    \ wildcard imports\n- If the approved modules do not contain what you need, reuse\
+    \ the closest existing implementation and keep the gap explicit instead of inventing\
+    \ a path\n\n## Reference implementations\n\n### Payoff protocol + Cashflows/PresentValue\
+    \ return types\n```python\n\"\"\"Payoff protocol and base classes for pricing\
+    \ instruments.\n\nEvery priceable instrument in Trellis implements the Payoff\
+    \ protocol.\nA payoff takes market data (via MarketState) and returns a present\
+    \ value.\nThis module also provides base classes for two common pricing patterns:\n\
+    \n- ResolvedInputPayoff: for analytical or tree-based pricing where market\n \
+    \ data is extracted once, then fed into a pricing formula.\n- MonteCarloPathPayoff:\
+    \ for simulation-based pricing where paths are\n  generated and payoffs are computed\
+    \ per path then averaged.\n\"\"\"\n\nfrom __future__ import annotations\n\nfrom\
+    \ abc import ABC, abstractmethod\nfrom datetime import date\nfrom typing import\
+    \ Generic, Protocol, TypeVar, runtime_checkable\n\nfrom trellis.core.date_utils\
+    \ import year_fraction\nfrom trellis.core.differentiable import get_numpy\nfrom\
+    \ trellis.core.market_state import MarketState\nfrom trellis.core.types import\
+    \ DayCountC\n# [truncated reference]\n```\n\n### Date utilities used by generated\
+    \ payoffs\n```python\n\"\"\"Date utilities: day count conventions, schedule generation,\
+    \ year fractions.\"\"\"\n\nfrom __future__ import annotations\n\nimport calendar\n\
+    from collections.abc import Iterable\nfrom datetime import date, datetime, timedelta\n\
+    from typing import Union\n\nfrom trellis.core.types import (\n    ContractTimeline,\n\
+    \    DayCountConvention,\n    EventSchedule,\n    Frequency,\n    TimelineRole,\n\
+    )\n\nDateLike = Union[date, datetime]\nExplicitDateInput = ContractTimeline |\
+    \ EventSchedule | Iterable[DateLike | str] | str\n\n\ndef _to_date(d: DateLike)\
+    \ -> date:\n    \"\"\"Normalize ``date``/``datetime`` inputs to plain ``date``\
+    \ objects.\"\"\"\n    if isinstance(d, datetime):\n        return d.date()\n \
+    \   return d\n\n\ndef add_months(dt: DateLike, months: int) -> date:\n    \"\"\
+    \"Add *months* calendar months, clamping the day to the new month's max.\"\"\"\
+    \n    d = _to_date(dt)\n    total_months = d.month - 1 + months\n    year = d.year\
+    \ + total\n# [truncated reference]\n```\n\n### MarketState capabilities and access\
+    \ patterns\n```python\n\"\"\"MarketState: immutable container of market data used\
+    \ for pricing.\n\nA MarketState holds everything a payoff needs to compute a price:\n\
+    discount curves, volatility surfaces, spot prices, credit curves, etc.\nIt is\
+    \ frozen (immutable) so that multiple payoffs can safely share the\nsame market\
+    \ snapshot without risk of accidental modification.\n\"\"\"\n\nfrom __future__\
+    \ import annotations\n\nfrom dataclasses import dataclass\nfrom datetime import\
+    \ date\nfrom typing import TYPE_CHECKING\n\nfrom trellis.core.types import DiscountCurve\n\
+    \nif TYPE_CHECKING:\n    from trellis.core.state_space import StateSpace\n   \
+    \ from trellis.curves.credit_curve import CreditCurve\n    from trellis.curves.forward_curve\
+    \ import ForwardCurve\n    from trellis.instruments.fx import FXRate\n    from\
+    \ trellis.models.vol_surface import VolSurface\n\n\nclass MissingCapabilityError(Exception):\n\
+    \    \"\"\"Raised when a MarketState lacks market data r\n# [truncated reference]\n\
+    ```\n\n### Frequency/day-count types\n```python\n\"\"\"Core protocols, enums,\
+    \ and data structures shared across Trellis.\n\nDefines the fundamental types\
+    \ that most other modules depend on:\nfrequency enums, day count conventions,\
+    \ the DiscountCurve and Instrument\nprotocols, and simple data containers like\
+    \ schedules and pricing results.\n\"\"\"\n\nfrom __future__ import annotations\n\
+    \nfrom dataclasses import dataclass, field\nfrom datetime import date\nfrom enum\
+    \ import Enum\nfrom typing import Protocol, runtime_checkable\n\n# ---------------------------------------------------------------------------\n\
+    # Greek specification types\n# ---------------------------------------------------------------------------\n\
+    \n# What risk sensitivities to compute alongside the price.\n#   None       —\
+    \ price only, no sensitivities\n#   \"all\"      — every known sensitivity (dv01,\
+    \ duration, convexity, etc.)\n#   list[str]  — specific sensitivities by name\
+    \ (e.g. [\"dv01\", \"duration\"])\n# [truncated reference]\n```\n\n[omitted 1\
+    \ additional reference modules]\n\n\n## Output\nReturn the COMPLETE Python module\
+    \ — copy the skeleton exactly, but replace the\n`raise NotImplementedError(...)`\
+    \ line with the actual implementation of `evaluate()`.\nDo NOT change imports,\
+    \ class names, spec fields, or the requirements property.\nOnly implement the\
+    \ evaluate() method body. You may add imports at the top.\nNo markdown fences,\
+    \ no explanation — just the Python code."
+  model: gpt-5.4-mini
+- seq: 1
+  function: llm_generate_json
+  stage: critic
+  prompt_hash: 3efb04c0582dffb75be6667c4e39f4c4a37cd00a720c9fe9e5cea76f11b68e2a
+  response_text: '{"check_id": "price_non_negative", "description": "Likely sign/leg
+    orientation error for CDS PV.", "severity": "error", "evidence": "The instrument
+    spec explicitly says \"Compute the mark-to-market PV (protection leg minus premium
+    leg)\" for a protection buyer, but the implementation directly returns `price_cds_monte_carlo(...)`
+    without any visible adjustment or sign check. If the helper is buyer-side conventional,
+    a mismatched orientation would produce a negative PV in a default-free / low-spread
+    state and can violate non-negativity for the requested long protection position.",
+    "remediation": "Verify the helper''s sign convention and, if needed, flip the
+    PV to match protection buyer economics (protection leg minus premium leg) before
+    returning.", "status": "suspect"}'
+  prompt_text: "You are a quantitative model validator reviewing agent-generated pricing\
+    \ code.\nYour job is to find deterministic review concerns, not to praise. Be\
+    \ adversarial.\n\n## Code to review\n```python\n\"\"\"Agent-generated payoff:\
+    \ Build a pricer for: CDS pricing: hazard rate MC vs survival prob analytical\n\
+    \nStandard single-name CDS, protection buyer side.\nNotional: $10,000,000.  Maturity:\
+    \ 5Y from settlement.\nPremium leg: quarterly payments, Act/360 day count.\nRunning\
+    \ CDS spread: 150 bp.  Recovery rate: 40%.\nUse the investment-grade (IG) credit\
+    \ curve from the market snapshot\n(as_of 2024-11-15) — this provides term-dependent\
+    \ hazard rates\nbootstrapped from market CDS spreads at 1Y, 3Y, 5Y, and 10Y tenors.\n\
+    Do NOT use a flat hazard rate — the model must respect the full\nhazard rate term\
+    \ structure.\nUse the USD OIS curve for risk-free discounting.\nMethod 1: Monte\
+    \ Carlo simulation of default times from the hazard curve.\nMethod 2: Analytical\
+    \ (deterministic) survival-probability integration.\nCompute the mark-to-market\
+    \ PV (protection leg minus premium leg).\n\nConstruct methods: monte_carlo\nComparison\
+    \ targets: mc_cds (monte_carlo), analytical_cds (analytical)\nCross-validation\
+    \ harness:\n  internal targets: mc_cds, analytical_cds\n  external targets: quantlib,\
+    \ financepy\nNew component: cds_pricing\n\nImplementation target: mc_cds\nPreferred\
+    \ method family: monte_carlo\n\nImplementation target: mc_cds.\"\"\"\n\nfrom __future__\
+    \ import annotations\n\nfrom dataclasses import dataclass\nfrom datetime import\
+    \ date\n\nfrom trellis.core.market_state import MarketState\nfrom trellis.core.types\
+    \ import DayCountConvention, Frequency\nfrom trellis.core.differentiable import\
+    \ get_numpy\nfrom trellis.models.credit_default_swap import build_cds_schedule,\
+    \ price_cds_monte_carlo, interval_default_probability\n\n\n\n@dataclass(frozen=True)\n\
+    class CDSSpec:\n    \"\"\"Specification for Build a pricer for: CDS pricing: hazard\
+    \ rate MC vs survival prob analytical\n\nStandard single-name CDS, protection\
+    \ buyer side.\nNotional: $10,000,000.  Maturity: 5Y from settlement.\nPremium\
+    \ leg: quarterly payments, Act/360 day count.\nRunning CDS spread: 150 bp.  Recovery\
+    \ rate: 40%.\nUse the investment-grade (IG) credit curve from the market snapshot\n\
+    (as_of 2024-11-15) — this provides term-dependent hazard rates\nbootstrapped from\
+    \ market CDS spreads at 1Y, 3Y, 5Y, and 10Y tenors.\nDo NOT use a flat hazard\
+    \ rate — the model must respect the full\nhazard rate term structure.\nUse the\
+    \ USD OIS curve for risk-free discounting.\nMethod 1: Monte Carlo simulation of\
+    \ default times from the hazard curve.\nMethod 2: Analytical (deterministic) survival-probability\
+    \ integration.\nCompute the mark-to-market PV (protection leg minus premium leg).\n\
+    \nConstruct methods: monte_carlo\nComparison targets: mc_cds (monte_carlo), analytical_cds\
+    \ (analytical)\nCross-validation harness:\n  internal targets: mc_cds, analytical_cds\n\
+    \  external targets: quantlib, financepy\nNew component: cds_pricing\n\nImplementation\
+    \ target: mc_cds\nPreferred method family: monte_carlo\n\nImplementation target:\
+    \ mc_cds.\"\"\"\n    notional: float\n    spread: float\n    start_date: date\n\
+    \    end_date: date\n    recovery: float = 0.4\n    frequency: Frequency = Frequency.QUARTERLY\n\
+    \    day_count: DayCountConvention = DayCountConvention.ACT_360\n    n_paths:\
+    \ int = 250000\n\n\nclass CDSPayoff:\n    \"\"\"Build a pricer for: CDS pricing:\
+    \ hazard rate MC vs survival prob analytical\n\nStandard single-name CDS, protection\
+    \ buyer side.\nNotional: $10,000,000.  Maturity: 5Y from settlement.\nPremium\
+    \ leg: quarterly payments, Act/360 day count.\nRunning CDS spread: 150 bp.  Recovery\
+    \ rate: 40%.\nUse the investment-grade (IG) credit curve from the market snapshot\n\
+    (as_of 2024-11-15) — this provides term-dependent hazard rates\nbootstrapped from\
+    \ market CDS spreads at 1Y, 3Y, 5Y, and 10Y tenors.\nDo NOT use a flat hazard\
+    \ rate — the model must respect the full\nhazard rate term structure.\nUse the\
+    \ USD OIS curve for risk-free discounting.\nMethod 1: Monte Carlo simulation of\
+    \ default times from the hazard curve.\nMethod 2: Analytical (deterministic) survival-probability\
+    \ integration.\nCompute the mark-to-market PV (protection leg minus premium leg).\n\
+    \nConstruct methods: monte_carlo\nComparison targets: mc_cds (monte_carlo), analytical_cds\
+    \ (analytical)\nCross-validation harness:\n  internal targets: mc_cds, analytical_cds\n\
+    \  external targets: quantlib, financepy\nNew component: cds_pricing\n\nImplementation\
+    \ target: mc_cds\nPreferred method family: monte_carlo\n\nImplementation target:\
+    \ mc_cds.\"\"\"\n\n    def __init__(self, spec: CDSSpec):\n        self._spec\
+    \ = spec\n\n    @property\n    def spec(self) -> CDSSpec:\n        return self._spec\n\
+    \n    @property\n    def requirements(self) -> set[str]:\n        return {\"credit_curve\"\
+    , \"discount_curve\"}\n\n    def evaluate(self, market_state: MarketState) ->\
+    \ float:\n        spec = self._spec\n        from trellis.models.credit_default_swap\
+    \ import build_cds_schedule, price_cds_monte_carlo\n\n        np = get_numpy()\n\
+    \n        spec = self._spec\n        spread = float(spec.spread)\n        if spread\
+    \ > 1.0:\n            spread *= 1e-4\n\n        schedule = build_cds_schedule(\n\
+    \        spec.start_date,\n        spec.end_date,\n        spec.frequency,\n \
+    \       spec.day_count,\n        time_origin=spec.start_date,\n        )\n\n \
+    \       return float(\n        price_cds_monte_carlo(\n            notional=float(spec.notional),\n\
+    \            spread_quote=spread,\n            recovery=float(spec.recovery),\n\
+    \            schedule=schedule,\n            credit_curve=market_state.credit_curve,\n\
+    \            discount_curve=market_state.discount,\n            n_paths=int(spec.n_paths),\n\
+    \            seed=42,\n        )\n        )\n\n```\n\n## Instrument description\n\
+    Build a pricer for: CDS pricing: hazard rate MC vs survival prob analytical\n\n\
+    Standard single-name CDS, protection buyer side.\nNotional: $10,000,000.  Maturity:\
+    \ 5Y from settlement.\nPremium leg: quarterly payments, Act/360 day count.\nRunning\
+    \ CDS spread: 150 bp.  Recovery rate: 40%.\nUse the investment-grade (IG) credit\
+    \ curve from the market snapshot\n(as_of 2024-11-15) — this provides term-dependent\
+    \ hazard rates\nbootstrapped from market CDS spreads at 1Y, 3Y, 5Y, and 10Y tenors.\n\
+    Do NOT use a flat hazard rate — the model must respect the full\nhazard rate term\
+    \ structure.\nUse the USD OIS curve for risk-free discounting.\nMethod 1: Monte\
+    \ Carlo simulation of default times from the hazard curve.\nMethod 2: Analytical\
+    \ (deterministic) survival-probability integration.\nCompute the mark-to-market\
+    \ PV (protection leg minus premium leg).\n\nConstruct methods: monte_carlo\nComparison\
+    \ targets: mc_cds (monte_carlo), analytical_cds (analytical)\nCross-validation\
+    \ harness:\n  internal targets: mc_cds, analytical_cds\n  external targets: quantlib,\
+    \ financepy\nNew component: cds_pricing\n\nImplementation target: mc_cds\nPreferred\
+    \ method family: monte_carlo\n\nImplementation target: mc_cds\n\n## Shared Knowledge\n\
+    ## Distilled Review Memory\n\n- Review principles:\n  - `P1`: Always calibrate\
+    \ rate trees to the discount curve before pricing\n  - `P2`: Callable bonds need\
+    \ issuer_call lattice control, discrete coupons, and exercise=par+coupon\n  -\
+    \ `P3`: Convert vol units at the boundary between market data and model\n- Review\
+    \ checkpoints:\n  - CONVERGENCE: Use at least 10,000 paths. Verify that the standard\
+    \ error is <1% of the price. If path-dependent, use at least 100 time steps per\
+    \ year.\n  - DISCRETE OBSERVATIONS: For instruments with discrete fixing/observation\
+    \ dates (Asian options, barriers), simulate paths that pass through those exact\
+    \ dates. Do not interpolate between steps.\n  - EARLY EXERCISE: For American or\
+    \ Bermudan exercise in Monte Carlo, use an approved optimal-stopping control primitive\
+    \ instead of inventing method=\"lsm\" or treating engine.price(...) as a substitute\
+    \ for early-exercise control. Trellis currently implements longstaff_schwartz.\
+    \ Planned policy classes include tsitsiklis_van_roy, primal_dual_mc, and stochastic_mesh.\
+    \ If the control primitive uses continuation regression, the basis or estimator\
+    \ choice is explicit; LaguerreBasis is a common option, not a mandatory route\
+    \ primitive.\n- Canonical model grammar:\n  - `credit_single_name_reduced_form`\
+    \ -> `Reduced-form single-name credit`\n  - `heston_smile_workflow` -> `Heston`\n\
+    - Known failure traps:\n  - `MC payoff must use market_state.discount` -> The\
+    \ generated Monte Carlo payoff did not call the required market_state.discount\
+    \ API (so the MC harness could not detect discount-curve usage) and the agent-produced\
+    \ module contained a Python indentation/syntax error preventing compilation. Additionally,\
+    \ the payoff shape requirement (1D per-path PV) was not respected in prior attempts.\n\
+    \  - `MC payoff must use required primitives` -> The generated Monte‑Carlo payoff\
+    \ was implemented as ordinary numpy/opaque operations and did not adapt to the\
+    \ selected assembly's required semantic primitive (trellis.core.differentiable.get_numpy).\
+    \ The payoff also risked returning the wrong shape (e.g. (n_paths, n_steps+1)).\n\
+    \n## Generated Skills\n- [lesson] NthToDefaultPayoff analytical must use Gaussian\
+    \ copula integration, not independent binomial: Use the Gaussian copula conditional\
+    \ independence formula (integrate over common factor Z). This is the analytical\
+    \ counterpart of the GaussianCopula MC. from math import comb from scipy import\
+    \ integrate from scipy.stat...\n\n## Instrument Disambiguation\n- Treat this request\
+    \ as a single-name CDS / credit_default_swap contract.\n- Do not reinterpret CDS\
+    \ here as nth_to_default, basket CDS, first-to-default, or any multi-name credit\
+    \ product.\n- Do not import copula or Gaussian-copula machinery unless the request\
+    \ explicitly says nth-to-default, first-to-default, basket CDS, or multiple reference\
+    \ names.\n\n\n## Compiled Route Contract\n- Method family: `monte_carlo`\n- Instrument\
+    \ type: `cds`\n- Semantic contract: `credit_default_swap`, request=`credit_default_swap`,\
+    \ bridge=`canonical_semantic`, instrument=`cds`, payoff=`credit_default_swap`,\
+    \ structure=`single_reference_entity`\n- Valuation context: market_source=`unbound_market_snapshot`\n\
+    - Lane boundary: family=`monte_carlo`, kind=`exact_target_binding`, timeline_roles=`settlement`,\
+    \ `payment`, `observation`, exact_bindings=`trellis.models.credit_default_swap.build_cds_schedule`,\
+    \ `trellis.models.credit_default_swap.price_cds_monte_carlo`\n- Lowering boundary:\
+    \ family_ir=`CreditDefaultSwapIR`, expr=`ThenExpr`, helpers=`trellis.models.credit_default_swap.build_cds_schedule`,\
+    \ `trellis.models.credit_default_swap.interval_default_probability`, route_alias=`credit_default_swap_monte_carlo`\n\
+    - Validation contract: bundle=`monte_carlo:credit_default_swap`, checks=`check_cds_spread_quote_normalization`,\
+    \ `check_cds_credit_curve_sensitivity`, `premium_leg_accrues_on_schedule`, `protection_leg_triggers_on_default`,\
+    \ residual_risks=`comparison_relations_unspecified`\n- Lane obligations:\n  -\
+    \ Lane family: `monte_carlo`\n  - Plan kind: `exact_target_binding`\n  - Timeline\
+    \ roles: `settlement`, `payment`, `observation`\n  - Market bindings: `discount_curve`,\
+    \ `credit_curve`\n  - Control semantics: `pricing_mode:monte_carlo`, `schedule_role:payment_dates`\n\
+    \  - State obligations: `survival_state`, `premium_leg_schedule`, `default_indicator`\n\
+    \  - Construction steps:\n    - Build the CDS schedule with `build_cds_schedule`\
+    \ and keep the leg semantics explicit: premium_leg, protection_leg.\n    - Bind\
+    \ discount and credit-curve inputs to the `monte_carlo` lane without routing through\
+    \ equity-option kernels.\n    - Price the schedule-driven contract through `price_cds_monte_carlo`\
+    \ unless the request introduces a genuinely new credit kernel.\n  - Exact backend\
+    \ bindings:\n    - `trellis.models.credit_default_swap.build_cds_schedule`\n \
+    \   - `trellis.models.credit_default_swap.interval_default_probability`\n    -\
+    \ `trellis.models.credit_default_swap.price_cds_monte_carlo`\n    - `trellis.core.differentiable.get_numpy`\n\
+    \  - Exact binding signatures:\n    - `build_cds_schedule(start_date: 'date',\
+    \ end_date: 'date', frequency: 'Frequency', day_count: 'DayCountConvention', *,\
+    \ time_origin: 'date | None' = None) -> 'EventSchedule'`\n    - `price_cds_monte_carlo(*,\
+    \ notional: 'float', spread_quote: 'float', recovery: 'float', schedule: 'EventSchedule',\
+    \ credit_curve: 'CreditCurveLike', discount_curve: 'DiscountCurveLike', n_paths:\
+    \ 'int' = 50000, seed: 'int' = 42) -> 'float'`\n- Route authority:\n  - binding=`trellis.models.credit_default_swap.price_cds_monte_carlo`,\
+    \ engine=`monte_carlo`, authority=`exact_backend_fit`\n  - Route alias: `credit_default_swap_monte_carlo`\n\
+    \  - Validation bundle: `monte_carlo:credit_default_swap`\n  - Validation checks:\
+    \ `check_cds_spread_quote_normalization`, `check_cds_credit_curve_sensitivity`,\
+    \ `check_non_negativity`, `check_price_sanity`\n  - Canary coverage: canaries=`T38`\n\
+    \  - Helper authority: `trellis.models.credit_default_swap.build_cds_schedule`,\
+    \ `trellis.models.credit_default_swap.interval_default_probability`\n  - Exact\
+    \ target bindings: `trellis.models.credit_default_swap.build_cds_schedule`, `trellis.models.credit_default_swap.price_cds_monte_carlo`\n\
+    - Backend binding:\n  - Route: `credit_default_swap_monte_carlo`\n  - Engine family:\
+    \ `monte_carlo`\n  - Route family: `credit_default_swap`\n  - Selected primitives:\n\
+    \    - `trellis.models.credit_default_swap.build_cds_schedule` (schedule_builder)\n\
+    \    - `trellis.models.credit_default_swap.interval_default_probability` (event_probability)\n\
+    \    - `trellis.models.credit_default_swap.price_cds_monte_carlo` (route_helper)\n\
+    \    - `trellis.core.differentiable.get_numpy` (array_backend)\n  - Resolved instructions:\n\
+    \    - [hard_constraint] Use the route helper directly inside `evaluate()`; do\
+    \ not rebuild the process, engine, or discount glue manually.\n    - [route_hint]\
+    \ Use `trellis.models.credit_default_swap.build_cds_schedule` to build the route\
+    \ schedule before pricing.\n    - [route_hint] Do not hard-code observation or\
+    \ payment grids inside the payoff body.\n    - [route_hint] Do not hard-code n_paths=50000\
+    \ for comparison-quality single-name CDS. Use spec.n_paths when available; otherwise\
+    \ choose a comparison-stable count such as 250000.\n    - [route_hint] Do not\
+    \ import or instantiate `MonteCarloEngine` for a single-name CDS route. Here Monte\
+    \ Carlo means direct random default-time draws on the explicit payment schedule,\
+    \ not a generic diffusion-engine wrapper.\n    - [route_hint] Do not collapse\
+    \ the Monte Carlo CDS leg to scalar alive state, a single RNG draw per payment\
+    \ date, or a one-scenario loop that breaks after default.\n    - [route_hint]\
+    \ Use hazard_rate only for within-interval default-time interpolation after an\
+    \ interval default is selected. Do not replace interval default probability with\
+    \ a midpoint-hazard approximation when survival probabilities are available.\n\
+    \    - [route_hint] Do not discount protection at sampled default times tau in\
+    \ the comparison build.\n  - Schedule construction:\n    - [route_hint] Use `trellis.models.credit_default_swap.build_cds_schedule`\
+    \ to build the route schedule before pricing.\n    - [route_hint] Do not hard-code\
+    \ observation or payment grids inside the payoff body.\n    - [route_hint] Do\
+    \ not import or instantiate `MonteCarloEngine` for a single-name CDS route. Here\
+    \ Monte Carlo means direct random default-time draws on the explicit payment schedule,\
+    \ not a generic diffusion-engine wrapper.\n    - [route_hint] Carry a persistent\
+    \ `alive` indicator across the schedule and update it after each interval. Do\
+    \ not overwrite the default state from scratch inside the loop.\n    - [historical_note]\
+    \ For single-name CDS Monte Carlo pricing, prefer the checked-in build_cds_schedule(...)\
+    \ and price_cds_monte_carlo(...) helpers so the adapter stays thin.\n    - [historical_note]\
+    \ If the helper cannot be reused, fall back to build_period_schedule(...) so the\
+    \ adapter iterates over explicit periods with accrual fractions and model times\
+    \ instead of rebuilding payment_dates and prev_date logic by hand.\n    - [historical_note]\
+    \ For comparison tasks, keep protection-leg discounting aligned with the analytical\
+    \ schedule loop and use the payment-date discount factor discount(t_pay) for interval\
+    \ default mass.\n    - [historical_note] Use spec.start_date as the time origin\
+    \ for Monte Carlo schedule times so the MC and analytical CDS comparators share\
+    \ the same t convention.\n  - Required adapters:\n    - `use_credit_curve_hazard_rate_or_survival_probability`\n\
+    \    - `declare_credit_curve_and_discount_curve_requirements`\n  - Backend notes:\n\
+    \    - For single-name CDS Monte Carlo pricing, prefer the checked-in build_cds_schedule(...)\
+    \ and price_cds_monte_carlo(...) helpers so the adapter stays thin.\n    - If\
+    \ the spec exposes n_paths, pass spec.n_paths through to price_cds_monte_carlo(...)\
+    \ instead of hard-coding a smaller comparison-path count in the adapter.\n   \
+    \ - Do not hard-code n_paths=50000 for comparison-quality single-name CDS. Use\
+    \ spec.n_paths when available; otherwise choose a comparison-stable count such\
+    \ as 250000.\n    - Keep comparison-task randomness reproducible with seed=42\
+    \ unless the spec explicitly carries a different seed input.\n- Approved modules\
+    \ in scope:\n  - `trellis.core.date_utils`\n  - `trellis.core.differentiable`\n\
+    \  - `trellis.core.market_state`\n  - `trellis.core.payoff`\n  - `trellis.core.types`\n\
+    \  - `trellis.models.black`\n  - `trellis.models.credit_default_swap`\n  - `trellis.models.monte_carlo.basket_state`\n\
+    - Review the generated code against this compiled boundary. Treat route, helper,\
+    \ or validation drift as real findings.\n\n\n## Available deterministic checks\n\
+    You may ONLY select from this bounded menu:\n- `price_non_negative`: Price should\
+    \ remain non-negative. Use when the route prices a long-only vanilla or option-like\
+    \ payoff that should not produce a negative PV under the default review market\
+    \ state. Deterministic contract: Fail when price_payoff(payoff, ms) < -1e-6.\n\
+    \n\n## Review policy\n- Do not write Python code.\n- Do not invent new checks,\
+    \ formulas, or test procedures.\n- Only emit a finding when the code strongly\
+    \ suggests the selected check is likely to fail.\n- If none of the available checks\
+    \ are justified, return [].\n\n## Output\nReturn a JSON array of concerns. Each\
+    \ concern:\n{\n    \"check_id\": \"one of the available check ids\",\n    \"description\"\
+    : \"short concern summary\",\n    \"severity\": \"error\" or \"warning\",\n  \
+    \  \"evidence\": \"specific code reference or reasoning\",\n    \"remediation\"\
+    : \"what to change\",\n    \"status\": \"suspect\"\n}\n\nFocus on pricing errors\
+    \ that the deterministic checks can confirm.\nReturn at most 3 concerns, ordered\
+    \ by severity.\nReturn ONLY the JSON array."
+  model: gpt-5.4-mini
+- seq: 2
+  function: llm_generate
+  stage: code_generation
+  prompt_hash: 48fb4541b102bfd9e05ff6b3e35f263c45a5b71037de9c066149e577ba66f1e8
+  response_text: "def evaluate(self, market_state: MarketState) -> float:\n    spec\
+    \ = self._spec\n\n    if market_state.discount is None:\n        raise ValueError(\"\
+    CDSPayoff requires a discount curve in market_state\")\n    if market_state.credit_curve\
+    \ is None:\n        raise ValueError(\"CDSPayoff requires a credit curve in market_state\"\
+    )\n\n    spread = float(spec.spread)\n    if spread > 1.0:\n        spread *=\
+    \ 1e-4\n\n    schedule = build_cds_schedule(\n        spec.start_date,\n     \
+    \   spec.end_date,\n        spec.frequency,\n        spec.day_count,\n       \
+    \ time_origin=spec.start_date,\n    )\n\n    return float(\n        price_cds_analytical(\n\
+    \            notional=float(spec.notional),\n            spread_quote=spread,\n\
+    \            recovery=float(spec.recovery),\n            schedule=schedule,\n\
+    \            credit_curve=market_state.credit_curve,\n            discount_curve=market_state.discount,\n\
+    \        )\n    )"
+  prompt_text: "You are implementing the evaluate() method for `CDSPayoff` in the\
+    \ Trellis pricing library.\n\n## Complete module (skeleton — everything is fixed\
+    \ except evaluate)\n```python\n\"\"\"Agent-generated payoff: Build a pricer for:\
+    \ CDS pricing: hazard rate MC vs survival prob analytical\n\nStandard single-name\
+    \ CDS, protection buyer side.\nNotional: $10,000,000.  Maturity: 5Y from settlement.\n\
+    Premium leg: quarterly payments, Act/360 day count.\nRunning CDS spread: 150 bp.\
+    \  Recovery rate: 40%.\nUse the investment-grade (IG) credit curve from the market\
+    \ snapshot\n(as_of 2024-11-15) — this provides term-dependent hazard rates\nbootstrapped\
+    \ from market CDS spreads at 1Y, 3Y, 5Y, and 10Y tenors.\nDo NOT use a flat hazard\
+    \ rate — the model must respect the full\nhazard rate term structure.\nUse the\
+    \ USD OIS curve for risk-free discounting.\nMethod 1: Monte Carlo simulation of\
+    \ default times from the hazard curve.\nMethod 2: Analytical (deterministic) survival-probability\
+    \ integration.\nCompute the mark-to-market PV (protection leg minus premium leg).\n\
+    \nConstruct methods: monte_carlo\nComparison targets: mc_cds (monte_carlo), analytical_cds\
+    \ (analytical)\nCross-validation harness:\n  internal targets: mc_cds, analytical_cds\n\
+    \  external targets: quantlib, financepy\nNew component: cds_pricing\n\nImplementation\
+    \ target: analytical_cds\nPreferred method family: analytical\n\nImplementation\
+    \ target: analytical_cds.\"\"\"\n\nfrom __future__ import annotations\n\nfrom\
+    \ dataclasses import dataclass\nfrom datetime import date\n\nfrom trellis.core.market_state\
+    \ import MarketState\nfrom trellis.core.types import DayCountConvention, Frequency\n\
+    from trellis.models.credit_default_swap import build_cds_schedule, price_cds_analytical\n\
+    \n\n\n@dataclass(frozen=True)\nclass CDSSpec:\n    \"\"\"Specification for Build\
+    \ a pricer for: CDS pricing: hazard rate MC vs survival prob analytical\n\nStandard\
+    \ single-name CDS, protection buyer side.\nNotional: $10,000,000.  Maturity: 5Y\
+    \ from settlement.\nPremium leg: quarterly payments, Act/360 day count.\nRunning\
+    \ CDS spread: 150 bp.  Recovery rate: 40%.\nUse the investment-grade (IG) credit\
+    \ curve from the market snapshot\n(as_of 2024-11-15) — this provides term-dependent\
+    \ hazard rates\nbootstrapped from market CDS spreads at 1Y, 3Y, 5Y, and 10Y tenors.\n\
+    Do NOT use a flat hazard rate — the model must respect the full\nhazard rate term\
+    \ structure.\nUse the USD OIS curve for risk-free discounting.\nMethod 1: Monte\
+    \ Carlo simulation of default times from the hazard curve.\nMethod 2: Analytical\
+    \ (deterministic) survival-probability integration.\nCompute the mark-to-market\
+    \ PV (protection leg minus premium leg).\n\nConstruct methods: monte_carlo\nComparison\
+    \ targets: mc_cds (monte_carlo), analytical_cds (analytical)\nCross-validation\
+    \ harness:\n  internal targets: mc_cds, analytical_cds\n  external targets: quantlib,\
+    \ financepy\nNew component: cds_pricing\n\nImplementation target: analytical_cds\n\
+    Preferred method family: analytical\n\nImplementation target: analytical_cds.\"\
+    \"\"\n    notional: float\n    spread: float\n    start_date: date\n    end_date:\
+    \ date\n    recovery: float = 0.4\n    frequency: Frequency = Frequency.QUARTERLY\n\
+    \    day_count: DayCountConvention = DayCountConvention.ACT_360\n\n\nclass CDSPayoff:\n\
+    \    \"\"\"Build a pricer for: CDS pricing: hazard rate MC vs survival prob analytical\n\
+    \nStandard single-name CDS, protection buyer side.\nNotional: $10,000,000.  Maturity:\
+    \ 5Y from settlement.\nPremium leg: quarterly payments, Act/360 day count.\nRunning\
+    \ CDS spread: 150 bp.  Recovery rate: 40%.\nUse the investment-grade (IG) credit\
+    \ curve from the market snapshot\n(as_of 2024-11-15) — this provides term-dependent\
+    \ hazard rates\nbootstrapped from market CDS spreads at 1Y, 3Y, 5Y, and 10Y tenors.\n\
+    Do NOT use a flat hazard rate — the model must respect the full\nhazard rate term\
+    \ structure.\nUse the USD OIS curve for risk-free discounting.\nMethod 1: Monte\
+    \ Carlo simulation of default times from the hazard curve.\nMethod 2: Analytical\
+    \ (deterministic) survival-probability integration.\nCompute the mark-to-market\
+    \ PV (protection leg minus premium leg).\n\nConstruct methods: monte_carlo\nComparison\
+    \ targets: mc_cds (monte_carlo), analytical_cds (analytical)\nCross-validation\
+    \ harness:\n  internal targets: mc_cds, analytical_cds\n  external targets: quantlib,\
+    \ financepy\nNew component: cds_pricing\n\nImplementation target: analytical_cds\n\
+    Preferred method family: analytical\n\nImplementation target: analytical_cds.\"\
+    \"\"\n\n    def __init__(self, spec: CDSSpec):\n        self._spec = spec\n\n\
+    \    @property\n    def spec(self) -> CDSSpec:\n        return self._spec\n\n\
+    \    @property\n    def requirements(self) -> set[str]:\n        return {\"credit_curve\"\
+    , \"discount_curve\"}\n\n    def evaluate(self, market_state: MarketState) ->\
+    \ float:\n        spec = self._spec\n        raise NotImplementedError(\"evaluate\
+    \ not yet implemented\")\n\n```\n\n## Your task\nWrite ONLY the body of the `evaluate()`\
+    \ method. The signature is already defined:\n\n    def evaluate(self, market_state:\
+    \ MarketState) -> float:\n\n## Spec fields available via self._spec\n- `self._spec.notional`\
+    \ (float): Protection notional\n- `self._spec.spread` (float): CDS running spread\
+    \ in decimal form (e.g. 0.015 = 150bps, not 150.0)\n- `self._spec.recovery` (float):\
+    \ Recovery rate\n- `self._spec.start_date` (date): Protection start date\n- `self._spec.end_date`\
+    \ (date): Protection end date\n- `self._spec.frequency` (Frequency): Premium payment\
+    \ frequency\n- `self._spec.day_count` (DayCountConvention): Day count convention\n\
+    \n## Pricing Method (selected by the quant agent — you MUST use this)\nMethod:\
+    \ **analytical**\nReasoning: product_ir_compiler\nSelection basis and assumptions:\n\
+    - Selection basis: `explicit_preference`\n- Assumptions / defaulted context:\n\
+    \  - `simplest_valid_assumption_set`\n  - `closed_form_or_quasi_closed_form_route`\n\
+    \  - `no_path_sampling_required`\n  - `multiple_valid_methods_available`\n  -\
+    \ `schedule_dependent_product`\nRoute-bound modules to import and use:\n- `trellis.models.credit_default_swap`\n\
+    \nYou MUST import and use these route-bound modules in your implementation.\n\
+    Do not import a generic parent package such as `from trellis.models import ...`\
+    \ just to satisfy the method family.\n\n## API Map — start here before guessing\
+    \ module paths\n\nUse this navigation card to choose the right module family first.\
+    \ Confirm exact symbols with `find_symbol` or `list_exports` before calling `read_module`.\n\
+    \n### Core Types\n#### MarketState\n- Module: `trellis.core.market_state`\n- Class:\
+    \ `MarketState`\n- Frozen: `true`\n- Fields: `as_of`, `settlement`, `discount`,\
+    \ `forward_curve`, `vol_surface`, `state_space`, `credit_curve`, `forecast_curves`,\
+    \ `fx_rates`\n- Accessors: `discount_factor`, `zero_rate`, `forward_rate`, `forecast_forward`,\
+    \ `black_vol`, `survival_prob`, `hazard_rate`, `risky_discount`\n- Capabilities:\
+    \ `discount_curve → discount is not None`, `forward_curve → forward_curve is not\
+    \ None (auto from discount)`, `black_vol_surface → vol_surface is not None`, `state_space\
+    \ → state_space is not None`, `credit_curve → credit_curve is not None`, `fx_rates\
+    \ → fx_rates is not None`\n#### Payoff\n- Module: `trellis.core.payoff`\n- Protocol:\
+    \ `Payoff`\n- Required methods: `evaluate`\n- Required properties: `requirements`\n\
+    - Runtime checkable: `true`\n- Notes:\n  - Each payoff handles its own discounting\
+    \ internally\n  - The returned float is the final PV\n  - DeterministicCashflowPayoff\
+    \ wraps any Instrument into Payoff\n\n### Model Families\n#### equity_tree\n-\
+    \ Module: `trellis.models.equity_option_tree`\n- Key imports:\n  - `from trellis.models.equity_option_tree\
+    \ import price_vanilla_equity_option_tree`\n  - `from trellis.models.trees.lattice\
+    \ import build_spot_lattice, lattice_backward_induction`\n- Notes:\n  - American/Bermudan\
+    \ equity options should prefer the checked-in helper `price_vanilla_equity_option_tree(...)`\n\
+    \  - If you need the lower-level path, import the lattice builder/backward induction\
+    \ submodules directly\n#### rate_lattice\n- Module: `trellis.models.trees.lattice`\n\
+    - Key imports:\n  - `from trellis.models.trees.lattice import build_rate_lattice,\
+    \ lattice_backward_induction`\n  - `from trellis.models.zcb_option_tree import\
+    \ price_zcb_option_tree`\n- Notes:\n  - Callable bonds, puttable bonds, and Bermudan\
+    \ swaptions use a calibrated rate lattice from a TreeModel specification such\
+    \ as Hull-White or Black-Derman-Toy\n  - lattice_backward_induction handles cashflow_at_node\
+    \ and exercise_fn\n#### monte_carlo\n- Module: `trellis.models.monte_carlo`\n\
+    - Key imports:\n  - `from trellis.models.monte_carlo.engine import MonteCarloEngine`\n\
+    \  - `from trellis.models.monte_carlo.lsm import longstaff_schwartz, longstaff_schwartz_result`\n\
+    \  - `from trellis.models.monte_carlo.early_exercise import EarlyExercisePolicyResult,\
+    \ LeastSquaresContinuationEstimator`\n  - `from trellis.models.monte_carlo.schemes\
+    \ import LaguerreBasis`\n  - `from trellis.models.monte_carlo import euler_maruyama,\
+    \ milstein, brownian_bridge`\n  - `from trellis.models.monte_carlo import antithetic,\
+    \ control_variate`\n  - `from trellis.models.processes.gbm import GBM`\n- Notes:\n\
+    \  - For American/Bermudan Monte Carlo, simulate paths then call an approved early-exercise\
+    \ control primitive; Trellis currently implements longstaff_schwartz\n  - If the\
+    \ control primitive uses continuation regression, choose the estimator or basis\
+    \ explicitly; LaguerreBasis is optional, not mandatory\n#### qmc\n- Module: `trellis.models.qmc`\n\
+    - Key imports:\n  - `from trellis.models.qmc import sobol_normals, brownian_bridge`\n\
+    \  - `from trellis.models.processes.gbm import GBM`\n- Notes:\n  - QMC is an accelerator\
+    \ family layered on Monte Carlo-style estimators\n  - Current support is Sobol-based\
+    \ normal draws and Brownian-bridge construction\n#### pde\n- Module: `trellis.models.pde`\n\
+    - Key imports:\n  - `from trellis.models.equity_option_pde import price_vanilla_equity_option_pde`\n\
+    \  - `from trellis.models.pde.grid import Grid`\n  - `from trellis.models.pde.theta_method\
+    \ import theta_method_1d`\n  - `from trellis.models.pde.operator import BlackScholesOperator`\n\
+    \  - `from trellis.models.pde import psor_1d  # American options`\n  - `from trellis.models.pde\
+    \ import HullWhitePDEOperator`\n- Notes:\n  - Vanilla European equity PDE routes\
+    \ should prefer the checked-in helper `price_vanilla_equity_option_pde(...)`\n\
+    \  - Use theta_method_1d, NOT legacy crank_nicolson_1d or implicit_fd_1d\n####\
+    \ fft\n- Module: `trellis.models.transforms`\n- Key imports:\n  - `from trellis.models.transforms\
+    \ import fft_price, cos_price`\n- Notes:\n  - fft_price expects CF of log(S_T)\
+    \ — include log(S0)\n  - cos_price expects CF of log(S_T/S0) — log-return only\n\
+    #### copulas\n- Module: `trellis.models.copulas`\n- Key imports:\n  - `from trellis.models.copulas\
+    \ import GaussianCopula, StudentTCopula, FactorCopula`\n#### analytical\n- Module:\
+    \ `trellis.models.zcb_option`\n- Key imports:\n  - `from trellis.models.zcb_option\
+    \ import resolve_zcb_option_hw_inputs, price_zcb_option_jamshidian`\n  - `from\
+    \ trellis.models.analytical.jamshidian import ResolvedJamshidianInputs, zcb_option_hw_raw`\n\
+    \  - `from trellis.models.analytical import zcb_option_hw`\n  - `from trellis.models.analytical\
+    \ import terminal_vanilla_from_basis`\n  - `from trellis.models.rate_style_swaption\
+    \ import ResolvedSwaptionBlack76Inputs, resolve_swaption_black76_inputs, price_swaption_black76_raw,\
+    \ price_bermudan_swaption_black76_lower_bound`\n#### calibration\n- Module: `trellis.models.calibration`\n\
+    - Key imports:\n  - `from trellis.models.calibration import implied_vol, implied_vol_jaeckel`\n\
+    \  - `from trellis.models.calibration import RatesCalibrationResult, calibrate_cap_floor_black_vol,\
+    \ calibrate_swaption_black_vol, swaption_terms`\n  - `from trellis.models.calibration\
+    \ import calibrate_sabr`\n  - `from trellis.models.calibration import dupire_local_vol`\n\
+    \n### Utilities\n#### black76\n- Module: `trellis.models.black`\n- Imports:\n\
+    \  - `from trellis.models.black import black76_call, black76_put, black76_asset_or_nothing_call,\
+    \ black76_asset_or_nothing_put, black76_cash_or_nothing_call, black76_cash_or_nothing_put`\n\
+    #### garman_kohlhagen\n- Module: `trellis.models.analytical.fx`\n- Imports:\n\
+    \  - `from trellis.models.analytical.fx import ResolvedGarmanKohlhagenInputs,\
+    \ garman_kohlhagen_price_raw`\n  - `from trellis.models.black import garman_kohlhagen_call,\
+    \ garman_kohlhagen_put`\n#### rate_style_swaption\n- Module: `trellis.models.rate_style_swaption`\n\
+    - Imports:\n  - `from trellis.models.rate_style_swaption import ResolvedSwaptionBlack76Inputs,\
+    \ resolve_swaption_black76_inputs, price_swaption_black76_raw, price_swaption_black76`\n\
+    \  - `from trellis.models.rate_style_swaption import price_bermudan_swaption_black76_lower_bound`\n\
+    #### jamshidian_zcb_option\n- Module: `trellis.models.zcb_option`\n- Imports:\n\
+    \  - `from trellis.models.zcb_option import ResolvedZCBOptionInputs, resolve_zcb_option_hw_inputs,\
+    \ price_zcb_option_jamshidian`\n  - `from trellis.models.analytical.jamshidian\
+    \ import ResolvedJamshidianInputs, zcb_option_hw_raw`\n#### schedule\n- Module:\
+    \ `trellis.core.date_utils`\n- Imports:\n  - `from trellis.core.date_utils import\
+    \ generate_schedule`\n#### day_count\n- Module: `trellis.core.date_utils`\n- Imports:\n\
+    \  - `from trellis.core.date_utils import year_fraction`\n#### vol_surface\n-\
+    \ Module: `trellis.models.vol_surface`\n- Imports:\n  - `from trellis.models.vol_surface\
+    \ import VolSurface, FlatVol`\n#### cashflow_engine\n- Module: `trellis.models.cashflow_engine`\n\
+    - Imports:\n  - `from trellis.models.cashflow_engine import Waterfall, Tranche`\n\
+    \  - `from trellis.models.cashflow_engine import PSA, CPR, RateDependent`\n  -\
+    \ `from trellis.models.cashflow_engine import level_pay, scheduled, custom`\n\
+    #### credit_curve\n- Module: `trellis.curves.credit_curve`\n- Imports:\n  - `from\
+    \ trellis.curves.credit_curve import CreditCurve`\n- Notes:\n  - CreditCurve.flat(hazard_rate)\
+    \ is the simplest starting point for CDS or nth-to-default tasks\n## Distilled\
+    \ Build Memory\n\n- Product: `cds` / `cds` / `none`\n- Default method family:\
+    \ `analytical`\n- Method intent: Closed-form or semi-closed-form pricing under\
+    \ specific modeling assumptions. Each solution contract below is valid only within\
+    \ its stated assumptions and payoff definition. The contracts are not interchangeable.\n\
+    - Non-negotiable requirements:\n  - OUTPUT CONTRACT: evaluate() must return a\
+    \ float present value. Return a non-empty JSON-serializable structure only when\
+    \ a caller explicitly expects structured output.\n  - BLACK-SCHOLES FORWARD CONSISTENCY:\
+    \ Derive the forward from spot and discounting before calling Black-style kernels.\
+    \ With no dividends, F = S0 / discount_curve.discount(T); then PV = discount_curve.discount(T)\
+    \ * Black(F, K, sigma, T). This is valid under lognormal spot (GBM) with deterministic\
+    \ rates and European exercise only.\n  - EQUITY MARKET DATA CONTRACT: Requires\
+    \ discounting and Black vol. Spot is an instrument/spec input, not a separate\
+    \ MarketState capability unless the product explicitly sources it from a live\
+    \ market snapshot.\n- Canonical model grammar:\n  - `credit_single_name_reduced_form`\
+    \ -> `Reduced-form single-name credit`\n  - `rates_bootstrap_curve` -> `Rates\
+    \ bootstrap curve bundle`\n- Repeated fixes to reuse:\n  - `CDS spread / curve\
+    \ unit mismatch` -> Enforce and normalize input conventions (auto-convert spread\
+    \ in bps to decimal if > 1, require explicit units), require and validate presence\
+    \ of discount_curve and credit_curve before pricing, and add PV sanity checks\
+    \ (compare |PV| to notional) to fail fast with actionable errors.\n  - `Missing\
+    \ CDS contract specification` -> Provide a complete CDS product specification\
+    \ (effective/termination dates, payment frequency, day-count, business-day convention,\
+    \ notional, coupon/spread, recovery rate, accrual-on-default rule, settlement\
+    \ lag) and add or link an instrument-specific cookbook/evaluate() template plus\
+    \ the primitive payoff adapter; ensure discount and hazard inputs use pinned conventions\
+    \ and consistent units.\n\n## Generated Skills\n- [lesson] NthToDefaultPayoff\
+    \ analytical must use Gaussian copula integration, not independent binomial: Use\
+    \ the Gaussian copula conditional independence formula (integrate over common\
+    \ factor Z). This is the analytical counterpart of the GaussianCopula MC. from\
+    \ math import comb from scipy import integrate from scipy.stat...\n\n## Instrument\
+    \ Disambiguation\n- Treat this request as a single-name CDS / credit_default_swap\
+    \ contract.\n- Do not reinterpret CDS here as nth_to_default, basket CDS, first-to-default,\
+    \ or any multi-name credit product.\n- Do not import copula or Gaussian-copula\
+    \ machinery unless the request explicitly says nth-to-default, first-to-default,\
+    \ basket CDS, or multiple reference names.\n## Structured Lane Card\n- Method\
+    \ family: `analytical`\n- Instrument type: `cds`\n- Semantic contract: `credit_default_swap`,\
+    \ request=`credit_default_swap`, bridge=`canonical_semantic`, instrument=`cds`,\
+    \ payoff=`credit_default_swap`, structure=`single_reference_entity`\n- Valuation\
+    \ context: market_source=`unbound_market_snapshot`\n- Lane boundary: family=`analytical`,\
+    \ kind=`exact_target_binding`, timeline_roles=`settlement`, `payment`, `observation`,\
+    \ exact_bindings=`trellis.models.credit_default_swap.build_cds_schedule`, `trellis.models.credit_default_swap.price_cds_analytical`\n\
+    - Lowering boundary: family_ir=`CreditDefaultSwapIR`, expr=`ThenExpr`, helpers=`trellis.models.credit_default_swap.build_cds_schedule`,\
+    \ `trellis.models.credit_default_swap.price_cds_analytical`, route_alias=`credit_default_swap_analytical`\n\
+    - Validation contract: bundle=`analytical:credit_default_swap`, checks=`check_cds_spread_quote_normalization`,\
+    \ `check_cds_credit_curve_sensitivity`, `premium_leg_accrues_on_schedule`, `protection_leg_triggers_on_default`,\
+    \ residual_risks=`comparison_relations_unspecified`\n- Lane obligations:\n  -\
+    \ Lane family: `analytical`\n  - Plan kind: `exact_target_binding`\n  - Timeline\
+    \ roles: `settlement`, `payment`, `observation`\n  - Market bindings: `discount_curve`,\
+    \ `credit_curve`\n  - Control semantics: `pricing_mode:analytical`, `schedule_role:payment_dates`\n\
+    \  - State obligations: `survival_state`, `premium_leg_schedule`, `default_indicator`\n\
+    \  - Construction steps:\n    - Build the CDS schedule with `build_cds_schedule`\
+    \ and keep the leg semantics explicit: premium_leg, protection_leg.\n    - Bind\
+    \ discount and credit-curve inputs to the `analytical` lane without routing through\
+    \ equity-option kernels.\n    - Price the schedule-driven contract through `price_cds_analytical`\
+    \ unless the request introduces a genuinely new credit kernel.\n  - Exact backend\
+    \ bindings:\n    - `trellis.models.credit_default_swap.build_cds_schedule`\n \
+    \   - `trellis.models.credit_default_swap.price_cds_analytical`\n  - Exact binding\
+    \ signatures:\n    - `build_cds_schedule(start_date: 'date', end_date: 'date',\
+    \ frequency: 'Frequency', day_count: 'DayCountConvention', *, time_origin: 'date\
+    \ | None' = None) -> 'EventSchedule'`\n    - `price_cds_analytical(*, notional:\
+    \ 'float', spread_quote: 'float', recovery: 'float', schedule: 'EventSchedule',\
+    \ credit_curve: 'CreditCurveLike', discount_curve: 'DiscountCurveLike') -> 'float'`\n\
+    - Route authority:\n  - binding=`trellis.models.credit_default_swap.price_cds_analytical`,\
+    \ engine=`analytical`, authority=`exact_backend_fit`\n  - Route alias: `credit_default_swap_analytical`\n\
+    \  - Validation bundle: `analytical:credit_default_swap`\n  - Validation checks:\
+    \ `check_cds_spread_quote_normalization`, `check_cds_credit_curve_sensitivity`,\
+    \ `check_non_negativity`, `check_price_sanity`\n  - Canary coverage: canaries=`T38`\n\
+    \  - Helper authority: `trellis.models.credit_default_swap.build_cds_schedule`,\
+    \ `trellis.models.credit_default_swap.price_cds_analytical`\n  - Exact target\
+    \ bindings: `trellis.models.credit_default_swap.build_cds_schedule`, `trellis.models.credit_default_swap.price_cds_analytical`\n\
+    - Backend binding:\n  - Route: `credit_default_swap_analytical`\n  - Engine family:\
+    \ `analytical`\n  - Route family: `credit_default_swap`\n  - Selected primitives:\n\
+    \    - `trellis.models.credit_default_swap.build_cds_schedule` (schedule_builder)\n\
+    \    - `trellis.models.credit_default_swap.price_cds_analytical` (route_helper)\n\
+    \  - Resolved instructions:\n    - [hard_constraint] Use the route helper directly\
+    \ inside `evaluate()`; do not rebuild the process, engine, or discount glue manually.\n\
+    \    - [route_hint] Use `trellis.models.credit_default_swap.build_cds_schedule`\
+    \ to build the route schedule before pricing.\n    - [route_hint] Do not hard-code\
+    \ observation or payment grids inside the payoff body.\n    - [route_hint] Keep\
+    \ the premium leg to spread * accrual * df * survival only. Do not add a separate\
+    \ accrued-on-default premium adjustment term.\n    - [route_hint] Do not average\
+    \ adjacent discount factors, trapezoid the protection leg, or introduce midpoint\
+    \ discount terms such as 0.5 * (prev_discount + discount).\n    - [route_hint]\
+    \ Do not reinterpret a single-name CDS as nth-to-default, basket CDS, or first-to-default.\n\
+    \    - [route_hint] Do not import copulas or reuse Black76 call/put primitives\
+    \ for credit-default pricing.\n    - [historical_note] For single-name CDS analytical\
+    \ pricing, prefer the checked-in build_cds_schedule(...) and price_cds_analytical(...)\
+    \ helpers so the adapter stays thin.\n  - Schedule construction:\n    - [route_hint]\
+    \ Use `trellis.models.credit_default_swap.build_cds_schedule` to build the route\
+    \ schedule before pricing.\n    - [route_hint] Do not hard-code observation or\
+    \ payment grids inside the payoff body.\n    - [historical_note] For single-name\
+    \ CDS analytical pricing, prefer the checked-in build_cds_schedule(...) and price_cds_analytical(...)\
+    \ helpers so the adapter stays thin.\n    - [historical_note] Use market_state.credit_curve.survival_probability(t)\
+    \ directly for schedule-step survival updates and market_state.discount.discount(t)\
+    \ for discounting.\n    - [historical_note] Use spec.start_date as the time origin\
+    \ for year_fraction-based schedule times so the analytical and Monte Carlo comparators\
+    \ share the same t convention.\n    - [historical_note] If the helper cannot be\
+    \ reused, fall back to explicit periods from build_period_schedule(...); use period.accrual_fraction,\
+    \ period.t_payment, and period.payment_date directly.\n  - Required adapters:\n\
+    \    - `use_credit_curve_survival_probability_thin_adapter`\n    - `declare_credit_curve_and_discount_curve_requirements`\n\
+    \  - Backend notes:\n    - For single-name CDS analytical pricing, prefer the\
+    \ checked-in build_cds_schedule(...) and price_cds_analytical(...) helpers so\
+    \ the adapter stays thin.\n    - CDS running spreads are often quoted in basis\
+    \ points in task text. Convert them to decimals before accrual, for example 150\
+    \ bp -> 0.015.\n    - Use market_state.credit_curve.survival_probability(t) directly\
+    \ for schedule-step survival updates and market_state.discount.discount(t) for\
+    \ discounting.\n    - Use spec.start_date as the time origin for year_fraction-based\
+    \ schedule times so the analytical and Monte Carlo comparators share the same\
+    \ t convention.\n- Primary modules to inspect/reuse:\n  - `trellis.models.black`\n\
+    \  - `trellis.models.credit_default_swap`\n- Post-build test targets:\n  - `tests/test_agent/test_build_loop.py`\n\
+    - Instruction precedence: follow the lane obligations in this card first. Treat\
+    \ backend route/helper details as exact-fit bindings, not as permission to invent\
+    \ a different numerical path.\n- Treat route authority as backend-fit evidence,\
+    \ not as permission to invent a different synthesis plan.\n- Use approved Trellis\
+    \ imports only. Prefer thin adapters when the compiler found an exact backend;\
+    \ otherwise build the smallest lane-consistent kernel the plan requires.\n## Backend\
+    \ Lookup (Secondary To Lane Obligations)\n- Lane family: `analytical`\n- Lane\
+    \ plan kind: `exact_target_binding`\n- Method family: `analytical`\n- Route: `credit_default_swap_analytical`\n\
+    - Engine family: `analytical`\n- Required primitive symbols:\n  - `trellis.models.credit_default_swap.build_cds_schedule`\n\
+    \  - `trellis.models.credit_default_swap.price_cds_analytical`\n- Adapter obligations:\n\
+    \  - `use_credit_curve_survival_probability_thin_adapter`\n  - `declare_credit_curve_and_discount_curve_requirements`\n\
+    ## Thin Adapter Plan\n- Target payoff class: `CDSPayoff`\n- Required market reads:\n\
+    \  - `market_state.credit_curve`\n  - `market_state.discount`\n- Required primitive\
+    \ calls:\n  - `trellis.models.credit_default_swap.price_cds_analytical`\n- Required\
+    \ adapter steps:\n  - `use_credit_curve_survival_probability_thin_adapter`\n \
+    \ - `declare_credit_curve_and_discount_curve_requirements`\n- Return contract:\
+    \ Return a Python `float` present value from `evaluate()`.\n## Invariant Pack\n\
+    - The generated payoff should be compatible with these deterministic validation\
+    \ checks:\n  - `check_cds_spread_quote_normalization`\n  - `check_cds_credit_curve_sensitivity`\n\
+    \  - `check_non_negativity`\n  - `check_price_sanity`\n## Family Route Guidance\n\
+    - For single-name CDS analytical routes, build the premium leg and protection\
+    \ leg directly from the credit curve on the explicit payment schedule.\n- Prefer\
+    \ `build_cds_schedule` and `price_cds_analytical` from `trellis.models.credit_default_swap`\
+    \ so the adapter stays thin and reuses the checked-in leg logic.\n- Prefer `build_period_schedule(...)`\
+    \ over raw `generate_schedule(...)` so the route reads explicit `SchedulePeriod`\
+    \ objects instead of rebuilding `prev_date` and coupon boundaries by hand.\n-\
+    \ CDS running spreads are often quoted in basis points in task text. Convert them\
+    \ to decimals before accrual, for example `150 bp -> 0.015`.\n- After that normalization\
+    \ step, use only the local `spread` variable in the premium leg. Do not read raw\
+    \ `spec.spread` again later in the body.\n- Use `market_state.credit_curve.survival_probability(t)`\
+    \ directly; do not route credit-default pricing through Black76 call/put primitives.\n\
+    - Do not reinterpret the request as nth-to-default or basket credit, and do not\
+    \ import copula helpers for a single-name CDS.\n- Use `spec.start_date` as the\
+    \ time origin for schedule year fractions so the analytical and Monte Carlo CDS\
+    \ legs share the same `t` convention.\n- Keep discounting explicit with `market_state.discount.discount(pay_t)`\
+    \ and use that payment-date discount factor for both the premium leg and the interval\
+    \ default mass.\n- Keep the premium leg to `spread * accrual * df * survival`\
+    \ only. Do not add an accrued-on-default premium adjustment like `0.5 * spread\
+    \ * accrual * df * (prev_survival - survival)`.\n- Do not average adjacent discount\
+    \ factors, trapezoid the protection leg, or introduce midpoint expressions like\
+    \ `0.5 * (prev_discount + discount)`.\n- A good shape is: initialize `premium_leg\
+    \ = 0.0`, `protection_leg = 0.0`, build `periods = build_period_schedule(...).periods`,\
+    \ loop over the periods, update the running survival probability, then `return\
+    \ protection_leg - premium_leg`.\n## Conventions\n- evaluate() returns a FLOAT\
+    \ — the present value (PV) of the instrument\n- You MUST handle all discounting\
+    \ internally — use `market_state.discount.discount(t)`\n- For forward rates: `market_state.forecast_forward_curve(self._spec.rate_index)`\n\
+    - For vol: `market_state.vol_surface.black_vol(T, strike)`\n- For discount factors:\
+    \ `market_state.discount.discount(t)`\n- `market_state.fx_rates[pair]` returns\
+    \ an `FXRate` wrapper; extract `.spot` before scalar arithmetic or process seeding\n\
+    - Schedule generation: prefer `build_payment_timeline(...)`, `build_observation_timeline(...)`,\
+    \ or `build_period_schedule(...)` for accrual/event routes; use `generate_schedule(start,\
+    \ end, freq)` only for plain date lists with no period semantics\n- Year fractions:\
+    \ `year_fraction(date1, date2, day_count)`\n- Never use wall-clock dates such\
+    \ as `date.today()` or `datetime.now()` inside `evaluate()`; derive valuation\
+    \ time from `market_state` or shared resolver outputs.\n- Black76: `black76_call(F,\
+    \ K, sigma, T)`, `black76_put(F, K, sigma, T)` — undiscounted\n- Black76 digital:\
+    \ `black76_cash_or_nothing_call(F, K, sigma, T)`, `black76_cash_or_nothing_put(F,\
+    \ K, sigma, T)` — undiscounted cash-or-nothing digitals\n- For CDS / nth-to-default:\
+    \ use `market_state.credit_curve.survival_probability(t)` and `market_state.credit_curve.hazard_rate(t)`\
+    \ on an explicit payment/default schedule; do not route credit-default pricing\
+    \ through Black76 call/put primitives.\n- For equity trees: prefer `from trellis.models.equity_option_tree\
+    \ import price_vanilla_equity_option_tree`; the lower-level lattice path is `from\
+    \ trellis.models.trees.lattice import build_spot_lattice, lattice_backward_induction`\n\
+    - For vanilla European PDE routes: prefer `from trellis.models.equity_option_pde\
+    \ import price_vanilla_equity_option_pde`; the lower-level fallback is `from trellis.models.pde.grid\
+    \ import Grid`, `from trellis.models.pde.operator import BlackScholesOperator`,\
+    \ and `from trellis.models.pde.theta_method import theta_method_1d`\n- For rate\
+    \ lattices: prefer helper surfaces such as `price_callable_bond_tree(...)`, `price_bermudan_swaption_tree(...)`,\
+    \ or `price_zcb_option_tree(...)`; the lower-level fallback is `from trellis.models.trees.lattice\
+    \ import build_rate_lattice, lattice_backward_induction`\n- For schedule-dependent\
+    \ rate lattices: `from trellis.models.trees.control import lattice_steps_from_timeline,\
+    \ resolve_lattice_exercise_policy`\n- For MC: `from trellis.models.monte_carlo\
+    \ import MonteCarloEngine`\n- For QMC accelerators: `from trellis.models.qmc import\
+    \ sobol_normals, brownian_bridge`\n- For copulas: `from trellis.models.copulas\
+    \ import GaussianCopula, FactorCopula`\n- Do not invent MonteCarloEngine method\
+    \ strings. Valid `method=` values are `euler`, `milstein`, and `exact`.\n- For\
+    \ Monte Carlo early exercise, use an approved control primitive; do not pretend\
+    \ that `MonteCarloEngine.price(...)` or `method=\"lsm\"` implements early exercise.\
+    \ Approved policy classes: `longstaff_schwartz` [implemented], `tsitsiklis_van_roy`\
+    \ [implemented], `primal_dual_mc` [implemented], `stochastic_mesh` [implemented].\
+    \ Currently implemented in Trellis: `longstaff_schwartz`, `tsitsiklis_van_roy`,\
+    \ `primal_dual_mc`, `stochastic_mesh`.\n- If you use `LaguerreBasis`, import it\
+    \ from `trellis.models.monte_carlo.schemes`, not from `trellis.models.monte_carlo.lsm`.\n\
+    - For FFT/COS pricing, characteristic functions must accept vector `u` and use\
+    \ array-safe numerics such as `numpy`, not scalar `math`/`cmath`.\n- Black76 basis:\
+    \ `black76_asset_or_nothing_call(F, K, sigma, T)`, `black76_asset_or_nothing_put(F,\
+    \ K, sigma, T)`, `black76_cash_or_nothing_call(F, K, sigma, T)`, `black76_cash_or_nothing_put(F,\
+    \ K, sigma, T)` — exact terminal basis claims.\n- For terminal vanilla payoffs,\
+    \ prefer exact basis assembly via `terminal_vanilla_from_basis(...)` from `trellis.models.analytical`.\n\
+    - For FX vanilla options, treat the route as Garman-Kohlhagen: map spot FX and\
+    \ domestic/foreign discount factors to `ResolvedGarmanKohlhagenInputs`, then prefer\
+    \ `garman_kohlhagen_price_raw(spec.option_type, resolved)` from `trellis.models.analytical.fx`;\
+    \ use explicit basis-claim assembly only when the request explicitly needs the\
+    \ decomposition.\n- For cash-or-nothing digital options, use the Black76 digital\
+    \ helpers directly; do not approximate them with vanilla call/put prices or divide\
+    \ by spot.\n- You MUST use only real, approved `trellis.*` imports from the structured\
+    \ generation plan and import registry\n- Treat the compiler-emitted lane obligations\
+    \ in the structured generation plan as the backbone of the implementation.\n-\
+    \ Reuse the listed exact backend bindings when present; otherwise build the smallest\
+    \ lane-consistent kernel that satisfies the construction steps.\n- Do not replace\
+    \ selected primitives with bespoke numerical kernels or alternative Trellis routes\
+    \ unless the plan explicitly permits a new lane implementation.\n- Do not add\
+    \ wildcard imports\n- If the approved modules do not contain what you need, reuse\
+    \ the closest existing implementation and keep the gap explicit instead of inventing\
+    \ a path\n\n## Reference implementations\n\n### Payoff protocol + Cashflows/PresentValue\
+    \ return types\n```python\n\"\"\"Payoff protocol and base classes for pricing\
+    \ instruments.\n\nEvery priceable instrument in Trellis implements the Payoff\
+    \ protocol.\nA payoff takes market data (via MarketState) and returns a present\
+    \ value.\nThis module also provides base classes for two common pricing patterns:\n\
+    \n- ResolvedInputPayoff: for analytical or tree-based pricing where market\n \
+    \ data is extracted once, then fed into a pricing formula.\n- MonteCarloPathPayoff:\
+    \ for simulation-based pricing where paths are\n  generated and payoffs are computed\
+    \ per path then averaged.\n\"\"\"\n\nfrom __future__ import annotations\n\nfrom\
+    \ abc import ABC, abstractmethod\nfrom datetime import date\nfrom typing import\
+    \ Generic, Protocol, TypeVar, runtime_checkable\n\nfrom trellis.core.date_utils\
+    \ import year_fraction\nfrom trellis.core.differentiable import get_numpy\nfrom\
+    \ trellis.core.market_state import MarketState\nfrom trellis.core.types import\
+    \ DayCountC\n# [truncated reference]\n```\n\n### Date utilities used by generated\
+    \ payoffs\n```python\n\"\"\"Date utilities: day count conventions, schedule generation,\
+    \ year fractions.\"\"\"\n\nfrom __future__ import annotations\n\nimport calendar\n\
+    from collections.abc import Iterable\nfrom datetime import date, datetime, timedelta\n\
+    from typing import Union\n\nfrom trellis.core.types import (\n    ContractTimeline,\n\
+    \    DayCountConvention,\n    EventSchedule,\n    Frequency,\n    TimelineRole,\n\
+    )\n\nDateLike = Union[date, datetime]\nExplicitDateInput = ContractTimeline |\
+    \ EventSchedule | Iterable[DateLike | str] | str\n\n\ndef _to_date(d: DateLike)\
+    \ -> date:\n    \"\"\"Normalize ``date``/``datetime`` inputs to plain ``date``\
+    \ objects.\"\"\"\n    if isinstance(d, datetime):\n        return d.date()\n \
+    \   return d\n\n\ndef add_months(dt: DateLike, months: int) -> date:\n    \"\"\
+    \"Add *months* calendar months, clamping the day to the new month's max.\"\"\"\
+    \n    d = _to_date(dt)\n    total_months = d.month - 1 + months\n    year = d.year\
+    \ + total\n# [truncated reference]\n```\n\n### MarketState capabilities and access\
+    \ patterns\n```python\n\"\"\"MarketState: immutable container of market data used\
+    \ for pricing.\n\nA MarketState holds everything a payoff needs to compute a price:\n\
+    discount curves, volatility surfaces, spot prices, credit curves, etc.\nIt is\
+    \ frozen (immutable) so that multiple payoffs can safely share the\nsame market\
+    \ snapshot without risk of accidental modification.\n\"\"\"\n\nfrom __future__\
+    \ import annotations\n\nfrom dataclasses import dataclass\nfrom datetime import\
+    \ date\nfrom typing import TYPE_CHECKING\n\nfrom trellis.core.types import DiscountCurve\n\
+    \nif TYPE_CHECKING:\n    from trellis.core.state_space import StateSpace\n   \
+    \ from trellis.curves.credit_curve import CreditCurve\n    from trellis.curves.forward_curve\
+    \ import ForwardCurve\n    from trellis.instruments.fx import FXRate\n    from\
+    \ trellis.models.vol_surface import VolSurface\n\n\nclass MissingCapabilityError(Exception):\n\
+    \    \"\"\"Raised when a MarketState lacks market data r\n# [truncated reference]\n\
+    ```\n\n### Frequency/day-count types\n```python\n\"\"\"Core protocols, enums,\
+    \ and data structures shared across Trellis.\n\nDefines the fundamental types\
+    \ that most other modules depend on:\nfrequency enums, day count conventions,\
+    \ the DiscountCurve and Instrument\nprotocols, and simple data containers like\
+    \ schedules and pricing results.\n\"\"\"\n\nfrom __future__ import annotations\n\
+    \nfrom dataclasses import dataclass, field\nfrom datetime import date\nfrom enum\
+    \ import Enum\nfrom typing import Protocol, runtime_checkable\n\n# ---------------------------------------------------------------------------\n\
+    # Greek specification types\n# ---------------------------------------------------------------------------\n\
+    \n# What risk sensitivities to compute alongside the price.\n#   None       —\
+    \ price only, no sensitivities\n#   \"all\"      — every known sensitivity (dv01,\
+    \ duration, convexity, etc.)\n#   list[str]  — specific sensitivities by name\
+    \ (e.g. [\"dv01\", \"duration\"])\n# [truncated reference]\n```\n\n[omitted 2\
+    \ additional reference modules]\n\n\n## Output\nReturn the COMPLETE Python module\
+    \ — copy the skeleton exactly, but replace the\n`raise NotImplementedError(...)`\
+    \ line with the actual implementation of `evaluate()`.\nDo NOT change imports,\
+    \ class names, spec fields, or the requirements property.\nOnly implement the\
+    \ evaluate() method body. You may add imports at the top.\nNo markdown fences,\
+    \ no explanation — just the Python code."
+  model: gpt-5.4-mini
+- seq: 3
+  function: llm_generate_json
+  stage: critic
+  prompt_hash: c1901df7ad8d26d2929811c43fd391bf82b0cd3aae736c202d2075c18d4d7ed4
+  response_text: '{"check_id": "price_non_negative", "description": "The pricer can
+    return a negative PV for a protection buyer CDS when the running spread is too
+    high relative to the protection leg, and this code does not enforce any non-negativity
+    guard.", "severity": "warning", "evidence": "evaluate() directly returns price_cds_analytical(...).
+    The product is protection buyer side, and the model computes protection leg minus
+    premium leg; if the premium leg dominates under the supplied curve/spread conventions,
+    the result can be negative. There is no clamp or validation against negative PV.",
+    "remediation": "Add explicit contract validation or downstream handling for negative
+    MTM results, or confirm the sign convention and market-state inputs guarantee
+    a non-negative buyer PV under the expected scenarios.", "status": "suspect"}'
+  prompt_text: "You are a quantitative model validator reviewing agent-generated pricing\
+    \ code.\nYour job is to find deterministic review concerns, not to praise. Be\
+    \ adversarial.\n\n## Code to review\n```python\n\"\"\"Agent-generated payoff:\
+    \ Build a pricer for: CDS pricing: hazard rate MC vs survival prob analytical\n\
+    \nStandard single-name CDS, protection buyer side.\nNotional: $10,000,000.  Maturity:\
+    \ 5Y from settlement.\nPremium leg: quarterly payments, Act/360 day count.\nRunning\
+    \ CDS spread: 150 bp.  Recovery rate: 40%.\nUse the investment-grade (IG) credit\
+    \ curve from the market snapshot\n(as_of 2024-11-15) — this provides term-dependent\
+    \ hazard rates\nbootstrapped from market CDS spreads at 1Y, 3Y, 5Y, and 10Y tenors.\n\
+    Do NOT use a flat hazard rate — the model must respect the full\nhazard rate term\
+    \ structure.\nUse the USD OIS curve for risk-free discounting.\nMethod 1: Monte\
+    \ Carlo simulation of default times from the hazard curve.\nMethod 2: Analytical\
+    \ (deterministic) survival-probability integration.\nCompute the mark-to-market\
+    \ PV (protection leg minus premium leg).\n\nConstruct methods: monte_carlo\nComparison\
+    \ targets: mc_cds (monte_carlo), analytical_cds (analytical)\nCross-validation\
+    \ harness:\n  internal targets: mc_cds, analytical_cds\n  external targets: quantlib,\
+    \ financepy\nNew component: cds_pricing\n\nImplementation target: analytical_cds\n\
+    Preferred method family: analytical\n\nImplementation target: analytical_cds.\"\
+    \"\"\n\nfrom __future__ import annotations\n\nfrom dataclasses import dataclass\n\
+    from datetime import date\n\nfrom trellis.core.market_state import MarketState\n\
+    from trellis.core.types import DayCountConvention, Frequency\nfrom trellis.models.credit_default_swap\
+    \ import build_cds_schedule, price_cds_analytical\n\n\n\n@dataclass(frozen=True)\n\
+    class CDSSpec:\n    \"\"\"Specification for Build a pricer for: CDS pricing: hazard\
+    \ rate MC vs survival prob analytical\n\nStandard single-name CDS, protection\
+    \ buyer side.\nNotional: $10,000,000.  Maturity: 5Y from settlement.\nPremium\
+    \ leg: quarterly payments, Act/360 day count.\nRunning CDS spread: 150 bp.  Recovery\
+    \ rate: 40%.\nUse the investment-grade (IG) credit curve from the market snapshot\n\
+    (as_of 2024-11-15) — this provides term-dependent hazard rates\nbootstrapped from\
+    \ market CDS spreads at 1Y, 3Y, 5Y, and 10Y tenors.\nDo NOT use a flat hazard\
+    \ rate — the model must respect the full\nhazard rate term structure.\nUse the\
+    \ USD OIS curve for risk-free discounting.\nMethod 1: Monte Carlo simulation of\
+    \ default times from the hazard curve.\nMethod 2: Analytical (deterministic) survival-probability\
+    \ integration.\nCompute the mark-to-market PV (protection leg minus premium leg).\n\
+    \nConstruct methods: monte_carlo\nComparison targets: mc_cds (monte_carlo), analytical_cds\
+    \ (analytical)\nCross-validation harness:\n  internal targets: mc_cds, analytical_cds\n\
+    \  external targets: quantlib, financepy\nNew component: cds_pricing\n\nImplementation\
+    \ target: analytical_cds\nPreferred method family: analytical\n\nImplementation\
+    \ target: analytical_cds.\"\"\"\n    notional: float\n    spread: float\n    start_date:\
+    \ date\n    end_date: date\n    recovery: float = 0.4\n    frequency: Frequency\
+    \ = Frequency.QUARTERLY\n    day_count: DayCountConvention = DayCountConvention.ACT_360\n\
+    \n\nclass CDSPayoff:\n    \"\"\"Build a pricer for: CDS pricing: hazard rate MC\
+    \ vs survival prob analytical\n\nStandard single-name CDS, protection buyer side.\n\
+    Notional: $10,000,000.  Maturity: 5Y from settlement.\nPremium leg: quarterly\
+    \ payments, Act/360 day count.\nRunning CDS spread: 150 bp.  Recovery rate: 40%.\n\
+    Use the investment-grade (IG) credit curve from the market snapshot\n(as_of 2024-11-15)\
+    \ — this provides term-dependent hazard rates\nbootstrapped from market CDS spreads\
+    \ at 1Y, 3Y, 5Y, and 10Y tenors.\nDo NOT use a flat hazard rate — the model must\
+    \ respect the full\nhazard rate term structure.\nUse the USD OIS curve for risk-free\
+    \ discounting.\nMethod 1: Monte Carlo simulation of default times from the hazard\
+    \ curve.\nMethod 2: Analytical (deterministic) survival-probability integration.\n\
+    Compute the mark-to-market PV (protection leg minus premium leg).\n\nConstruct\
+    \ methods: monte_carlo\nComparison targets: mc_cds (monte_carlo), analytical_cds\
+    \ (analytical)\nCross-validation harness:\n  internal targets: mc_cds, analytical_cds\n\
+    \  external targets: quantlib, financepy\nNew component: cds_pricing\n\nImplementation\
+    \ target: analytical_cds\nPreferred method family: analytical\n\nImplementation\
+    \ target: analytical_cds.\"\"\"\n\n    def __init__(self, spec: CDSSpec):\n  \
+    \      self._spec = spec\n\n    @property\n    def spec(self) -> CDSSpec:\n  \
+    \      return self._spec\n\n    @property\n    def requirements(self) -> set[str]:\n\
+    \        return {\"credit_curve\", \"discount_curve\"}\n\n    def evaluate(self,\
+    \ market_state: MarketState) -> float:\n        spec = self._spec\n        spec\
+    \ = self._spec\n\n        if market_state.discount is None:\n            raise\
+    \ ValueError(\"CDSPayoff requires a discount curve in market_state\")\n      \
+    \  if market_state.credit_curve is None:\n            raise ValueError(\"CDSPayoff\
+    \ requires a credit curve in market_state\")\n\n        spread = float(spec.spread)\n\
+    \        if spread > 1.0:\n            spread *= 1e-4\n\n        schedule = build_cds_schedule(\n\
+    \            spec.start_date,\n            spec.end_date,\n            spec.frequency,\n\
+    \            spec.day_count,\n            time_origin=spec.start_date,\n     \
+    \   )\n\n        return float(\n            price_cds_analytical(\n          \
+    \      notional=float(spec.notional),\n                spread_quote=spread,\n\
+    \                recovery=float(spec.recovery),\n                schedule=schedule,\n\
+    \                credit_curve=market_state.credit_curve,\n                discount_curve=market_state.discount,\n\
+    \            )\n        )\n\n```\n\n## Instrument description\nBuild a pricer\
+    \ for: CDS pricing: hazard rate MC vs survival prob analytical\n\nStandard single-name\
+    \ CDS, protection buyer side.\nNotional: $10,000,000.  Maturity: 5Y from settlement.\n\
+    Premium leg: quarterly payments, Act/360 day count.\nRunning CDS spread: 150 bp.\
+    \  Recovery rate: 40%.\nUse the investment-grade (IG) credit curve from the market\
+    \ snapshot\n(as_of 2024-11-15) — this provides term-dependent hazard rates\nbootstrapped\
+    \ from market CDS spreads at 1Y, 3Y, 5Y, and 10Y tenors.\nDo NOT use a flat hazard\
+    \ rate — the model must respect the full\nhazard rate term structure.\nUse the\
+    \ USD OIS curve for risk-free discounting.\nMethod 1: Monte Carlo simulation of\
+    \ default times from the hazard curve.\nMethod 2: Analytical (deterministic) survival-probability\
+    \ integration.\nCompute the mark-to-market PV (protection leg minus premium leg).\n\
+    \nConstruct methods: monte_carlo\nComparison targets: mc_cds (monte_carlo), analytical_cds\
+    \ (analytical)\nCross-validation harness:\n  internal targets: mc_cds, analytical_cds\n\
+    \  external targets: quantlib, financepy\nNew component: cds_pricing\n\nImplementation\
+    \ target: analytical_cds\nPreferred method family: analytical\n\nImplementation\
+    \ target: analytical_cds\n\n## Shared Knowledge\n## Distilled Review Memory\n\n\
+    - Review principles:\n  - `P1`: Always calibrate rate trees to the discount curve\
+    \ before pricing\n  - `P2`: Callable bonds need issuer_call lattice control, discrete\
+    \ coupons, and exercise=par+coupon\n  - `P3`: Convert vol units at the boundary\
+    \ between market data and model\n- Review checkpoints:\n  - OUTPUT CONTRACT: evaluate()\
+    \ must return a float present value. Return a non-empty JSON-serializable structure\
+    \ only when a caller explicitly expects structured output.\n  - BLACK-SCHOLES\
+    \ FORWARD CONSISTENCY: Derive the forward from spot and discounting before calling\
+    \ Black-style kernels. With no dividends, F = S0 / discount_curve.discount(T);\
+    \ then PV = discount_curve.discount(T) * Black(F, K, sigma, T). This is valid\
+    \ under lognormal spot (GBM) with deterministic rates and European exercise only.\n\
+    \  - EQUITY MARKET DATA CONTRACT: Requires discounting and Black vol. Spot is\
+    \ an instrument/spec input, not a separate MarketState capability unless the product\
+    \ explicitly sources it from a live market snapshot.\n- Canonical model grammar:\n\
+    \  - `credit_single_name_reduced_form` -> `Reduced-form single-name credit`\n\
+    \  - `rates_bootstrap_curve` -> `Rates bootstrap curve bundle`\n- Known failure\
+    \ traps:\n  - `CDS spread / curve unit mismatch` -> Input conventions and required\
+    \ market data were not validated: running spread was treated with wrong units\
+    \ (bps vs decimal) and required curves (credit/discount) were missing or not passed\
+    \ to the analytical routine, causing unit/convention and data-availability errors.\n\
+    \  - `Missing CDS contract specification` -> The analytical CDS pricer requires\
+    \ an explicit instrument product shape (schedule, accrual, coupon/spread, recovery,\
+    \ settlement conventions, payoff adapter) but the request/DSl omitted these fields\
+    \ and no instrument-specific cookbook or payoff adapter was available.\n\n## Generated\
+    \ Skills\n- [lesson] NthToDefaultPayoff analytical must use Gaussian copula integration,\
+    \ not independent binomial: Use the Gaussian copula conditional independence formula\
+    \ (integrate over common factor Z). This is the analytical counterpart of the\
+    \ GaussianCopula MC. from math import comb from scipy import integrate from scipy.stat...\n\
+    \n## Instrument Disambiguation\n- Treat this request as a single-name CDS / credit_default_swap\
+    \ contract.\n- Do not reinterpret CDS here as nth_to_default, basket CDS, first-to-default,\
+    \ or any multi-name credit product.\n- Do not import copula or Gaussian-copula\
+    \ machinery unless the request explicitly says nth-to-default, first-to-default,\
+    \ basket CDS, or multiple reference names.\n\n\n## Compiled Route Contract\n-\
+    \ Method family: `analytical`\n- Instrument type: `cds`\n- Semantic contract:\
+    \ `credit_default_swap`, request=`credit_default_swap`, bridge=`canonical_semantic`,\
+    \ instrument=`cds`, payoff=`credit_default_swap`, structure=`single_reference_entity`\n\
+    - Valuation context: market_source=`unbound_market_snapshot`\n- Lane boundary:\
+    \ family=`analytical`, kind=`exact_target_binding`, timeline_roles=`settlement`,\
+    \ `payment`, `observation`, exact_bindings=`trellis.models.credit_default_swap.build_cds_schedule`,\
+    \ `trellis.models.credit_default_swap.price_cds_analytical`\n- Lowering boundary:\
+    \ family_ir=`CreditDefaultSwapIR`, expr=`ThenExpr`, helpers=`trellis.models.credit_default_swap.build_cds_schedule`,\
+    \ `trellis.models.credit_default_swap.price_cds_analytical`, route_alias=`credit_default_swap_analytical`\n\
+    - Validation contract: bundle=`analytical:credit_default_swap`, checks=`check_cds_spread_quote_normalization`,\
+    \ `check_cds_credit_curve_sensitivity`, `premium_leg_accrues_on_schedule`, `protection_leg_triggers_on_default`,\
+    \ residual_risks=`comparison_relations_unspecified`\n- Lane obligations:\n  -\
+    \ Lane family: `analytical`\n  - Plan kind: `exact_target_binding`\n  - Timeline\
+    \ roles: `settlement`, `payment`, `observation`\n  - Market bindings: `discount_curve`,\
+    \ `credit_curve`\n  - Control semantics: `pricing_mode:analytical`, `schedule_role:payment_dates`\n\
+    \  - State obligations: `survival_state`, `premium_leg_schedule`, `default_indicator`\n\
+    \  - Construction steps:\n    - Build the CDS schedule with `build_cds_schedule`\
+    \ and keep the leg semantics explicit: premium_leg, protection_leg.\n    - Bind\
+    \ discount and credit-curve inputs to the `analytical` lane without routing through\
+    \ equity-option kernels.\n    - Price the schedule-driven contract through `price_cds_analytical`\
+    \ unless the request introduces a genuinely new credit kernel.\n  - Exact backend\
+    \ bindings:\n    - `trellis.models.credit_default_swap.build_cds_schedule`\n \
+    \   - `trellis.models.credit_default_swap.price_cds_analytical`\n  - Exact binding\
+    \ signatures:\n    - `build_cds_schedule(start_date: 'date', end_date: 'date',\
+    \ frequency: 'Frequency', day_count: 'DayCountConvention', *, time_origin: 'date\
+    \ | None' = None) -> 'EventSchedule'`\n    - `price_cds_analytical(*, notional:\
+    \ 'float', spread_quote: 'float', recovery: 'float', schedule: 'EventSchedule',\
+    \ credit_curve: 'CreditCurveLike', discount_curve: 'DiscountCurveLike') -> 'float'`\n\
+    - Route authority:\n  - binding=`trellis.models.credit_default_swap.price_cds_analytical`,\
+    \ engine=`analytical`, authority=`exact_backend_fit`\n  - Route alias: `credit_default_swap_analytical`\n\
+    \  - Validation bundle: `analytical:credit_default_swap`\n  - Validation checks:\
+    \ `check_cds_spread_quote_normalization`, `check_cds_credit_curve_sensitivity`,\
+    \ `check_non_negativity`, `check_price_sanity`\n  - Canary coverage: canaries=`T38`\n\
+    \  - Helper authority: `trellis.models.credit_default_swap.build_cds_schedule`,\
+    \ `trellis.models.credit_default_swap.price_cds_analytical`\n  - Exact target\
+    \ bindings: `trellis.models.credit_default_swap.build_cds_schedule`, `trellis.models.credit_default_swap.price_cds_analytical`\n\
+    - Backend binding:\n  - Route: `credit_default_swap_analytical`\n  - Engine family:\
+    \ `analytical`\n  - Route family: `credit_default_swap`\n  - Selected primitives:\n\
+    \    - `trellis.models.credit_default_swap.build_cds_schedule` (schedule_builder)\n\
+    \    - `trellis.models.credit_default_swap.price_cds_analytical` (route_helper)\n\
+    \  - Resolved instructions:\n    - [hard_constraint] Use the route helper directly\
+    \ inside `evaluate()`; do not rebuild the process, engine, or discount glue manually.\n\
+    \    - [route_hint] Use `trellis.models.credit_default_swap.build_cds_schedule`\
+    \ to build the route schedule before pricing.\n    - [route_hint] Do not hard-code\
+    \ observation or payment grids inside the payoff body.\n    - [route_hint] Keep\
+    \ the premium leg to spread * accrual * df * survival only. Do not add a separate\
+    \ accrued-on-default premium adjustment term.\n    - [route_hint] Do not average\
+    \ adjacent discount factors, trapezoid the protection leg, or introduce midpoint\
+    \ discount terms such as 0.5 * (prev_discount + discount).\n    - [route_hint]\
+    \ Do not reinterpret a single-name CDS as nth-to-default, basket CDS, or first-to-default.\n\
+    \    - [route_hint] Do not import copulas or reuse Black76 call/put primitives\
+    \ for credit-default pricing.\n    - [historical_note] For single-name CDS analytical\
+    \ pricing, prefer the checked-in build_cds_schedule(...) and price_cds_analytical(...)\
+    \ helpers so the adapter stays thin.\n  - Schedule construction:\n    - [route_hint]\
+    \ Use `trellis.models.credit_default_swap.build_cds_schedule` to build the route\
+    \ schedule before pricing.\n    - [route_hint] Do not hard-code observation or\
+    \ payment grids inside the payoff body.\n    - [historical_note] For single-name\
+    \ CDS analytical pricing, prefer the checked-in build_cds_schedule(...) and price_cds_analytical(...)\
+    \ helpers so the adapter stays thin.\n    - [historical_note] Use market_state.credit_curve.survival_probability(t)\
+    \ directly for schedule-step survival updates and market_state.discount.discount(t)\
+    \ for discounting.\n    - [historical_note] Use spec.start_date as the time origin\
+    \ for year_fraction-based schedule times so the analytical and Monte Carlo comparators\
+    \ share the same t convention.\n    - [historical_note] If the helper cannot be\
+    \ reused, fall back to explicit periods from build_period_schedule(...); use period.accrual_fraction,\
+    \ period.t_payment, and period.payment_date directly.\n  - Required adapters:\n\
+    \    - `use_credit_curve_survival_probability_thin_adapter`\n    - `declare_credit_curve_and_discount_curve_requirements`\n\
+    \  - Backend notes:\n    - For single-name CDS analytical pricing, prefer the\
+    \ checked-in build_cds_schedule(...) and price_cds_analytical(...) helpers so\
+    \ the adapter stays thin.\n    - CDS running spreads are often quoted in basis\
+    \ points in task text. Convert them to decimals before accrual, for example 150\
+    \ bp -> 0.015.\n    - Use market_state.credit_curve.survival_probability(t) directly\
+    \ for schedule-step survival updates and market_state.discount.discount(t) for\
+    \ discounting.\n    - Use spec.start_date as the time origin for year_fraction-based\
+    \ schedule times so the analytical and Monte Carlo comparators share the same\
+    \ t convention.\n- Approved modules in scope:\n  - `trellis.core.date_utils`\n\
+    \  - `trellis.core.differentiable`\n  - `trellis.core.market_state`\n  - `trellis.core.payoff`\n\
+    \  - `trellis.core.types`\n  - `trellis.models.analytical`\n  - `trellis.models.analytical.barrier`\n\
+    \  - `trellis.models.analytical.fx`\n- Review the generated code against this\
+    \ compiled boundary. Treat route, helper, or validation drift as real findings.\n\
+    \n\n## Available deterministic checks\nYou may ONLY select from this bounded menu:\n\
+    - `price_non_negative`: Price should remain non-negative. Use when the route prices\
+    \ a long-only vanilla or option-like payoff that should not produce a negative\
+    \ PV under the default review market state. Deterministic contract: Fail when\
+    \ price_payoff(payoff, ms) < -1e-6.\n\n\n## Review policy\n- Do not write Python\
+    \ code.\n- Do not invent new checks, formulas, or test procedures.\n- Only emit\
+    \ a finding when the code strongly suggests the selected check is likely to fail.\n\
+    - If none of the available checks are justified, return [].\n\n## Output\nReturn\
+    \ a JSON array of concerns. Each concern:\n{\n    \"check_id\": \"one of the available\
+    \ check ids\",\n    \"description\": \"short concern summary\",\n    \"severity\"\
+    : \"error\" or \"warning\",\n    \"evidence\": \"specific code reference or reasoning\"\
+    ,\n    \"remediation\": \"what to change\",\n    \"status\": \"suspect\"\n}\n\n\
+    Focus on pricing errors that the deterministic checks can confirm.\nReturn at\
+    \ most 3 concerns, ordered by severity.\nReturn ONLY the JSON array."
+  model: gpt-5.4-mini

--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -46,6 +46,31 @@ That lets sparse manifest rows keep their normal task-inventory shape while
 the curated regression surface still carries the fuller descriptions or market
 blocks needed to exercise canonical comparison cases honestly.
 
+The same runner now also has a full-task replay mode for diagnosis-heavy
+canaries:
+
+- record with
+  ``PYTHONHASHSEED=0 /Users/steveyang/miniforge3/bin/python3 scripts/record_cassettes.py --task T13``
+- replay with
+  ``PYTHONHASHSEED=0 /Users/steveyang/miniforge3/bin/python3 scripts/run_canary.py --task T13 --replay``
+- full-task canary cassettes live under ``cassettes/full_task/``
+
+The hash seed matters because the replay contract hashes the full prompt text.
+Use ``PYTHONHASHSEED=0`` for both recording and replay so prompt surfaces that
+still depend on iteration order stay stable across processes.
+
+Unlike the older tier-2 pipeline cassettes, the full-task canary path replays
+the real ``run_task(...)`` surface. That means the replay still exercises the
+runtime contract, comparison harness, task-run persistence, and diagnosis
+packet/dossier writes, but it does not spend live model tokens.
+
+Full-task cassette sessions also keep the knowledge store read-only during
+record and replay. The build still performs its normal LLM reflection calls,
+but it does not write new lessons, traces, cookbook candidates, or promotion
+candidates back into the canonical knowledge store. This keeps the replay
+prompt surface aligned with the state that the cassette was recorded against
+instead of letting the recording run mutate later retrieval inputs.
+
 Evals And Stress Tasks
 ----------------------
 
@@ -73,6 +98,16 @@ for run diagnosis; the dossier is the human-facing view that opens first when
 you need to understand a failure or confirm a success. The batch runner now
 surfaces those packet paths directly on the task result so you do not have to
 reconstruct them from traces or summary files.
+
+For cassette-backed canary replays, the task result and persisted task-run
+record now carry explicit execution metadata:
+
+- ``execution_mode`` is ``cassette_replay`` instead of ``live``
+- ``llm_cassette`` records the cassette name, path, and replay policy
+
+That keeps replay runs obvious to humans and downstream tooling without
+changing the packet or task-result schema that remediation and canary summary
+tools already consume.
 
 The task record and diagnosis packet also preserve post-build checkpoint
 metadata. That metadata records the transition from a validated method build

--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -50,14 +50,17 @@ The same runner now also has a full-task replay mode for diagnosis-heavy
 canaries:
 
 - record with
-  ``PYTHONHASHSEED=0 /Users/steveyang/miniforge3/bin/python3 scripts/record_cassettes.py --task T13``
+  ``PYTHONHASHSEED=0 python3 scripts/record_cassettes.py --task T13``
 - replay with
-  ``PYTHONHASHSEED=0 /Users/steveyang/miniforge3/bin/python3 scripts/run_canary.py --task T13 --replay``
+  ``PYTHONHASHSEED=0 python3 scripts/run_canary.py --task T13 --replay``
 - full-task canary cassettes live under ``cassettes/full_task/``
 
 The hash seed matters because the replay contract hashes the full prompt text.
 Use ``PYTHONHASHSEED=0`` for both recording and replay so prompt surfaces that
 still depend on iteration order stay stable across processes.
+Run these commands with the repo-standard miniforge interpreter; if your shell
+``python3`` resolves elsewhere, invoke the configured interpreter path from
+``AGENTS.md`` directly.
 
 Unlike the older tier-2 pipeline cassettes, the full-task canary path replays
 the real ``run_task(...)`` surface. That means the replay still exercises the

--- a/docs/developer/task_diagnostics.rst
+++ b/docs/developer/task_diagnostics.rst
@@ -38,6 +38,22 @@ The packet and dossier live under:
 The batch runner also surfaces those paths on the task result itself so a
 caller can jump directly to the packet after a batch finishes.
 
+Replay marker
+-------------
+
+Full-task canary replays now persist the same task-run and diagnosis artifacts
+as live runs, but they also mark the execution surface explicitly:
+
+- ``execution_mode`` is set to ``cassette_replay``
+- ``llm_cassette`` records the cassette name, path, and replay policy
+
+That metadata is stored on the top-level task result and the persisted task-run
+record so diagnosis, remediation, and canary-summary tooling can tell live and
+cassette-backed runs apart without needing a separate artifact schema.
+
+For replay stability, record and replay full-task canary cassettes with
+``PYTHONHASHSEED=0`` and keep them under ``cassettes/full_task/``.
+
 How to read one
 ---------------
 

--- a/docs/plans/backlog-burn-down-execution.md
+++ b/docs/plans/backlog-burn-down-execution.md
@@ -1,0 +1,155 @@
+# Backlog Burn-Down Execution Program
+
+## Objective
+
+Clear the remaining actionable backlog before starting new project work, while
+keeping longer-range expansion epics out of the burn-down queue.
+
+This program turns the audited backlog into a strict execution order with
+reviewable delivery slices, validation gates, and closeout rules that match
+`AGENTS.md`.
+
+Status mirror last synced: `2026-04-10`
+
+Current status:
+
+- `QUA-458` is complete.
+- The next actionable ticket in queue order is `QUA-710`.
+
+## Operating Rules
+
+- Linear is the source of truth for ticket state and scope changes.
+- Work one implementation ticket per branch and PR unless the user explicitly
+  asks to bundle tickets.
+- Follow the ticket workflow in `AGENTS.md` for every delivery slice:
+  upstream review, on-screen ticket announcement, TDD, doc update, Linear
+  handoff, plan sync, self-review, commit.
+- Update `LIMITATIONS.md` whenever a ticket changes the supported surface or
+  closes a documented limitation.
+- Close umbrella tickets only after their child delivery slices, docs, and
+  validation gates are complete.
+
+## In Scope
+
+These tickets are actionable backlog burn-down work:
+
+1. `QUA-458` canary replay: full-task cassette path with diagnosis parity
+2. `QUA-710` canary telemetry: trustworthy latency, token, and attempt baselines
+3. `QUA-428` stale test triage process and tooling
+4. `QUA-430` local gate and release-gate configuration
+5. `QUA-700` canary suite closeout after replay / telemetry / gate hardening
+6. `QUA-543` stress tranche: remaining `E22` compare-ready regression
+7. `QUA-417` route registry cleanup for smaller builder obligation surfaces
+8. `QUA-544` proving runs: first-pass knowledge-light reliability
+9. `QUA-429` lesson-to-test pipeline base slice
+10. `QUA-447` semantic template follow-on for the lesson-to-test path
+11. `QUA-545` maintenance tail for residual cleanup that does not justify a
+    broader project
+
+## Out of Scope
+
+These remain future-project backlog, not burn-down work:
+
+- `QUA-349`
+- `QUA-368`
+- `QUA-365`
+- `QUA-363`
+- `QUA-364`
+- `QUA-593` and children `QUA-615` to `QUA-618`
+- `QUA-594` and children `QUA-619` to `QUA-621`, `QUA-638` to `QUA-642`
+- `QUA-276` roadmap index
+
+If these should move into near-term delivery, they need their own plan and
+priority reset rather than being silently treated as backlog cleanup.
+
+## Ordered Waves
+
+### Wave 1: Replay, telemetry, and gate closeout
+
+This wave restores a low-cost, trustworthy canary surface before any new
+feature work.
+
+| Order | Ticket | Expected artifact |
+| --- | --- | --- |
+| 1 | `QUA-458` | Full-task canary replay from cassettes with diagnosis parity |
+| 2 | `QUA-710` | Trustworthy canary history for tokens, attempts, and elapsed time |
+| 3 | `QUA-428` | Current stale-test inventory and triage flow |
+| 4 | `QUA-430` | Stable local gate commands and release guidance |
+| 5 | `QUA-700` | Canary umbrella closeout with docs and final rerun evidence |
+
+Wave 1 closeout gate:
+
+- replay path exists and is documented
+- canary telemetry is trustworthy enough to compare runs over time
+- gate commands and release posture are documented
+- `QUA-700` is closed only after the above slices are done
+
+### Wave 2: Remaining correctness and route-surface cleanup
+
+This wave removes the highest-value remaining correctness and builder-surface
+debt once canary iteration is cheap again.
+
+| Order | Ticket | Expected artifact |
+| --- | --- | --- |
+| 6 | `QUA-543` | `E22` stress path restored to a compare-ready state |
+| 7 | `QUA-417` | Narrower route-registry / builder obligation surface |
+
+Wave 2 closeout gate:
+
+- the remaining stress-path regression is resolved or split cleanly
+- route-surface cleanup lands with the relevant regional validation
+
+### Wave 3: Reliability and durable learning loop
+
+This wave focuses on the first-pass builder quality and the path from lessons
+to durable regression coverage.
+
+| Order | Ticket | Expected artifact |
+| --- | --- | --- |
+| 8 | `QUA-544` | Improved first-pass knowledge-light proving reliability |
+| 9 | `QUA-429` | Base lesson-to-test pipeline |
+| 10 | `QUA-447` | Semantic template follow-on on top of the base pipeline |
+
+Wave 3 closeout gate:
+
+- first-pass proving reliability is materially better and measured
+- the lesson-to-test path exists end-to-end
+- semantic follow-on scope stays additive rather than reopening the base slice
+
+### Wave 4: Maintenance tail
+
+| Order | Ticket | Expected artifact |
+| --- | --- | --- |
+| 11 | `QUA-545` | Residual maintenance cleanup with explicit scope boundary |
+
+## Ticket Selection Rule
+
+Always pick the earliest ticket in the ordered queue whose Linear status is not
+`Done`, unless the user explicitly redirects work.
+
+If a ticket has become stale because other landed work already satisfies it:
+
+1. audit the ticket against the current repo
+2. update or close it in Linear
+3. sync the relevant plan mirror
+4. continue to the next actionable ticket without creating duplicate work
+
+## Current Start Point
+
+Execution started with `QUA-458` and now moves next to `QUA-710`.
+
+Plain-English goal:
+
+- replay full `run_task(...)` canary paths from recorded LLM cassettes so
+  diagnosis-heavy canaries can be inspected without live token spend
+
+Primary files and surfaces:
+
+- `trellis/agent/cassette.py`
+- `trellis/agent/config.py`
+- `trellis/agent/task_runtime.py`
+- `trellis/agent/task_run_store.py`
+- `scripts/run_canary.py`
+- `scripts/record_cassettes.py`
+- `docs/developer/`
+- targeted tests under `tests/test_agent/` and `tests/test_contracts/`

--- a/docs/plans/canary-suite-stabilization.md
+++ b/docs/plans/canary-suite-stabilization.md
@@ -166,7 +166,7 @@ Each agent assigned to this workstream should begin with:
 
 ## Linear Mirror
 
-Status mirror last synced: `2026-04-09`
+Status mirror last synced: `2026-04-10`
 
 ### Workstream Ticket
 
@@ -187,12 +187,16 @@ Status mirror last synced: `2026-04-09`
 | `QUA-707` | Analytical swaption cross-validation recovery for `T73` | Done |
 | `QUA-708` | Transform/Heston cross-validation recovery for `T40` | Done |
 | `QUA-709` | Copula cross-validation recovery for `T49` | Done |
-| `QUA-458` | Full-task canary replay with diagnosis parity | Backlog |
+| `QUA-458` | Full-task canary replay with diagnosis parity | Done |
 | `QUA-710` | Trustworthy canary telemetry and historical baselines | Backlog |
 | `QUA-430` | Local gate and release-gate configuration | Backlog |
 
 Note:
 
+- `QUA-700` now remains open only for telemetry / gate closeout
+  (`QUA-710`, `QUA-430`). The direct canary recovery tranche and the
+  full-task replay tranche (`QUA-458`) are complete after the `2026-04-09`
+  full curated rerun plus the `2026-04-10` cassette-backed replay landing.
 - `T01` is now green through the short-rate comparison-regime workstream in
   `docs/plans/short-rate-comparison-regime-and-claim-helpers.md` under
   `QUA-746` through `QUA-751`. The recovery path materializes task-level

--- a/scripts/canary_common.py
+++ b/scripts/canary_common.py
@@ -1,0 +1,26 @@
+"""Shared helpers for curated canary scripts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+CANARY_FILE = ROOT / "CANARY_TASKS.yaml"
+FULL_TASK_CASSETTES_DIR = ROOT / "cassettes" / "full_task"
+
+
+def merge_canary_task_payload(task: dict, canary: dict) -> dict:
+    """Overlay curated canary fields onto the live task registry payload."""
+    merged = dict(task)
+    for key in (
+        "description",
+        "market",
+        "market_assertions",
+        "construct",
+        "cross_validate",
+        "new_component",
+    ):
+        value = canary.get(key)
+        if value is not None:
+            merged[key] = value
+    return merged

--- a/scripts/record_cassettes.py
+++ b/scripts/record_cassettes.py
@@ -1,4 +1,4 @@
-"""Record LLM cassettes for all canary tasks.
+"""Record full-task LLM cassettes for canary tasks.
 
 Usage:
     python scripts/record_cassettes.py            # record all canary cassettes
@@ -8,7 +8,7 @@ Usage:
 This is a one-time token spend (~$2-3 for all canary tasks).
 Cassettes are saved to cassettes/ and should be committed to git.
 
-See QUA-427 for design context.
+See QUA-458 for the full-task replay design context.
 """
 
 from __future__ import annotations
@@ -32,7 +32,8 @@ from trellis.agent.config import load_env
 load_env()
 
 CANARY_FILE = ROOT / "CANARY_TASKS.yaml"
-CASSETTES_DIR = ROOT / "cassettes"
+FULL_TASK_CASSETTES_DIR = ROOT / "cassettes" / "full_task"
+CANARY_MAX_RETRIES = 3
 
 
 def load_canary_set() -> list[dict]:
@@ -40,51 +41,56 @@ def load_canary_set() -> list[dict]:
     return raw.get("canary_set", [])
 
 
+def merge_canary_task_payload(task: dict, canary: dict) -> dict:
+    """Overlay curated canary fields onto the live task registry payload."""
+    merged = dict(task)
+    for key in (
+        "description",
+        "market",
+        "market_assertions",
+        "construct",
+        "cross_validate",
+        "new_component",
+    ):
+        value = canary.get(key)
+        if value is not None:
+            merged[key] = value
+    return merged
+
+
 def record_cassette_for_task(
-    task_id: str,
-    task_title: str,
-    construct: str,
+    task: dict,
+    canary: dict,
     *,
     model: str = "gpt-5.4-mini",
-) -> Path:
+) -> tuple[Path, dict]:
     """Record a cassette for a single canary task.
 
-    Runs the build pipeline with cassette recording enabled.
-    Returns the cassette file path.
+    Runs the full ``run_task(...)`` pipeline with cassette recording enabled.
+    Returns the cassette file path plus the recorded task result.
     """
-    from trellis.agent.cassette import CassetteRecorder
-    from trellis.agent import config as agent_config
-    from trellis.agent.executor import build_payoff
+    from trellis.agent.cassette import llm_cassette_session
+    from trellis.agent.task_runtime import build_market_state, run_task
 
-    cassette_path = CASSETTES_DIR / f"{task_id}.yaml"
-    recorder = CassetteRecorder(cassette_path, name=task_id, store_prompts=True)
-
-    # Wrap LLM functions
-    real_generate = agent_config.llm_generate
-    real_generate_json = agent_config.llm_generate_json
-
-    agent_config.llm_generate = recorder.wrap_generate(real_generate)
-    agent_config.llm_generate_json = recorder.wrap_generate_json(real_generate_json)
-
-    try:
-        build_payoff(
-            task_title,
-            instrument_type=construct if isinstance(construct, str) else None,
+    task_id = task["id"]
+    cassette_path = FULL_TASK_CASSETTES_DIR / f"{task_id}.yaml"
+    merged_task = merge_canary_task_payload(task, canary)
+    market_state = build_market_state()
+    with llm_cassette_session(
+        cassette_path,
+        mode="record",
+        name=task_id,
+        store_prompts=True,
+    ):
+        result = run_task(
+            merged_task,
+            market_state,
             model=model,
             force_rebuild=True,
+            validation="standard",
+            max_retries=CANARY_MAX_RETRIES,
         )
-    except Exception as exc:
-        print(f"  WARNING: Build failed for {task_id}: {exc}")
-        print(f"  Cassette still saved with {len(recorder)} calls recorded.")
-    finally:
-        agent_config.llm_generate = real_generate
-        agent_config.llm_generate_json = real_generate_json
-
-    recorder.flush(
-        provider=agent_config.get_provider(),
-        model=model,
-    )
-    return cassette_path
+    return cassette_path, result
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -96,8 +102,11 @@ def main(argv: list[str] | None = None) -> int:
 
     canaries = load_canary_set()
 
-    # Load TASKS.yaml for titles
-    tasks = yaml.safe_load((ROOT / "TASKS.yaml").read_text(encoding="utf-8"))
+    from trellis.agent.task_runtime import load_tasks
+
+    # Use the same task-loading path as the canary runner so record and replay
+    # see the same normalized task payload.
+    tasks = load_tasks(status=None)
     task_lookup = {t["id"]: t for t in tasks}
 
     if args.task:
@@ -114,12 +123,12 @@ def main(argv: list[str] | None = None) -> int:
         print(f"\nEstimated cost: ~${sum(c.get('estimated_cost_usd', 0.12) for c in canaries):.2f}")
         return 0
 
-    CASSETTES_DIR.mkdir(parents=True, exist_ok=True)
+    FULL_TASK_CASSETTES_DIR.mkdir(parents=True, exist_ok=True)
 
     print(f"\n{'=' * 65}")
     print(f"  CASSETTE RECORDING — {len(canaries)} tasks")
     print(f"  Model: {args.model}")
-    print(f"  Output: {CASSETTES_DIR}")
+    print(f"  Output: {FULL_TASK_CASSETTES_DIR}")
     print(f"  Started: {datetime.now().isoformat()}")
     print(f"{'=' * 65}")
 
@@ -135,14 +144,14 @@ def main(argv: list[str] | None = None) -> int:
         start = time.time()
 
         try:
-            path = record_cassette_for_task(
-                task_id,
-                task["title"],
-                task.get("construct", ""),
+            path, result = record_cassette_for_task(
+                task,
+                canary,
                 model=args.model,
             )
             elapsed = time.time() - start
-            print(f"  recorded ({elapsed:.1f}s) → {path.name}")
+            status = "recorded" if result.get("success") else "recorded with task failure"
+            print(f"  {status} ({elapsed:.1f}s) → {path.name}")
             recorded += 1
         except Exception as exc:
             elapsed = time.time() - start
@@ -150,7 +159,7 @@ def main(argv: list[str] | None = None) -> int:
 
     print(f"\n{'=' * 65}")
     print(f"  Recorded: {recorded}/{len(canaries)} cassettes")
-    print(f"  Location: {CASSETTES_DIR}")
+    print(f"  Location: {FULL_TASK_CASSETTES_DIR}")
     print(f"{'=' * 65}")
 
     return 0 if recorded == len(canaries) else 1

--- a/scripts/record_cassettes.py
+++ b/scripts/record_cassettes.py
@@ -6,7 +6,7 @@ Usage:
     python scripts/record_cassettes.py --dry-run   # show what would be recorded
 
 This is a one-time token spend (~$2-3 for all canary tasks).
-Cassettes are saved to cassettes/ and should be committed to git.
+Cassettes are saved to cassettes/full_task/ and should be committed to git.
 
 See QUA-458 for the full-task replay design context.
 """
@@ -27,35 +27,17 @@ os.environ.setdefault("LLM_PROVIDER", "openai")
 
 import yaml
 
+from canary_common import CANARY_FILE, FULL_TASK_CASSETTES_DIR, merge_canary_task_payload
 from trellis.agent.config import load_env
 
 load_env()
 
-CANARY_FILE = ROOT / "CANARY_TASKS.yaml"
-FULL_TASK_CASSETTES_DIR = ROOT / "cassettes" / "full_task"
 CANARY_MAX_RETRIES = 3
 
 
 def load_canary_set() -> list[dict]:
     raw = yaml.safe_load(CANARY_FILE.read_text(encoding="utf-8"))
     return raw.get("canary_set", [])
-
-
-def merge_canary_task_payload(task: dict, canary: dict) -> dict:
-    """Overlay curated canary fields onto the live task registry payload."""
-    merged = dict(task)
-    for key in (
-        "description",
-        "market",
-        "market_assertions",
-        "construct",
-        "cross_validate",
-        "new_component",
-    ):
-        value = canary.get(key)
-        if value is not None:
-            merged[key] = value
-    return merged
 
 
 def record_cassette_for_task(

--- a/scripts/run_canary.py
+++ b/scripts/run_canary.py
@@ -3,6 +3,7 @@
 Usage:
     python scripts/run_canary.py                     # run all canaries
     python scripts/run_canary.py --task T38          # run single canary
+    python scripts/run_canary.py --task T38 --replay # replay single canary from cassette
     python scripts/run_canary.py --dry-run           # show plan, no execution
     python scripts/run_canary.py --budget 1.50       # override budget limit
     python scripts/run_canary.py --subset core       # run core subset (lattice + MC + PDE)
@@ -41,6 +42,7 @@ from trellis.agent.golden_traces import (
 )
 
 CANARY_FILE = ROOT / "CANARY_TASKS.yaml"
+FULL_TASK_CASSETTES_DIR = ROOT / "cassettes" / "full_task"
 
 # Engine families considered "core" for the --subset=core option
 CORE_FAMILIES = {"lattice", "monte_carlo", "pde", "credit"}
@@ -139,6 +141,9 @@ def run_canaries(
     validation: str = "standard",
     knowledge_light: bool = False,
     output_file: str | None = None,
+    replay: bool = False,
+    cassette_dir: str | Path | None = None,
+    cassette_stale_policy: str = "error",
 ) -> list[dict]:
     """Run canary tasks and return results.
 
@@ -147,6 +152,11 @@ def run_canaries(
     from trellis.agent.task_runtime import build_market_state, load_tasks, run_task
 
     budget = budget_override or meta.get("total_budget_usd", 3.0)
+    cassette_root = (
+        Path(cassette_dir)
+        if cassette_dir is not None
+        else FULL_TASK_CASSETTES_DIR
+    )
     # Canary coverage is curated independently of task lifecycle state, so the
     # runner must look across the full task registry rather than only "pending"
     # entries.
@@ -163,6 +173,8 @@ def run_canaries(
     print(f"  CANARY RUN — {len(canaries)} tasks")
     print(f"  Model: {model}")
     print(f"  Budget: ${budget:.2f}")
+    if replay:
+        print(f"  Replay: cassette-backed ({cassette_root})")
     print(f"  Started: {datetime.now().isoformat()}")
     print(f"{'=' * 65}")
 
@@ -180,20 +192,55 @@ def run_canaries(
             })
             continue
         task = merge_canary_task_payload(task, canary)
+        cassette_path = cassette_root / f"{task_id}.yaml"
 
         start = time.time()
         print(f"\n  [{idx}/{len(canaries)}] {task_id:6s}  {canary.get('engine_family', '?'):14s}", end="", flush=True)
 
-        try:
-            result = run_task(
-                task,
-                market_state,
-                model=model,
-                force_rebuild=True,
-                validation=validation,
-                max_retries=CANARY_MAX_RETRIES,
-                knowledge_profile="knowledge_light" if knowledge_light else None,
+        if replay and not cassette_path.exists():
+            error = (
+                f"Missing cassette for {task_id} at {cassette_path}. "
+                f"Record it with scripts/record_cassettes.py --task {task_id}"
             )
+            print("  SKIP — missing cassette")
+            results.append({
+                "canary_id": task_id,
+                "engine_family": canary.get("engine_family"),
+                "success": False,
+                "skipped": True,
+                "reason": "missing_cassette",
+                "error": error,
+            })
+            continue
+
+        try:
+            run_kwargs = {
+                "model": model,
+                "force_rebuild": True,
+                "validation": validation,
+                "max_retries": CANARY_MAX_RETRIES,
+                "knowledge_profile": "knowledge_light" if knowledge_light else None,
+            }
+            if replay:
+                from trellis.agent.cassette import llm_cassette_session
+
+                with llm_cassette_session(
+                    cassette_path,
+                    mode="replay",
+                    stale_policy=cassette_stale_policy,
+                    name=task_id,
+                ):
+                    result = run_task(
+                        task,
+                        market_state,
+                        **run_kwargs,
+                    )
+            else:
+                result = run_task(
+                    task,
+                    market_state,
+                    **run_kwargs,
+                )
         except Exception as exc:
             result = {
                 "task_id": task_id,
@@ -201,6 +248,14 @@ def run_canaries(
                 "error": str(exc),
                 "elapsed_seconds": time.time() - start,
             }
+            if replay:
+                result["execution_mode"] = "cassette_replay"
+                result["llm_cassette"] = {
+                    "mode": "replay",
+                    "name": task_id,
+                    "path": str(cassette_path),
+                    "stale_policy": cassette_stale_policy,
+                }
 
         elapsed = time.time() - start
         tokens = int((result.get("token_usage_summary") or {}).get("total_tokens") or 0)
@@ -327,6 +382,21 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         help="Use the compiler-first minimal knowledge profile during canary builds",
     )
     parser.add_argument("--output", help="Output file path for results JSON")
+    parser.add_argument(
+        "--replay",
+        action="store_true",
+        help="Replay canaries from recorded LLM cassettes instead of making live model calls",
+    )
+    parser.add_argument(
+        "--cassette-dir",
+        help="Directory containing canary cassette YAML files (default: cassettes/)",
+    )
+    parser.add_argument(
+        "--cassette-stale-policy",
+        choices=["warn", "error"],
+        default="error",
+        help="How replay mode handles prompt-hash drift",
+    )
     parser.add_argument("--check-drift", action="store_true", help="Compare results against golden traces and report drift")
     parser.add_argument("--update-golden", action="store_true", help="Promote passing results to golden traces (requires all pass)")
     return parser.parse_args(argv)
@@ -357,6 +427,9 @@ def main(argv: list[str] | None = None) -> int:
         validation=args.validation,
         knowledge_light=args.knowledge_light,
         output_file=output_file,
+        replay=args.replay,
+        cassette_dir=args.cassette_dir,
+        cassette_stale_policy=args.cassette_stale_policy,
     )
 
     all_passed = all(r.get("success", False) for r in results if not r.get("skipped"))

--- a/scripts/run_canary.py
+++ b/scripts/run_canary.py
@@ -31,6 +31,7 @@ os.environ.setdefault("LLM_PROVIDER", "openai")
 import yaml
 
 from trellis.agent.config import load_env
+from canary_common import CANARY_FILE, FULL_TASK_CASSETTES_DIR, merge_canary_task_payload
 
 load_env()
 
@@ -40,9 +41,6 @@ from trellis.agent.golden_traces import (
     format_drift_report,
     update_golden_from_results,
 )
-
-CANARY_FILE = ROOT / "CANARY_TASKS.yaml"
-FULL_TASK_CASSETTES_DIR = ROOT / "cassettes" / "full_task"
 
 # Engine families considered "core" for the --subset=core option
 CORE_FAMILIES = {"lattice", "monte_carlo", "pde", "credit"}
@@ -84,23 +82,6 @@ def filter_canaries(
     if subset == "core":
         return [c for c in canaries if c.get("engine_family") in CORE_FAMILIES]
     return canaries
-
-
-def merge_canary_task_payload(task: dict, canary: dict) -> dict:
-    """Overlay curated canary fields onto the live task registry payload."""
-    merged = dict(task)
-    for key in (
-        "description",
-        "market",
-        "market_assertions",
-        "construct",
-        "cross_validate",
-        "new_component",
-    ):
-        value = canary.get(key)
-        if value is not None:
-            merged[key] = value
-    return merged
 
 
 # ---------------------------------------------------------------------------
@@ -389,7 +370,7 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     )
     parser.add_argument(
         "--cassette-dir",
-        help="Directory containing canary cassette YAML files (default: cassettes/)",
+        help="Directory containing canary cassette YAML files (default: cassettes/full_task/)",
     )
     parser.add_argument(
         "--cassette-stale-policy",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,8 +71,7 @@ def llm_cassette(request, monkeypatch):
     The cassette name is derived from the test name by default, or can be
     specified via ``@pytest.mark.parametrize("llm_cassette", ["name"], indirect=True)``.
     """
-    from trellis.agent import config as agent_config
-    from trellis.agent.cassette import CassetteRecorder, CassetteReplayer
+    from trellis.agent.cassette import llm_cassette_session
 
     # Determine cassette name
     if hasattr(request, "param") and request.param:
@@ -84,28 +83,18 @@ def llm_cassette(request, monkeypatch):
     cassette_path = cassette_dir / f"{cassette_name}.yaml"
 
     if os.environ.get("TRELLIS_CASSETTE_RECORD", "0") == "1":
-        # Record mode: wrap real functions
-        recorder = CassetteRecorder(cassette_path, name=cassette_name)
-        real_generate = agent_config.llm_generate
-        real_generate_json = agent_config.llm_generate_json
-        monkeypatch.setattr(
-            agent_config, "llm_generate",
-            recorder.wrap_generate(real_generate),
-        )
-        monkeypatch.setattr(
-            agent_config, "llm_generate_json",
-            recorder.wrap_generate_json(real_generate_json),
-        )
-        yield recorder
-        recorder.flush(
-            provider=agent_config.get_provider(),
-            model=agent_config.get_default_model(),
-        )
+        with llm_cassette_session(
+            cassette_path,
+            mode="record",
+            name=cassette_name,
+        ) as recorder:
+            yield recorder
     else:
-        # Replay mode: return stored responses
         stale_policy = os.environ.get("TRELLIS_CASSETTE_STALE_POLICY", "warn")
-        replayer = CassetteReplayer(cassette_path, stale_policy=stale_policy)
-        monkeypatch.setattr(agent_config, "llm_generate", replayer.generate)
-        monkeypatch.setattr(agent_config, "llm_generate_json", replayer.generate_json)
-        yield replayer
-        replayer.assert_all_consumed()
+        with llm_cassette_session(
+            cassette_path,
+            mode="replay",
+            stale_policy=stale_policy,
+            name=cassette_name,
+        ) as replayer:
+            yield replayer

--- a/tests/test_agent/test_canary_runner.py
+++ b/tests/test_agent/test_canary_runner.py
@@ -6,7 +6,6 @@ All tests use mocked task execution — no LLM calls, no tokens spent.
 from __future__ import annotations
 
 from pathlib import Path
-import json
 from datetime import datetime, timezone
 
 import pytest

--- a/tests/test_agent/test_canary_runner.py
+++ b/tests/test_agent/test_canary_runner.py
@@ -6,6 +6,8 @@ All tests use mocked task execution — no LLM calls, no tokens spent.
 from __future__ import annotations
 
 from pathlib import Path
+import json
+from datetime import datetime, timezone
 
 import pytest
 import yaml
@@ -313,6 +315,126 @@ class TestRunCanaries:
         assert captured["description"] == "European call option on a non-dividend-paying stock."
         assert captured["construct"] == "monte_carlo"
 
+    def test_run_canaries_replay_mode_skips_missing_cassettes(self, monkeypatch, tmp_path):
+        seen = {"run_task_calls": 0}
+
+        def fake_build_market_state():
+            return object()
+
+        def fake_load_tasks(*, status="pending", path=None):
+            return [{"id": "T13", "title": "European call: theta-method convergence order"}]
+
+        def fake_run_task(task, market_state, **kwargs):
+            seen["run_task_calls"] += 1
+            return {"task_id": task["id"], "success": True}
+
+        monkeypatch.setattr(
+            "trellis.agent.task_runtime.build_market_state",
+            fake_build_market_state,
+        )
+        monkeypatch.setattr(
+            "trellis.agent.task_runtime.load_tasks",
+            fake_load_tasks,
+        )
+        monkeypatch.setattr(
+            "trellis.agent.task_runtime.run_task",
+            fake_run_task,
+        )
+
+        results = run_canaries(
+            [{"id": "T13", "engine_family": "pde", "complexity": "simple"}],
+            {"total_budget_usd": 1.0},
+            replay=True,
+            cassette_dir=tmp_path,
+        )
+
+        assert seen["run_task_calls"] == 0
+        assert results == [
+            {
+                "canary_id": "T13",
+                "engine_family": "pde",
+                "success": False,
+                "skipped": True,
+                "reason": "missing_cassette",
+                "error": (
+                    "Missing cassette for T13 at "
+                    f"{tmp_path / 'T13.yaml'}. "
+                    "Record it with scripts/record_cassettes.py --task T13"
+                ),
+            }
+        ]
+
+    def test_run_canaries_replay_mode_uses_full_task_cassette(self, monkeypatch, tmp_path):
+        from trellis.agent.cassette import _prompt_hash
+
+        prompt = "runner replay prompt"
+        cassette_path = tmp_path / "T38.yaml"
+        cassette_path.write_text(
+            yaml.safe_dump(
+                {
+                    "meta": {
+                        "recorded_at": datetime.now(timezone.utc).isoformat(),
+                        "total_calls": 1,
+                    },
+                    "calls": [
+                        {
+                            "seq": 0,
+                            "function": "llm_generate",
+                            "stage": "critic",
+                            "prompt_hash": _prompt_hash(prompt),
+                            "response_text": "runner replay response",
+                        }
+                    ],
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+
+        seen: dict[str, object] = {}
+
+        def fake_build_market_state():
+            return object()
+
+        def fake_load_tasks(*, status="pending", path=None):
+            return [{"id": "T38", "title": "CDS pricing canary"}]
+
+        def fake_run_task(task, market_state, **kwargs):
+            from trellis.agent import critic
+
+            seen["llm_text"] = critic.llm_generate(prompt)
+            return {
+                "task_id": task["id"],
+                "success": True,
+                "execution_mode": "cassette_replay",
+                "token_usage_summary": {"total_tokens": 0},
+            }
+
+        monkeypatch.setattr(
+            "trellis.agent.task_runtime.build_market_state",
+            fake_build_market_state,
+        )
+        monkeypatch.setattr(
+            "trellis.agent.task_runtime.load_tasks",
+            fake_load_tasks,
+        )
+        monkeypatch.setattr(
+            "trellis.agent.task_runtime.run_task",
+            fake_run_task,
+        )
+
+        results = run_canaries(
+            [{"id": "T38", "engine_family": "credit", "complexity": "complex"}],
+            {"total_budget_usd": 1.0},
+            replay=True,
+            cassette_dir=tmp_path,
+        )
+
+        assert seen["llm_text"] == "runner replay response"
+        assert results[0]["success"] is True
+        assert results[0]["execution_mode"] == "cassette_replay"
+        assert results[0]["token_usage_summary"]["total_tokens"] == 0
+
 
 # ---------------------------------------------------------------------------
 # CANARY_TASKS.yaml validity
@@ -518,6 +640,22 @@ class TestDriftIntegration:
         args = _parse_args(["--check-drift", "--update-golden"])
         assert args.check_drift is True
         assert args.update_golden is True
+
+    def test_parse_args_replay_flags(self):
+        from run_canary import _parse_args
+
+        args = _parse_args(
+            [
+                "--replay",
+                "--cassette-dir",
+                "/tmp/cassettes",
+                "--cassette-stale-policy",
+                "error",
+            ]
+        )
+        assert args.replay is True
+        assert args.cassette_dir == "/tmp/cassettes"
+        assert args.cassette_stale_policy == "error"
 
         args_none = _parse_args([])
         assert args_none.check_drift is False

--- a/tests/test_agent/test_reflect_loop.py
+++ b/tests/test_agent/test_reflect_loop.py
@@ -218,3 +218,48 @@ def test_reflect_trace_records_agent_observations(monkeypatch, tmp_path):
     trace_data = yaml.safe_load(trace_path.read_text())
     assert trace_data["agent_observations"][0]["agent"] == "critic"
     assert trace_data["agent_observations"][0]["summary"] == "Potential double discounting"
+
+
+def test_reflect_on_build_keeps_knowledge_store_read_only_inside_cassette_session(monkeypatch, tmp_path):
+    from trellis.agent.cassette import llm_cassette_session
+    from trellis.agent.knowledge.gap_check import GapReport
+    from trellis.agent.knowledge.reflect import reflect_on_build
+    from trellis.agent.knowledge.schema import ProductDecomposition
+
+    knowledge_root = tmp_path / "knowledge"
+    _seed_minimal_knowledge_dir(knowledge_root)
+    _patch_knowledge_paths(monkeypatch, knowledge_root)
+    monkeypatch.setattr("trellis.agent.knowledge.reflect._should_distill", lambda: False)
+    monkeypatch.setattr(
+        "trellis.agent.knowledge.reflect._llm_reflect",
+        lambda *args, **kwargs: {
+            "lesson": None,
+            "knowledge_gaps": ["Need a stable CDS helper note"],
+            "cookbook_extract": None,
+        },
+    )
+
+    cassette_path = tmp_path / "noop.yaml"
+    with llm_cassette_session(cassette_path, mode="record", name="reflect_read_only"):
+        actions = reflect_on_build(
+            description="European call option",
+            decomposition=ProductDecomposition(
+                instrument="european_option",
+                features=("vanilla",),
+                method="analytical",
+                learned=False,
+            ),
+            gap_report=GapReport(has_cookbook=False, confidence=0.2, retrieved_lesson_ids=[]),
+            retrieved_lesson_ids=[],
+            success=True,
+            failures=[],
+            code="return 0.0",
+            attempt=1,
+            model=None,
+        )
+
+    assert actions["gaps_identified"] == ["Need a stable CDS helper note"]
+    assert actions["knowledge_trace_saved"] is None
+    assert actions["knowledge_gap_log_saved"] is None
+    assert actions["cookbook_candidate_saved"] is None
+    assert list((knowledge_root / "traces").iterdir()) == []

--- a/tests/test_agent/test_task_runtime.py
+++ b/tests/test_agent/test_task_runtime.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import date, datetime
-from pathlib import Path
 from types import ModuleType, SimpleNamespace
 import sys
 

--- a/tests/test_agent/test_task_runtime.py
+++ b/tests/test_agent/test_task_runtime.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import date, datetime
+from pathlib import Path
 from types import ModuleType, SimpleNamespace
 import sys
 
 import pytest
+import yaml
 
 
 def test_run_task_passes_force_rebuild_and_validation():
@@ -635,6 +637,101 @@ def test_run_task_persists_latest_record(monkeypatch):
     assert result["task_diagnosis_headline"] == "Demo task completed successfully."
     assert result["task_diagnosis_persist_error"] == ""
     assert result["task_diagnosis_persist_skipped"] == ""
+
+
+def test_run_task_marks_cassette_replay_runs_and_persists_metadata(monkeypatch, tmp_path):
+    from trellis.agent.cassette import _prompt_hash, llm_cassette_session
+    from trellis.agent.task_runtime import run_task
+
+    prompt = "critic replay prompt"
+    cassette_path = tmp_path / "T13.yaml"
+    cassette_path.write_text(
+        yaml.safe_dump(
+            {
+                "meta": {
+                    "recorded_at": "2026-04-10T12:00:00+00:00",
+                    "total_calls": 1,
+                    "name": "T13",
+                },
+                "calls": [
+                    {
+                        "seq": 0,
+                        "function": "llm_generate",
+                        "stage": "critic",
+                        "prompt_hash": _prompt_hash(prompt),
+                        "response_text": "cassette critic response",
+                    }
+                ],
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    persisted: dict[str, object] = {}
+    seen: dict[str, object] = {}
+
+    class FakeResult:
+        success = True
+        attempts = 1
+        gap_confidence = 0.8
+        knowledge_gaps = []
+        payoff_cls = type("FakePayoff", (), {})
+        failures = []
+        reflection = {}
+
+    def fake_build(**kwargs):
+        from trellis.agent import critic
+
+        seen["llm_text"] = critic.llm_generate(prompt)
+        return FakeResult()
+
+    def fake_persist(task, result):
+        persisted["task"] = task
+        persisted["result"] = dict(result)
+        return {
+            "history_path": "/tmp/task_runs/history/T13/run.json",
+            "latest_path": "/tmp/task_runs/latest/T13.json",
+            "latest_index_path": "/tmp/task_results_latest.json",
+            "diagnosis_packet_path": "/tmp/task_runs/diagnostics/history/T13/run.json",
+            "diagnosis_dossier_path": "/tmp/task_runs/diagnostics/history/T13/run.md",
+            "latest_diagnosis_packet_path": "/tmp/task_runs/diagnostics/latest/T13.json",
+            "latest_diagnosis_dossier_path": "/tmp/task_runs/diagnostics/latest/T13.md",
+            "diagnosis_headline": "Replay task completed successfully.",
+            "diagnosis_failure_bucket": "success",
+            "diagnosis_decision_stage": "completed",
+            "diagnosis_next_action": "No action required.",
+            "diagnosis_persist_error": "",
+            "diagnosis_persist_skipped": "",
+        }
+
+    monkeypatch.setattr(
+        "trellis.agent.task_run_store.persist_task_run_record",
+        fake_persist,
+    )
+
+    with llm_cassette_session(
+        cassette_path,
+        mode="replay",
+        stale_policy="error",
+        name="T13",
+    ):
+        result = run_task(
+            {"id": "T13", "title": "European call: theta-method convergence order"},
+            market_state=object(),
+            build_fn=fake_build,
+        )
+
+    assert seen["llm_text"] == "cassette critic response"
+    assert result["execution_mode"] == "cassette_replay"
+    assert result["llm_cassette"]["mode"] == "replay"
+    assert result["llm_cassette"]["name"] == "T13"
+    assert result["llm_cassette"]["path"] == str(cassette_path)
+    assert persisted["task"]["id"] == "T13"
+    assert persisted["result"]["execution_mode"] == "cassette_replay"
+    assert persisted["result"]["llm_cassette"]["path"] == str(cassette_path)
+    assert result["task_diagnosis_packet_path"] == "/tmp/task_runs/diagnostics/history/T13/run.json"
+    assert result["task_diagnosis_dossier_path"] == "/tmp/task_runs/diagnostics/history/T13/run.md"
 
 
 def test_run_task_uses_single_construct_as_preferred_method():

--- a/tests/test_contracts/conftest.py
+++ b/tests/test_contracts/conftest.py
@@ -15,6 +15,7 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 CASSETTES_DIR = REPO_ROOT / "cassettes"
+FULL_TASK_CASSETTES_DIR = CASSETTES_DIR / "full_task"
 CANARY_FILE = REPO_ROOT / "CANARY_TASKS.yaml"
 
 
@@ -67,6 +68,16 @@ def cassette_path_for(task_id: str) -> Path:
 def cassette_available(task_id: str) -> bool:
     """Check whether a cassette file exists for *task_id*."""
     return cassette_path_for(task_id).exists()
+
+
+def full_task_cassette_path_for(task_id: str) -> Path:
+    """Return the expected full-task replay cassette path for a canary task."""
+    return FULL_TASK_CASSETTES_DIR / f"{task_id}.yaml"
+
+
+def full_task_cassette_available(task_id: str) -> bool:
+    """Check whether a full-task cassette exists for *task_id*."""
+    return full_task_cassette_path_for(task_id).exists()
 
 
 def requires_cassette(task_id: str):

--- a/tests/test_contracts/test_canary_replay_contracts.py
+++ b/tests/test_contracts/test_canary_replay_contracts.py
@@ -32,7 +32,7 @@ def _full_task_replay_test(task_id: str):
         not full_task_cassette_available(task_id),
         reason=(
             f"Full-task cassette not recorded for {task_id}. "
-            f"Run: /Users/steveyang/miniforge3/bin/python3 scripts/record_cassettes.py --task {task_id}"
+            f"Run: PYTHONHASHSEED=0 {sys.executable} scripts/record_cassettes.py --task {task_id}"
         ),
     )
     class _ReplayTest:

--- a/tests/test_contracts/test_canary_replay_contracts.py
+++ b/tests/test_contracts/test_canary_replay_contracts.py
@@ -1,0 +1,91 @@
+"""Tier 2 contract tests for full-task canary replay (QUA-458).
+
+These tests exercise the real canary runner in replay mode against committed
+full-task cassettes. They are intentionally narrower than the older
+build-pipeline cassette contracts: the acceptance target here is ``run_task``
+plus diagnosis-packet parity with zero live token spend.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+from tests.test_contracts.conftest import (
+    CANARY_META,
+    FULL_TASK_CASSETTES_DIR,
+    full_task_cassette_available,
+)
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+
+
+def _full_task_replay_test(task_id: str):
+    @pytest.mark.tier2
+    @pytest.mark.skipif(
+        not full_task_cassette_available(task_id),
+        reason=(
+            f"Full-task cassette not recorded for {task_id}. "
+            f"Run: /Users/steveyang/miniforge3/bin/python3 scripts/record_cassettes.py --task {task_id}"
+        ),
+    )
+    class _ReplayTest:
+        def test_canary_replay_runs_zero_token_with_diagnosis_artifacts(self, tmp_path):
+            canary = CANARY_META.get(task_id)
+            assert canary is not None, f"{task_id} missing from CANARY_TASKS.yaml"
+            output_path = tmp_path / f"{task_id}.json"
+            command = [
+                sys.executable,
+                str(ROOT / "scripts" / "run_canary.py"),
+                "--task",
+                task_id,
+                "--replay",
+                "--cassette-dir",
+                str(FULL_TASK_CASSETTES_DIR),
+                "--output",
+                str(output_path),
+        ]
+            env = {
+                "HOME": os.environ.get("HOME", ""),
+                "PATH": os.environ.get("PATH", ""),
+                "LANG": os.environ.get("LANG", "en_US.UTF-8"),
+                "TERM": os.environ.get("TERM", "xterm-256color"),
+                "TMPDIR": os.environ.get("TMPDIR", "/tmp"),
+                "PYTHONHASHSEED": "0",
+            }
+            completed = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                cwd=ROOT,
+                env=env,
+            )
+            assert completed.returncode == 0, completed.stdout + completed.stderr
+
+            results = json.loads(output_path.read_text())
+            assert len(results) == 1
+            result = results[0]
+            assert result["success"] is True
+            assert result["execution_mode"] == "cassette_replay"
+            assert result["llm_cassette"]["path"] == str(
+                FULL_TASK_CASSETTES_DIR / f"{task_id}.yaml"
+            )
+            assert (result.get("token_usage_summary") or {}).get("total_tokens") == 0
+            assert Path(result["task_diagnosis_packet_path"]).exists()
+            assert Path(result["task_diagnosis_dossier_path"]).exists()
+            assert Path(result["task_diagnosis_latest_packet_path"]).exists()
+            assert Path(result["task_diagnosis_latest_dossier_path"]).exists()
+
+    _ReplayTest.__name__ = f"TestCanaryReplay_{task_id}"
+    _ReplayTest.__qualname__ = f"TestCanaryReplay_{task_id}"
+    return _ReplayTest
+
+
+TestCanaryReplay_T13 = _full_task_replay_test("T13")
+TestCanaryReplay_T38 = _full_task_replay_test("T38")

--- a/tests/test_contracts/test_cassette_freshness.py
+++ b/tests/test_contracts/test_cassette_freshness.py
@@ -21,7 +21,7 @@ def test_cassettes_are_fresh():
     if not CASSETTES_DIR.exists():
         pytest.skip("No cassettes directory found — record cassettes first")
 
-    cassette_files = list(CASSETTES_DIR.glob("*.yaml"))
+    cassette_files = list(CASSETTES_DIR.rglob("*.yaml"))
     if not cassette_files:
         pytest.skip("No cassette files found — record cassettes first")
 
@@ -48,7 +48,7 @@ def test_cassette_files_are_valid_yaml():
 
     import yaml
 
-    cassette_files = list(CASSETTES_DIR.glob("*.yaml"))
+    cassette_files = list(CASSETTES_DIR.rglob("*.yaml"))
     if not cassette_files:
         pytest.skip("No cassette files")
 

--- a/trellis/agent/cassette.py
+++ b/trellis/agent/cassette.py
@@ -24,6 +24,8 @@ import hashlib
 import json
 import logging
 import warnings
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -32,6 +34,10 @@ from typing import Any, Callable
 import yaml
 
 _log = logging.getLogger(__name__)
+_LLM_CASSETTE_CONTEXT: ContextVar[dict[str, Any] | None] = ContextVar(
+    "llm_cassette_context",
+    default=None,
+)
 
 # ---------------------------------------------------------------------------
 # Exceptions
@@ -354,3 +360,79 @@ def load_cassette(path: str | Path) -> dict[str, Any]:
     if not p.exists():
         raise CassetteNotFoundError(f"Cassette not found: {p}")
     return yaml.safe_load(p.read_text(encoding="utf-8"))
+
+
+def current_llm_cassette_context() -> dict[str, Any] | None:
+    """Return metadata for the active cassette scope, if any."""
+    current = _LLM_CASSETTE_CONTEXT.get()
+    if current is None:
+        return None
+    return dict(current)
+
+
+@contextmanager
+def llm_cassette_session(
+    path: str | Path,
+    *,
+    mode: str,
+    stale_policy: str = CassetteReplayer.STALE_POLICY_WARN,
+    store_prompts: bool = True,
+    name: str | None = None,
+):
+    """Run the current LLM call path against a recorder or replayer.
+
+    This scopes cassette control through ``trellis.agent.config.llm_generate``
+    and ``llm_generate_json`` so callers that imported those functions at
+    module scope still respect the active cassette session.
+    """
+    from trellis.agent.config import (
+        _llm_generate_json_live,
+        _llm_generate_live,
+        get_default_model,
+        get_provider,
+        llm_override_scope,
+    )
+
+    cassette_path = Path(path)
+    cassette_name = name or cassette_path.stem
+    if mode == "record":
+        handler: CassetteRecorder | CassetteReplayer = CassetteRecorder(
+            cassette_path,
+            store_prompts=store_prompts,
+            name=cassette_name,
+        )
+        generate = handler.wrap_generate(_llm_generate_live)
+        generate_json = handler.wrap_generate_json(_llm_generate_json_live)
+    elif mode == "replay":
+        handler = CassetteReplayer(cassette_path, stale_policy=stale_policy)
+        generate = handler.generate
+        generate_json = handler.generate_json
+    else:
+        raise ValueError(f"Unsupported cassette mode: {mode!r}")
+
+    metadata = {
+        "mode": mode,
+        "name": cassette_name,
+        "path": str(cassette_path),
+    }
+    if mode == "replay":
+        metadata["stale_policy"] = stale_policy
+
+    token = _LLM_CASSETTE_CONTEXT.set(metadata)
+    try:
+        with llm_override_scope(
+            generate=generate,
+            generate_json=generate_json,
+        ):
+            yield handler
+    finally:
+        _LLM_CASSETTE_CONTEXT.reset(token)
+        if mode == "record":
+            assert isinstance(handler, CassetteRecorder)
+            handler.flush(
+                provider=get_provider(),
+                model=get_default_model(),
+            )
+        else:
+            assert isinstance(handler, CassetteReplayer)
+            handler.assert_all_consumed()

--- a/trellis/agent/config.py
+++ b/trellis/agent/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 import json
 import os
 import threading
@@ -10,7 +11,7 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 _LOADED = False
 
@@ -69,7 +70,19 @@ _LLM_REQUEST_CONTEXT: ContextVar[dict[str, Any] | None] = ContextVar(
     "llm_request_context",
     default=None,
 )
+_LLM_OVERRIDE_HANDLERS: ContextVar["LLMOverrideHandlers | None"] = ContextVar(
+    "llm_override_handlers",
+    default=None,
+)
 LLM_WAIT_LOG_ROOT = Path(__file__).resolve().parents[2] / "task_runs" / "llm_waits"
+
+
+@dataclass(frozen=True)
+class LLMOverrideHandlers:
+    """Temporary override functions for LLM text and JSON requests."""
+
+    generate: Callable[..., str]
+    generate_json: Callable[..., dict]
 
 
 class TokenBudgetExceeded(RuntimeError):
@@ -283,6 +296,19 @@ def llm_generate(
     max_retries: int | None = None,
 ) -> str:
     """Call the LLM and return text response."""
+    override = _LLM_OVERRIDE_HANDLERS.get()
+    if override is not None:
+        return override.generate(prompt, model=model, max_retries=max_retries)
+    return _llm_generate_live(prompt, model=model, max_retries=max_retries)
+
+
+def _llm_generate_live(
+    prompt: str,
+    model: str | None = None,
+    *,
+    max_retries: int | None = None,
+) -> str:
+    """Call the live LLM provider and return text response."""
     load_env()
     provider = get_provider()
     model = model or get_default_model()
@@ -312,6 +338,19 @@ def llm_generate_json(
     max_retries: int | None = None,
 ) -> dict:
     """Call LLM with JSON response format and return parsed dict."""
+    override = _LLM_OVERRIDE_HANDLERS.get()
+    if override is not None:
+        return override.generate_json(prompt, model=model, max_retries=max_retries)
+    return _llm_generate_json_live(prompt, model=model, max_retries=max_retries)
+
+
+def _llm_generate_json_live(
+    prompt: str,
+    model: str | None = None,
+    *,
+    max_retries: int | None = None,
+) -> dict:
+    """Call the live LLM provider for a JSON response and return parsed data."""
     load_env()
     provider = get_provider()
     model = model or get_default_model()
@@ -331,6 +370,25 @@ def llm_generate_json(
         response_text=text,
     )
     return _parse_llm_json_response(text, provider=provider, model=model)
+
+
+@contextmanager
+def llm_override_scope(
+    *,
+    generate: Callable[..., str],
+    generate_json: Callable[..., dict],
+):
+    """Temporarily override LLM text/JSON calls in the current context."""
+    token = _LLM_OVERRIDE_HANDLERS.set(
+        LLMOverrideHandlers(
+            generate=generate,
+            generate_json=generate_json,
+        )
+    )
+    try:
+        yield
+    finally:
+        _LLM_OVERRIDE_HANDLERS.reset(token)
 
 
 def _validate_llm_text_response(text: str | None, *, provider: str, model: str) -> str:

--- a/trellis/agent/knowledge/reflect.py
+++ b/trellis/agent/knowledge/reflect.py
@@ -122,11 +122,14 @@ def reflect_on_build(
         "decomposition_saved": False,
         "distill_run": False,
         "agent_observation_count": len(agent_observations or []),
+        "scorer_retrained": False,
+        "validators_promoted": False,
     }
+    knowledge_writes_allowed = _knowledge_store_mutations_allowed()
 
     try:
         # 1. Attribution — boost retrieved lessons and routes on success
-        if success:
+        if success and knowledge_writes_allowed:
             actions["lessons_attributed"] = _attribute_success(
                 retrieved_lesson_ids
             )
@@ -135,7 +138,7 @@ def reflect_on_build(
             )
 
         # 2. Save learned decomposition on success
-        if success and decomposition.learned:
+        if success and decomposition.learned and knowledge_writes_allowed:
             _save_decomposition(decomposition)
             actions["decomposition_saved"] = True
 
@@ -150,7 +153,7 @@ def reflect_on_build(
             if reflection:
                 # Capture lesson if one was identified
                 lesson_data = reflection.get("lesson")
-                if lesson_data and isinstance(lesson_data, dict):
+                if lesson_data and isinstance(lesson_data, dict) and knowledge_writes_allowed:
                     lid, lesson_contract, lesson_outcome = _capture_structured_lesson(
                         lesson_data, decomposition, success, attempt,
                     )
@@ -162,19 +165,30 @@ def reflect_on_build(
                 gaps = reflection.get("knowledge_gaps", [])
                 if gaps:
                     actions["gaps_identified"] = gaps
-                    actions["knowledge_gap_log_saved"] = _record_gaps(
-                        gaps,
-                        decomposition,
-                        gap_report,
-                    )
+                    if knowledge_writes_allowed:
+                        actions["knowledge_gap_log_saved"] = _record_gaps(
+                            gaps,
+                            decomposition,
+                            gap_report,
+                        )
 
                 # Enrich cookbook if missing
                 cookbook_extract = reflection.get("cookbook_extract")
-                if cookbook_extract and not gap_report.has_cookbook and success:
+                if (
+                    cookbook_extract
+                    and not gap_report.has_cookbook
+                    and success
+                    and knowledge_writes_allowed
+                ):
                     _enrich_cookbook(decomposition.method, cookbook_extract)
                     actions["cookbook_enriched"] = True
 
-            if success and not gap_report.has_cookbook and not actions["cookbook_enriched"]:
+            if (
+                success
+                and not gap_report.has_cookbook
+                and not actions["cookbook_enriched"]
+                and knowledge_writes_allowed
+            ):
                 actions["cookbook_candidate_saved"] = _record_cookbook_candidate(
                     decomposition.method,
                     description,
@@ -184,7 +198,12 @@ def reflect_on_build(
             # Capture discovered route if build was ad-hoc
             if reflection:
                 route_data = reflection.get("route_discovery")
-                if route_data and isinstance(route_data, dict) and success:
+                if (
+                    route_data
+                    and isinstance(route_data, dict)
+                    and success
+                    and knowledge_writes_allowed
+                ):
                     rid, outcome = _capture_discovered_route(
                         route_data, decomposition, attempt,
                     )
@@ -192,32 +211,44 @@ def reflect_on_build(
                     actions["route_discovery_outcome"] = outcome
 
         # 4. Record trace
-        actions["knowledge_trace_saved"] = _record_full_trace(
-            description, decomposition, gap_report, retrieved_lesson_ids,
-            success, failures, code, attempt, actions, agent_observations or [],
-        )
-        if actions.get("lesson_captured") and actions["knowledge_trace_saved"]:
-            _attach_source_trace(
-                actions["lesson_captured"],
-                actions["knowledge_trace_saved"],
+        if knowledge_writes_allowed:
+            actions["knowledge_trace_saved"] = _record_full_trace(
+                description, decomposition, gap_report, retrieved_lesson_ids,
+                success, failures, code, attempt, actions, agent_observations or [],
             )
+            if actions.get("lesson_captured") and actions["knowledge_trace_saved"]:
+                _attach_source_trace(
+                    actions["lesson_captured"],
+                    actions["knowledge_trace_saved"],
+                )
 
         # 5. Maybe distill
-        if _should_distill():
+        if knowledge_writes_allowed and _should_distill():
             from trellis.agent.knowledge.promotion import distill
             distill()
             actions["distill_run"] = True
 
         # 6. Maybe retrain route scorer
-        actions["scorer_retrained"] = _maybe_retrain_scorer()
+        if knowledge_writes_allowed:
+            actions["scorer_retrained"] = _maybe_retrain_scorer()
 
         # 7. Maybe promote semantic validators
-        actions["validators_promoted"] = _maybe_promote_validators()
+        if knowledge_writes_allowed:
+            actions["validators_promoted"] = _maybe_promote_validators()
 
     except Exception:
         pass  # Reflection must never block the build
 
     return actions
+
+
+def _knowledge_store_mutations_allowed() -> bool:
+    """Return False when the current runtime should not mutate the knowledge store."""
+    try:
+        from trellis.agent.cassette import current_llm_cassette_context
+    except Exception:
+        return True
+    return current_llm_cassette_context() is None
 
 
 # ---------------------------------------------------------------------------

--- a/trellis/agent/task_run_store.py
+++ b/trellis/agent/task_run_store.py
@@ -193,6 +193,10 @@ def build_task_run_record(
             "targets": list(result.get("comparison_targets") or []),
             "summary": dict(result.get("cross_validation") or {}),
         },
+        "execution": {
+            "mode": str(result.get("execution_mode") or "live"),
+            "llm_cassette": dict(result.get("llm_cassette") or {}),
+        },
         "market": dict(result.get("market_context") or {}),
         "framework": framework,
         "method_runs": method_runs,
@@ -225,6 +229,7 @@ def build_task_run_record(
             "deviations_pct": dict((result.get("cross_validation") or {}).get("deviations_pct") or {}),
             "token_usage": dict(result.get("token_usage_summary") or {}),
             "framework_outcome": framework.get("outcome_type"),
+            "execution_mode": str(result.get("execution_mode") or "live"),
             "learning": learning,
         },
     }

--- a/trellis/agent/task_runtime.py
+++ b/trellis/agent/task_runtime.py
@@ -925,6 +925,7 @@ def run_task(
     price_fn: Callable[[Any, Any], float] | None = None,
 ) -> dict:
     """Execute one task through the knowledge-aware build pipeline."""
+    from trellis.agent.cassette import current_llm_cassette_context
     from trellis.agent.task_run_store import persist_task_run_record, summarize_task_learning
 
     if build_fn is None:
@@ -940,6 +941,12 @@ def run_task(
     construct_methods = _task_construct_methods(task)
     comparison_targets = _task_comparison_targets(task, construct_methods)
     comparison_task = len(comparison_targets) > 1
+    cassette_context = current_llm_cassette_context()
+    execution_mode = (
+        f"cassette_{cassette_context['mode']}"
+        if cassette_context is not None
+        else "live"
+    )
 
     print(f"\n{'=' * 60}")
     print(f"  {task_id}: {task['title']}")
@@ -962,7 +969,10 @@ def run_task(
         "new_component": task.get("new_component"),
         "semantic_contract_id": getattr(getattr(semantic_contract, "product", None), "semantic_id", None),
         "runtime_controls": _runtime_bisection_controls(),
+        "execution_mode": execution_mode,
     }
+    if cassette_context is not None:
+        result_data["llm_cassette"] = cassette_context
 
     try:
         _validate_task_contract(task, instrument_type, construct_methods)


### PR DESCRIPTION
## Summary
- add full-task canary cassette record/replay through `run_task(...)` instead of payoff-only recording
- persist replay metadata on task runtime results and stored task runs, and make reflection read-only during cassette sessions
- add committed full-task canaries for `T13` and `T38`, plus docs and the backlog burn-down execution plan

## Validation
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_canary_runner.py tests/test_agent/test_task_runtime.py tests/test_agent/test_reflect_loop.py tests/test_agent/test_cassette.py tests/test_agent/test_task_run_store.py tests/test_contracts/test_cassette_freshness.py tests/test_contracts/test_canary_replay_contracts.py tests/test_contracts/test_pipeline_contracts.py -q`
- `PYTHONHASHSEED=0 /Users/steveyang/miniforge3/bin/python3 scripts/record_cassettes.py --task T13`
- `PYTHONHASHSEED=0 /Users/steveyang/miniforge3/bin/python3 scripts/record_cassettes.py --task T38`
- `PYTHONHASHSEED=0 /Users/steveyang/miniforge3/bin/python3 scripts/run_canary.py --task T13 --replay`
- `PYTHONHASHSEED=0 /Users/steveyang/miniforge3/bin/python3 scripts/run_canary.py --task T38 --replay`

## Notes
- committed full-task cassettes live under `cassettes/full_task/`
- replay stability for the committed canaries currently depends on `PYTHONHASHSEED=0`
- unrelated local worktree changes were left out of this PR
