### PR TITLE
QUA-428: stale test triage process and tooling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,7 @@ the miniforge interpreter.
 - Cross-validation: `tests/test_crossval/test_xv_{topic}.py`
 - Verification: `tests/test_verification/test_{topic}.py`
 - Use `pytest.importorskip("QuantLib")` for optional external library tests
+- Run `/Users/steveyang/miniforge3/bin/python3 scripts/test_hygiene.py` when touching skip/xfail/quarantine markers
 - Update `LIMITATIONS.md` when resolving or discovering limitations
 
 ## Module Ownership

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -21,6 +21,7 @@ Core Developer Topics
    audit_and_observability
    task_and_eval_loops
    task_diagnostics
+   test_hygiene
    learning_mechanism
    legacy_test_audit
    knowledge_skill_layer

--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -29,6 +29,19 @@ strata:
 - ``global_workflow`` for user-facing workflow tests that span modules
 - ``legacy_compat`` for deprecated or compatibility-only behavior
 
+The stale-test hygiene layer now sits alongside those strata rather than
+replacing them. Use ``scripts/test_hygiene.py`` to inventory `skip`, `xfail`,
+`importorskip`, and ``legacy_compat`` usage with approximate git-age buckets:
+
+- ``quarantine`` for fresh markers
+- ``stale`` for markers that have lingered for at least 30 days
+- ``ancient`` for markers that are 90 days or older
+
+Pytest collection also now rejects ancient ``xfail`` markers that do not carry
+a linked ticket id such as ``QUA-123`` or ``CR-10``. That guard is
+intentionally narrow: it keeps unticketed xfails visible without turning every
+skip into a hard failure.
+
 Operational Scripts
 -------------------
 
@@ -39,6 +52,7 @@ The repo ships a small task-operations toolchain:
 - ``scripts/benchmark_tasks.py``: benchmark cached generated payoffs without rebuilding
 - ``scripts/remediate.py``: analyze failures, categorize knowledge gaps, and patch common knowledge issues
 - ``scripts/evaluate_shared_memory.py``: compare two task-result tranches and render a shared-memory improvement report
+- ``scripts/test_hygiene.py``: report stale skip/xfail/quarantine markers for local test-hygiene triage
 
 For curated canaries specifically, ``scripts/run_canary.py`` now executes the
 live task entry plus any richer canary-only fields from ``CANARY_TASKS.yaml``.

--- a/docs/developer/test_hygiene.md
+++ b/docs/developer/test_hygiene.md
@@ -1,0 +1,81 @@
+# Test Hygiene
+
+`QUA-428` adds a durable stale-test workflow so Trellis does not quietly
+accumulate old `skip`, `xfail`, or quarantine markers as the runtime and gate
+surfaces change.
+
+## Local Command
+
+Run the hygiene scan with the repo-standard interpreter:
+
+```bash
+/Users/steveyang/miniforge3/bin/python3 scripts/test_hygiene.py
+```
+
+To make ancient unticketed `xfail` markers fail locally:
+
+```bash
+/Users/steveyang/miniforge3/bin/python3 scripts/test_hygiene.py --fail-on-ancient-unticketed-xfail
+```
+
+The report scans `tests/` for:
+
+- `@pytest.mark.skip(...)`
+- `@pytest.mark.skipif(...)`
+- `@pytest.mark.xfail(...)`
+- `pytest.skip(...)`
+- `pytest.xfail(...)`
+- `pytest.importorskip(...)`
+- `legacy_compat` marker usage
+
+Marker age is approximate. The tool uses `git log` last-touch time for the
+owning file and falls back to filesystem mtime when needed.
+
+## Buckets
+
+- `quarantine`: younger than 30 days
+- `stale`: 30 to 89 days
+- `ancient`: 90 days or older
+
+These buckets are triage hints, not automatic rewrite instructions.
+
+## Decision Tree
+
+1. Does the test still defend a live contract?
+2. If yes, update it to the current surface and remove the skip/xfail.
+3. If no, delete it instead of leaving dead coverage behind.
+4. If the marker is shielding a real bug, include the ticket id in the reason.
+5. If the work is host-dependent, token-consuming, or otherwise non-default,
+   move it to the correct tier instead of burying it in the baseline unit run.
+
+Examples:
+
+- good: `@pytest.mark.xfail(reason="QUA-428 stale selector still under review")`
+- bad: `@pytest.mark.xfail(reason="temporary")`
+
+## Local Enforcement
+
+Pytest collection now blocks `xfail` markers that are both:
+
+- ancient
+- missing a linked ticket id such as `QUA-123` or `CR-10`
+
+The enforcement hook is intentionally narrow. It does not fail on every skip,
+and it does not rewrite tests for you. It exists to stop long-lived unticketed
+xfails from becoming invisible.
+
+For rare local debugging sessions, you can bypass the collection guard with:
+
+```bash
+TRELLIS_ALLOW_STALE_XFAIL=1 /Users/steveyang/miniforge3/bin/python3 -m pytest tests -x -q -m "not integration"
+```
+
+## Cadence
+
+- run `scripts/test_hygiene.py` when touching test markers
+- run it before tightening local or CI gates
+- review the report periodically during backlog cleanup and before release work
+
+This tool is advisory for broad stale-test inventory and triage. The normal
+non-integration pytest command remains the primary day-to-day correctness gate.
+

