### PR TITLE
QUA-710: persist trustworthy canary batch telemetry

### DIFF
--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -74,6 +74,51 @@ candidates back into the canonical knowledge store. This keeps the replay
 prompt surface aligned with the state that the cassette was recorded against
 instead of letting the recording run mutate later retrieval inputs.
 
+Every canary batch now also writes a dedicated aggregate telemetry record under
+``task_runs/canary_batches/``:
+
+- ``task_runs/canary_batches/history/<batch_id>.json`` keeps the immutable
+  per-batch history
+- ``task_runs/canary_batches/latest/<scope>.json`` keeps the latest batch for a
+  stable comparison scope such as ``live__full_curated__standard__default``
+
+Those records sit on top of the existing per-task run history. They do not
+replace ``task_runs/history/``; instead they provide the trustworthy canary
+view that raw task runs could not guarantee on their own.
+
+Each batch record carries:
+
+- explicit lineage for ``live`` versus ``cassette_replay`` execution
+- whether the batch is benchmark-eligible
+- the selection scope (full curated set, subset, or single task)
+- aggregate pass/fail, elapsed-time, token, and attempt metrics
+- per-canary entries with links back to the underlying task-run and diagnosis
+  artifacts
+
+For maintenance tooling, the deterministic loaders live in
+``trellis.agent.task_run_store``:
+
+- ``load_canary_batch_records()``
+- ``load_canary_task_history()``
+
+Use those loaders, not ad hoc scans over ``task_runs/history/``, when you want
+to compare canary latency, token, or attempt trends over time. The batch store
+excludes ordinary ad hoc task runs by construction and can filter replay-backed
+history out of the benchmark view. Root-level pytest runs are also marked as
+synthetic so they do not become accidental benchmark baselines.
+
+To compare against the ``2026-04-09`` full curated rerun baseline, treat that
+date's documented ``14/14`` pass as the historical anchor and compare fresh
+batch records that match the same live scope:
+
+- ``execution_mode=live``
+- ``batch_scope=full_curated``
+- ``validation=standard``
+- ``knowledge_profile=default``
+
+Fresh partial-task reruns are still useful for diagnosis, but they should not
+be described as replacements for the full curated baseline.
+
 Evals And Stress Tasks
 ----------------------
 

--- a/docs/developer/task_diagnostics.rst
+++ b/docs/developer/task_diagnostics.rst
@@ -105,6 +105,34 @@ rollups through ``trellis.agent.task_run_store``:
 - ``load_latest_skill_telemetry_rollup()``
 - ``load_latest_route_health_rollup()``
 
+Canary batch telemetry
+----------------------
+
+Canary runs now persist one explicit batch record under
+``task_runs/canary_batches/`` in addition to the per-task diagnosis artifacts.
+
+That batch layer exists because the raw task-run store mixes ordinary ad hoc
+task executions, replay-backed runs, and any historical one-off reruns. The
+canary batch record gives tooling a trustworthy benchmark surface instead of
+forcing it to infer canary lineage from task ids alone.
+
+Each batch record captures:
+
+- ``execution_mode`` so live and replay runs stay separate
+- ``benchmark_eligible`` so replay-backed history can be excluded cleanly
+- the batch scope (full curated set, subset, or single task)
+- aggregate pass, elapsed-time, token, and attempt metrics
+- per-canary links back to the underlying task-run and diagnosis artifacts
+
+The deterministic loaders are:
+
+- ``load_canary_batch_records()``
+- ``load_canary_task_history()``
+
+Use ``load_canary_task_history(..., benchmark_only=True)`` when you want a
+live-only history surface for one canary without mixing in replay runs or
+root-level pytest artifacts.
+
 Connector-stress batch surfacing
 --------------------------------
 

--- a/docs/plans/backlog-burn-down-execution.md
+++ b/docs/plans/backlog-burn-down-execution.md
@@ -14,7 +14,8 @@ Status mirror last synced: `2026-04-10`
 Current status:
 
 - `QUA-458` is complete.
-- The next actionable ticket in queue order is `QUA-710`.
+- `QUA-710` is complete.
+- The next actionable ticket in queue order is `QUA-428`.
 
 ## Operating Rules
 
@@ -136,20 +137,17 @@ If a ticket has become stale because other landed work already satisfies it:
 
 ## Current Start Point
 
-Execution started with `QUA-458` and now moves next to `QUA-710`.
+Execution started with `QUA-458`, continued through `QUA-710`, and now moves
+next to `QUA-428`.
 
 Plain-English goal:
 
-- replay full `run_task(...)` canary paths from recorded LLM cassettes so
-  diagnosis-heavy canaries can be inspected without live token spend
+- inventory the remaining stale-test surface and make the triage flow explicit
+  so the local gate work can rely on a current, reviewable test baseline
 
 Primary files and surfaces:
 
-- `trellis/agent/cassette.py`
-- `trellis/agent/config.py`
-- `trellis/agent/task_runtime.py`
-- `trellis/agent/task_run_store.py`
-- `scripts/run_canary.py`
-- `scripts/record_cassettes.py`
-- `docs/developer/`
-- targeted tests under `tests/test_agent/` and `tests/test_contracts/`
+- stale-test inventory docs and queue mirrors
+- the current local/CI test entrypoints
+- any helper tooling used to classify stale or compatibility-only tests
+- the gate-facing docs that `QUA-430` will consume next

