### PR TITLE
QUA-430: add local test gate entrypoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,8 @@ the miniforge interpreter.
 - Cross-validation: `tests/test_crossval/test_xv_{topic}.py`
 - Verification: `tests/test_verification/test_{topic}.py`
 - Use `pytest.importorskip("QuantLib")` for optional external library tests
+- Use `make gate-pr` for PR-ready validation, `make gate-canary` for focused live canaries, and `make gate-release` for replay/drift/freshness release checks
+- Use `/Users/steveyang/miniforge3/bin/python3 scripts/should_run_canary.py` before paying for the live canary subset
 - Run `/Users/steveyang/miniforge3/bin/python3 scripts/test_hygiene.py` when touching skip/xfail/quarantine markers
 - Update `LIMITATIONS.md` when resolving or discovering limitations
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+PYTHON ?= /Users/steveyang/miniforge3/bin/python3
+PYTEST ?= $(PYTHON) -m pytest
+CANARY_FLAGS ?=
+
+.PHONY: gate-hygiene gate-tier2-contracts gate-pr gate-canary gate-release
+
+gate-hygiene:
+	$(PYTHON) scripts/test_hygiene.py --fail-on-ancient-unticketed-xfail
+
+gate-tier2-contracts:
+	$(PYTEST) tests/test_contracts/ -q -m tier2
+
+gate-pr:
+	$(MAKE) gate-hygiene
+	$(PYTEST) tests/ -x -q -m "not integration"
+	$(MAKE) gate-tier2-contracts
+
+gate-canary:
+	$(PYTHON) scripts/should_run_canary.py
+	PYTHONHASHSEED=0 $(PYTHON) scripts/run_canary.py --subset core $(CANARY_FLAGS)
+
+gate-release:
+	$(MAKE) gate-pr
+	$(PYTEST) tests/test_contracts/test_cassette_freshness.py -q -m tier2
+	PYTHONHASHSEED=0 $(PYTHON) scripts/run_canary.py --task T13 --replay --check-drift
+	PYTHONHASHSEED=0 $(PYTHON) scripts/run_canary.py --task T38 --replay --check-drift

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -21,6 +21,7 @@ Core Developer Topics
    audit_and_observability
    task_and_eval_loops
    task_diagnostics
+   test_gates
    test_hygiene
    learning_mechanism
    legacy_test_audit

--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -52,7 +52,25 @@ The repo ships a small task-operations toolchain:
 - ``scripts/benchmark_tasks.py``: benchmark cached generated payoffs without rebuilding
 - ``scripts/remediate.py``: analyze failures, categorize knowledge gaps, and patch common knowledge issues
 - ``scripts/evaluate_shared_memory.py``: compare two task-result tranches and render a shared-memory improvement report
+- ``scripts/should_run_canary.py``: decide whether current local changes justify the focused core canary gate
 - ``scripts/test_hygiene.py``: report stale skip/xfail/quarantine markers for local test-hygiene triage
+
+The repo root ``Makefile`` now exposes the explicit gate entrypoints:
+
+- ``make gate-pr`` for PR-ready validation
+- ``make gate-canary`` for the focused live canary subset
+- ``make gate-release`` for the broader replay/drift/freshness release gate
+
+Use ``scripts/should_run_canary.py`` before paying for the live canary subset.
+The helper reads local changed files from git status by default and recommends
+the focused ``core`` canary subset when runtime, pricing, task-manifest, or
+canary-runner surfaces move.
+
+The release gate keeps its canary evidence deterministic by replaying the
+committed full-task cassettes and then calling ``--check-drift``. That drift
+step still depends on a latest available decision checkpoint for the replayed
+task, so the runner will explicitly report when no checkpoint exists yet and
+the drift probe was skipped.
 
 For curated canaries specifically, ``scripts/run_canary.py`` now executes the
 live task entry plus any richer canary-only fields from ``CANARY_TASKS.yaml``.