--- a/docs/plans/backlog-burn-down-execution.md
+++ b/docs/plans/backlog-burn-down-execution.md
@@ -15,7 +15,8 @@ Current status:
 
 - `QUA-458` is complete.
 - `QUA-710` is complete.
-- The next actionable ticket in queue order is `QUA-428`.
+- `QUA-428` is complete.
+- The next actionable ticket in queue order is `QUA-430`.
 
 ## Operating Rules
 
@@ -137,17 +138,17 @@ If a ticket has become stale because other landed work already satisfies it:
 
 ## Current Start Point
 
-Execution started with `QUA-458`, continued through `QUA-710`, and now moves
-next to `QUA-428`.
+Execution started with `QUA-458`, continued through `QUA-710` and `QUA-428`,
+and now moves next to `QUA-430`.
 
 Plain-English goal:
 
-- inventory the remaining stale-test surface and make the triage flow explicit
-  so the local gate work can rely on a current, reviewable test baseline
+- codify the local PR/canary/release gate entrypoints on top of the now-live
+  replay, telemetry, and stale-test hygiene surfaces
 
 Primary files and surfaces:
 
-- stale-test inventory docs and queue mirrors
 - the current local/CI test entrypoints
-- any helper tooling used to classify stale or compatibility-only tests
-- the gate-facing docs that `QUA-430` will consume next
+- canary trigger logic and any path-based helper needed to keep canary runs targeted
+- the gate-facing docs and wrapper commands that turn the current pyramid into explicit operator workflows
+- the closeout path that leaves `QUA-700` with only final umbrella maintenance work

--- a/docs/plans/canary-suite-stabilization.md
+++ b/docs/plans/canary-suite-stabilization.md
@@ -189,18 +189,19 @@ Status mirror last synced: `2026-04-10`
 | `QUA-709` | Copula cross-validation recovery for `T49` | Done |
 | `QUA-458` | Full-task canary replay with diagnosis parity | Done |
 | `QUA-710` | Trustworthy canary telemetry and historical baselines | Done |
+| `QUA-428` | Stale-test triage process and tooling | Done |
 | `QUA-430` | Local gate and release-gate configuration | Backlog |
 
 Note:
 
-- `QUA-700` now remains open only for gate closeout (`QUA-430`), with the
-  stale-test hygiene slice (`QUA-428`) still feeding that work from the
-  adjacent burn-down queue. The direct canary recovery tranche, the full-task
-  replay tranche (`QUA-458`), and the trustworthy telemetry tranche
-  (`QUA-710`) are complete after the `2026-04-09` full curated rerun, the
-  `2026-04-10` cassette-backed replay landing, and the `2026-04-10` live `T13`
+- `QUA-700` now remains open only for gate closeout (`QUA-430`). The direct
+  canary recovery tranche, the full-task replay tranche (`QUA-458`), the
+  trustworthy telemetry tranche (`QUA-710`), and the stale-test hygiene slice
+  (`QUA-428`) are complete after the `2026-04-09` full curated rerun, the
+  `2026-04-10` cassette-backed replay landing, the `2026-04-10` live `T13`
   telemetry rerun that now persists aggregate canary batch records under