--- a/docs/plans/canary-suite-stabilization.md
+++ b/docs/plans/canary-suite-stabilization.md
@@ -188,15 +188,19 @@ Status mirror last synced: `2026-04-10`
 | `QUA-708` | Transform/Heston cross-validation recovery for `T40` | Done |
 | `QUA-709` | Copula cross-validation recovery for `T49` | Done |
 | `QUA-458` | Full-task canary replay with diagnosis parity | Done |
-| `QUA-710` | Trustworthy canary telemetry and historical baselines | Backlog |
+| `QUA-710` | Trustworthy canary telemetry and historical baselines | Done |
 | `QUA-430` | Local gate and release-gate configuration | Backlog |
 
 Note:
 
-- `QUA-700` now remains open only for telemetry / gate closeout
-  (`QUA-710`, `QUA-430`). The direct canary recovery tranche and the
-  full-task replay tranche (`QUA-458`) are complete after the `2026-04-09`
-  full curated rerun plus the `2026-04-10` cassette-backed replay landing.
+- `QUA-700` now remains open only for gate closeout (`QUA-430`), with the
+  stale-test hygiene slice (`QUA-428`) still feeding that work from the
+  adjacent burn-down queue. The direct canary recovery tranche, the full-task
+  replay tranche (`QUA-458`), and the trustworthy telemetry tranche
+  (`QUA-710`) are complete after the `2026-04-09` full curated rerun, the
+  `2026-04-10` cassette-backed replay landing, and the `2026-04-10` live `T13`
+  telemetry rerun that now persists aggregate canary batch records under
+  `task_runs/canary_batches/`.
 - `T01` is now green through the short-rate comparison-regime workstream in
   `docs/plans/short-rate-comparison-regime-and-claim-helpers.md` under
   `QUA-746` through `QUA-751`. The recovery path materializes task-level