--- a/docs/developer/test_gates.md
+++ b/docs/developer/test_gates.md
@@ -1,0 +1,77 @@
+# Test Gates
+
+`QUA-430` turns Trellis's current test pyramid into explicit local gate
+commands from repo root.
+
+## Commands
+
+All commands use the repo-standard interpreter through the root `Makefile`:
+
+```bash
+make gate-pr
+make gate-canary
+make gate-release
+```
+
+The `Makefile` defaults `PYTHON` to
+`/Users/steveyang/miniforge3/bin/python3`, so the gate commands stay pinned to
+the supported interpreter even if your shell `python3` resolves elsewhere.
+
+## Gate Selection
+
+- `make gate-pr`: default PR-ready gate. Runs stale-test hygiene, the full
+  non-integration suite, and the explicit tier-2 contract-test tranche.
+- `make gate-canary`: focused core canary gate for agent/runtime/pricing-core
+  changes. This calls `scripts/should_run_canary.py` first so the current path
+  diff is visible before the live canary subset runs.
+- `make gate-release`: broader release-facing gate. Runs `gate-pr`, then the
+  cassette freshness contract and replay-backed canary drift checks for the
+  committed full-task cassettes.
+
+## Canary Trigger Helper
+
+Use the trigger helper before paying for the live canary subset:
+
+```bash
+/Users/steveyang/miniforge3/bin/python3 scripts/should_run_canary.py
+```
+
+By default it reads local changed files from `git status --porcelain` and
+recommends the focused `core` canary subset when changes touch:
+
+- `trellis/agent/`, `trellis/core/`, `trellis/curves/`, `trellis/models/`, or
+  `trellis/instruments/`
+- `tests/test_agent/`, `tests/test_contracts/`, or `tests/test_tasks/`
+- `TASKS.yaml`, `CANARY_TASKS.yaml`, `scripts/run_canary.py`,
+  `scripts/canary_common.py`, or `scripts/record_cassettes.py`
+
+For explicit path checks, repeat `--path`:
+
+```bash
+/Users/steveyang/miniforge3/bin/python3 scripts/should_run_canary.py \
+  --path trellis/agent/task_runtime.py \
+  --path docs/developer/test_gates.md \
+  --json
+```
+
+## Cost Notes
+
+- `gate-pr` is the normal correctness gate and does not require live model
+  tokens.
+- `gate-canary` is live by default and intentionally narrower than the full
+  canary surface.
+- `gate-release` stays deterministic and zero-token by using committed
+  full-task replays plus drift/freshness checks.
+
+The release gate's drift step uses `scripts/run_canary.py --check-drift`, so
+it compares against the latest available decision checkpoint for the replayed
+task. If no latest checkpoint exists yet, the runner reports that the drift
+check was skipped. Treat that as a signal to refresh the task with a live
+canary run before leaning on drift output for a release claim.
+
+If you only want to smoke-test the `gate-canary` wiring without spending
+tokens, use:
+
+```bash
+make gate-canary CANARY_FLAGS=--dry-run
+```

--- a/docs/plans/backlog-burn-down-execution.md
+++ b/docs/plans/backlog-burn-down-execution.md
@@ -16,7 +16,8 @@ Current status:
 - `QUA-458` is complete.
 - `QUA-710` is complete.
 - `QUA-428` is complete.
-- The next actionable ticket in queue order is `QUA-430`.
+- `QUA-430` is complete.
+- The next actionable ticket in queue order is `QUA-700`.
 
 ## Operating Rules
 
@@ -138,17 +139,16 @@ If a ticket has become stale because other landed work already satisfies it:
 
 ## Current Start Point
 
-Execution started with `QUA-458`, continued through `QUA-710` and `QUA-428`,
-and now moves next to `QUA-430`.
+Execution started with `QUA-458`, continued through `QUA-710`, `QUA-428`, and
+`QUA-430`, and now moves next to `QUA-700`.
 
 Plain-English goal:
 