-  `task_runs/canary_batches/`.
+  `task_runs/canary_batches/`, and the `2026-04-10` local hygiene tool /
+  collection guard landing.
 - `T01` is now green through the short-rate comparison-regime workstream in
   `docs/plans/short-rate-comparison-regime-and-claim-helpers.md` under
   `QUA-746` through `QUA-751`. The recovery path materializes task-level

--- a/scripts/test_hygiene.py
+++ b/scripts/test_hygiene.py
@@ -1,0 +1,12 @@
+"""Report stale skip/xfail/quarantine markers in the test suite."""
+
+from __future__ import annotations
+
+import sys
+
+from trellis.testing.hygiene import main
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,8 @@ from pathlib import Path
 
 import pytest
 
+from trellis.testing.hygiene import scan_repo, stale_unticketed_xfails
+
 # ---------------------------------------------------------------------------
 # Cassette directories
 # ---------------------------------------------------------------------------
@@ -22,6 +24,8 @@ _GLOBAL_WORKFLOW_TEST_PATHS = {
     "tests/test_pipeline.py",
     "tests/test_contracts/test_pipeline_contracts.py",
 }
+_ALLOW_STALE_XFAIL_ENV = "TRELLIS_ALLOW_STALE_XFAIL"
+_STALE_XFAIL_ANCIENT_DAYS_ENV = "TRELLIS_STALE_XFAIL_ANCIENT_DAYS"
 
 
 # ---------------------------------------------------------------------------
@@ -52,6 +56,26 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
             item.add_marker(pytest.mark.verification)
         if rel_path in _GLOBAL_WORKFLOW_TEST_PATHS:
             item.add_marker(pytest.mark.global_workflow)