--- a/scripts/run_canary.py
+++ b/scripts/run_canary.py
@@ -272,8 +272,10 @@ def run_canaries(
             break
 
     # Summary
+    skip_count = sum(1 for item in results if item.get("skipped"))
+    completed_count = len(results) - skip_count
     print(f"\n{'=' * 65}")
-    print(f"  CANARY RESULTS: {pass_count}/{len(results)} passed")
+    print(f"  CANARY RESULTS: {pass_count}/{completed_count} passed, {skip_count} skipped")
     print(f"  Total tokens: {total_tokens}")
     print(f"  Total time: {total_time:.1f}s")
 

--- a/scripts/run_canary.py
+++ b/scripts/run_canary.py
@@ -20,7 +20,7 @@ import json
 import os
 import sys
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -125,11 +125,14 @@ def run_canaries(
     replay: bool = False,
     cassette_dir: str | Path | None = None,
     cassette_stale_policy: str = "error",
+    requested_task_id: str | None = None,
+    requested_subset: str | None = None,
 ) -> list[dict]:
     """Run canary tasks and return results.
 
     Returns list of result dicts with canary metadata attached.
     """
+    from trellis.agent.task_run_store import persist_canary_batch_record
     from trellis.agent.task_runtime import build_market_state, load_tasks, run_task
 
     budget = budget_override or meta.get("total_budget_usd", 3.0)
@@ -138,6 +141,7 @@ def run_canaries(
         if cassette_dir is not None
         else FULL_TASK_CASSETTES_DIR
     )
+    started_at = datetime.now(timezone.utc)
     # Canary coverage is curated independently of task lifecycle state, so the
     # runner must look across the full task registry rather than only "pending"
     # entries.
@@ -156,7 +160,7 @@ def run_canaries(
     print(f"  Budget: ${budget:.2f}")
     if replay:
         print(f"  Replay: cassette-backed ({cassette_root})")
-    print(f"  Started: {datetime.now().isoformat()}")
+    print(f"  Started: {started_at.isoformat()}")
     print(f"{'=' * 65}")
 
     for idx, canary in enumerate(canaries, 1):
@@ -272,7 +276,37 @@ def run_canaries(
     print(f"  CANARY RESULTS: {pass_count}/{len(results)} passed")
     print(f"  Total tokens: {total_tokens}")
     print(f"  Total time: {total_time:.1f}s")
+
+    finished_at = datetime.now(timezone.utc)
+    try:
+        persisted = persist_canary_batch_record(
+            canaries=canaries,
+            meta=meta,
+            results=results,
+            model=model,
+            validation=validation,
+            knowledge_light=knowledge_light,
+            replay=replay,
+            requested_task_id=requested_task_id,
+            requested_subset=requested_subset,
+            root=ROOT,
+            started_at=started_at,
+            finished_at=finished_at,
+        )
+        for result in results:
+            result["canary_batch_id"] = persisted["batch_id"]
+            result["canary_batch_history_path"] = persisted["history_path"]
+            result["canary_batch_latest_path"] = persisted["latest_path"]
+        print(f"  Canary telemetry: {persisted['history_path']}")
+    except Exception as exc:
+        error = str(exc)[:200]
+        for result in results:
+            result["canary_batch_persist_error"] = error
+        print(f"  Canary telemetry: FAILED ({error})")
+
     if output_file:
+        with open(output_file, "w") as f:
+            json.dump(results, f, indent=2, default=str)
         print(f"  Results saved: {output_file}")
     print(f"{'=' * 65}")
 
@@ -411,6 +445,8 @@ def main(argv: list[str] | None = None) -> int:
         replay=args.replay,
         cassette_dir=args.cassette_dir,
         cassette_stale_policy=args.cassette_stale_policy,
+        requested_task_id=args.task,
+        requested_subset=args.subset,
     )
 
     all_passed = all(r.get("success", False) for r in results if not r.get("skipped"))

--- a/tests/test_agent/test_canary_runner.py
+++ b/tests/test_agent/test_canary_runner.py
@@ -260,7 +260,7 @@ class TestRunCanaries:
         assert results[0]["canary_batch_id"].startswith("canary_")
         assert results[0]["canary_batch_history_path"].endswith(".json")
         assert results[0]["canary_batch_latest_path"].endswith(
-            "/task_runs/canary_batches/latest/live__full_curated__standard__default.json"
+            "/task_runs/canary_batches/latest/live__full_curated__standard__default__gpt-5.4-mini.json"
         )
 
     def test_run_canaries_prefers_curated_canary_description(self, monkeypatch):
@@ -361,8 +361,53 @@ class TestRunCanaries:
         )
         assert results[0]["canary_batch_id"].startswith("canary_")
         assert results[0]["canary_batch_latest_path"].endswith(
-            "/task_runs/canary_batches/latest/cassette_replay__full_curated__standard__default.json"
+            "/task_runs/canary_batches/latest/cassette_replay__full_curated__standard__default__gpt-5.4-mini.json"
         )
+
+    def test_run_canaries_summary_reports_completed_and_skipped_counts(self, monkeypatch, tmp_path, capsys):
+        def fake_build_market_state():
+            return object()
+
+        def fake_load_tasks(*, status="pending", path=None):
+            return [
+                {"id": "T13", "title": "European call: theta-method convergence order"},
+                {"id": "T38", "title": "CDS pricing canary"},
+            ]
+
+        def fake_run_task(task, market_state, **kwargs):
+            return {
+                "task_id": task["id"],
+                "success": True,
+                "token_usage_summary": {"total_tokens": 123},
+            }
+
+        (tmp_path / "T38.yaml").write_text("meta: {}\ncalls: []\n", encoding="utf-8")
+
+        monkeypatch.setattr(
+            "trellis.agent.task_runtime.build_market_state",
+            fake_build_market_state,
+        )
+        monkeypatch.setattr(
+            "trellis.agent.task_runtime.load_tasks",
+            fake_load_tasks,
+        )
+        monkeypatch.setattr(
+            "trellis.agent.task_runtime.run_task",
+            fake_run_task,
+        )
+
+        run_canaries(
+            [
+                {"id": "T13", "engine_family": "pde", "complexity": "simple"},
+                {"id": "T38", "engine_family": "credit", "complexity": "complex"},
+            ],
+            {"total_budget_usd": 1.0},
+            replay=True,
+            cassette_dir=tmp_path,
+        )
+
+        output = capsys.readouterr().out
+        assert "CANARY RESULTS: 1/1 passed, 1 skipped" in output
 
     def test_run_canaries_replay_mode_uses_full_task_cassette(self, monkeypatch, tmp_path):
         from trellis.agent.cassette import _prompt_hash

--- a/tests/test_agent/test_canary_runner.py
+++ b/tests/test_agent/test_canary_runner.py
@@ -251,16 +251,17 @@ class TestRunCanaries:
             {"total_budget_usd": 1.0},
         )
 
-        assert results == [
-            {
-                "task_id": "T02",
-                "success": True,
-                "token_usage_summary": {"total_tokens": 123},
-                "canary_id": "T02",
-                "engine_family": "lattice",
-                "complexity": "simple",
-            }
-        ]
+        assert results[0]["task_id"] == "T02"
+        assert results[0]["success"] is True
+        assert results[0]["token_usage_summary"] == {"total_tokens": 123}
+        assert results[0]["canary_id"] == "T02"
+        assert results[0]["engine_family"] == "lattice"
+        assert results[0]["complexity"] == "simple"
+        assert results[0]["canary_batch_id"].startswith("canary_")
+        assert results[0]["canary_batch_history_path"].endswith(".json")
+        assert results[0]["canary_batch_latest_path"].endswith(
+            "/task_runs/canary_batches/latest/live__full_curated__standard__default.json"
+        )
 
     def test_run_canaries_prefers_curated_canary_description(self, monkeypatch):
         captured: dict[str, object] = {}
@@ -348,20 +349,20 @@ class TestRunCanaries:
         )
 
         assert seen["run_task_calls"] == 0