-- codify the local PR/canary/release gate entrypoints on top of the now-live
-  replay, telemetry, and stale-test hygiene surfaces
+- close the canary umbrella now that replay, telemetry, hygiene, and gate
+  entrypoints are all landed
 
 Primary files and surfaces:
 
-- the current local/CI test entrypoints
-- canary trigger logic and any path-based helper needed to keep canary runs targeted
-- the gate-facing docs and wrapper commands that turn the current pyramid into explicit operator workflows
-- the closeout path that leaves `QUA-700` with only final umbrella maintenance work
+- `docs/plans/canary-suite-stabilization.md`
+- the current canary rerun evidence and gate command docs
+- any final docs or Linear cleanup needed to turn `QUA-700` from backlog into completed umbrella maintenance

--- a/docs/plans/canary-suite-stabilization.md
+++ b/docs/plans/canary-suite-stabilization.md
@@ -190,18 +190,19 @@ Status mirror last synced: `2026-04-10`
 | `QUA-458` | Full-task canary replay with diagnosis parity | Done |
 | `QUA-710` | Trustworthy canary telemetry and historical baselines | Done |
 | `QUA-428` | Stale-test triage process and tooling | Done |
-| `QUA-430` | Local gate and release-gate configuration | Backlog |
+| `QUA-430` | Local gate and release-gate configuration | Done |
 
 Note:
 
-- `QUA-700` now remains open only for gate closeout (`QUA-430`). The direct
-  canary recovery tranche, the full-task replay tranche (`QUA-458`), the
-  trustworthy telemetry tranche (`QUA-710`), and the stale-test hygiene slice
-  (`QUA-428`) are complete after the `2026-04-09` full curated rerun, the
-  `2026-04-10` cassette-backed replay landing, the `2026-04-10` live `T13`
-  telemetry rerun that now persists aggregate canary batch records under
-  `task_runs/canary_batches/`, and the `2026-04-10` local hygiene tool /
-  collection guard landing.
+- `QUA-700` now remains open only for umbrella closeout. The direct canary
+  recovery tranche, the full-task replay tranche (`QUA-458`), the trustworthy
+  telemetry tranche (`QUA-710`), the stale-test hygiene slice (`QUA-428`), and
+  the explicit local gate entrypoints (`QUA-430`) are complete after the
+  `2026-04-09` full curated rerun, the `2026-04-10` cassette-backed replay
+  landing, the `2026-04-10` live `T13` telemetry rerun that now persists
+  aggregate canary batch records under `task_runs/canary_batches/`, the
+  `2026-04-10` local hygiene tool / collection guard landing, and the
+  `2026-04-10` `gate-pr` / `gate-canary` / `gate-release` command landing.
 - `T01` is now green through the short-rate comparison-regime workstream in
   `docs/plans/short-rate-comparison-regime-and-claim-helpers.md` under
   `QUA-746` through `QUA-751`. The recovery path materializes task-level