+
+    if os.environ.get(_ALLOW_STALE_XFAIL_ENV, "").strip().lower() in {"1", "true", "yes", "on"}:
+        return
+
+    ancient_days = int(os.environ.get(_STALE_XFAIL_ANCIENT_DAYS_ENV, "90") or "90")
+    violations = stale_unticketed_xfails(
+        scan_repo(REPO_ROOT, ancient_days=ancient_days),
+    )
+    if violations:
+        lines = [
+            "Ancient xfails without linked ticket ids are not allowed.",
+            "Add a ticket like QUA-123 to the xfail reason, refresh/remove the xfail,",
+            f"or override temporarily with {_ALLOW_STALE_XFAIL_ENV}=1.",
+            "",
+        ]
+        for finding in violations:
+            rel_path = Path(finding.path).resolve().relative_to(REPO_ROOT).as_posix()
+            reason = finding.reason or "no reason"
+            lines.append(f"- {rel_path}:{finding.line} ({finding.age_days}d) {reason}")
+        raise pytest.UsageError("\n".join(lines))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli/test_test_hygiene.py
+++ b/tests/test_cli/test_test_hygiene.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def test_scan_repo_reports_skip_xfail_and_quarantine_markers(tmp_path):
+    from trellis.testing.hygiene import scan_repo
+
+    test_root = tmp_path / "tests" / "test_sample.py"
+    test_root.parent.mkdir(parents=True, exist_ok=True)
+    test_root.write_text(
+        """
+import pytest
+
+@pytest.mark.skip(reason="waiting on fixture")
+def test_skip_decorator():
+    assert True
+
+@pytest.mark.xfail(reason="QUA-999 regression still open")
+def test_ticketed_xfail():
+    assert False
+
+@pytest.mark.legacy_compat
+def test_legacy():
+    assert True
+
+def test_runtime_skip():
+    pytest.skip("host-specific precondition")
+
+def test_importorskip():
+    pytest.importorskip("QuantLib")
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    findings = scan_repo(
+        tmp_path,
+        age_days_fn=lambda path: 12,
+    )
+
+    assert [(finding.kind, finding.bucket) for finding in findings] == [
+        ("skip", "quarantine"),
+        ("xfail", "quarantine"),
+        ("legacy_compat", "quarantine"),
+        ("skip", "quarantine"),
+        ("importorskip", "quarantine"),
+    ]
+    assert findings[1].ticket == "QUA-999"
+    assert findings[3].reason == "host-specific precondition"
+    assert findings[4].reason == "QuantLib"
+
+
+def test_stale_unticketed_xfails_only_flags_ancient_entries(tmp_path):
+    from trellis.testing.hygiene import scan_repo, stale_unticketed_xfails
+
+    test_root = tmp_path / "tests" / "test_xfail.py"
+    test_root.parent.mkdir(parents=True, exist_ok=True)
+    test_root.write_text(
+        """
+import pytest
+
+@pytest.mark.xfail(reason="missing ticket")
+def test_old_xfail():
+    assert False
+
+@pytest.mark.xfail(reason="QUA-321 tracked follow-on")
+def test_ticketed_xfail():
+    assert False
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    findings = scan_repo(
+        tmp_path,
+        age_days_fn=lambda path: 120,
+    )
+    violations = stale_unticketed_xfails(findings)
+
+    assert len(violations) == 1
+    assert violations[0].kind == "xfail"
+    assert violations[0].bucket == "ancient"
+    assert violations[0].ticket == ""
+
+
+def test_hygiene_main_formats_report_and_fails_on_ancient_unticketed_xfail(tmp_path, capsys):
+    from trellis.testing import hygiene
+
+    test_root = tmp_path / "tests" / "test_xfail.py"
+    test_root.parent.mkdir(parents=True, exist_ok=True)
+    test_root.write_text(
+        """
+import pytest
+
+@pytest.mark.xfail(reason="old xfail without ticket")
+def test_old_xfail():
+    assert False
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    original_scan_repo = hygiene.scan_repo
+
+    def fake_scan_repo(root, **kwargs):
+        return original_scan_repo(root, age_days_fn=lambda path: 150, **kwargs)
+
+    hygiene.scan_repo = fake_scan_repo
+    try:
+        exit_code = hygiene.main(
+            [
+                "--root",
+                str(tmp_path),
+                "--fail-on-ancient-unticketed-xfail",
+            ]
+        )
+    finally:
+        hygiene.scan_repo = original_scan_repo
+
+    output = capsys.readouterr().out
+    assert exit_code == 1
+    assert "Stale test hygiene report" in output
+    assert "Ancient xfails without linked ticket ids:" in output
+    assert "tests/test_xfail.py:3" in output
+
+
+def test_collection_guard_rejects_ancient_unticketed_xfails(monkeypatch):
+    import tests.conftest as root_conftest
+    from trellis.testing.hygiene import HygieneFinding
+
+    finding = HygieneFinding(
+        path=str(root_conftest.REPO_ROOT / "tests" / "test_sample.py"),
+        line=17,
+        kind="xfail",
+        source="decorator",
+        reason="temporary workaround",
+        ticket="",
+        age_days=150,
+        bucket="ancient",
+        requires_ticket=True,
+    )
+    monkeypatch.setattr(root_conftest, "scan_repo", lambda *args, **kwargs: [finding])
+
+    with pytest.raises(pytest.UsageError, match="Ancient xfails without linked ticket ids are not allowed"):
+        root_conftest.pytest_collection_modifyitems(None, [])
+
+
+def test_collection_guard_allows_override_for_local_debugging(monkeypatch):
+    import tests.conftest as root_conftest
+    from trellis.testing.hygiene import HygieneFinding
+
+    finding = HygieneFinding(
+        path=str(root_conftest.REPO_ROOT / "tests" / "test_sample.py"),
+        line=17,
+        kind="xfail",
+        source="decorator",
+        reason="temporary workaround",
+        ticket="",
+        age_days=150,
+        bucket="ancient",
+        requires_ticket=True,
+    )
+    monkeypatch.setattr(root_conftest, "scan_repo", lambda *args, **kwargs: [finding])
+    monkeypatch.setenv("TRELLIS_ALLOW_STALE_XFAIL", "1")
+
+    root_conftest.pytest_collection_modifyitems(None, [])

--- a/trellis/testing/__init__.py
+++ b/trellis/testing/__init__.py
@@ -1,0 +1,2 @@
+"""Testing-support utilities shared by local tooling and pytest hooks."""
+

--- a/trellis/testing/hygiene.py
+++ b/trellis/testing/hygiene.py
@@ -1,0 +1,385 @@
+"""Stale-test hygiene helpers shared by CLI tooling and pytest enforcement."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+import re
+import subprocess
+from typing import Callable
+
+
+_TICKET_RE = re.compile(r"\b(?:QUA|CR)-\d+\b")
+_DEFAULT_QUARANTINE_DAYS = 30
+_DEFAULT_ANCIENT_DAYS = 90
+
+
+@dataclass(frozen=True)
+class HygieneFinding:
+    """One skip/xfail/quarantine occurrence discovered in a test file."""
+
+    path: str
+    line: int
+    kind: str
+    source: str
+    reason: str
+    ticket: str
+    age_days: int
+    bucket: str
+    requires_ticket: bool
+
+
+def git_last_touch_age_days(path: Path, *, repo_root: Path, now: datetime | None = None) -> int:
+    """Approximate finding age from git last-touch time for the owning file."""
+    now = now or datetime.now(timezone.utc)
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repo_root),
+                "log",
+                "-1",
+                "--format=%ct",
+                "--",
+                str(path.relative_to(repo_root)),
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        raw = result.stdout.strip()
+        if raw:
+            touched_at = datetime.fromtimestamp(int(raw), tz=timezone.utc)
+            return max((now - touched_at).days, 0)
+    except Exception:
+        pass
+
+    touched_at = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+    return max((now - touched_at).days, 0)
+
+
+def bucket_age(age_days: int, *, quarantine_days: int, ancient_days: int) -> str:
+    """Classify a marker by approximate age bucket."""
+    if age_days >= ancient_days:
+        return "ancient"
+    if age_days >= quarantine_days:
+        return "stale"
+    return "quarantine"
+
+
+def scan_repo(
+    root: Path,
+    *,
+    age_days_fn: Callable[[Path], int] | None = None,
+    quarantine_days: int = _DEFAULT_QUARANTINE_DAYS,
+    ancient_days: int = _DEFAULT_ANCIENT_DAYS,
+) -> list[HygieneFinding]:
+    """Scan ``tests/`` under one repo root for skip/xfail/quarantine markers."""
+    test_root = root / "tests"
+    if not test_root.exists():
+        return []
+
+    age_days_fn = age_days_fn or (lambda path: git_last_touch_age_days(path, repo_root=root))
+    findings: list[HygieneFinding] = []
+    for path in sorted(test_root.rglob("*.py")):
+        findings.extend(
+            scan_test_file(
+                path,
+                age_days=age_days_fn(path),
+                quarantine_days=quarantine_days,
+                ancient_days=ancient_days,
+            )
+        )
+    return findings
+
+
+def scan_test_file(
+    path: Path,
+    *,
+    age_days: int,
+    quarantine_days: int = _DEFAULT_QUARANTINE_DAYS,
+    ancient_days: int = _DEFAULT_ANCIENT_DAYS,
+) -> list[HygieneFinding]:
+    """Scan one test file for skip/xfail/quarantine markers."""
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(path))
+    bucket = bucket_age(
+        age_days,
+        quarantine_days=quarantine_days,
+        ancient_days=ancient_days,
+    )
+
+    findings: list[HygieneFinding] = []
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            for decorator in node.decorator_list:
+                finding = _finding_from_marker_expr(
+                    decorator,
+                    path=path,
+                    age_days=age_days,
+                    bucket=bucket,
+                    source_kind="decorator",
+                )
+                if finding is not None:
+                    findings.append(finding)
+        if isinstance(node, ast.Assign):
+            for finding in _findings_from_pytestmark_assign(
+                node,
+                path=path,
+                age_days=age_days,
+                bucket=bucket,
+            ):
+                findings.append(finding)
+        if isinstance(node, ast.Call):
+            finding = _finding_from_runtime_call(
+                node,
+                path=path,
+                age_days=age_days,
+                bucket=bucket,
+            )
+            if finding is not None:
+                findings.append(finding)
+    return sorted(findings, key=lambda item: (item.path, item.line, item.kind))
+
+
+def stale_unticketed_xfails(
+    findings: list[HygieneFinding],
+    *,
+    ancient_only: bool = True,
+) -> list[HygieneFinding]:
+    """Return xfail findings that are old enough to trip local enforcement."""
+    out: list[HygieneFinding] = []
+    for finding in findings:
+        if finding.kind != "xfail" or finding.ticket:
+            continue
+        if ancient_only and finding.bucket != "ancient":
+            continue
+        out.append(finding)
+    return out
+
+
+def format_report(
+    findings: list[HygieneFinding],
+    *,
+    root: Path,
+) -> str:
+    """Render a compact human-readable stale-test hygiene report."""
+    if not findings:
+        return "No skip/xfail/quarantine findings."
+
+    bucket_counts = {"quarantine": 0, "stale": 0, "ancient": 0}
+    kind_counts: dict[str, int] = {}
+    for finding in findings:
+        bucket_counts[finding.bucket] = bucket_counts.get(finding.bucket, 0) + 1
+        kind_counts[finding.kind] = kind_counts.get(finding.kind, 0) + 1
+
+    lines = [
+        "Stale test hygiene report",
+        f"Findings: {len(findings)}",
+        "Buckets: "
+        f"quarantine={bucket_counts.get('quarantine', 0)}, "
+        f"stale={bucket_counts.get('stale', 0)}, "
+        f"ancient={bucket_counts.get('ancient', 0)}",
+        "Kinds: "
+        + ", ".join(f"{kind}={count}" for kind, count in sorted(kind_counts.items())),
+        "",
+    ]
+    for finding in findings:
+        rel_path = Path(finding.path).relative_to(root).as_posix()
+        suffix = f" ticket={finding.ticket}" if finding.ticket else ""
+        reason = f" reason={finding.reason}" if finding.reason else ""
+        lines.append(
+            f"[{finding.bucket}] {finding.kind:13s} {rel_path}:{finding.line} "
+            f"age={finding.age_days}d{suffix}{reason}"
+        )
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Return the CLI parser for the stale-test hygiene tool."""
+    parser = argparse.ArgumentParser(description="Report stale skip/xfail/quarantine test markers.")
+    parser.add_argument("--root", default=str(Path(__file__).resolve().parents[2]))
+    parser.add_argument("--quarantine-days", type=int, default=_DEFAULT_QUARANTINE_DAYS)
+    parser.add_argument("--ancient-days", type=int, default=_DEFAULT_ANCIENT_DAYS)
+    parser.add_argument(
+        "--fail-on-ancient-unticketed-xfail",
+        action="store_true",
+        help="Exit non-zero when ancient xfails do not carry a linked ticket id.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for ``scripts/test_hygiene.py``."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    root = Path(args.root).resolve()
+    findings = scan_repo(
+        root,
+        quarantine_days=args.quarantine_days,
+        ancient_days=args.ancient_days,
+    )
+    print(format_report(findings, root=root))
+
+    violations = stale_unticketed_xfails(findings)
+    if args.fail_on_ancient_unticketed_xfail and violations:
+        print("")
+        print("Ancient xfails without linked ticket ids:")
+        for finding in violations:
+            rel_path = Path(finding.path).relative_to(root).as_posix()
+            print(f"- {rel_path}:{finding.line} ({finding.age_days}d) {finding.reason or 'no reason'}")
+        return 1
+    return 0
+
+
+def _finding_from_marker_expr(
+    expr: ast.expr,
+    *,
+    path: Path,
+    age_days: int,
+    bucket: str,
+    source_kind: str,
+) -> HygieneFinding | None:
+    kind = _marker_kind(expr)
+    if kind is None:
+        return None
+    reason = _marker_reason(expr)
+    ticket = _extract_ticket(reason)
+    return HygieneFinding(
+        path=str(path),
+        line=int(getattr(expr, "lineno", 1) or 1),
+        kind=kind,
+        source=source_kind,
+        reason=reason,
+        ticket=ticket,
+        age_days=age_days,
+        bucket=bucket,
+        requires_ticket=(kind == "xfail"),
+    )
+
+
+def _findings_from_pytestmark_assign(
+    node: ast.Assign,
+    *,
+    path: Path,
+    age_days: int,
+    bucket: str,
+) -> list[HygieneFinding]:
+    targets = [target.id for target in node.targets if isinstance(target, ast.Name)]
+    if "pytestmark" not in targets:
+        return []
+    value = node.value
+    expressions: list[ast.expr] = []
+    if isinstance(value, (ast.Tuple, ast.List)):
+        expressions.extend(item for item in value.elts if isinstance(item, ast.expr))
+    elif isinstance(value, ast.expr):
+        expressions.append(value)
+    return [
+        finding
+        for expr in expressions
+        if (finding := _finding_from_marker_expr(
+            expr,
+            path=path,
+            age_days=age_days,
+            bucket=bucket,
+            source_kind="pytestmark",
+        )) is not None
+    ]
+
+
+def _finding_from_runtime_call(
+    node: ast.Call,
+    *,
+    path: Path,
+    age_days: int,
+    bucket: str,
+) -> HygieneFinding | None:
+    kind = _runtime_kind(node)
+    if kind is None:
+        return None
+    reason = _runtime_reason(node, kind=kind)
+    ticket = _extract_ticket(reason)
+    return HygieneFinding(
+        path=str(path),
+        line=int(getattr(node, "lineno", 1) or 1),
+        kind=kind,
+        source="call",
+        reason=reason,
+        ticket=ticket,
+        age_days=age_days,
+        bucket=bucket,
+        requires_ticket=(kind == "xfail"),
+    )
+
+
+def _marker_kind(expr: ast.expr) -> str | None:
+    if isinstance(expr, ast.Call):
+        name = _attr_path(expr.func)
+    else:
+        name = _attr_path(expr)
+    mapping = {
+        "pytest.mark.skip": "skip",
+        "pytest.mark.skipif": "skipif",
+        "pytest.mark.xfail": "xfail",
+        "pytest.mark.legacy_compat": "legacy_compat",
+    }
+    return mapping.get(name)
+
+
+def _runtime_kind(node: ast.Call) -> str | None:
+    mapping = {
+        "pytest.skip": "skip",
+        "pytest.xfail": "xfail",
+        "pytest.importorskip": "importorskip",
+    }
+    return mapping.get(_attr_path(node.func))
+
+
+def _marker_reason(expr: ast.expr) -> str:
+    if not isinstance(expr, ast.Call):
+        return ""
+    return _call_reason(expr, default_positional_index=0)
+
+
+def _runtime_reason(node: ast.Call, *, kind: str) -> str:
+    if kind == "importorskip":
+        if node.args and isinstance(node.args[0], ast.Constant) and isinstance(node.args[0].value, str):
+            return str(node.args[0].value)
+        return ""
+    return _call_reason(node, default_positional_index=0)
+
+
+def _call_reason(node: ast.Call, *, default_positional_index: int) -> str:
+    for keyword in node.keywords:
+        if keyword.arg == "reason":
+            return _constant_str(keyword.value)
+    if len(node.args) > default_positional_index:
+        return _constant_str(node.args[default_positional_index])
+    return ""
+
+
+def _constant_str(node: ast.AST) -> str:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return str(node.value)
+    return ""
+
+
+def _attr_path(node: ast.AST) -> str:
+    parts: list[str] = []
+    current: ast.AST | None = node
+    while isinstance(current, ast.Attribute):
+        parts.append(current.attr)
+        current = current.value
+    if isinstance(current, ast.Name):
+        parts.append(current.id)
+    return ".".join(reversed(parts))
+
+
+def _extract_ticket(reason: str) -> str:
+    match = _TICKET_RE.search(reason or "")
+    return match.group(0) if match else ""


### PR DESCRIPTION
## Summary
- add repo-wide stale-test hygiene scanning and a local collection guard for ancient unticketed xfails
- document the hygiene workflow in developer docs and AGENTS guidance
- sync the backlog/canary plan mirrors so QUA-430 is the next actionable ticket

## Validation
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_cli/test_test_hygiene.py -q
- /Users/steveyang/miniforge3/bin/python3 scripts/test_hygiene.py --fail-on-ancient-unticketed-xfail
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/ -x -q -m "not integration"