-        assert results == [
-            {
-                "canary_id": "T13",
-                "engine_family": "pde",
-                "success": False,
-                "skipped": True,
-                "reason": "missing_cassette",
-                "error": (
-                    "Missing cassette for T13 at "
-                    f"{tmp_path / 'T13.yaml'}. "
-                    "Record it with scripts/record_cassettes.py --task T13"
-                ),
-            }
-        ]
+        assert results[0]["canary_id"] == "T13"
+        assert results[0]["engine_family"] == "pde"
+        assert results[0]["success"] is False
+        assert results[0]["skipped"] is True
+        assert results[0]["reason"] == "missing_cassette"
+        assert results[0]["error"] == (
+            "Missing cassette for T13 at "
+            f"{tmp_path / 'T13.yaml'}. "
+            "Record it with scripts/record_cassettes.py --task T13"
+        )
+        assert results[0]["canary_batch_id"].startswith("canary_")
+        assert results[0]["canary_batch_latest_path"].endswith(
+            "/task_runs/canary_batches/latest/cassette_replay__full_curated__standard__default.json"
+        )
 
     def test_run_canaries_replay_mode_uses_full_task_cassette(self, monkeypatch, tmp_path):
         from trellis.agent.cassette import _prompt_hash
@@ -433,6 +434,94 @@ class TestRunCanaries:
         assert results[0]["success"] is True
         assert results[0]["execution_mode"] == "cassette_replay"
         assert results[0]["token_usage_summary"]["total_tokens"] == 0