--- a/scripts/should_run_canary.py
+++ b/scripts/should_run_canary.py
@@ -1,0 +1,11 @@
+"""Decide whether the focused canary gate should run for local changes."""
+
+from __future__ import annotations
+
+import sys
+
+from trellis.testing.gates import main
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_cli/test_should_run_canary.py
+++ b/tests/test_cli/test_should_run_canary.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def test_should_run_canary_flags_runtime_and_model_changes():
+    from trellis.testing.gates import should_run_canary
+
+    decision = should_run_canary(
+        [
+            "docs/developer/test_gates.md",
+            "trellis/agent/task_runtime.py",
+            "trellis/models/zcb_option.py",
+        ]
+    )
+
+    assert decision.run_canary is True
+    assert decision.subset == "core"
+    assert "trellis/agent/" in decision.reasons
+    assert "trellis/models/" in decision.reasons
+
+
+def test_should_run_canary_skips_docs_only_changes():
+    from trellis.testing.gates import should_run_canary
+
+    decision = should_run_canary(
+        [
+            "docs/developer/task_and_eval_loops.rst",
+            "docs/plans/backlog-burn-down-execution.md",
+        ]
+    )
+
+    assert decision.run_canary is False
+    assert decision.subset == ""
+    assert decision.reasons == ()
+
+
+def test_should_run_canary_ignores_ephemeral_artifacts():
+    from trellis.testing.gates import should_run_canary
+
+    decision = should_run_canary(
+        [
+            "task_results_latest.json",
+            "task_runs/history/run_123.json",
+            "trellis/agent/knowledge/traces/platform/session_price.events.ndjson",
+        ]
+    )
+
+    assert decision.run_canary is False
+    assert decision.changed_paths == ()
+
+
+def test_load_changed_paths_from_git_status_handles_rename_and_untracked(monkeypatch, tmp_path):
+    from trellis.testing.gates import load_changed_paths_from_git_status
+
+    class _Result:
+        stdout = " M tests/test_cli/test_should_run_canary.py\nR  old/path.py -> new/path.py\n?? scripts/should_run_canary.py\n"
+
+    monkeypatch.setattr(
+        "trellis.testing.gates.subprocess.run",
+        lambda *args, **kwargs: _Result(),
+    )
+
+    paths = load_changed_paths_from_git_status(tmp_path)
+
+    assert paths == [
+        "tests/test_cli/test_should_run_canary.py",
+        "new/path.py",
+        "scripts/should_run_canary.py",
+    ]
+
+
+def test_should_run_canary_cli_supports_explicit_paths(capsys):
+    from trellis.testing import gates
+
+    exit_code = gates.main(
+        [
+            "--path",
+            "docs/developer/test_gates.md",
+            "--path",
+            "scripts/run_canary.py",
+            "--json",
+        ]
+    )
+
+    output = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert output["run_canary"] is True
+    assert output["subset"] == "core"
+    assert "scripts/run_canary.py" in output["matched_paths"]

