### PR TITLE
QUA-700: close canary stabilization umbrella

### DIFF
--- a/docs/plans/backlog-burn-down-execution.md
+++ b/docs/plans/backlog-burn-down-execution.md
@@ -17,7 +17,9 @@ Current status:
 - `QUA-710` is complete.
 - `QUA-428` is complete.
 - `QUA-430` is complete.
-- The next actionable ticket in queue order is `QUA-700`.
+- `QUA-700` is complete.
+- Wave 1 is complete.
+- The next actionable ticket in queue order is `QUA-543`.
 
 ## Operating Rules
 
@@ -139,16 +141,16 @@ If a ticket has become stale because other landed work already satisfies it:
 
 ## Current Start Point
 
-Execution started with `QUA-458`, continued through `QUA-710`, `QUA-428`, and
-`QUA-430`, and now moves next to `QUA-700`.
+Execution started with `QUA-458`, continued through `QUA-710`, `QUA-428`,
+`QUA-430`, and the `QUA-700` umbrella closeout, and now moves next to
+`QUA-543`.
 
 Plain-English goal:
 
-- close the canary umbrella now that replay, telemetry, hygiene, and gate
-  entrypoints are all landed
+- restore the remaining `E22` stress-path regression to a compare-ready state
 
 Primary files and surfaces:
 
-- `docs/plans/canary-suite-stabilization.md`
-- the current canary rerun evidence and gate command docs
-- any final docs or Linear cleanup needed to turn `QUA-700` from backlog into completed umbrella maintenance
+- the current `E22` stress-path implementation and comparison harness
+- the proving and stress-run evidence around the remaining compare-ready gap
+- any route or helper cleanup needed to make the stress tranche stable without reopening the completed canary wave

--- a/docs/plans/canary-suite-stabilization.md
+++ b/docs/plans/canary-suite-stabilization.md
@@ -172,7 +172,7 @@ Status mirror last synced: `2026-04-10`
 
 | Ticket | Status |
 | --- | --- |
-| `QUA-700` Canary suite: stabilization, remediation, and gate readiness | Backlog |
+| `QUA-700` Canary suite: stabilization, remediation, and gate readiness | Done |
 
 ### Ordered Queue
 
@@ -194,15 +194,19 @@ Status mirror last synced: `2026-04-10`
 
 Note:
 
-- `QUA-700` now remains open only for umbrella closeout. The direct canary
-  recovery tranche, the full-task replay tranche (`QUA-458`), the trustworthy
-  telemetry tranche (`QUA-710`), the stale-test hygiene slice (`QUA-428`), and
-  the explicit local gate entrypoints (`QUA-430`) are complete after the
-  `2026-04-09` full curated rerun, the `2026-04-10` cassette-backed replay
-  landing, the `2026-04-10` live `T13` telemetry rerun that now persists
-  aggregate canary batch records under `task_runs/canary_batches/`, the
-  `2026-04-10` local hygiene tool / collection guard landing, and the
-  `2026-04-10` `gate-pr` / `gate-canary` / `gate-release` command landing.
+- `QUA-700` is now complete. The direct canary recovery tranche, the full-task
+  replay tranche (`QUA-458`), the trustworthy telemetry tranche (`QUA-710`),
+  the stale-test hygiene slice (`QUA-428`), and the explicit local gate
+  entrypoints (`QUA-430`) are all landed after the `2026-04-09` full curated
+  rerun, the `2026-04-10` cassette-backed replay landing, the `2026-04-10`
+  live `T13` telemetry rerun that now persists aggregate canary batch records
+  under `task_runs/canary_batches/`, the `2026-04-10` local hygiene tool /
+  collection guard landing, and the `2026-04-10` `gate-pr` / `gate-canary` /
+  `gate-release` command landing.
+- The release gate currently probes the repo's existing drift surface and will
+  report when no latest checkpoint is available for the replayed task. That
+  caveat no longer reopens the stabilization umbrella; it is now an
+  operational note on top of an otherwise complete canary workflow.
 - `T01` is now green through the short-rate comparison-regime workstream in
   `docs/plans/short-rate-comparison-regime-and-claim-helpers.md` under
   `QUA-746` through `QUA-751`. The recovery path materializes task-level


### PR DESCRIPTION
## Summary
- mark the canary stabilization umbrella complete now that replay, telemetry, hygiene, and local gates are all landed
- sync the canary plan mirror to reflect the umbrella closeout and retained drift caveat
- advance the backlog burn-down queue to QUA-543

## Validation
- docs/Linear closeout only; no new code path
- underlying validation comes from the already-landed child slices, most recently make gate-release in QUA-430