+
+    def test_run_canaries_persists_canary_batch_telemetry(self, monkeypatch, tmp_path):
+        seen: dict[str, object] = {}
+
+        def fake_build_market_state():
+            return object()
+
+        def fake_load_tasks(*, status="pending", path=None):
+            return [{"id": "T13", "title": "European call: theta-method convergence order"}]
+
+        def fake_run_task(task, market_state, **kwargs):
+            return {
+                "task_id": task["id"],
+                "success": True,
+                "elapsed_seconds": 4.2,
+                "attempts": 2,
+                "token_usage_summary": {"total_tokens": 321},
+                "task_run_history_path": "/tmp/task_runs/history/T13/live.json",
+            }
+
+        def fake_persist_canary_batch_record(
+            *,
+            canaries,
+            meta,
+            results,
+            model,
+            validation,
+            knowledge_light,
+            replay,
+            requested_task_id,
+            requested_subset,
+            root,
+            started_at,
+            finished_at,
+        ):
+            seen["canaries"] = canaries
+            seen["meta"] = meta
+            seen["results"] = results
+            seen["model"] = model
+            seen["validation"] = validation
+            seen["knowledge_light"] = knowledge_light
+            seen["replay"] = replay
+            seen["requested_task_id"] = requested_task_id
+            seen["requested_subset"] = requested_subset
+            seen["root"] = root
+            seen["started_at"] = started_at
+            seen["finished_at"] = finished_at
+            return {
+                "batch_id": "canary_20260410T120000Z",
+                "history_path": str(tmp_path / "task_runs" / "canary_batches" / "history" / "canary_20260410T120000Z.json"),
+                "latest_path": str(tmp_path / "task_runs" / "canary_batches" / "latest" / "live__full_curated__standard__default.json"),
+            }
+
+        monkeypatch.setattr(
+            "trellis.agent.task_runtime.build_market_state",
+            fake_build_market_state,
+        )
+        monkeypatch.setattr(
+            "trellis.agent.task_runtime.load_tasks",
+            fake_load_tasks,
+        )
+        monkeypatch.setattr(
+            "trellis.agent.task_runtime.run_task",
+            fake_run_task,
+        )
+        monkeypatch.setattr(
+            "trellis.agent.task_run_store.persist_canary_batch_record",
+            fake_persist_canary_batch_record,
+        )
+
+        results = run_canaries(
+            [{"id": "T13", "engine_family": "pde", "complexity": "simple"}],
+            {"total_budget_usd": 1.0, "version": 7},
+            model="gpt-5.4-mini",
+            validation="standard",
+        )
+
+        assert seen["replay"] is False
+        assert seen["requested_task_id"] is None
+        assert seen["requested_subset"] is None
+        assert seen["knowledge_light"] is False
+        assert seen["model"] == "gpt-5.4-mini"
+        assert seen["validation"] == "standard"
+        assert seen["results"][0]["task_id"] == "T13"
+        assert results[0]["canary_batch_id"] == "canary_20260410T120000Z"
+        assert results[0]["canary_batch_history_path"].endswith(
+            "/task_runs/canary_batches/history/canary_20260410T120000Z.json"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_agent/test_task_run_store.py
+++ b/tests/test_agent/test_task_run_store.py
@@ -755,12 +755,16 @@ def test_persist_canary_batch_record_writes_history_and_latest_views(tmp_path):
     assert record["summary"]["execution_mode"] == "live"
     assert record["summary"]["batch_scope"] == "full_curated"
     assert record["summary"]["benchmark_eligible"] is True
+    assert record["summary"]["comparison_key"] == "live:full_curated:standard:default:gpt-5.4-mini"
     assert record["summary"]["task_count"] == 2
     assert record["summary"]["pass_count"] == 1
     assert record["summary"]["failure_count"] == 1
     assert record["summary"]["total_tokens"] == 975
     assert record["summary"]["total_attempts"] == 5
     assert record["canaries"][0]["task_run_history_path"] == "/tmp/task_runs/history/T13/live.json"
+    assert persisted["latest_path"].endswith(
+        "/task_runs/canary_batches/latest/live__full_curated__standard__default__gpt-5.4-mini.json"
+    )
 
 
 def test_load_canary_task_history_excludes_replay_runs_from_benchmark_view(tmp_path):

--- a/tests/test_agent/test_task_run_store.py
+++ b/tests/test_agent/test_task_run_store.py
@@ -701,6 +701,132 @@ def test_persist_task_run_record_can_skip_diagnosis_artifacts(monkeypatch, tmp_p
     assert persisted["diagnosis_persist_error"] == ""
 
 
+def test_persist_canary_batch_record_writes_history_and_latest_views(tmp_path):
+    from trellis.agent.task_run_store import (
+        load_canary_batch_records,
+        persist_canary_batch_record,
+    )
+
+    persisted = persist_canary_batch_record(
+        canaries=[
+            {"id": "T13", "engine_family": "pde", "complexity": "simple"},
+            {"id": "T38", "engine_family": "credit", "complexity": "complex"},
+        ],
+        meta={"version": 3, "refresh_cadence": "weekly", "total_budget_usd": 3.12},
+        results=[
+            {
+                "task_id": "T13",
+                "canary_id": "T13",
+                "success": True,
+                "elapsed_seconds": 4.2,
+                "attempts": 2,
+                "token_usage_summary": {"total_tokens": 321},
+                "task_run_history_path": "/tmp/task_runs/history/T13/live.json",
+            },
+            {
+                "task_id": "T38",
+                "canary_id": "T38",
+                "success": False,
+                "elapsed_seconds": 7.8,
+                "attempts": 3,
+                "token_usage_summary": {"total_tokens": 654},
+                "task_run_history_path": "/tmp/task_runs/history/T38/live.json",
+                "error": "comparison failed",
+            },
+        ],
+        model="gpt-5.4-mini",
+        validation="standard",
+        knowledge_light=False,
+        replay=False,
+        requested_task_id=None,
+        requested_subset=None,
+        root=tmp_path,
+        started_at=datetime(2026, 4, 10, 12, 0, tzinfo=timezone.utc),
+        finished_at=datetime(2026, 4, 10, 12, 5, tzinfo=timezone.utc),
+    )
+
+    history_records = load_canary_batch_records(root=tmp_path)
+
+    assert Path(persisted["history_path"]).exists()
+    assert Path(persisted["latest_path"]).exists()
+    assert persisted["batch_id"] == "canary_20260410T120000000000Z"
+    assert len(history_records) == 1
+    record = history_records[0]
+    assert record["summary"]["execution_mode"] == "live"
+    assert record["summary"]["batch_scope"] == "full_curated"
+    assert record["summary"]["benchmark_eligible"] is True
+    assert record["summary"]["task_count"] == 2
+    assert record["summary"]["pass_count"] == 1
+    assert record["summary"]["failure_count"] == 1
+    assert record["summary"]["total_tokens"] == 975
+    assert record["summary"]["total_attempts"] == 5
+    assert record["canaries"][0]["task_run_history_path"] == "/tmp/task_runs/history/T13/live.json"
+
+
+def test_load_canary_task_history_excludes_replay_runs_from_benchmark_view(tmp_path):
+    from trellis.agent.task_run_store import (
+        load_canary_task_history,
+        persist_canary_batch_record,
+    )
+
+    persist_canary_batch_record(
+        canaries=[{"id": "T13", "engine_family": "pde", "complexity": "simple"}],
+        meta={"version": 3},
+        results=[
+            {
+                "task_id": "T13",
+                "canary_id": "T13",
+                "success": True,
+                "elapsed_seconds": 4.0,
+                "attempts": 2,
+                "token_usage_summary": {"total_tokens": 300},
+            }
+        ],
+        model="gpt-5.4-mini",
+        validation="standard",
+        knowledge_light=False,
+        replay=False,
+        requested_task_id=None,
+        requested_subset=None,
+        root=tmp_path,
+        started_at=datetime(2026, 4, 10, 12, 0, tzinfo=timezone.utc),
+        finished_at=datetime(2026, 4, 10, 12, 1, tzinfo=timezone.utc),
+    )
+    persist_canary_batch_record(
+        canaries=[{"id": "T13", "engine_family": "pde", "complexity": "simple"}],
+        meta={"version": 3},
+        results=[
+            {
+                "task_id": "T13",
+                "canary_id": "T13",
+                "success": True,
+                "elapsed_seconds": 0.1,
+                "attempts": 1,
+                "token_usage_summary": {"total_tokens": 0},
+                "execution_mode": "cassette_replay",
+            }
+        ],
+        model="gpt-5.4-mini",
+        validation="standard",
+        knowledge_light=False,
+        replay=True,
+        requested_task_id=None,
+        requested_subset=None,
+        root=tmp_path,
+        started_at=datetime(2026, 4, 10, 13, 0, tzinfo=timezone.utc),
+        finished_at=datetime(2026, 4, 10, 13, 1, tzinfo=timezone.utc),
+    )
+
+    all_history = load_canary_task_history("T13", root=tmp_path)
+    benchmark_history = load_canary_task_history("T13", root=tmp_path, benchmark_only=True)
+
+    assert len(all_history) == 2
+    assert {item["execution_mode"] for item in all_history} == {"live", "cassette_replay"}
+    assert len(benchmark_history) == 1
+    assert benchmark_history[0]["execution_mode"] == "live"
+    assert benchmark_history[0]["benchmark_eligible"] is True
+
+
 def test_collect_trace_summaries_reads_analytical_trace_json(tmp_path):
     import json
 

--- a/trellis/agent/task_run_store.py
+++ b/trellis/agent/task_run_store.py
@@ -173,7 +173,7 @@ def persist_canary_batch_record(
         requested_subset=requested_subset,
     )
     knowledge_profile = "knowledge_light" if knowledge_light else "default"
-    comparison_key = f"{execution_mode}:{scope_slug}:{validation}:{knowledge_profile}"
+    comparison_key = f"{execution_mode}:{scope_slug}:{validation}:{knowledge_profile}:{model}"
     synthetic_source = _synthetic_canary_source(root)
     benchmark_eligible = execution_mode == "live" and not synthetic_source
 
@@ -240,7 +240,7 @@ def persist_canary_batch_record(
     latest_root.mkdir(parents=True, exist_ok=True)
 
     history_path = history_root / f"{batch_id}.json"
-    latest_path = latest_root / f"{_scope_slug_to_latest_key(scope_slug, execution_mode, validation, knowledge_profile)}.json"
+    latest_path = latest_root / f"{_scope_slug_to_latest_key(scope_slug, execution_mode, validation, knowledge_profile, model)}.json"
     history_path.write_text(json.dumps(record, indent=2, default=str))
     latest_path.write_text(json.dumps(record, indent=2, default=str))
     return {
@@ -332,9 +332,10 @@ def _scope_slug_to_latest_key(
     execution_mode: str,
     validation: str,
     knowledge_profile: str,
+    model: str,
 ) -> str:
     """Return the stable latest filename stem for one canary batch scope."""
-    return f"{execution_mode}__{scope_slug}__{validation}__{knowledge_profile}"
+    return f"{execution_mode}__{scope_slug}__{validation}__{knowledge_profile}__{model}"
 
 
 def _build_canary_batch_entry(

--- a/trellis/agent/task_run_store.py
+++ b/trellis/agent/task_run_store.py
@@ -6,6 +6,7 @@ import json
 from datetime import datetime, timezone
 import os
 from pathlib import Path
+from statistics import median
 from typing import Any, Mapping
 
 import yaml
@@ -23,6 +24,9 @@ TASK_RUN_ROOT = ROOT / "task_runs"
 TASK_RUN_HISTORY_ROOT = TASK_RUN_ROOT / "history"
 TASK_RUN_LATEST_ROOT = TASK_RUN_ROOT / "latest"
 TASK_RUN_LATEST_INDEX = ROOT / "task_results_latest.json"
+CANARY_BATCH_ROOT = TASK_RUN_ROOT / "canary_batches"
+CANARY_BATCH_HISTORY_ROOT = CANARY_BATCH_ROOT / "history"
+CANARY_BATCH_LATEST_ROOT = CANARY_BATCH_ROOT / "latest"
 _SKIP_TASK_DIAGNOSIS_PERSIST_ENV = "TRELLIS_SKIP_TASK_DIAGNOSIS_PERSIST"
 
 
@@ -144,6 +148,288 @@ def load_latest_task_run_records(
             continue
         records.append(normalized)
     return sorted(records, key=lambda item: str(item.get("task_id") or ""))
+
+
+def persist_canary_batch_record(
+    *,
+    canaries: list[dict[str, Any]],
+    meta: Mapping[str, Any],
+    results: list[dict[str, Any]],
+    model: str,
+    validation: str,
+    knowledge_light: bool,
+    replay: bool,
+    requested_task_id: str | None,
+    requested_subset: str | None,
+    root: Path = ROOT,
+    started_at: datetime,
+    finished_at: datetime,
+) -> dict[str, str]:
+    """Persist one explicit canary-batch record and stable latest view."""
+    batch_id = f"canary_{started_at.astimezone(timezone.utc).strftime('%Y%m%dT%H%M%S%fZ')}"
+    execution_mode = "cassette_replay" if replay else "live"
+    batch_scope, scope_slug = _canary_batch_scope(
+        requested_task_id=requested_task_id,
+        requested_subset=requested_subset,
+    )
+    knowledge_profile = "knowledge_light" if knowledge_light else "default"
+    comparison_key = f"{execution_mode}:{scope_slug}:{validation}:{knowledge_profile}"
+    synthetic_source = _synthetic_canary_source(root)
+    benchmark_eligible = execution_mode == "live" and not synthetic_source
+
+    by_task_id = {
+        str((payload.get("canary_id") or payload.get("task_id") or "")).strip(): dict(payload)
+        for payload in results
+        if isinstance(payload, Mapping)
+    }
+    entries = [
+        _build_canary_batch_entry(
+            canary=dict(canary),
+            result=by_task_id.get(str(canary.get("id") or "").strip(), {}),
+            batch_id=batch_id,
+            execution_mode=execution_mode,
+            benchmark_eligible=benchmark_eligible,
+        )
+        for canary in canaries
+    ]
+    summary = _summarize_canary_batch(
+        entries,
+        execution_mode=execution_mode,
+        batch_scope=batch_scope,
+        scope_slug=scope_slug,
+        benchmark_eligible=benchmark_eligible,
+        synthetic_source=synthetic_source,
+        model=model,
+        validation=validation,
+        knowledge_profile=knowledge_profile,
+        comparison_key=comparison_key,
+        requested_task_id=requested_task_id,
+        requested_subset=requested_subset,
+        started_at=started_at,
+        finished_at=finished_at,
+    )
+    record = {
+        "batch_id": batch_id,
+        "started_at": started_at.astimezone(timezone.utc).isoformat(),
+        "finished_at": finished_at.astimezone(timezone.utc).isoformat(),
+        "selection": {
+            "requested_task_id": requested_task_id,
+            "requested_subset": requested_subset,
+        },
+        "config": {
+            "model": model,
+            "validation": validation,
+            "knowledge_profile": knowledge_profile,
+            "replay": replay,
+            "execution_mode": execution_mode,
+            "comparison_key": comparison_key,
+            "synthetic_source": synthetic_source or None,
+        },
+        "manifest": {
+            "version": meta.get("version"),
+            "refresh_cadence": meta.get("refresh_cadence"),
+            "total_budget_usd": meta.get("total_budget_usd"),
+        },
+        "summary": summary,
+        "canaries": entries,
+    }
+
+    history_root = root / CANARY_BATCH_HISTORY_ROOT.relative_to(ROOT)
+    latest_root = root / CANARY_BATCH_LATEST_ROOT.relative_to(ROOT)
+    history_root.mkdir(parents=True, exist_ok=True)
+    latest_root.mkdir(parents=True, exist_ok=True)
+
+    history_path = history_root / f"{batch_id}.json"
+    latest_path = latest_root / f"{_scope_slug_to_latest_key(scope_slug, execution_mode, validation, knowledge_profile)}.json"
+    history_path.write_text(json.dumps(record, indent=2, default=str))
+    latest_path.write_text(json.dumps(record, indent=2, default=str))
+    return {
+        "batch_id": batch_id,
+        "history_path": str(history_path),
+        "latest_path": str(latest_path),
+    }
+
+
+def load_canary_batch_records(
+    *,
+    root: Path = ROOT,
+    execution_mode: str | None = None,
+    benchmark_only: bool = False,
+) -> list[dict[str, Any]]:
+    """Load persisted canary batch records from history."""
+    history_root = root / CANARY_BATCH_HISTORY_ROOT.relative_to(ROOT)
+    if not history_root.exists():
+        return []
+
+    records: list[dict[str, Any]] = []
+    for path in sorted(history_root.glob("*.json")):
+        payload = json.loads(path.read_text())
+        summary = dict(payload.get("summary") or {})
+        if execution_mode is not None and str(summary.get("execution_mode") or "") != execution_mode:
+            continue
+        if benchmark_only and not bool(summary.get("benchmark_eligible")):
+            continue
+        records.append(payload)
+    return sorted(records, key=lambda item: str(item.get("started_at") or ""))
+
+
+def load_canary_task_history(
+    task_id: str,
+    *,
+    root: Path = ROOT,
+    execution_mode: str | None = None,
+    benchmark_only: bool = False,
+) -> list[dict[str, Any]]:
+    """Flatten persisted canary batch history for one task ID."""
+    history: list[dict[str, Any]] = []
+    for batch in load_canary_batch_records(
+        root=root,
+        execution_mode=execution_mode,
+        benchmark_only=benchmark_only,
+    ):
+        summary = dict(batch.get("summary") or {})
+        for item in batch.get("canaries") or []:
+            if str(item.get("task_id") or "") != str(task_id):
+                continue
+            history.append(
+                {
+                    **dict(item),
+                    "batch_id": batch.get("batch_id"),
+                    "started_at": batch.get("started_at"),
+                    "finished_at": batch.get("finished_at"),
+                    "batch_scope": summary.get("batch_scope"),
+                    "comparison_key": summary.get("comparison_key"),
+                    "benchmark_eligible": bool(summary.get("benchmark_eligible")),
+                }
+            )
+    return sorted(history, key=lambda item: str(item.get("started_at") or ""))
+
+
+def _canary_batch_scope(
+    *,
+    requested_task_id: str | None,
+    requested_subset: str | None,
+) -> tuple[str, str]:
+    """Return the human-readable scope plus a filename-safe slug."""
+    if requested_task_id:
+        task_id = str(requested_task_id).strip()
+        return "single_task", f"single_task_{task_id}"
+    if requested_subset:
+        subset = str(requested_subset).strip()
+        return f"subset:{subset}", f"subset_{subset}"
+    return "full_curated", "full_curated"
+
+
+def _synthetic_canary_source(root: Path) -> str:
+    """Return a synthetic-source marker when a canary batch comes from pytest."""
+    if os.environ.get("PYTEST_CURRENT_TEST") and root.resolve() == ROOT.resolve():
+        return "pytest"
+    return ""
+
+
+def _scope_slug_to_latest_key(
+    scope_slug: str,
+    execution_mode: str,
+    validation: str,
+    knowledge_profile: str,
+) -> str:
+    """Return the stable latest filename stem for one canary batch scope."""
+    return f"{execution_mode}__{scope_slug}__{validation}__{knowledge_profile}"
+
+
+def _build_canary_batch_entry(
+    *,
+    canary: Mapping[str, Any],
+    result: Mapping[str, Any],
+    batch_id: str,
+    execution_mode: str,
+    benchmark_eligible: bool,
+) -> dict[str, Any]:
+    """Project one canary task result into the persisted batch history shape."""
+    token_usage = dict(result.get("token_usage_summary") or {})
+    return {
+        "batch_id": batch_id,
+        "task_id": str(canary.get("id") or result.get("task_id") or "").strip(),
+        "engine_family": str(canary.get("engine_family") or result.get("engine_family") or "").strip(),
+        "complexity": str(canary.get("complexity") or result.get("complexity") or "").strip(),
+        "success": bool(result.get("success")),
+        "skipped": bool(result.get("skipped")),
+        "reason": str(result.get("reason") or "").strip(),
+        "error": str(result.get("error") or "").strip(),
+        "execution_mode": str(result.get("execution_mode") or execution_mode),
+        "benchmark_eligible": benchmark_eligible and str(result.get("execution_mode") or execution_mode) == "live",
+        "elapsed_seconds": round(float(result.get("elapsed_seconds") or 0.0), 4),
+        "attempts": int(result.get("attempts") or 0),
+        "token_usage": token_usage,
+        "total_tokens": int(token_usage.get("total_tokens") or 0),
+        "task_run_history_path": str(result.get("task_run_history_path") or "").strip(),
+        "task_run_latest_path": str(result.get("task_run_latest_path") or "").strip(),
+        "task_diagnosis_packet_path": str(result.get("task_diagnosis_packet_path") or "").strip(),
+        "task_diagnosis_dossier_path": str(result.get("task_diagnosis_dossier_path") or "").strip(),
+    }
+
+
+def _summarize_canary_batch(
+    entries: list[Mapping[str, Any]],
+    *,
+    execution_mode: str,
+    batch_scope: str,
+    scope_slug: str,
+    benchmark_eligible: bool,
+    synthetic_source: str,
+    model: str,
+    validation: str,
+    knowledge_profile: str,
+    comparison_key: str,
+    requested_task_id: str | None,
+    requested_subset: str | None,
+    started_at: datetime,
+    finished_at: datetime,
+) -> dict[str, Any]:
+    """Summarize one canary batch into stable aggregate metrics."""
+    completed = [item for item in entries if not bool(item.get("skipped"))]
+    elapsed_values = [float(item.get("elapsed_seconds") or 0.0) for item in completed]
+    token_values = [int(item.get("total_tokens") or 0) for item in completed]
+    attempt_values = [int(item.get("attempts") or 0) for item in completed]
+    pass_count = sum(1 for item in completed if bool(item.get("success")))
+    failure_count = sum(1 for item in completed if not bool(item.get("success")))
+    skip_count = sum(1 for item in entries if bool(item.get("skipped")))
+    completed_count = len(completed)
+    return {
+        "execution_mode": execution_mode,
+        "batch_scope": batch_scope,
+        "scope_slug": scope_slug,
+        "benchmark_eligible": benchmark_eligible,
+        "benchmark_exclusion_reason": (
+            ""
+            if benchmark_eligible
+            else (f"synthetic:{synthetic_source}" if synthetic_source else "replay")
+        ),
+        "comparison_key": comparison_key,
+        "model": model,
+        "validation": validation,
+        "knowledge_profile": knowledge_profile,
+        "synthetic_source": synthetic_source or None,
+        "requested_task_id": requested_task_id,
+        "requested_subset": requested_subset,
+        "task_count": len(entries),
+        "completed_count": completed_count,
+        "pass_count": pass_count,
+        "failure_count": failure_count,
+        "skip_count": skip_count,
+        "pass_rate": _fraction(pass_count, completed_count),
+        "total_elapsed_seconds": round(sum(elapsed_values), 4),
+        "avg_elapsed_seconds": _fraction(sum(elapsed_values), completed_count),
+        "median_elapsed_seconds": round(median(elapsed_values), 4) if elapsed_values else 0.0,
+        "total_tokens": sum(token_values),
+        "avg_tokens": _fraction(sum(token_values), completed_count),
+        "median_tokens": round(median(token_values), 4) if token_values else 0.0,
+        "total_attempts": sum(attempt_values),
+        "avg_attempts": _fraction(sum(attempt_values), completed_count),
+        "max_attempts": max(attempt_values) if attempt_values else 0,
+        "started_at": started_at.astimezone(timezone.utc).isoformat(),
+        "finished_at": finished_at.astimezone(timezone.utc).isoformat(),
+    }
 
 
 def build_task_run_record(


### PR DESCRIPTION
## Summary
- persist dedicated canary batch history and latest-scope views on top of the existing task-run store
- have `scripts/run_canary.py` write explicit batch lineage, aggregate elapsed/token/attempt metrics, and attach the saved batch paths back onto task results
- document how to query live-only canary history and compare future runs against the April 9, 2026 curated baseline

## Validation
- `PYTHONHASHSEED=0 /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_canary_runner.py tests/test_agent/test_task_run_store.py tests/test_contracts/test_canary_replay_contracts.py tests/test_contracts/test_cassette_freshness.py -q`
- `PYTHONHASHSEED=0 /Users/steveyang/miniforge3/bin/python3 scripts/run_canary.py --task T13 --output /tmp/qua710_t13_live.json`

## Notes
- root-level pytest canary batches are marked synthetic so they do not become benchmark-eligible baselines
- the trustworthy batch store starts with post-QUA-710 runs; the April 9, 2026 full curated rerun remains the documented historical anchor until a fresh full-curated live rerun lands in the new store
- unrelated local plan edits, `_agent` edits, and generated run artifacts were left out of this PR