--- a/trellis/testing/gates.py
+++ b/trellis/testing/gates.py
@@ -1,0 +1,172 @@
+"""Gate helpers for local PR/canary/release workflows."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict, dataclass
+import json
+from pathlib import Path
+import subprocess
+
+
+_CANARY_PREFIX_REASONS: dict[str, str] = {
+    "trellis/agent/": "agent runtime or compiler path changed",
+    "trellis/core/": "core pricing interfaces changed",
+    "trellis/curves/": "curve construction changed",
+    "trellis/models/": "pricing model code changed",
+    "trellis/instruments/": "instrument adapter changed",
+    "tests/test_agent/": "agent regression coverage changed",
+    "tests/test_contracts/": "contract coverage changed",
+    "tests/test_tasks/": "task regression coverage changed",
+}
+_CANARY_FILE_REASONS: dict[str, str] = {
+    "TASKS.yaml": "task manifest changed",
+    "CANARY_TASKS.yaml": "canary manifest changed",
+    "scripts/run_canary.py": "canary runner changed",
+    "scripts/canary_common.py": "canary payload merge changed",
+    "scripts/record_cassettes.py": "cassette recording path changed",
+}
+_DEFAULT_BASE = "HEAD"
+_IGNORED_PREFIXES = (
+    "task_runs/",
+    "trellis/agent/knowledge/traces/",
+)
+_IGNORED_EXACT = {
+    "task_results_latest.json",
+}
+
+
+@dataclass(frozen=True)
+class CanaryTriggerDecision:
+    """Decision about whether the focused canary gate should run."""
+
+    run_canary: bool
+    subset: str
+    reasons: tuple[str, ...]
+    matched_paths: tuple[str, ...]
+    changed_paths: tuple[str, ...]
+
+
+def load_changed_paths_from_git_status(repo_root: Path) -> list[str]:
+    """Return changed local paths from ``git status --porcelain``."""
+    result = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo_root),
+            "status",
+            "--porcelain=v1",
+            "--untracked-files=all",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    paths: list[str] = []
+    for raw_line in result.stdout.splitlines():
+        if not raw_line:
+            continue
+        line = raw_line[3:]
+        if " -> " in line:
+            line = line.split(" -> ", 1)[1]
+        path = line.strip()
+        if path:
+            paths.append(path)
+    return paths
+
+
+def should_run_canary(paths: list[str]) -> CanaryTriggerDecision:
+    """Classify whether the focused canary gate should run for changed paths."""
+    normalized = tuple(_normalize_path(path) for path in paths if _normalize_path(path))
+    matched_paths: list[str] = []
+    reasons: list[str] = []
+
+    for path in normalized:
+        exact_reason = _CANARY_FILE_REASONS.get(path)
+        if exact_reason is not None:
+            matched_paths.append(path)
+            reasons.append(path)
+            continue
+        for prefix, _ in _CANARY_PREFIX_REASONS.items():
+            if path.startswith(prefix):
+                matched_paths.append(path)
+                reasons.append(prefix)
+                break
+
+    deduped_reasons = tuple(dict.fromkeys(reasons))
+    return CanaryTriggerDecision(
+        run_canary=bool(matched_paths),
+        subset="core" if matched_paths else "",
+        reasons=deduped_reasons,
+        matched_paths=tuple(matched_paths),
+        changed_paths=normalized,
+    )
+
+
+def format_decision(decision: CanaryTriggerDecision) -> str:
+    """Render a compact human-readable trigger summary."""
+    lines = [
+        f"run_canary={'yes' if decision.run_canary else 'no'}",
+        f"subset={decision.subset or 'none'}",
+        f"changed_paths={len(decision.changed_paths)}",
+    ]
+    if decision.reasons:
+        lines.append("reasons=" + ", ".join(decision.reasons))
+    if decision.matched_paths:
+        lines.append("matched_paths=" + ", ".join(decision.matched_paths))
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI parser for ``scripts/should_run_canary.py``."""
+    parser = argparse.ArgumentParser(description="Decide whether the focused canary gate should run.")
+    parser.add_argument(
+        "--path",
+        action="append",
+        dest="paths",
+        default=[],
+        help="Explicit changed path to classify. Repeatable.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the decision as JSON.",
+    )
+    parser.add_argument(
+        "--root",
+        default=str(Path(__file__).resolve().parents[2]),
+        help="Repo root used when loading changed paths from git status.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for canary-trigger classification."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    root = Path(args.root).resolve()
+    changed_paths = args.paths or load_changed_paths_from_git_status(root)
+    decision = should_run_canary(changed_paths)
+
+    if args.json:
+        print(json.dumps(asdict(decision), indent=2, sort_keys=True))
+    else:
+        print(format_decision(decision))
+    return 0
+
+
+def _normalize_path(path: str) -> str:
+    text = str(path).strip()
+    if not text:
+        return ""
+    if text.startswith("./"):
+        text = text[2:]
+    normalized = text.replace("\\", "/")
+    if normalized in _IGNORED_EXACT:
+        return ""
+    if normalized.startswith("task_results_") and normalized.endswith(".json"):
+        return ""
+    if any(normalized.startswith(prefix) for prefix in _IGNORED_PREFIXES):
+        return ""
+    return normalized


### PR DESCRIPTION
## Summary
- add repo-root gate commands for PR, canary, and release workflows
- add a path-based canary trigger helper and tests for its classification rules
- document the gate commands and sync the canary/backlog plan mirrors

## Validation
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_cli/test_should_run_canary.py tests/test_cli/test_test_hygiene.py -q
- make gate-canary CANARY_FLAGS=--dry-run
- make gate-release