### PR TITLE
agent: harden knowledge-light proving reliability

### DIFF
--- a/cassettes/full_task/T13.yaml
+++ b/cassettes/full_task/T13.yaml
@@ -1,64 +1,19 @@
 meta:
-  recorded_at: '2026-04-10T15:37:09.749483+00:00'
+  recorded_at: '2026-04-11T00:34:30.994893+00:00'
   provider: openai
   model: gpt-5.4-mini
-  total_calls: 4
+  total_calls: 7
   name: T13
 calls:
 - seq: 0
   function: llm_generate
   stage: code_generation
-  prompt_hash: 869f7788cd5c3e36e463581a65cf54262ef7eb52bb9b95d0cc2731f49b734952
-  response_text: "from __future__ import annotations\n\nfrom dataclasses import dataclass\n\
-    from datetime import date\n\nfrom trellis.core.market_state import MarketState\n\
-    from trellis.core.types import DayCountConvention\nfrom trellis.models.equity_option_pde\
-    \ import price_vanilla_equity_option_pde\n\n\n\n@dataclass(frozen=True)\nclass\
-    \ EuropeanOptionSpec:\n    \"\"\"Specification for Build a pricer for: European\
-    \ call: theta-method convergence order measurement\n\nEuropean call option on\
-    \ a non-dividend-paying stock.\nS0=100, K=105, T=1Y, risk-free rate r=5%, volatility\
-    \ sigma=20%.\nSolve with the Black-Scholes PDE operator using Crank-Nicolson\n\
-    (theta=0.5) and fully implicit (theta=1.0) on a 200-point spot grid\n× 100 time\
-    \ steps.\nMeasure convergence order by doubling the grid: the CN scheme should\n\
-    show O(dt^2 + dS^2) convergence and the implicit scheme O(dt + dS^2).\nCompare\
-    \ both to the Black-Scholes analytical price.\n\nConstruct methods: pde_solver\n\
-    Comparison targets: theta_0.5 (pde_solver), theta_1.0 (pde_solver), black_scholes\
-    \ (analytical)\nCross-validation harness:\n  internal targets: theta_0.5, theta_1.0\n\
-    \  analytical benchmark: black_scholes\n  external targets: quantlib\nNew component:\
-    \ convergence_order_diagnostic\n\nImplementation target: theta_0.5\nPreferred\
-    \ method family: pde_solver\n\nImplementation target: theta_0.5.\"\"\"\n    notional:\
-    \ float\n    spot: float\n    strike: float\n    expiry_date: date\n    option_type:\
-    \ str = \"'call'\"\n    day_count: DayCountConvention = DayCountConvention.ACT_365\n\
-    \n\nclass EuropeanOptionAnalyticalPayoff:\n    \"\"\"Build a pricer for: European\
-    \ call: theta-method convergence order measurement\n\nEuropean call option on\
-    \ a non-dividend-paying stock.\nS0=100, K=105, T=1Y, risk-free rate r=5%, volatility\
-    \ sigma=20%.\nSolve with the Black-Scholes PDE operator using Crank-Nicolson\n\
-    (theta=0.5) and fully implicit (theta=1.0) on a 200-point spot grid\n× 100 time\
-    \ steps.\nMeasure convergence order by doubling the grid: the CN scheme should\n\
-    show O(dt^2 + dS^2) convergence and the implicit scheme O(dt + dS^2).\nCompare\
-    \ both to the Black-Scholes analytical price.\n\nConstruct methods: pde_solver\n\
-    Comparison targets: theta_0.5 (pde_solver), theta_1.0 (pde_solver), black_scholes\
-    \ (analytical)\nCross-validation harness:\n  internal targets: theta_0.5, theta_1.0\n\
-    \  analytical benchmark: black_scholes\n  external targets: quantlib\nNew component:\
-    \ convergence_order_diagnostic\n\nImplementation target: theta_0.5\nPreferred\
-    \ method family: pde_solver\n\nImplementation target: theta_0.5.\"\"\"\n\n   \
-    \ def __init__(self, spec: EuropeanOptionSpec):\n        self._spec = spec\n\n\
-    \    @property\n    def spec(self) -> EuropeanOptionSpec:\n        return self._spec\n\
-    \n    @property\n    def requirements(self) -> set[str]:\n        return {\"black_vol_surface\"\
-    , \"discount_curve\"}\n\n    def evaluate(self, market_state: MarketState) ->\
-    \ float:\n        spec = self._spec\n        theta = 0.5\n        option_type\
-    \ = str(spec.option_type).strip(\"'\\\"\").lower()\n        if option_type not\
-    \ in {\"call\", \"put\"}:\n            raise ValueError(f\"Unsupported option_type:\
-    \ {spec.option_type!r}\")\n        try:\n            return float(\n         \
-    \       price_vanilla_equity_option_pde(\n                    market_state,\n\
-    \                    spec,\n                    theta=theta,\n               \
-    \ )\n            )\n        except TypeError:\n            class _AdapterSpec:\n\
-    \                def __init__(self, src):\n                    self.notional =\
-    \ src.notional\n                    self.spot = src.spot\n                   \
-    \ self.strike = src.strike\n                    self.expiry_date = src.expiry_date\n\
-    \                    self.option_type = option_type\n                    self.day_count\
-    \ = src.day_count\n\n            return float(\n                price_vanilla_equity_option_pde(\n\
-    \                    market_state,\n                    _AdapterSpec(spec),\n\
-    \                    theta=theta,\n                )\n            )"
+  prompt_hash: 6197fcb39b14239a94033474adabc4fc9ff165d3541c3677a5215aa29ea6d480
+  response_text: "from trellis.models.equity_option_pde import price_vanilla_equity_option_pde\n\
+    \n        option_type = str(spec.option_type).lower()\n        if option_type\
+    \ not in {\"call\", \"put\"}:\n            raise ValueError(f\"Unsupported option_type:\
+    \ {spec.option_type!r}\")\n\n        return float(price_vanilla_equity_option_pde(market_state,\
+    \ spec, theta=0.5))"
   prompt_text: "You are implementing the evaluate() method for `EuropeanOptionAnalyticalPayoff`\
     \ in the Trellis pricing library.\n\n## Complete module (skeleton — everything\
     \ is fixed except evaluate)\n```python\n\"\"\"Agent-generated payoff: Build a\
@@ -92,7 +47,7 @@ calls:
     \ convergence_order_diagnostic\n\nImplementation target: theta_0.5\nPreferred\
     \ method family: pde_solver\n\nImplementation target: theta_0.5.\"\"\"\n    notional:\
     \ float\n    spot: float\n    strike: float\n    expiry_date: date\n    option_type:\
-    \ str = \"'call'\"\n    day_count: DayCountConvention = DayCountConvention.ACT_365\n\
+    \ str = 'call'\n    day_count: DayCountConvention = DayCountConvention.ACT_365\n\
     \n\nclass EuropeanOptionAnalyticalPayoff:\n    \"\"\"Build a pricer for: European\
     \ call: theta-method convergence order measurement\n\nEuropean call option on\
     \ a non-dividend-paying stock.\nS0=100, K=105, T=1Y, risk-free rate r=5%, volatility\
@@ -425,27 +380,12 @@ calls:
 - seq: 1
   function: llm_generate_json
   stage: critic
-  prompt_hash: 672a1d8e20d5223babb10d7e8424717b496162ab0fc59cf0a95a3dcc1951752f
-  response_text: '{"check_id": "volatility_input_usage", "description": "The adapter
-    hard-codes a plain `spec` object that may not satisfy the backend''s required
-    volatility-bearing market bindings, and it never validates or forwards any explicit
-    volatility input from the instrument spec.", "severity": "warning", "evidence":
-    "`evaluate()` calls `price_vanilla_equity_option_pde(market_state, spec, theta=theta)`
-    directly, and the only fallback is an `_AdapterSpec` that copies notional/spot/strike/expiry/date
-    fields only. The compiled contract says the route requires `black_vol_surface`
-    and `expiry_black_vol`, but this code never constructs or checks a volatility
-    surface binding before pricing.", "remediation": "Ensure the market state provides
-    the required flat/term volatility input expected by `price_vanilla_equity_option_pde`,
-    and validate that the adapter forwards the volatility-bearing state rather than
-    relying on a shape-only spec object.", "status": "suspect"}'
+  prompt_hash: 19905e8fe29033e0111a46fdac5b198cf70dd914f2c271d8d00d8e8fe2543ce7
+  response_text: '{}'
   prompt_text: "You are a quantitative model validator reviewing agent-generated pricing\
     \ code.\nYour job is to find deterministic review concerns, not to praise. Be\
-    \ adversarial.\n\n## Code to review\n```python\nfrom __future__ import annotations\n\
-    \nfrom dataclasses import dataclass\nfrom datetime import date\n\nfrom trellis.core.market_state\
-    \ import MarketState\nfrom trellis.core.types import DayCountConvention\nfrom\
-    \ trellis.models.equity_option_pde import price_vanilla_equity_option_pde\n\n\n\
-    \n@dataclass(frozen=True)\nclass EuropeanOptionSpec:\n    \"\"\"Specification\
-    \ for Build a pricer for: European call: theta-method convergence order measurement\n\
+    \ adversarial.\n\n## Code to review\n```python\n\"\"\"Agent-generated payoff:\
+    \ Build a pricer for: European call: theta-method convergence order measurement\n\
     \nEuropean call option on a non-dividend-paying stock.\nS0=100, K=105, T=1Y, risk-free\
     \ rate r=5%, volatility sigma=20%.\nSolve with the Black-Scholes PDE operator\
     \ using Crank-Nicolson\n(theta=0.5) and fully implicit (theta=1.0) on a 200-point\
@@ -457,8 +397,25 @@ calls:
     \ theta_1.0\n  analytical benchmark: black_scholes\n  external targets: quantlib\n\
     New component: convergence_order_diagnostic\n\nImplementation target: theta_0.5\n\
     Preferred method family: pde_solver\n\nImplementation target: theta_0.5.\"\"\"\
-    \n    notional: float\n    spot: float\n    strike: float\n    expiry_date: date\n\
-    \    option_type: str = \"'call'\"\n    day_count: DayCountConvention = DayCountConvention.ACT_365\n\
+    \n\nfrom __future__ import annotations\n\nfrom dataclasses import dataclass\n\
+    from datetime import date\n\nfrom trellis.core.market_state import MarketState\n\
+    from trellis.core.types import DayCountConvention\nfrom trellis.models.equity_option_pde\
+    \ import price_vanilla_equity_option_pde\n\n\n\n@dataclass(frozen=True)\nclass\
+    \ EuropeanOptionSpec:\n    \"\"\"Specification for Build a pricer for: European\
+    \ call: theta-method convergence order measurement\n\nEuropean call option on\
+    \ a non-dividend-paying stock.\nS0=100, K=105, T=1Y, risk-free rate r=5%, volatility\
+    \ sigma=20%.\nSolve with the Black-Scholes PDE operator using Crank-Nicolson\n\
+    (theta=0.5) and fully implicit (theta=1.0) on a 200-point spot grid\n× 100 time\
+    \ steps.\nMeasure convergence order by doubling the grid: the CN scheme should\n\
+    show O(dt^2 + dS^2) convergence and the implicit scheme O(dt + dS^2).\nCompare\
+    \ both to the Black-Scholes analytical price.\n\nConstruct methods: pde_solver\n\
+    Comparison targets: theta_0.5 (pde_solver), theta_1.0 (pde_solver), black_scholes\
+    \ (analytical)\nCross-validation harness:\n  internal targets: theta_0.5, theta_1.0\n\
+    \  analytical benchmark: black_scholes\n  external targets: quantlib\nNew component:\
+    \ convergence_order_diagnostic\n\nImplementation target: theta_0.5\nPreferred\
+    \ method family: pde_solver\n\nImplementation target: theta_0.5.\"\"\"\n    notional:\
+    \ float\n    spot: float\n    strike: float\n    expiry_date: date\n    option_type:\
+    \ str = 'call'\n    day_count: DayCountConvention = DayCountConvention.ACT_365\n\
     \n\nclass EuropeanOptionAnalyticalPayoff:\n    \"\"\"Build a pricer for: European\
     \ call: theta-method convergence order measurement\n\nEuropean call option on\
     \ a non-dividend-paying stock.\nS0=100, K=105, T=1Y, risk-free rate r=5%, volatility\
@@ -476,50 +433,39 @@ calls:
     \    @property\n    def spec(self) -> EuropeanOptionSpec:\n        return self._spec\n\
     \n    @property\n    def requirements(self) -> set[str]:\n        return {\"black_vol_surface\"\
     , \"discount_curve\"}\n\n    def evaluate(self, market_state: MarketState) ->\
-    \ float:\n        spec = self._spec\n        theta = 0.5\n        option_type\
-    \ = str(spec.option_type).strip(\"'\\\"\").lower()\n        if option_type not\
-    \ in {\"call\", \"put\"}:\n            raise ValueError(f\"Unsupported option_type:\
-    \ {spec.option_type!r}\")\n        try:\n            return float(\n         \
-    \       price_vanilla_equity_option_pde(\n                    market_state,\n\
-    \                    spec,\n                    theta=theta,\n               \
-    \ )\n            )\n        except TypeError:\n            class _AdapterSpec:\n\
-    \                def __init__(self, src):\n                    self.notional =\
-    \ src.notional\n                    self.spot = src.spot\n                   \
-    \ self.strike = src.strike\n                    self.expiry_date = src.expiry_date\n\
-    \                    self.option_type = option_type\n                    self.day_count\
-    \ = src.day_count\n\n            return float(\n                price_vanilla_equity_option_pde(\n\
-    \                    market_state,\n                    _AdapterSpec(spec),\n\
-    \                    theta=theta,\n                )\n            )\n```\n\n##\
-    \ Instrument description\nBuild a pricer for: European call: theta-method convergence\
-    \ order measurement\n\nEuropean call option on a non-dividend-paying stock.\n\
-    S0=100, K=105, T=1Y, risk-free rate r=5%, volatility sigma=20%.\nSolve with the\
-    \ Black-Scholes PDE operator using Crank-Nicolson\n(theta=0.5) and fully implicit\
-    \ (theta=1.0) on a 200-point spot grid\n× 100 time steps.\nMeasure convergence\
-    \ order by doubling the grid: the CN scheme should\nshow O(dt^2 + dS^2) convergence\
-    \ and the implicit scheme O(dt + dS^2).\nCompare both to the Black-Scholes analytical\
-    \ price.\n\nConstruct methods: pde_solver\nComparison targets: theta_0.5 (pde_solver),\
-    \ theta_1.0 (pde_solver), black_scholes (analytical)\nCross-validation harness:\n\
-    \  internal targets: theta_0.5, theta_1.0\n  analytical benchmark: black_scholes\n\
-    \  external targets: quantlib\nNew component: convergence_order_diagnostic\n\n\
-    Implementation target: theta_0.5\nPreferred method family: pde_solver\n\nImplementation\
-    \ target: theta_0.5\n\n## Shared Knowledge\n## Distilled Review Memory\n\n- Review\
-    \ principles:\n  - `P1`: Always calibrate rate trees to the discount curve before\
-    \ pricing\n  - `P2`: Callable bonds need issuer_call lattice control, discrete\
-    \ coupons, and exercise=par+coupon\n  - `P3`: Convert vol units at the boundary\
-    \ between market data and model\n- Review checkpoints:\n  - GRID: Use at least\
-    \ 200 spatial points and 200+ time steps. For barrier options, use non-uniform\
-    \ grid concentrated near the barrier.\n  - BOUNDARY CONDITIONS: Set V(0,t)=0 for\
-    \ calls, V(S_max,t)=S_max-K*exp(-r*(T-t)) for calls. For puts: V(0,t)=K*exp(-r*(T-t)),\
-    \ V(S_max,t)=0.\n  - STABILITY: Crank-Nicolson (theta=0.5) is second-order but\
-    \ may oscillate near discontinuities. Use Rannacher smoothing (2-4 implicit steps\
-    \ at start) for digital/barrier payoffs.\n- Canonical model grammar:\n  - `local_vol_surface_workflow`\
-    \ -> `Dupire local vol`\n  - `sabr_smile_workflow` -> `SABR smile`\n- Known failure\
-    \ traps:\n  - `BlackScholesOperator constructor mismatch` -> The generated code\
-    \ treated the PDE operator as if it accepted scalar 'r' and 'sigma' keywords,\
-    \ but trellis.models.pde.operator.BlackScholesOperator actually expects callables\
-    \ '(sigma_fn, r_fn)'. The mismatch caused constructor failure during module build.\n\
-    \  - `PDE price blow-up from unit/scale mismatch` -> The generated PDE branch\
-    \ called theta_method_1d with the obsolete operator/s_grid/t_grid/boundary_conditions\
+    \ float:\n        spec = self._spec\n        option_type = str(spec.option_type).lower()\n\
+    \        if option_type not in {\"call\", \"put\"}:\n            raise ValueError(f\"\
+    Unsupported option_type: {spec.option_type!r}\")\n\n        return float(price_vanilla_equity_option_pde(market_state,\
+    \ spec, theta=0.5))\n\n```\n\n## Instrument description\nBuild a pricer for: European\
+    \ call: theta-method convergence order measurement\n\nEuropean call option on\
+    \ a non-dividend-paying stock.\nS0=100, K=105, T=1Y, risk-free rate r=5%, volatility\
+    \ sigma=20%.\nSolve with the Black-Scholes PDE operator using Crank-Nicolson\n\
+    (theta=0.5) and fully implicit (theta=1.0) on a 200-point spot grid\n× 100 time\
+    \ steps.\nMeasure convergence order by doubling the grid: the CN scheme should\n\
+    show O(dt^2 + dS^2) convergence and the implicit scheme O(dt + dS^2).\nCompare\
+    \ both to the Black-Scholes analytical price.\n\nConstruct methods: pde_solver\n\
+    Comparison targets: theta_0.5 (pde_solver), theta_1.0 (pde_solver), black_scholes\
+    \ (analytical)\nCross-validation harness:\n  internal targets: theta_0.5, theta_1.0\n\
+    \  analytical benchmark: black_scholes\n  external targets: quantlib\nNew component:\
+    \ convergence_order_diagnostic\n\nImplementation target: theta_0.5\nPreferred\
+    \ method family: pde_solver\n\nImplementation target: theta_0.5\n\n## Shared Knowledge\n\
+    ## Distilled Review Memory\n\n- Review principles:\n  - `P1`: Always calibrate\
+    \ rate trees to the discount curve before pricing\n  - `P2`: Callable bonds need\
+    \ issuer_call lattice control, discrete coupons, and exercise=par+coupon\n  -\
+    \ `P3`: Convert vol units at the boundary between market data and model\n- Review\
+    \ checkpoints:\n  - GRID: Use at least 200 spatial points and 200+ time steps.\
+    \ For barrier options, use non-uniform grid concentrated near the barrier.\n \
+    \ - BOUNDARY CONDITIONS: Set V(0,t)=0 for calls, V(S_max,t)=S_max-K*exp(-r*(T-t))\
+    \ for calls. For puts: V(0,t)=K*exp(-r*(T-t)), V(S_max,t)=0.\n  - STABILITY: Crank-Nicolson\
+    \ (theta=0.5) is second-order but may oscillate near discontinuities. Use Rannacher\
+    \ smoothing (2-4 implicit steps at start) for digital/barrier payoffs.\n- Canonical\
+    \ model grammar:\n  - `local_vol_surface_workflow` -> `Dupire local vol`\n  -\
+    \ `sabr_smile_workflow` -> `SABR smile`\n- Known failure traps:\n  - `BlackScholesOperator\
+    \ constructor mismatch` -> The generated code treated the PDE operator as if it\
+    \ accepted scalar 'r' and 'sigma' keywords, but trellis.models.pde.operator.BlackScholesOperator\
+    \ actually expects callables '(sigma_fn, r_fn)'. The mismatch caused constructor\
+    \ failure during module build.\n  - `PDE price blow-up from unit/scale mismatch`\
+    \ -> The generated PDE branch called theta_method_1d with the obsolete operator/s_grid/t_grid/boundary_conditions\
     \ signature and then read the wrong element of the result instead of interpolating\
     \ the returned solution over grid.x. The actual API is theta_method_1d(grid, operator,\
     \ terminal_condition, theta=..., lower_bc_fn=..., upper_bc_fn=...), and it returns\
@@ -589,16 +535,10 @@ calls:
 - seq: 2
   function: llm_generate
   stage: code_generation
-  prompt_hash: e81de32bb1cade880e869861c4188e91277416285f60ab91a72b32541a699a01
+  prompt_hash: 8e039b86d1bc1edf4c59ba3560080cfcca289bef296bcd00d2459ccd5c177204
   response_text: "spec = self._spec\n        from trellis.models.equity_option_pde\
-    \ import price_vanilla_equity_option_pde\n\n        if not hasattr(market_state,\
-    \ \"vol_surface\") or market_state.vol_surface is None:\n            raise ValueError(\"\
-    market_state.vol_surface is required for PDE pricing\")\n        if not hasattr(market_state,\
-    \ \"discount\") or market_state.discount is None:\n            raise ValueError(\"\
-    market_state.discount is required for PDE pricing\")\n\n        theta = 0.5 if\
-    \ \"0.5\" in type(self).__doc__ or False else 1.0\n        return float(\n   \
-    \         price_vanilla_equity_option_pde(\n                market_state,\n  \
-    \              spec,\n                theta=1.0,\n            )\n        )"
+    \ import price_vanilla_equity_option_pde\n\n        theta = 0.5\n        return\
+    \ float(price_vanilla_equity_option_pde(market_state, spec, theta=theta) * spec.notional)"
   prompt_text: "You are implementing the evaluate() method for `EuropeanOptionAnalyticalPayoff`\
     \ in the Trellis pricing library.\n\n## Complete module (skeleton — everything\
     \ is fixed except evaluate)\n```python\n\"\"\"Agent-generated payoff: Build a\
@@ -632,7 +572,7 @@ calls:
     \ convergence_order_diagnostic\n\nImplementation target: theta_1.0\nPreferred\
     \ method family: pde_solver\n\nImplementation target: theta_1.0.\"\"\"\n    notional:\
     \ float\n    spot: float\n    strike: float\n    expiry_date: date\n    option_type:\
-    \ str = \"'call'\"\n    day_count: DayCountConvention = DayCountConvention.ACT_365\n\
+    \ str = 'call'\n    day_count: DayCountConvention = DayCountConvention.ACT_365\n\
     \n\nclass EuropeanOptionAnalyticalPayoff:\n    \"\"\"Build a pricer for: European\
     \ call: theta-method convergence order measurement\n\nEuropean call option on\
     \ a non-dividend-paying stock.\nS0=100, K=105, T=1Y, risk-free rate r=5%, volatility\
@@ -963,22 +903,1097 @@ calls:
     \ no explanation — just the Python code."
   model: gpt-5.4-mini
 - seq: 3
+  function: llm_generate
+  stage: code_generation
+  prompt_hash: 02ceb803d7d2a2db2c7cb0ec9a388d0d0c8c7aeff3870060932895a816bd3ca5
+  response_text: "spec = self._spec\n        if not hasattr(market_state, \"vol_surface\"\
+    ) or market_state.vol_surface is None:\n            raise ValueError(\"market_state.vol_surface\
+    \ is required for PDE pricing\")\n        if not hasattr(market_state, \"discount\"\
+    ) or market_state.discount is None:\n            raise ValueError(\"market_state.discount\
+    \ is required for PDE pricing\")\n\n        T = year_fraction(market_state.as_of,\
+    \ spec.expiry_date, spec.day_count)\n        if T <= 0.0:\n            intrinsic\
+    \ = max(spec.spot - spec.strike, 0.0) if spec.option_type.lower() == \"call\"\
+    \ else max(spec.strike - spec.spot, 0.0)\n            return float(spec.notional\
+    \ * intrinsic)\n\n        theta = 1.0\n        if \"0.5\" in type(self).__doc__\
+    \ if type(self).__doc__ else False:\n            theta = 0.5\n        price =\
+    \ price_vanilla_equity_option_pde(market_state, spec, theta=theta)\n        return\
+    \ float(price * spec.notional)"
+  prompt_text: "You are implementing the evaluate() method for `EuropeanOptionAnalyticalPayoff`\
+    \ in the Trellis pricing library.\n\n## Complete module (skeleton — everything\
+    \ is fixed except evaluate)\n```python\n\"\"\"Agent-generated payoff: Build a\
+    \ pricer for: European call: theta-method convergence order measurement\n\nEuropean\
+    \ call option on a non-dividend-paying stock.\nS0=100, K=105, T=1Y, risk-free\
+    \ rate r=5%, volatility sigma=20%.\nSolve with the Black-Scholes PDE operator\
+    \ using Crank-Nicolson\n(theta=0.5) and fully implicit (theta=1.0) on a 200-point\
+    \ spot grid\n× 100 time steps.\nMeasure convergence order by doubling the grid:\
+    \ the CN scheme should\nshow O(dt^2 + dS^2) convergence and the implicit scheme\
+    \ O(dt + dS^2).\nCompare both to the Black-Scholes analytical price.\n\nConstruct\
+    \ methods: pde_solver\nComparison targets: theta_0.5 (pde_solver), theta_1.0 (pde_solver),\
+    \ black_scholes (analytical)\nCross-validation harness:\n  internal targets: theta_0.5,\
+    \ theta_1.0\n  analytical benchmark: black_scholes\n  external targets: quantlib\n\
+    New component: convergence_order_diagnostic\n\nImplementation target: theta_1.0\n\
+    Preferred method family: pde_solver\n\nImplementation target: theta_1.0.\"\"\"\
+    \n\nfrom __future__ import annotations\n\nfrom dataclasses import dataclass\n\
+    from datetime import date\n\nfrom trellis.core.market_state import MarketState\n\
+    from trellis.core.types import DayCountConvention\nfrom trellis.models.equity_option_pde\
+    \ import price_vanilla_equity_option_pde\n\n\n\n@dataclass(frozen=True)\nclass\
+    \ EuropeanOptionSpec:\n    \"\"\"Specification for Build a pricer for: European\
+    \ call: theta-method convergence order measurement\n\nEuropean call option on\
+    \ a non-dividend-paying stock.\nS0=100, K=105, T=1Y, risk-free rate r=5%, volatility\
+    \ sigma=20%.\nSolve with the Black-Scholes PDE operator using Crank-Nicolson\n\
+    (theta=0.5) and fully implicit (theta=1.0) on a 200-point spot grid\n× 100 time\
+    \ steps.\nMeasure convergence order by doubling the grid: the CN scheme should\n\
+    show O(dt^2 + dS^2) convergence and the implicit scheme O(dt + dS^2).\nCompare\
+    \ both to the Black-Scholes analytical price.\n\nConstruct methods: pde_solver\n\
+    Comparison targets: theta_0.5 (pde_solver), theta_1.0 (pde_solver), black_scholes\
+    \ (analytical)\nCross-validation harness:\n  internal targets: theta_0.5, theta_1.0\n\
+    \  analytical benchmark: black_scholes\n  external targets: quantlib\nNew component:\
+    \ convergence_order_diagnostic\n\nImplementation target: theta_1.0\nPreferred\
+    \ method family: pde_solver\n\nImplementation target: theta_1.0.\"\"\"\n    notional:\
+    \ float\n    spot: float\n    strike: float\n    expiry_date: date\n    option_type:\
+    \ str = 'call'\n    day_count: DayCountConvention = DayCountConvention.ACT_365\n\
+    \n\nclass EuropeanOptionAnalyticalPayoff:\n    \"\"\"Build a pricer for: European\
+    \ call: theta-method convergence order measurement\n\nEuropean call option on\
+    \ a non-dividend-paying stock.\nS0=100, K=105, T=1Y, risk-free rate r=5%, volatility\
+    \ sigma=20%.\nSolve with the Black-Scholes PDE operator using Crank-Nicolson\n\
+    (theta=0.5) and fully implicit (theta=1.0) on a 200-point spot grid\n× 100 time\
+    \ steps.\nMeasure convergence order by doubling the grid: the CN scheme should\n\
+    show O(dt^2 + dS^2) convergence and the implicit scheme O(dt + dS^2).\nCompare\
+    \ both to the Black-Scholes analytical price.\n\nConstruct methods: pde_solver\n\
+    Comparison targets: theta_0.5 (pde_solver), theta_1.0 (pde_solver), black_scholes\
+    \ (analytical)\nCross-validation harness:\n  internal targets: theta_0.5, theta_1.0\n\
+    \  analytical benchmark: black_scholes\n  external targets: quantlib\nNew component:\
+    \ convergence_order_diagnostic\n\nImplementation target: theta_1.0\nPreferred\
+    \ method family: pde_solver\n\nImplementation target: theta_1.0.\"\"\"\n\n   \
+    \ def __init__(self, spec: EuropeanOptionSpec):\n        self._spec = spec\n\n\
+    \    @property\n    def spec(self) -> EuropeanOptionSpec:\n        return self._spec\n\
+    \n    @property\n    def requirements(self) -> set[str]:\n        return {\"black_vol_surface\"\
+    , \"discount_curve\"}\n\n    def evaluate(self, market_state: MarketState) ->\
+    \ float:\n        spec = self._spec\n        raise NotImplementedError(\"evaluate\
+    \ not yet implemented\")\n\n```\n\n## Your task\nWrite ONLY the body of the `evaluate()`\
+    \ method. The signature is already defined:\n\n    def evaluate(self, market_state:\
+    \ MarketState) -> float:\n\n## Spec fields available via self._spec\n- `self._spec.notional`\
+    \ (float): Notional / number of shares\n- `self._spec.spot` (float): Current spot\
+    \ price\n- `self._spec.strike` (float): Option strike price\n- `self._spec.expiry_date`\
+    \ (date): Option expiry date\n- `self._spec.option_type` (str): Option type: 'call'\
+    \ or 'put'\n- `self._spec.day_count` (DayCountConvention): Day count convention\n\
+    \n## Pricing Method (selected by the quant agent — you MUST use this)\nMethod:\
+    \ **pde_solver**\nReasoning: product_ir_compiler\nSelection basis and assumptions:\n\
+    - Selection basis: `explicit_preference`\n- Assumptions / defaulted context:\n\
+    \  - `simplest_valid_assumption_set`\n  - `finite_difference_discretization_route`\n\
+    \  - `boundary_conditions_required`\nRoute-bound modules to import and use:\n\
+    - `trellis.models.equity_option_pde`\n\nYou MUST import and use these route-bound\
+    \ modules in your implementation.\nDo not import a generic parent package such\
+    \ as `from trellis.models import ...` just to satisfy the method family.\n\n##\
+    \ API Map — start here before guessing module paths\n\nUse this navigation card\
+    \ to choose the right module family first. Confirm exact symbols with `find_symbol`\
+    \ or `list_exports` before calling `read_module`.\n\n### Core Types\n#### MarketState\n\
+    - Module: `trellis.core.market_state`\n- Class: `MarketState`\n- Frozen: `true`\n\
+    - Fields: `as_of`, `settlement`, `discount`, `forward_curve`, `vol_surface`, `state_space`,\
+    \ `credit_curve`, `forecast_curves`, `fx_rates`\n- Accessors: `discount_factor`,\
+    \ `zero_rate`, `forward_rate`, `forecast_forward`, `black_vol`, `survival_prob`,\
+    \ `hazard_rate`, `risky_discount`\n- Capabilities: `discount_curve → discount\
+    \ is not None`, `forward_curve → forward_curve is not None (auto from discount)`,\
+    \ `black_vol_surface → vol_surface is not None`, `state_space → state_space is\
+    \ not None`, `credit_curve → credit_curve is not None`, `fx_rates → fx_rates is\
+    \ not None`\n#### Payoff\n- Module: `trellis.core.payoff`\n- Protocol: `Payoff`\n\
+    - Required methods: `evaluate`\n- Required properties: `requirements`\n- Runtime\
+    \ checkable: `true`\n- Notes:\n  - Each payoff handles its own discounting internally\n\
+    \  - The returned float is the final PV\n  - DeterministicCashflowPayoff wraps\
+    \ any Instrument into Payoff\n\n### Model Families\n#### equity_tree\n- Module:\
+    \ `trellis.models.equity_option_tree`\n- Key imports:\n  - `from trellis.models.equity_option_tree\
+    \ import price_vanilla_equity_option_tree`\n  - `from trellis.models.trees.lattice\
+    \ import build_spot_lattice, lattice_backward_induction`\n- Notes:\n  - American/Bermudan\
+    \ equity options should prefer the checked-in helper `price_vanilla_equity_option_tree(...)`\n\
+    \  - If you need the lower-level path, import the lattice builder/backward induction\
+    \ submodules directly\n#### rate_lattice\n- Module: `trellis.models.trees.lattice`\n\
+    - Key imports:\n  - `from trellis.models.trees.lattice import build_rate_lattice,\
+    \ lattice_backward_induction`\n  - `from trellis.models.zcb_option_tree import\
+    \ price_zcb_option_tree`\n- Notes:\n  - Callable bonds, puttable bonds, and Bermudan\
+    \ swaptions use a calibrated rate lattice from a TreeModel specification such\
+    \ as Hull-White or Black-Derman-Toy\n  - lattice_backward_induction handles cashflow_at_node\
+    \ and exercise_fn\n#### monte_carlo\n- Module: `trellis.models.monte_carlo`\n\
+    - Key imports:\n  - `from trellis.models.monte_carlo.engine import MonteCarloEngine`\n\
+    \  - `from trellis.models.monte_carlo.lsm import longstaff_schwartz, longstaff_schwartz_result`\n\
+    \  - `from trellis.models.monte_carlo.early_exercise import EarlyExercisePolicyResult,\
+    \ LeastSquaresContinuationEstimator`\n  - `from trellis.models.monte_carlo.schemes\
+    \ import LaguerreBasis`\n  - `from trellis.models.monte_carlo import euler_maruyama,\
+    \ milstein, brownian_bridge`\n  - `from trellis.models.monte_carlo import antithetic,\
+    \ control_variate`\n  - `from trellis.models.processes.gbm import GBM`\n- Notes:\n\
+    \  - For American/Bermudan Monte Carlo, simulate paths then call an approved early-exercise\
+    \ control primitive; Trellis currently implements longstaff_schwartz\n  - If the\
+    \ control primitive uses continuation regression, choose the estimator or basis\
+    \ explicitly; LaguerreBasis is optional, not mandatory\n#### qmc\n- Module: `trellis.models.qmc`\n\
+    - Key imports:\n  - `from trellis.models.qmc import sobol_normals, brownian_bridge`\n\
+    \  - `from trellis.models.processes.gbm import GBM`\n- Notes:\n  - QMC is an accelerator\
+    \ family layered on Monte Carlo-style estimators\n  - Current support is Sobol-based\
+    \ normal draws and Brownian-bridge construction\n#### pde\n- Module: `trellis.models.pde`\n\
+    - Key imports:\n  - `from trellis.models.equity_option_pde import price_vanilla_equity_option_pde`\n\
+    \  - `from trellis.models.pde.grid import Grid`\n  - `from trellis.models.pde.theta_method\
+    \ import theta_method_1d`\n  - `from trellis.models.pde.operator import BlackScholesOperator`\n\
+    \  - `from trellis.models.pde import psor_1d  # American options`\n  - `from trellis.models.pde\
+    \ import HullWhitePDEOperator`\n- Notes:\n  - Vanilla European equity PDE routes\
+    \ should prefer the checked-in helper `price_vanilla_equity_option_pde(...)`\n\
+    \  - Use theta_method_1d, NOT legacy crank_nicolson_1d or implicit_fd_1d\n####\
+    \ fft\n- Module: `trellis.models.transforms`\n- Key imports:\n  - `from trellis.models.transforms\
+    \ import fft_price, cos_price`\n- Notes:\n  - fft_price expects CF of log(S_T)\
+    \ — include log(S0)\n  - cos_price expects CF of log(S_T/S0) — log-return only\n\
+    #### copulas\n- Module: `trellis.models.copulas`\n- Key imports:\n  - `from trellis.models.copulas\
+    \ import GaussianCopula, StudentTCopula, FactorCopula`\n#### analytical\n- Module:\
+    \ `trellis.models.zcb_option`\n- Key imports:\n  - `from trellis.models.zcb_option\
+    \ import resolve_zcb_option_hw_inputs, price_zcb_option_jamshidian`\n  - `from\
+    \ trellis.models.analytical.jamshidian import ResolvedJamshidianInputs, zcb_option_hw_raw`\n\
+    \  - `from trellis.models.analytical import zcb_option_hw`\n  - `from trellis.models.analytical\
+    \ import terminal_vanilla_from_basis`\n  - `from trellis.models.rate_style_swaption\
+    \ import ResolvedSwaptionBlack76Inputs, resolve_swaption_black76_inputs, price_swaption_black76_raw,\
+    \ price_bermudan_swaption_black76_lower_bound`\n#### calibration\n- Module: `trellis.models.calibration`\n\
+    - Key imports:\n  - `from trellis.models.calibration import implied_vol, implied_vol_jaeckel`\n\
+    \  - `from trellis.models.calibration import RatesCalibrationResult, calibrate_cap_floor_black_vol,\
+    \ calibrate_swaption_black_vol, swaption_terms`\n  - `from trellis.models.calibration\
+    \ import calibrate_sabr`\n  - `from trellis.models.calibration import dupire_local_vol`\n\
+    \n### Utilities\n#### black76\n- Module: `trellis.models.black`\n- Imports:\n\
+    \  - `from trellis.models.black import black76_call, black76_put, black76_asset_or_nothing_call,\
+    \ black76_asset_or_nothing_put, black76_cash_or_nothing_call, black76_cash_or_nothing_put`\n\
+    #### garman_kohlhagen\n- Module: `trellis.models.analytical.fx`\n- Imports:\n\
+    \  - `from trellis.models.analytical.fx import ResolvedGarmanKohlhagenInputs,\
+    \ garman_kohlhagen_price_raw`\n  - `from trellis.models.black import garman_kohlhagen_call,\
+    \ garman_kohlhagen_put`\n#### rate_style_swaption\n- Module: `trellis.models.rate_style_swaption`\n\
+    - Imports:\n  - `from trellis.models.rate_style_swaption import ResolvedSwaptionBlack76Inputs,\
+    \ resolve_swaption_black76_inputs, price_swaption_black76_raw, price_swaption_black76`\n\
+    \  - `from trellis.models.rate_style_swaption import price_bermudan_swaption_black76_lower_bound`\n\
+    #### jamshidian_zcb_option\n- Module: `trellis.models.zcb_option`\n- Imports:\n\
+    \  - `from trellis.models.zcb_option import ResolvedZCBOptionInputs, resolve_zcb_option_hw_inputs,\
+    \ price_zcb_option_jamshidian`\n  - `from trellis.models.analytical.jamshidian\
+    \ import ResolvedJamshidianInputs, zcb_option_hw_raw`\n#### schedule\n- Module:\
+    \ `trellis.core.date_utils`\n- Imports:\n  - `from trellis.core.date_utils import\
+    \ generate_schedule`\n#### day_count\n- Module: `trellis.core.date_utils`\n- Imports:\n\
+    \  - `from trellis.core.date_utils import year_fraction`\n#### vol_surface\n-\
+    \ Module: `trellis.models.vol_surface`\n- Imports:\n  - `from trellis.models.vol_surface\
+    \ import VolSurface, FlatVol`\n#### cashflow_engine\n- Module: `trellis.models.cashflow_engine`\n\
+    - Imports:\n  - `from trellis.models.cashflow_engine import Waterfall, Tranche`\n\
+    \  - `from trellis.models.cashflow_engine import PSA, CPR, RateDependent`\n  -\
+    \ `from trellis.models.cashflow_engine import level_pay, scheduled, custom`\n\
+    #### credit_curve\n- Module: `trellis.curves.credit_curve`\n- Imports:\n  - `from\
+    \ trellis.curves.credit_curve import CreditCurve`\n- Notes:\n  - CreditCurve.flat(hazard_rate)\
+    \ is the simplest starting point for CDS or nth-to-default tasks\n## Distilled\
+    \ Build Memory\n\n- Product: `european_option` / `vanilla_option` / `european`\n\
+    - Default method family: `pde_solver`\n- Method intent: One-dimensional finite-difference\
+    \ theta-method pricing with optional obstacle handling\n- Non-negotiable requirements:\n\
+    \  - GRID: Use at least 200 spatial points and 200+ time steps. For barrier options,\
+    \ use non-uniform grid concentrated near the barrier.\n  - BOUNDARY CONDITIONS:\
+    \ Set V(0,t)=0 for calls, V(S_max,t)=S_max-K*exp(-r*(T-t)) for calls. For puts:\
+    \ V(0,t)=K*exp(-r*(T-t)), V(S_max,t)=0.\n  - STABILITY: Crank-Nicolson (theta=0.5)\
+    \ is second-order but may oscillate near discontinuities. Use Rannacher smoothing\
+    \ (2-4 implicit steps at start) for digital/barrier payoffs.\n- Canonical model\
+    \ grammar:\n  - `local_vol_surface_workflow` -> `Dupire local vol`\n  - `sabr_smile_workflow`\
+    \ -> `SABR smile`\n- Repeated fixes to reuse:\n  - `BlackScholesOperator constructor\
+    \ mismatch` -> Import BlackScholesOperator from trellis.models.pde.operator and\
+    \ pass callables, for example BlackScholesOperator(lambda s, t: sigma, lambda\
+    \ t: r). Add a signature smoke test or cookbook template to lock the constructor\
+    \ shape and keep the solver path aligned with the real API.\n  - `PDE price blow-up\
+    \ from unit/scale mismatch` -> Build Grid(x_min=0.0, x_max=S_max, n_x=n_x, T=T,\
+    \ n_t=n_t), construct BlackScholesOperator(lambda s, t: sigma, lambda t: r), call\
+    \ theta_method_1d(grid, op, terminal, theta=0.5, lower_bc_fn=..., upper_bc_fn=...),\
+    \ then interpolate the returned vector with np.interp(spec.spot, grid.x, V) before\
+    \ multiplying by notional.\n\n## Generated Skills\n- [cookbook] fft_pricing: Characteristic-function\
+    \ pricing for European-style options under models such as Heston\n- [lesson] Unit\
+    \ conversion causes huge PV: Enforce and document input conventions (vol as decimal,\
+    \ discount curve vs zero rate semantics, notional scaling), derive r from discount\
+    \ factors via r = -ln(df)/T or use forward/Black76 consistently, add unit/conversi...\n\
+    \n## Stage-Aware Skills\n- [route_hint] vanilla_equity_theta_pde route helper:\
+    \ Use the selected route helper directly inside `evaluate()`; do not rebuild the\
+    \ process, engine, or discount glue manually.\n- [route_hint] vanilla_equity_theta_pde\
+    \ note 1: For vanilla European equity PDE routes, prefer `price_vanilla_equity_option_pde(market_state,\
+    \ spec, theta=...)` so the adapter stays thin.\n## Retry Focus\n- Match the runtime\
+    \ contract exactly: required curves, units, and payoff-leg signs must be explicit\
+    \ in code.\n- Prefer a smaller, explicit implementation over a broad helper abstraction\
+    \ when recovering from validation failures.\n## Route-Specific Recovery\n- Vanilla\
+    \ European PDE routes should stay on the checked-in helper surface whenever the\
+    \ contract is plain call/put Black-Scholes.\n- Prefer `from trellis.models.equity_option_pde\
+    \ import price_vanilla_equity_option_pde` and delegate to that helper from the\
+    \ adapter.\n- Map `implementation_target=theta_0.5` to `theta=0.5` and `implementation_target=theta_1.0`\
+    \ to `theta=1.0`.\n- Do not rebuild terminal intrinsic branches, boundary callables,\
+    \ scalar interpolation, or discount-to-rate glue inline when the checked-in helper\
+    \ already matches the route.\n- Use the lower-level `Grid`, `BlackScholesOperator`,\
+    \ and `theta_method_1d` primitives only if the payoff or boundary contract genuinely\
+    \ differs from plain vanilla European call/put.\n## Structured Lane Card\n- Method\
+    \ family: `pde_solver`\n- Instrument type: `european_option`\n- Lane boundary:\
+    \ family=`pde_solver`, kind=`exact_target_binding`, exact_bindings=`trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
+    - Lane obligations:\n  - Lane family: `pde_solver`\n  - Plan kind: `exact_target_binding`\n\
+    \  - Market bindings: `black_vol_surface`, `discount_curve`\n  - State obligations:\
+    \ `spot`, `strike`, `expiry`, `expiry_black_vol`\n  - Exact backend bindings:\n\
+    \    - `trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n  -\
+    \ Exact binding signatures:\n    - `price_vanilla_equity_option_pde(market_state:\
+    \ 'EquityPDEMarketStateLike', spec: 'VanillaEquityOptionSpecLike', *, theta: 'float'\
+    \ = 0.5, n_x: 'int | None' = None, n_t: 'int | None' = None, s_max_multiplier:\
+    \ 'float' = 4.0) -> 'float'`\n- Route authority:\n  - binding=`trellis.models.equity_option_pde.price_vanilla_equity_option_pde`,\
+    \ engine=`pde_solver`, authority=`exact_backend_fit`\n  - Route alias: `vanilla_equity_theta_pde`\n\
+    \  - Validation bundle: `pde_solver:european_option`\n  - Validation checks: `check_non_negativity`,\
+    \ `check_price_sanity`, `check_vol_sensitivity`, `check_vol_monotonicity`\n  -\
+    \ Exact target bindings: `trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
+    - Backend binding:\n  - Route: `vanilla_equity_theta_pde`\n  - Engine family:\
+    \ `pde_solver`\n  - Route family: `pde_solver`\n  - Selected primitives:\n   \
+    \ - `trellis.models.equity_option_pde.price_vanilla_equity_option_pde` (route_helper)\n\
+    \  - Resolved instructions:\n    - [hard_constraint] Use the route helper directly\
+    \ inside `evaluate()`; do not rebuild the process, engine, or discount glue manually.\n\
+    \    - [historical_note] For vanilla European equity PDE routes, prefer `price_vanilla_equity_option_pde(market_state,\
+    \ spec, theta=...)` so the adapter stays thin.\n    - [historical_note] Map `implementation_target=theta_0.5`\
+    \ to `theta=0.5` and `implementation_target=theta_1.0` to `theta=1.0`.\n    -\
+    \ [historical_note] The checked-in helper already owns grid sizing, terminal payoff\
+    \ assembly, boundary conditions, theta-method solve, and interpolation back to\
+    \ spot.\n    - [historical_note] Use the lower-level `Grid + BlackScholesOperator\
+    \ + theta_method_1d` path only when the payoff or boundary contract genuinely\
+    \ differs from plain vanilla European call/put.\n  - Required adapters:\n    -\
+    \ `reuse_checked_in_vanilla_equity_pde_helper`\n  - Backend notes:\n    - For\
+    \ vanilla European equity PDE routes, prefer `price_vanilla_equity_option_pde(market_state,\
+    \ spec, theta=...)` so the adapter stays thin.\n    - Map `implementation_target=theta_0.5`\
+    \ to `theta=0.5` and `implementation_target=theta_1.0` to `theta=1.0`.\n    -\
+    \ The checked-in helper already owns grid sizing, terminal payoff assembly, boundary\
+    \ conditions, theta-method solve, and interpolation back to spot.\n    - Use the\
+    \ lower-level `Grid + BlackScholesOperator + theta_method_1d` path only when the\
+    \ payoff or boundary contract genuinely differs from plain vanilla European call/put.\n\
+    - Primary modules to inspect/reuse:\n  - `trellis.models.pde.theta_method`\n-\
+    \ Post-build test targets:\n  - `tests/test_agent/test_build_loop.py`\n- Instruction\
+    \ precedence: follow the lane obligations in this card first. Treat backend route/helper\
+    \ details as exact-fit bindings, not as permission to invent a different numerical\
+    \ path.\n- Treat route authority as backend-fit evidence, not as permission to\
+    \ invent a different synthesis plan.\n- Use approved Trellis imports only. Prefer\
+    \ thin adapters when the compiler found an exact backend; otherwise build the\
+    \ smallest lane-consistent kernel the plan requires.\n## Backend Lookup (Secondary\
+    \ To Lane Obligations)\n- Lane family: `pde_solver`\n- Lane plan kind: `exact_target_binding`\n\
+    - Method family: `pde_solver`\n- Route: `vanilla_equity_theta_pde`\n- Engine family:\
+    \ `pde_solver`\n- Required primitive symbols:\n  - `trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
+    - Adapter obligations:\n  - `reuse_checked_in_vanilla_equity_pde_helper`\n## Thin\
+    \ Adapter Plan\n- Target payoff class: `EuropeanOptionAnalyticalPayoff`\n- Required\
+    \ market reads:\n  - `market_state.vol_surface.black_vol(...)`\n  - `market_state.discount`\n\
+    - Required primitive calls:\n  - `trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
+    - Required adapter steps:\n  - `reuse_checked_in_vanilla_equity_pde_helper`\n\
+    - Return contract: Return a Python `float` present value from `evaluate()`.\n\
+    ## Invariant Pack\n- The generated payoff should be compatible with these deterministic\
+    \ validation checks:\n  - `check_non_negativity`\n  - `check_price_sanity`\n \
+    \ - `check_vol_sensitivity`\n  - `check_vol_monotonicity`\n## Family Route Guidance\n\
+    - For vanilla European PDE routes, prefer `price_vanilla_equity_option_pde(market_state,\
+    \ self._spec, theta=...)` from `trellis.models.equity_option_pde`.\n- Map `implementation_target=theta_0.5`\
+    \ to `theta=0.5` and `implementation_target=theta_1.0` to `theta=1.0`.\n- Keep\
+    \ the wrapper thin: delegate grid sizing, boundary conditions, terminal payoff\
+    \ assembly, theta-method solve, and interpolation back to spot to the checked-in\
+    \ helper.\n- Only fall back to direct `Grid + BlackScholesOperator + theta_method_1d`\
+    \ assembly when the payoff or boundary contract genuinely differs from plain vanilla\
+    \ European call/put.\n## Conventions\n- evaluate() returns a FLOAT — the present\
+    \ value (PV) of the instrument\n- You MUST handle all discounting internally —\
+    \ use `market_state.discount.discount(t)`\n- For forward rates: `market_state.forecast_forward_curve(self._spec.rate_index)`\n\
+    - For vol: `market_state.vol_surface.black_vol(T, strike)`\n- For discount factors:\
+    \ `market_state.discount.discount(t)`\n- `market_state.fx_rates[pair]` returns\
+    \ an `FXRate` wrapper; extract `.spot` before scalar arithmetic or process seeding\n\
+    - Schedule generation: prefer `build_payment_timeline(...)`, `build_observation_timeline(...)`,\
+    \ or `build_period_schedule(...)` for accrual/event routes; use `generate_schedule(start,\
+    \ end, freq)` only for plain date lists with no period semantics\n- Year fractions:\
+    \ `year_fraction(date1, date2, day_count)`\n- Never use wall-clock dates such\
+    \ as `date.today()` or `datetime.now()` inside `evaluate()`; derive valuation\
+    \ time from `market_state` or shared resolver outputs.\n- Black76: `black76_call(F,\
+    \ K, sigma, T)`, `black76_put(F, K, sigma, T)` — undiscounted\n- Black76 digital:\
+    \ `black76_cash_or_nothing_call(F, K, sigma, T)`, `black76_cash_or_nothing_put(F,\
+    \ K, sigma, T)` — undiscounted cash-or-nothing digitals\n- For CDS / nth-to-default:\
+    \ use `market_state.credit_curve.survival_probability(t)` and `market_state.credit_curve.hazard_rate(t)`\
+    \ on an explicit payment/default schedule; do not route credit-default pricing\
+    \ through Black76 call/put primitives.\n- For equity trees: prefer `from trellis.models.equity_option_tree\
+    \ import price_vanilla_equity_option_tree`; the lower-level lattice path is `from\
+    \ trellis.models.trees.lattice import build_spot_lattice, lattice_backward_induction`\n\
+    - For vanilla European PDE routes: prefer `from trellis.models.equity_option_pde\
+    \ import price_vanilla_equity_option_pde`; the lower-level fallback is `from trellis.models.pde.grid\
+    \ import Grid`, `from trellis.models.pde.operator import BlackScholesOperator`,\
+    \ and `from trellis.models.pde.theta_method import theta_method_1d`\n- For rate\
+    \ lattices: prefer helper surfaces such as `price_callable_bond_tree(...)`, `price_bermudan_swaption_tree(...)`,\
+    \ or `price_zcb_option_tree(...)`; the lower-level fallback is `from trellis.models.trees.lattice\
+    \ import build_rate_lattice, lattice_backward_induction`\n- For schedule-dependent\
+    \ rate lattices: `from trellis.models.trees.control import lattice_steps_from_timeline,\
+    \ resolve_lattice_exercise_policy`\n- For MC: `from trellis.models.monte_carlo\
+    \ import MonteCarloEngine`\n- For QMC accelerators: `from trellis.models.qmc import\
+    \ sobol_normals, brownian_bridge`\n- For copulas: `from trellis.models.copulas\
+    \ import GaussianCopula, FactorCopula`\n- Do not invent MonteCarloEngine method\
+    \ strings. Valid `method=` values are `euler`, `milstein`, and `exact`.\n- For\
+    \ Monte Carlo early exercise, use an approved control primitive; do not pretend\
+    \ that `MonteCarloEngine.price(...)` or `method=\"lsm\"` implements early exercise.\
+    \ Approved policy classes: `longstaff_schwartz` [implemented], `tsitsiklis_van_roy`\
+    \ [implemented], `primal_dual_mc` [implemented], `stochastic_mesh` [implemented].\
+    \ Currently implemented in Trellis: `longstaff_schwartz`, `tsitsiklis_van_roy`,\
+    \ `primal_dual_mc`, `stochastic_mesh`.\n- If you use `LaguerreBasis`, import it\
+    \ from `trellis.models.monte_carlo.schemes`, not from `trellis.models.monte_carlo.lsm`.\n\
+    - For FFT/COS pricing, characteristic functions must accept vector `u` and use\
+    \ array-safe numerics such as `numpy`, not scalar `math`/`cmath`.\n- Black76 basis:\
+    \ `black76_asset_or_nothing_call(F, K, sigma, T)`, `black76_asset_or_nothing_put(F,\
+    \ K, sigma, T)`, `black76_cash_or_nothing_call(F, K, sigma, T)`, `black76_cash_or_nothing_put(F,\
+    \ K, sigma, T)` — exact terminal basis claims.\n- For terminal vanilla payoffs,\
+    \ prefer exact basis assembly via `terminal_vanilla_from_basis(...)` from `trellis.models.analytical`.\n\
+    - For FX vanilla options, treat the route as Garman-Kohlhagen: map spot FX and\
+    \ domestic/foreign discount factors to `ResolvedGarmanKohlhagenInputs`, then prefer\
+    \ `garman_kohlhagen_price_raw(spec.option_type, resolved)` from `trellis.models.analytical.fx`;\
+    \ use explicit basis-claim assembly only when the request explicitly needs the\
+    \ decomposition.\n- For cash-or-nothing digital options, use the Black76 digital\
+    \ helpers directly; do not approximate them with vanilla call/put prices or divide\
+    \ by spot.\n- You MUST use only real, approved `trellis.*` imports from the structured\
+    \ generation plan and import registry\n- Treat the compiler-emitted lane obligations\
+    \ in the structured generation plan as the backbone of the implementation.\n-\
+    \ Reuse the listed exact backend bindings when present; otherwise build the smallest\
+    \ lane-consistent kernel that satisfies the construction steps.\n- Do not replace\
+    \ selected primitives with bespoke numerical kernels or alternative Trellis routes\
+    \ unless the plan explicitly permits a new lane implementation.\n- Do not add\
+    \ wildcard imports\n- If the approved modules do not contain what you need, reuse\
+    \ the closest existing implementation and keep the gap explicit instead of inventing\
+    \ a path\n\n## Reference implementations\n\n### Payoff protocol + Cashflows/PresentValue\
+    \ return types\n```python\n\"\"\"Payoff protocol and base classes for pricing\
+    \ instruments.\n\nEvery priceable instrument in Trellis implements the Payoff\
+    \ protocol.\nA payoff takes market data (via MarketState) and returns a present\
+    \ value.\nThis module also provides base classes for two common pricing patterns:\n\
+    \n- ResolvedInputPayoff: for analytical or tree-based pricing where market\n \
+    \ data is extracted once, then fed into a pricing formula.\n- MonteCarloPathPayoff:\
+    \ for simulation-based pricing where paths are\n  generated and payoffs are computed\
+    \ per path then averaged.\n\"\"\"\n\nfrom __future__ import annotations\n\nfrom\
+    \ abc import ABC, abstractmethod\nfrom datetime import date\nfrom typing import\
+    \ Generic, Protocol, TypeVar, runtime_checkable\n\nfrom trellis.core.date_utils\
+    \ import year_fraction\nfrom trellis.core.differentiable import get_numpy\nfrom\
+    \ trellis.core.market_state import MarketState\nfrom trellis.core.types import\
+    \ DayCountC\n# [truncated reference]\n```\n\n### Date utilities used by generated\
+    \ payoffs\n```python\n\"\"\"Date utilities: day count conventions, schedule generation,\
+    \ year fractions.\"\"\"\n\nfrom __future__ import annotations\n\nimport calendar\n\
+    from collections.abc import Iterable\nfrom datetime import date, datetime, timedelta\n\
+    from typing import Union\n\nfrom trellis.core.types import (\n    ContractTimeline,\n\
+    \    DayCountConvention,\n    EventSchedule,\n    Frequency,\n    TimelineRole,\n\
+    )\n\nDateLike = Union[date, datetime]\nExplicitDateInput = ContractTimeline |\
+    \ EventSchedule | Iterable[DateLike | str] | str\n\n\ndef _to_date(d: DateLike)\
+    \ -> date:\n    \"\"\"Normalize ``date``/``datetime`` inputs to plain ``date``\
+    \ objects.\"\"\"\n    if isinstance(d, datetime):\n        return d.date()\n \
+    \   return d\n\n\ndef add_months(dt: DateLike, months: int) -> date:\n    \"\"\
+    \"Add *months* calendar months, clamping the day to the new month's max.\"\"\"\
+    \n    d = _to_date(dt)\n    total_months = d.month - 1 + months\n    year = d.year\
+    \ + total\n# [truncated reference]\n```\n\n### MarketState capabilities and access\
+    \ patterns\n```python\n\"\"\"MarketState: immutable container of market data used\
+    \ for pricing.\n\nA MarketState holds everything a payoff needs to compute a price:\n\
+    discount curves, volatility surfaces, spot prices, credit curves, etc.\nIt is\
+    \ frozen (immutable) so that multiple payoffs can safely share the\nsame market\
+    \ snapshot without risk of accidental modification.\n\"\"\"\n\nfrom __future__\
+    \ import annotations\n\nfrom dataclasses import dataclass\nfrom datetime import\
+    \ date\nfrom typing import TYPE_CHECKING\n\nfrom trellis.core.types import DiscountCurve\n\
+    \nif TYPE_CHECKING:\n    from trellis.core.state_space import StateSpace\n   \
+    \ from trellis.curves.credit_curve import CreditCurve\n    from trellis.curves.forward_curve\
+    \ import ForwardCurve\n    from trellis.instruments.fx import FXRate\n    from\
+    \ trellis.models.vol_surface import VolSurface\n\n\nclass MissingCapabilityError(Exception):\n\
+    \    \"\"\"Raised when a MarketState lacks market data r\n# [truncated reference]\n\
+    ```\n\n### Frequency/day-count types\n```python\n\"\"\"Core protocols, enums,\
+    \ and data structures shared across Trellis.\n\nDefines the fundamental types\
+    \ that most other modules depend on:\nfrequency enums, day count conventions,\
+    \ the DiscountCurve and Instrument\nprotocols, and simple data containers like\
+    \ schedules and pricing results.\n\"\"\"\n\nfrom __future__ import annotations\n\
+    \nfrom dataclasses import dataclass, field\nfrom datetime import date\nfrom enum\
+    \ import Enum\nfrom typing import Protocol, runtime_checkable\n\n# ---------------------------------------------------------------------------\n\
+    # Greek specification types\n# ---------------------------------------------------------------------------\n\
+    \n# What risk sensitivities to compute alongside the price.\n#   None       —\
+    \ price only, no sensitivities\n#   \"all\"      — every known sensitivity (dv01,\
+    \ duration, convexity, etc.)\n#   list[str]  — specific sensitivities by name\
+    \ (e.g. [\"dv01\", \"duration\"])\n# [truncated reference]\n```\n\n[omitted 6\
+    \ additional reference modules]\n\n\n## Output\nReturn the COMPLETE Python module\
+    \ — copy the skeleton exactly, but replace the\n`raise NotImplementedError(...)`\
+    \ line with the actual implementation of `evaluate()`.\nDo NOT change imports,\
+    \ class names, spec fields, or the requirements property.\nOnly implement the\
+    \ evaluate() method body. You may add imports at the top.\nNo markdown fences,\
+    \ no explanation — just the Python code.\n\n## VALIDATION FAILURES (your previous\
+    \ code had these issues):\n- [check_price_sanity] Price sanity check failed: |PV|\
+    \ = 1044.07, which exceeds 10.0× typical notional (100). The model likely has\
+    \ a unit conversion error (e.g., passing Black vol to a rate tree).\n  Actual:\
+    \ 1044.0689196990409\n  Expected: |PV| <= 1000.0000\n  Context: available_capabilities=['black_vol_surface',\
+    \ 'discount_curve', 'forward_curve'], discount_curve_type=YieldCurve, forecast_curve_keys=[],\
+    \ fx_pairs=[], max_multiple=10.0, model_parameter_keys=[], settlement=2024-11-15,\
+    \ spot=None, underlier_spot_keys=[], vol_surface_type=FlatVol\n\n\nFix ALL of\
+    \ the above issues in your implementation."
+  model: gpt-5.4-mini
+- seq: 4
+  function: llm_generate
+  stage: code_generation
+  prompt_hash: acc46459935ccedced278e7df0940f0027abbb9aa941f33aa36dce8770195fab
+  response_text: "spec = self._spec\n        from trellis.core.date_utils import year_fraction\n\
+    \        from trellis.models.equity_option_pde import price_vanilla_equity_option_pde\n\
+    \n        price = price_vanilla_equity_option_pde(market_state, spec, theta=1.0)\n\
+    \        return float(price)"
+  prompt_text: "You are implementing the evaluate() method for `EuropeanOptionAnalyticalPayoff`\
+    \ in the Trellis pricing library.\n\n## Complete module (skeleton — everything\
+    \ is fixed except evaluate)\n```python\n\"\"\"Agent-generated payoff: Build a\
+    \ pricer for: European call: theta-method convergence order measurement\n\nEuropean\
+    \ call option on a non-dividend-paying stock.\nS0=100, K=105, T=1Y, risk-free\
+    \ rate r=5%, volatility sigma=20%.\nSolve with the Black-Scholes PDE operator\
+    \ using Crank-Nicolson\n(theta=0.5) and fully implicit (theta=1.0) on a 200-point\
+    \ spot grid\n× 100 time steps.\nMeasure convergence order by doubling the grid:\
+    \ the CN scheme should\nshow O(dt^2 + dS^2) convergence and the implicit scheme\
+    \ O(dt + dS^2).\nCompare both to the Black-Scholes analytical price.\n\nConstruct\
+    \ methods: pde_solver\nComparison targets: theta_0.5 (pde_solver), theta_1.0 (pde_solver),\
+    \ black_scholes (analytical)\nCross-validation harness:\n  internal targets: theta_0.5,\
+    \ theta_1.0\n  analytical benchmark: black_scholes\n  external targets: quantlib\n\
+    New component: convergence_order_diagnostic\n\nImplementation target: theta_1.0\n\
+    Preferred method family: pde_solver\n\nImplementation target: theta_1.0.\"\"\"\
+    \n\nfrom __future__ import annotations\n\nfrom dataclasses import dataclass\n\
+    from datetime import date\n\nfrom trellis.core.market_state import MarketState\n\
+    from trellis.core.types import DayCountConvention\nfrom trellis.models.equity_option_pde\
+    \ import price_vanilla_equity_option_pde\n\n\n\n@dataclass(frozen=True)\nclass\
+    \ EuropeanOptionSpec:\n    \"\"\"Specification for Build a pricer for: European\
+    \ call: theta-method convergence order measurement\n\nEuropean call option on\
+    \ a non-dividend-paying stock.\nS0=100, K=105, T=1Y, risk-free rate r=5%, volatility\
+    \ sigma=20%.\nSolve with the Black-Scholes PDE operator using Crank-Nicolson\n\
+    (theta=0.5) and fully implicit (theta=1.0) on a 200-point spot grid\n× 100 time\
+    \ steps.\nMeasure convergence order by doubling the grid: the CN scheme should\n\
+    show O(dt^2 + dS^2) convergence and the implicit scheme O(dt + dS^2).\nCompare\
+    \ both to the Black-Scholes analytical price.\n\nConstruct methods: pde_solver\n\
+    Comparison targets: theta_0.5 (pde_solver), theta_1.0 (pde_solver), black_scholes\
+    \ (analytical)\nCross-validation harness:\n  internal targets: theta_0.5, theta_1.0\n\
+    \  analytical benchmark: black_scholes\n  external targets: quantlib\nNew component:\
+    \ convergence_order_diagnostic\n\nImplementation target: theta_1.0\nPreferred\
+    \ method family: pde_solver\n\nImplementation target: theta_1.0.\"\"\"\n    notional:\
+    \ float\n    spot: float\n    strike: float\n    expiry_date: date\n    option_type:\
+    \ str = 'call'\n    day_count: DayCountConvention = DayCountConvention.ACT_365\n\
+    \n\nclass EuropeanOptionAnalyticalPayoff:\n    \"\"\"Build a pricer for: European\
+    \ call: theta-method convergence order measurement\n\nEuropean call option on\
+    \ a non-dividend-paying stock.\nS0=100, K=105, T=1Y, risk-free rate r=5%, volatility\
+    \ sigma=20%.\nSolve with the Black-Scholes PDE operator using Crank-Nicolson\n\
+    (theta=0.5) and fully implicit (theta=1.0) on a 200-point spot grid\n× 100 time\
+    \ steps.\nMeasure convergence order by doubling the grid: the CN scheme should\n\
+    show O(dt^2 + dS^2) convergence and the implicit scheme O(dt + dS^2).\nCompare\
+    \ both to the Black-Scholes analytical price.\n\nConstruct methods: pde_solver\n\
+    Comparison targets: theta_0.5 (pde_solver), theta_1.0 (pde_solver), black_scholes\
+    \ (analytical)\nCross-validation harness:\n  internal targets: theta_0.5, theta_1.0\n\
+    \  analytical benchmark: black_scholes\n  external targets: quantlib\nNew component:\
+    \ convergence_order_diagnostic\n\nImplementation target: theta_1.0\nPreferred\
+    \ method family: pde_solver\n\nImplementation target: theta_1.0.\"\"\"\n\n   \
+    \ def __init__(self, spec: EuropeanOptionSpec):\n        self._spec = spec\n\n\
+    \    @property\n    def spec(self) -> EuropeanOptionSpec:\n        return self._spec\n\
+    \n    @property\n    def requirements(self) -> set[str]:\n        return {\"black_vol_surface\"\
+    , \"discount_curve\"}\n\n    def evaluate(self, market_state: MarketState) ->\
+    \ float:\n        spec = self._spec\n        raise NotImplementedError(\"evaluate\
+    \ not yet implemented\")\n\n```\n\n## Your task\nWrite ONLY the body of the `evaluate()`\
+    \ method. The signature is already defined:\n\n    def evaluate(self, market_state:\
+    \ MarketState) -> float:\n\n## Spec fields available via self._spec\n- `self._spec.notional`\
+    \ (float): Notional / number of shares\n- `self._spec.spot` (float): Current spot\
+    \ price\n- `self._spec.strike` (float): Option strike price\n- `self._spec.expiry_date`\
+    \ (date): Option expiry date\n- `self._spec.option_type` (str): Option type: 'call'\
+    \ or 'put'\n- `self._spec.day_count` (DayCountConvention): Day count convention\n\
+    \n## Pricing Method (selected by the quant agent — you MUST use this)\nMethod:\
+    \ **pde_solver**\nReasoning: product_ir_compiler\nSelection basis and assumptions:\n\
+    - Selection basis: `explicit_preference`\n- Assumptions / defaulted context:\n\
+    \  - `simplest_valid_assumption_set`\n  - `finite_difference_discretization_route`\n\
+    \  - `boundary_conditions_required`\nRoute-bound modules to import and use:\n\
+    - `trellis.models.equity_option_pde`\n\nYou MUST import and use these route-bound\
+    \ modules in your implementation.\nDo not import a generic parent package such\
+    \ as `from trellis.models import ...` just to satisfy the method family.\n\n##\
+    \ API Map — start here before guessing module paths\n\nUse this navigation card\
+    \ to choose the right module family first. Confirm exact symbols with `find_symbol`\
+    \ or `list_exports` before calling `read_module`.\n\n### Core Types\n#### MarketState\n\
+    - Module: `trellis.core.market_state`\n- Class: `MarketState`\n- Frozen: `true`\n\
+    - Fields: `as_of`, `settlement`, `discount`, `forward_curve`, `vol_surface`, `state_space`,\
+    \ `credit_curve`, `forecast_curves`, `fx_rates`\n- Accessors: `discount_factor`,\
+    \ `zero_rate`, `forward_rate`, `forecast_forward`, `black_vol`, `survival_prob`,\
+    \ `hazard_rate`, `risky_discount`\n- Capabilities: `discount_curve → discount\
+    \ is not None`, `forward_curve → forward_curve is not None (auto from discount)`,\
+    \ `black_vol_surface → vol_surface is not None`, `state_space → state_space is\
+    \ not None`, `credit_curve → credit_curve is not None`, `fx_rates → fx_rates is\
+    \ not None`\n#### Payoff\n- Module: `trellis.core.payoff`\n- Protocol: `Payoff`\n\
+    - Required methods: `evaluate`\n- Required properties: `requirements`\n- Runtime\
+    \ checkable: `true`\n- Notes:\n  - Each payoff handles its own discounting internally\n\
+    \  - The returned float is the final PV\n  - DeterministicCashflowPayoff wraps\
+    \ any Instrument into Payoff\n\n### Model Families\n#### equity_tree\n- Module:\
+    \ `trellis.models.equity_option_tree`\n- Key imports:\n  - `from trellis.models.equity_option_tree\
+    \ import price_vanilla_equity_option_tree`\n  - `from trellis.models.trees.lattice\
+    \ import build_spot_lattice, lattice_backward_induction`\n- Notes:\n  - American/Bermudan\
+    \ equity options should prefer the checked-in helper `price_vanilla_equity_option_tree(...)`\n\
+    \  - If you need the lower-level path, import the lattice builder/backward induction\
+    \ submodules directly\n#### rate_lattice\n- Module: `trellis.models.trees.lattice`\n\
+    - Key imports:\n  - `from trellis.models.trees.lattice import build_rate_lattice,\
+    \ lattice_backward_induction`\n  - `from trellis.models.zcb_option_tree import\
+    \ price_zcb_option_tree`\n- Notes:\n  - Callable bonds, puttable bonds, and Bermudan\
+    \ swaptions use a calibrated rate lattice from a TreeModel specification such\
+    \ as Hull-White or Black-Derman-Toy\n  - lattice_backward_induction handles cashflow_at_node\
+    \ and exercise_fn\n  - Zero-coupon bond option tree routes should prefer `price_zcb_option_tree(...)`\
+    \ instead of rebuilding nested backward induction inline\n#### monte_carlo\n-\
+    \ Module: `trellis.models.monte_carlo`\n- Key imports:\n  - `from trellis.models.monte_carlo.engine\
+    \ import MonteCarloEngine`\n  - `from trellis.models.monte_carlo.lsm import longstaff_schwartz,\
+    \ longstaff_schwartz_result`\n  - `from trellis.models.monte_carlo.early_exercise\
+    \ import EarlyExercisePolicyResult, LeastSquaresContinuationEstimator`\n  - `from\
+    \ trellis.models.monte_carlo.schemes import LaguerreBasis`\n  - `from trellis.models.monte_carlo\
+    \ import euler_maruyama, milstein, brownian_bridge`\n  - `from trellis.models.monte_carlo\
+    \ import antithetic, control_variate`\n  - `from trellis.models.processes.gbm\
+    \ import GBM`\n- Notes:\n  - For American/Bermudan Monte Carlo, simulate paths\
+    \ then call an approved early-exercise control primitive; Trellis currently implements\
+    \ longstaff_schwartz\n  - If the control primitive uses continuation regression,\
+    \ choose the estimator or basis explicitly; LaguerreBasis is optional, not mandatory\n\
+    \  - Do not invent method='lsm' on MonteCarloEngine\n#### qmc\n- Module: `trellis.models.qmc`\n\
+    - Key imports:\n  - `from trellis.models.qmc import sobol_normals, brownian_bridge`\n\
+    \  - `from trellis.models.processes.gbm import GBM`\n- Notes:\n  - QMC is an accelerator\
+    \ family layered on Monte Carlo-style estimators\n  - Current support is Sobol-based\
+    \ normal draws and Brownian-bridge construction\n#### pde\n- Module: `trellis.models.pde`\n\
+    - Key imports:\n  - `from trellis.models.equity_option_pde import price_vanilla_equity_option_pde`\n\
+    \  - `from trellis.models.pde.grid import Grid`\n  - `from trellis.models.pde.theta_method\
+    \ import theta_method_1d`\n  - `from trellis.models.pde.operator import BlackScholesOperator`\n\
+    \  - `from trellis.models.pde import psor_1d  # American options`\n  - `from trellis.models.pde\
+    \ import HullWhitePDEOperator`\n- Notes:\n  - Vanilla European equity PDE routes\
+    \ should prefer the checked-in helper `price_vanilla_equity_option_pde(...)`\n\
+    \  - Use theta_method_1d, NOT legacy crank_nicolson_1d or implicit_fd_1d\n  -\
+    \ theta=0.5 for Crank-Nicolson, theta=1.0 for fully implicit\n  - Grid constructor:\
+    \ Grid(x_min, x_max, n_x, T, n_t, log_spacing=False); never omit x_min or n_t\n\
+    \  - BlackScholesOperator constructor: BlackScholesOperator(sigma_fn, r_fn); pass\
+    \ callables, not scalar r/sigma keywords\n#### fft\n- Module: `trellis.models.transforms`\n\
+    - Key imports:\n  - `from trellis.models.transforms import fft_price, cos_price`\n\
+    - Notes:\n  - fft_price expects CF of log(S_T) — include log(S0)\n  - cos_price\
+    \ expects CF of log(S_T/S0) — log-return only\n#### copulas\n- Module: `trellis.models.copulas`\n\
+    - Key imports:\n  - `from trellis.models.copulas import GaussianCopula, StudentTCopula,\
+    \ FactorCopula`\n#### analytical\n- Module: `trellis.models.zcb_option`\n- Key\
+    \ imports:\n  - `from trellis.models.zcb_option import resolve_zcb_option_hw_inputs,\
+    \ price_zcb_option_jamshidian`\n  - `from trellis.models.analytical.jamshidian\
+    \ import ResolvedJamshidianInputs, zcb_option_hw_raw`\n  - `from trellis.models.analytical\
+    \ import zcb_option_hw`\n  - `from trellis.models.analytical import terminal_vanilla_from_basis`\n\
+    \  - `from trellis.models.rate_style_swaption import ResolvedSwaptionBlack76Inputs,\
+    \ resolve_swaption_black76_inputs, price_swaption_black76_raw, price_bermudan_swaption_black76_lower_bound`\n\
+    #### calibration\n- Module: `trellis.models.calibration`\n- Key imports:\n  -\
+    \ `from trellis.models.calibration import implied_vol, implied_vol_jaeckel`\n\
+    \  - `from trellis.models.calibration import RatesCalibrationResult, calibrate_cap_floor_black_vol,\
+    \ calibrate_swaption_black_vol, swaption_terms`\n  - `from trellis.models.calibration\
+    \ import calibrate_sabr`\n  - `from trellis.models.calibration import dupire_local_vol`\n\
+    \n### Utilities\n#### black76\n- Module: `trellis.models.black`\n- Imports:\n\
+    \  - `from trellis.models.black import black76_call, black76_put, black76_asset_or_nothing_call,\
+    \ black76_asset_or_nothing_put, black76_cash_or_nothing_call, black76_cash_or_nothing_put`\n\
+    #### garman_kohlhagen\n- Module: `trellis.models.analytical.fx`\n- Imports:\n\
+    \  - `from trellis.models.analytical.fx import ResolvedGarmanKohlhagenInputs,\
+    \ garman_kohlhagen_price_raw`\n  - `from trellis.models.black import garman_kohlhagen_call,\
+    \ garman_kohlhagen_put`\n#### rate_style_swaption\n- Module: `trellis.models.rate_style_swaption`\n\
+    - Imports:\n  - `from trellis.models.rate_style_swaption import ResolvedSwaptionBlack76Inputs,\
+    \ resolve_swaption_black76_inputs, price_swaption_black76_raw, price_swaption_black76`\n\
+    \  - `from trellis.models.rate_style_swaption import price_bermudan_swaption_black76_lower_bound`\n\
+    #### jamshidian_zcb_option\n- Module: `trellis.models.zcb_option`\n- Imports:\n\
+    \  - `from trellis.models.zcb_option import ResolvedZCBOptionInputs, resolve_zcb_option_hw_inputs,\
+    \ price_zcb_option_jamshidian`\n  - `from trellis.models.analytical.jamshidian\
+    \ import ResolvedJamshidianInputs, zcb_option_hw_raw`\n#### schedule\n- Module:\
+    \ `trellis.core.date_utils`\n- Imports:\n  - `from trellis.core.date_utils import\
+    \ generate_schedule`\n#### day_count\n- Module: `trellis.core.date_utils`\n- Imports:\n\
+    \  - `from trellis.core.date_utils import year_fraction`\n#### vol_surface\n-\
+    \ Module: `trellis.models.vol_surface`\n- Imports:\n  - `from trellis.models.vol_surface\
+    \ import VolSurface, FlatVol`\n#### cashflow_engine\n- Module: `trellis.models.cashflow_engine`\n\
+    - Imports:\n  - `from trellis.models.cashflow_engine import Waterfall, Tranche`\n\
+    \  - `from trellis.models.cashflow_engine import PSA, CPR, RateDependent`\n  -\
+    \ `from trellis.models.cashflow_engine import level_pay, scheduled, custom`\n\
+    #### credit_curve\n- Module: `trellis.curves.credit_curve`\n- Imports:\n  - `from\
+    \ trellis.curves.credit_curve import CreditCurve`\n- Notes:\n  - CreditCurve.flat(hazard_rate)\
+    \ is the simplest starting point for CDS or nth-to-default tasks\n  - CreditCurve.from_spreads(cds_spreads,\
+    \ recovery) bootstraps a hazard-rate term structure from CDS quotes\n\n## AVAILABLE\
+    \ IMPORTS — use ONLY these, NEVER invent module paths\n\n**CRITICAL**: If a module\
+    \ or symbol is not listed below, it does NOT exist.\nDo NOT guess paths like 'pde_solver',\
+    \ 'simulation', 'pricing', 'pdesolvers'.\nDo NOT use CamelCase in module paths\
+    \ (e.g., NOT 'coxRossRubinstein').\nEvery import in your code MUST come from this\
+    \ list.\n\n\n### Core\nfrom trellis.core.capabilities import MarketDataCapability,\
+    \ MethodCapability, analyze_gap, capability_summary, check_market_data, discover_capabilities,\
+    \ normalize_capability_name, normalize_market_data_requirements, validate_market_data_requirements\n\
+    from trellis.core.date_utils import add_months, build_contract_timeline, build_contract_timeline_from_dates,\
+    \ build_exercise_timeline_from_dates, build_observation_timeline, build_payment_timeline,\
+    \ build_period_schedule, coerce_contract_timeline_from_dates, generate_schedule,\
+    \ get_accrual_fraction, get_bracketing_dates, normalize_explicit_dates, year_fraction\n\
+    from trellis.core.differentiable import get_numpy, gradient, hessian, jacobian\n\
+    from trellis.core.market_state import MarketState, MissingCapabilityError\nfrom\
+    \ trellis.core.payoff import Cashflows, DeterministicCashflowPayoff, MonteCarloPathPayoff,\
+    \ Payoff, PresentValue, ResolvedInputPayoff\nfrom trellis.core.runtime_contract\
+    \ import ContractAwareMapping, ContractState, ContractViolation, MarketStateContractProxy,\
+    \ ResolvedInputs, RuntimeContext, wrap_market_state_with_contract\nfrom trellis.core.state_space\
+    \ import StateSpace\nfrom trellis.core.types import CashflowSchedule, ContractTimeline,\
+    \ DataProvider, DayCountConvention, DiscountCurve, DslMeasure, EventSchedule,\
+    \ Frequency, Instrument, PricingResult, SchedulePeriod, TimelineRole, normalize_dsl_measure\n\
+    \n### Curves\nfrom trellis.curves.bootstrap import BootstrapCalibrationDiagnostics,\
+    \ BootstrapCalibrationResult, BootstrapConventionBundle, BootstrapCurveInputBundle,\
+    \ BootstrapInstrument, BootstrapQuoteBucket, bootstrap, bootstrap_curve_input_bundle_from_payload,\
+    \ bootstrap_curve_result, bootstrap_named_curve_results, bootstrap_named_yield_curves,\
+    \ bootstrap_yield_curve, build_bootstrap_quote_buckets, build_bootstrap_solve_request,\
+    \ bump_bootstrap_quote_buckets\nfrom trellis.curves.credit_curve import CreditCurve\n\
+    from trellis.curves.forward_curve import ForwardCurve\nfrom trellis.curves.interpolation\
+    \ import linear_interp, log_linear_interp\nfrom trellis.curves.scenario_packs\
+    \ import RateCurveScenario, build_rate_curve_scenario_pack\nfrom trellis.curves.shocks\
+    \ import CurveShockBucket, CurveShockSurface, CurveShockWarning, build_curve_shock_surface\n\
+    from trellis.curves.yield_curve import YieldCurve\n\n### Models — Analytical\n\
+    from trellis.models.analytical import terminal_vanilla_from_basis\nfrom trellis.models.analytical.barrier\
+    \ import ResolvedBarrierInputs, barrier_image_raw, barrier_option_price, barrier_regime_selector_raw,\
+    \ down_and_in_call, down_and_in_call_raw, down_and_out_call, down_and_out_call_raw,\
+    \ rebate_raw, vanilla_call_raw\nfrom trellis.models.analytical.fx import ResolvedGarmanKohlhagenInputs,\
+    \ garman_kohlhagen_call_raw, garman_kohlhagen_price_raw, garman_kohlhagen_put_raw\n\
+    from trellis.models.analytical.jamshidian import ResolvedJamshidianInputs, zcb_option_hw,\
+    \ zcb_option_hw_raw\nfrom trellis.models.analytical.quanto import QuantoAnalyticalSpecLike,\
+    \ price_quanto_option_analytical, price_quanto_option_raw\nfrom trellis.models.analytical.support.cross_asset\
+    \ import effective_covariance_term, exchange_option_effective_vol, foreign_to_domestic_forward_bridge,\
+    \ quanto_adjusted_forward\nfrom trellis.models.analytical.support.discounting\
+    \ import continuous_rate_from_simple_rate, discount_factor_from_zero_rate, discounted_value,\
+    \ forward_discount_ratio, implied_zero_rate, safe_time_fraction, simple_rate_from_discount_factor\n\
+    from trellis.models.analytical.support.forwards import forward_from_carry_rate,\
+    \ forward_from_discount_factors, forward_from_dividend_yield\nfrom trellis.models.analytical.support.payoffs\
+    \ import asset_or_nothing_intrinsic, call_put_parity_gap, cash_or_nothing_intrinsic,\
+    \ normalized_option_type, terminal_intrinsic, terminal_vanilla_from_basis\nfrom\
+    \ trellis.models.black import black76_asset_or_nothing_call, black76_asset_or_nothing_put,\
+    \ black76_call, black76_cash_or_nothing_call, black76_cash_or_nothing_put, black76_put,\
+    \ garman_kohlhagen_call, garman_kohlhagen_put\nfrom trellis.models.resolution.basket_semantics\
+    \ import BasketSpecLike, CorrelationPreflightError, CorrelationPreflightReport,\
+    \ ResolvedBasketSemantics, resolve_basket_semantics\nfrom trellis.models.resolution.quanto\
+    \ import QuantoSpecLike, ResolvedQuantoInputs, resolve_quanto_correlation, resolve_quanto_foreign_curve,\
+    \ resolve_quanto_inputs, resolve_quanto_underlier_spot\nfrom trellis.models.resolution.short_rate_claims\
+    \ import DiscountBondClaimSpecLike, DiscountCurveLike, FlatShortRateVolSurface,\
+    \ ResolvedDiscountBondClaim, ResolvedShortRateRegime, ShortRateClaimMarketStateLike,\
+    \ ShortRateComparisonRegime, VolSurfaceLike, extract_short_rate_comparison_regime,\
+    \ normalize_discount_bond_strike, resolve_discount_bond_claim_inputs, resolve_discount_bond_option_type,\
+    \ resolve_short_rate_regime\nfrom trellis.models.resolution.single_state_diffusion\
+    \ import DiscountCurveLike, ResolvedSingleStateDiffusionInputs, SingleStateDiffusionMarketStateLike,\
+    \ SingleStateDiffusionSpecLike, VolSurfaceLike, gbm_log_ratio_char_fn, gbm_log_spot_char_fn,\
+    \ put_from_call_parity, resolve_single_state_diffusion_inputs, terminal_intrinsic_from_resolved\n\
+    \n### Models — Trees\nfrom trellis.models.trees.algebra import AnalyticalCalibration,\
+    \ CalibratedLatticeData, CalibrationDiagnostics, CalibrationStrategy, EventOverlaySpec,\
+    \ LatticeAlgebraEligibilityDecision, LatticeContractSpec, LatticeControlSpec,\
+    \ LatticeLinearClaimSpec, LatticeMeshSpec, LatticeModelSpec, LatticeRecipe, LatticeTopologySpec,\
+    \ LocalVolCalibration, NO_CALIBRATION_TARGET, NoCalibrationTarget, TERM_STRUCTURE_TARGET,\
+    \ TermStructureCalibration, TermStructureTarget, TwoFactorAnalyticalCalibration,\
+    \ VolSurfaceTarget, build_lattice, compile_lattice_recipe, equity_tree, lattice_algebra_eligible,\
+    \ price_on_lattice, short_rate_tree, with_control, with_overlay\nfrom trellis.models.trees.backward_induction\
+    \ import backward_induction\nfrom trellis.models.trees.binomial import BinomialTree\n\
+    from trellis.models.trees.control import ExerciseObjective, LatticeExercisePolicy,\
+    \ build_exercise_timeline_from_dates, build_payment_timeline, lattice_step_from_time,\
+    \ lattice_steps_from_timeline, merge_lattice_exercise_policy, resolve_lattice_exercise_policy,\
+    \ resolve_lattice_exercise_policy_from_control_style\nfrom trellis.models.trees.lattice\
+    \ import RecombiningLattice, build_generic_lattice, build_lattice, build_rate_lattice,\
+    \ build_spot_lattice, calibrate_lattice, lattice_backward_induction, price_on_lattice\n\
+    from trellis.models.trees.models import TreeModel, bdt_displacement, bdt_mean_reversion_probabilities,\
+    \ binomial_mean_reversion_probabilities_from_metric, equal_probabilities, ho_lee_displacement,\
+    \ hw_displacement, hw_mean_reversion_probabilities, identity_state_metric, log_rate_state_metric,\
+    \ lognormal_rate, normal_rate, shifted_lognormal_rate, standard_discount, trinomial_mean_reversion_probabilities_from_metric\n\
+    from trellis.models.trees.product_lattice import ProductRecombiningLattice2D,\
+    \ build_product_spot_lattice_2d\nfrom trellis.models.trees.trinomial import TrinomialTree\n\
+    \n### Models — Monte Carlo\nfrom trellis.models.monte_carlo.basket_state import\
+    \ build_basket_path_requirement, evaluate_ranked_observation_basket_paths, evaluate_ranked_observation_basket_state,\
+    \ observation_step_indices\nfrom trellis.models.monte_carlo.brownian_bridge import\
+    \ brownian_bridge\nfrom trellis.models.monte_carlo.discretization import euler_maruyama,\
+    \ exact_simulation, milstein\nfrom trellis.models.monte_carlo.early_exercise import\
+    \ ContinuationEstimator, EarlyExerciseDiagnostics, EarlyExercisePolicyResult,\
+    \ FastLaguerreContinuationEstimator, FastPolynomialContinuationEstimator, LeastSquaresContinuationEstimator,\
+    \ default_continuation_estimator, normalize_exercise_steps, polynomial_basis\n\
+    from trellis.models.monte_carlo.engine import MonteCarloEngine\nfrom trellis.models.monte_carlo.event_aware\
+    \ import EventAwareMonteCarloEvent, EventAwareMonteCarloProblem, EventAwareMonteCarloProblemSpec,\
+    \ EventAwareMonteCarloProcessSpec, build_discounted_swap_pv_payload, build_event_aware_monte_carlo_problem,\
+    \ build_event_aware_monte_carlo_problem_from_family_ir, build_event_aware_monte_carlo_process,\
+    \ build_event_time_map_from_family_ir, build_short_rate_discount_reducer, build_timed_event_aware_monte_carlo_problem_from_family_ir,\
+    \ price_event_aware_monte_carlo, resolve_hull_white_monte_carlo_process_inputs\n\
+    from trellis.models.monte_carlo.event_state import PathEventRecord, PathEventSpec,\
+    \ PathEventState, PathEventTimeline, apply_path_event_spec, build_event_path_requirement,\
+    \ event_step_indices, replay_path_event_timeline\nfrom trellis.models.monte_carlo.local_vol\
+    \ import LocalVolMonteCarloResult, local_vol_european_vanilla_price, local_vol_european_vanilla_price_result\n\
+    from trellis.models.monte_carlo.lsm import laguerre_basis, longstaff_schwartz,\
+    \ longstaff_schwartz_result\nfrom trellis.models.monte_carlo.path_state import\
+    \ BarrierMonitor, MonteCarloPathRequirement, MonteCarloPathState, PathReducer,\
+    \ StateAwarePayoff, barrier_payoff, terminal_value_payoff\nfrom trellis.models.monte_carlo.primal_dual\
+    \ import primal_dual_mc, primal_dual_mc_result\nfrom trellis.models.monte_carlo.profiling\
+    \ import MonteCarloPathKernelBenchmark, benchmark_path_kernel\nfrom trellis.models.monte_carlo.quanto\
+    \ import QuantoMonteCarloSpecLike, build_quanto_mc_initial_state, build_quanto_mc_process,\
+    \ price_quanto_option_monte_carlo, recommended_quanto_mc_engine_kwargs, terminal_quanto_option_payoff\n\
+    from trellis.models.monte_carlo.ranked_observation_payoffs import RankedObservationBasketSpecLike,\
+    \ build_ranked_observation_basket_initial_state, build_ranked_observation_basket_process,\
+    \ build_ranked_observation_basket_state_payoff, price_ranked_observation_basket_monte_carlo,\
+    \ recommended_ranked_observation_basket_mc_engine_kwargs, terminal_ranked_observation_basket_payoff\n\
+    from trellis.models.monte_carlo.schemes import Antithetic, BasisFunction, ChebyshevBasis,\
+    \ DiscretizationScheme, Euler, Exact, HermiteBasis, LaguerreBasis, LogEuler, Milstein,\
+    \ PolynomialBasis\nfrom trellis.models.monte_carlo.semantic_basket import RankedObservationBasketMonteCarloPayoff,\
+    \ RankedObservationBasketPathContract, RankedObservationBasketSpec, build_ranked_observation_basket_path_contract,\
+    \ price_ranked_observation_basket_monte_carlo\nfrom trellis.models.monte_carlo.single_state_diffusion\
+    \ import ResolvedSingleStateMonteCarloInputs, SingleStateMonteCarloResult, build_single_state_terminal_claim_monte_carlo_problem,\
+    \ build_single_state_terminal_claim_monte_carlo_problem_from_resolved, price_single_state_terminal_claim_monte_carlo_result,\
+    \ resolve_single_state_terminal_claim_monte_carlo_inputs\nfrom trellis.models.monte_carlo.stochastic_mesh\
+    \ import stochastic_mesh, stochastic_mesh_result\nfrom trellis.models.monte_carlo.tv_regression\
+    \ import tsitsiklis_van_roy, tsitsiklis_van_roy_result\nfrom trellis.models.monte_carlo.variance_reduction\
+    \ import antithetic, antithetic_normals, brownian_bridge_increments, control_variate,\
+    \ sobol_normals\n\n### Models — QMC\nfrom trellis.models.qmc import brownian_bridge,\
+    \ sobol_normals\n\n### Models — PDE\nfrom trellis.models.pde import crank_nicolson_1d,\
+    \ implicit_fd_1d\nfrom trellis.models.pde.crank_nicolson import crank_nicolson_1d\n\
+    from trellis.models.pde.event_aware import CompiledEventAwarePDEEventBucket, EventAwarePDEBoundarySpec,\
+    \ EventAwarePDEEventBucket, EventAwarePDEGridSpec, EventAwarePDEOperatorSpec,\
+    \ EventAwarePDEProblem, EventAwarePDEProblemSpec, EventAwarePDETransform, apply_event_bucket,\
+    \ apply_event_transform, build_event_aware_pde_operator, build_event_aware_pde_problem,\
+    \ evaluate_boundary_value, interpolate_pde_values, solve_event_aware_pde\nfrom\
+    \ trellis.models.pde.grid import Grid\nfrom trellis.models.pde.implicit_fd import\
+    \ implicit_fd_1d\nfrom trellis.models.pde.operator import BlackScholesOperator,\
+    \ CEVOperator, HeatOperator, PDEOperator\nfrom trellis.models.pde.psor import\
+    \ psor_1d\nfrom trellis.models.pde.rate_operator import HullWhitePDEOperator\n\
+    from trellis.models.pde.theta_method import theta_method_1d\nfrom trellis.models.pde.thomas\
+    \ import thomas_solve\n\n### Models — Transforms (FFT/COS)\nfrom trellis.models.transforms.cos_method\
+    \ import cos_price\nfrom trellis.models.transforms.fft_pricer import fft_price\n\
+    from trellis.models.transforms.single_state_diffusion import ResolvedSingleStateTransformInputs,\
+    \ SingleStateTransformResult, price_single_state_terminal_claim_transform_result,\
+    \ resolve_single_state_terminal_claim_transform_inputs\n\n### Models — Processes\n\
+    from trellis.models.processes.base import StochasticProcess\nfrom trellis.models.processes.cir\
+    \ import CIR\nfrom trellis.models.processes.correlated_gbm import CorrelatedGBM\n\
+    from trellis.models.processes.gbm import GBM\nfrom trellis.models.processes.heston\
+    \ import Heston, HestonRuntimeBinding, build_heston_parameter_payload, extract_heston_parameter_payload,\
+    \ resolve_heston_runtime_binding\nfrom trellis.models.processes.hull_white import\
+    \ HullWhite\nfrom trellis.models.processes.jump_diffusion import MertonJumpDiffusion\n\
+    from trellis.models.processes.local_vol import LocalVol\nfrom trellis.models.processes.sabr\
+    \ import SABRProcess\nfrom trellis.models.processes.vasicek import Vasicek\n\n\
+    ### Models — Copulas\nfrom trellis.models.copulas.factor import FactorCopula\n\
+    from trellis.models.copulas.gaussian import GaussianCopula\nfrom trellis.models.copulas.student_t\
+    \ import StudentTCopula\n\n### Models — Calibration\nfrom trellis.models.calibration.benchmarking\
+    \ import CalibrationBenchmarkArtifacts, CalibrationBenchmarkMeasurement, CalibrationBenchmarkScenario,\
+    \ benchmark_calibration_scenario, benchmark_calibration_workflow, build_calibration_benchmark_report,\
+    \ build_supported_calibration_benchmark_report, render_calibration_benchmark_report,\
+    \ save_calibration_benchmark_report, supported_calibration_benchmark_scenarios\n\
+    from trellis.models.calibration.credit import CreditHazardCalibrationQuote, CreditHazardCalibrationResult,\
+    \ calibrate_single_name_credit_curve_workflow\nfrom trellis.models.calibration.heston_fit\
+    \ import HestonSmileCalibrationResult, HestonSmileFitDiagnostics, HestonSmilePoint,\
+    \ HestonSmileSurface, build_heston_smile_surface, calibrate_heston_smile_workflow,\
+    \ fit_heston_smile_surface\nfrom trellis.models.calibration.implied_vol import\
+    \ implied_vol, implied_vol_jaeckel\nfrom trellis.models.calibration.local_vol\
+    \ import LocalVolCalibrationResult, LocalVolSurfaceDiagnostics, calibrate_local_vol_surface_workflow,\
+    \ dupire_local_vol, dupire_local_vol_result\nfrom trellis.models.calibration.materialization\
+    \ import CalibratedObjectMaterialization, materialize_black_vol_surface, materialize_credit_curve,\
+    \ materialize_local_vol_surface, materialize_model_parameter_set, resolve_materialized_object\n\
+    from trellis.models.calibration.quote_maps import CalibrationQuoteMap, QuoteAxisSpec,\
+    \ QuoteMapSpec, QuoteSemanticsSpec, QuoteSettlementSpec, QuoteTransformResult,\
+    \ QuoteUnitSpec, build_identity_quote_map, build_implied_vol_quote_map, supported_quote_map_surface\n\
+    from trellis.models.calibration.rates import HullWhiteCalibrationInstrument, HullWhiteCalibrationResult,\
+    \ RatesCalibrationResult, SwaptionLike, calibrate_cap_floor_black_vol, calibrate_hull_white,\
+    \ calibrate_swaption_black_vol, swaption_terms\nfrom trellis.models.calibration.sabr_fit\
+    \ import SABRSmileCalibrationResult, SABRSmileFitDiagnostics, SABRSmilePoint,\
+    \ SABRSmileSurface, build_sabr_smile_surface, calibrate_sabr, calibrate_sabr_smile_workflow,\
+    \ fit_sabr_smile_surface\nfrom trellis.models.calibration.solve_request import\
+    \ ConstraintSpec, ObjectiveBundle, SolveBackendRecord, SolveBackendRegistry, SolveBounds,\
+    \ SolveProvenance, SolveReplayArtifact, SolveRequest, SolveResult, UnsupportedSolveCapabilityError,\
+    \ WarmStart, build_solve_provenance, build_solve_replay_artifact, execute_solve_request\n\
+    \n### Models — Cashflow Engine\nfrom trellis.models.cashflow_engine.amortization\
+    \ import custom, level_pay, scheduled\nfrom trellis.models.cashflow_engine.prepayment\
+    \ import CPR, PSA, RateDependent\nfrom trellis.models.cashflow_engine.waterfall\
+    \ import Tranche, Waterfall\n\n### Models — Vol Surface\nfrom trellis.models.vol_surface\
+    \ import FlatVol, GridVolSurface, VolSurface\nfrom trellis.models.vol_surface_shocks\
+    \ import VolSurfaceShockBucket, VolSurfaceShockSurface, VolSurfaceShockWarning,\
+    \ build_vol_surface_shock_surface\n\n### Instruments (reference)\nfrom trellis.instruments.barrier_option\
+    \ import BarrierOptionPayoff, BarrierOptionSpec\nfrom trellis.instruments.bond\
+    \ import Bond, ParBond\nfrom trellis.instruments.callable_bond import CallableBondPayoff,\
+    \ CallableBondSpec\nfrom trellis.instruments.cap import CapFloorSpec, CapPayoff,\
+    \ FloorPayoff\nfrom trellis.instruments.nth_to_default import NthToDefaultPayoff,\
+    \ NthToDefaultSpec, price_nth_to_default_basket\nfrom trellis.instruments.swap\
+    \ import SwapPayoff, SwapSpec, par_swap_rate\n\n## Key Principles\n\n- **P1**:\
+    \ Always calibrate rate trees to the discount curve before pricing\n- **P2**:\
+    \ Callable bonds need issuer_call lattice control, discrete coupons, and exercise=par+coupon\n\
+    - **P3**: Convert vol units at the boundary between market data and model\n- **P4**:\
+    \ Monte Carlo: use ≥10k paths, verify SE <1% of price, use Laguerre basis at high\
+    \ vol (σ ≥ 0.40) to avoid LSM polynomial bias\n- **P5**: Numerical stability:\
+    \ use theta_method_1d with BlackScholesOperator (not legacy crank_nicolson_1d),\
+    \ center COS truncation on first cumulant to prevent overflow\n- **P6**: Cross-validation:\
+    \ measure the actual gap first, then set tolerance to 2-3x the measured gap —\
+    \ never wider than 1% of price or 5bp\n- **P7**: Bermudan swaption: all exercise\
+    \ dates enter the SAME underlying swap (start=first_exercise, end=first_exercise+tenor)\
+    \ — do not create a fresh shorter swap at each exercise date\n- **P8**: OAS computation:\
+    \ keep sigma_HW (vol model) fixed during the spread root-finding loop — only shift\
+    \ the discount curve, never recompute vol from the shifted forward rate\n- **P9**:\
+    \ Separate semantic understanding, method arbitration, and numerical pricing:\
+    \ draft the contract first, choose and explain the method second, and only then\
+    \ call the pricing kernel.\n- **P10**: Bootstrap before pricing: launch with the\
+    \ repo-pinned Python and an explicit shell/workdir, validate imports and module\
+    \ compilation first, and treat interpreter mismatches, shell-launch failures,\
+    \ ModuleNotFoundError, ImportError, and SyntaxError as setup defects, not pricing\
+    \ failures.\n- **P11**: Partial requests are normal: draft the semantic contract\
+    \ first, infer the required-input checklist from the product IR and method requirements,\
+    \ and let the LLM or a mock input provider fill only the missing market-data and\
+    \ convention gaps. Never guess silently.\n\n## Pricing Method: pde_solver\n\n\
+    One-dimensional finite-difference theta-method pricing with optional obstacle\
+    \ handling\n\n## Cookbook: PDE (finite difference theta-method)\nUse this pattern\
+    \ for low-dimensional Markov claims where a 1D PDE is natural.\n\nFor plain European\
+    \ call/put equity routes, prefer the checked-in helper\n`price_vanilla_equity_option_pde(market_state,\
+    \ spec, theta=...)` from\n`trellis.models.equity_option_pde` so the adapter stays\
+    \ thin.\n\n```python\ndef evaluate(self, market_state):\n    from trellis.core.date_utils\
+    \ import year_fraction\n    from trellis.models.pde.grid import Grid\n    from\
+    \ trellis.models.pde.theta_method import theta_method_1d\n    from trellis.models.pde.operator\
+    \ import BlackScholesOperator\n    import numpy as np\n\n    spec = self._spec\n\
+    \    T = year_fraction(market_state.settlement, spec.expiry_date, spec.day_count)\n\
+    \    r = float(market_state.discount.zero_rate(T))\n    sigma = float(market_state.vol_surface.black_vol(T,\
+    \ spec.strike))\n\n    S_max = 4.0 * spec.spot\n    n_x = 201\n    n_t = max(200,\
+    \ int(round(T * 252)))\n    grid = Grid(x_min=0.0, x_max=S_max, n_x=n_x, T=T,\
+    \ n_t=n_t)\n    # >>> INSTRUMENT-SPECIFIC: define terminal payoff and boundary\
+    \ conditions <<<\n    terminal = np.maximum(grid.x - spec.strike, 0.0)\n    op\
+    \ = BlackScholesOperator(lambda s, t: sigma, lambda t: r)\n\n    V = theta_method_1d(\n\
+    \        grid,\n        op,\n        terminal,\n        theta=0.5,\n        lower_bc_fn=lambda\
+    \ t: 0.0,\n        upper_bc_fn=lambda t: S_max - spec.strike * np.exp(-r * (T\
+    \ - t)),\n    )\n\n    # For American puts, pass exercise_values and exercise_fn=max.\n\
+    \    # For barrier or digital payoffs, use rannacher_timesteps to smooth\n   \
+    \ # the first backward steps and keep the boundary conditions explicit.\n\n  \
+    \  price = float(np.interp(spec.spot, grid.x, V))\n    return price * spec.notional\n\
+    ```\n\n\n## Product Semantics\n\n- Instrument: `european_option`\n- Payoff family:\
+    \ `vanilla_option`\n- Exercise style: `european`\n- State dependence: `terminal_markov`\n\
+    - Schedule dependence: `False`\n- Model family: `equity_diffusion`\n- Payoff traits:\
+    \ `discounting`, `vol_surface_dependence`\n- Candidate engine families: `analytical`\n\
+    \n## DATA CONTRACTS (input conventions)\n\n### VOL_BLACK_FOR_PDE\n- Source: `market_state.vol_surface.black_vol(T,\
+    \ K)`\n- Convention: Black lognormal implied vol (annualized)\n- Typical range:\
+    \ 0.10 to 0.60\n- **Your model expects**: Black lognormal vol (same units — no\
+    \ conversion needed)\n- **Conversion**: `none — use directly as sigma in BlackScholesOperator\
+    \ or GBM diffusion`\n- Model range after conversion: 0.10 to 0.60\n\n\n## MODELING\
+    \ REQUIREMENTS (you MUST satisfy all of these)\n\n1. GRID: Use at least 200 spatial\
+    \ points and 200+ time steps. For barrier options, use non-uniform grid concentrated\
+    \ near the barrier.\n\n2. BOUNDARY CONDITIONS: Set V(0,t)=0 for calls, V(S_max,t)=S_max-K*exp(-r*(T-t))\
+    \ for calls. For puts: V(0,t)=K*exp(-r*(T-t)), V(S_max,t)=0.\n\n3. STABILITY:\
+    \ Crank-Nicolson (theta=0.5) is second-order but may oscillate near discontinuities.\
+    \ Use Rannacher smoothing (2-4 implicit steps at start) for digital/barrier payoffs.\n\
+    \n4. PDE ROUTE SCOPE: Use Grid from trellis.models.pde.grid, BlackScholesOperator\
+    \ from trellis.models.pde.operator, and theta_method_1d from trellis.models.pde.theta_method.\
+    \ For American puts, pass exercise_values and exercise_fn=max. Keep lower_bc_fn\
+    \ / upper_bc_fn callables explicit for barrier and digital payoffs, and do not\
+    \ invent log_grid_pde, uniform_grid_pde, absorbing, or dirichlet helper tokens.\n\
+    \nThese are not optional. Failure to satisfy them produces incorrect prices.\n\
+    \n## Canonical Model Grammar (supported calibration workflows)\n\n### `local_vol_surface_workflow`\
+    \ — Dupire local-vol workflow\n- Model: `Dupire local vol`\n- Quote families:\
+    \ `implied_vol`\n- Calibration workflows: `calibrate_local_vol_surface_workflow`\n\
+    - Runtime materialization kind: `local_vol_surface`\n- Deferred scope: `stochastic_local_vol`,\
+    \ `local_vol_extrapolation_governance`\n### `sabr_smile_workflow` — SABR smile\
+    \ calibration\n- Model: `SABR smile`\n- Quote families: `implied_vol`\n- Calibration\
+    \ workflows: `calibrate_sabr_smile_workflow`\n- Deferred scope: `term_structure_sabr`,\
+    \ `direct_market_state_materialization`\n### `heston_smile_workflow` — Heston\
+    \ smile calibration\n- Model: `Heston`\n- Quote families: `implied_vol`\n- Calibration\
+    \ workflows: `calibrate_heston_smile_workflow`\n- Runtime materialization kind:\
+    \ `model_parameter_set`\n- Deferred scope: `term_structure_heston`, `hybrid_equity_rates`\n\
+    ### `credit_single_name_reduced_form` — Reduced-form single-name CDS calibration\n\
+    - Model: `Reduced-form single-name credit`\n- Quote families: `spread`, `hazard`\n\
+    - Calibration workflows: `calibrate_single_name_credit_curve_workflow`\n- Runtime\
+    \ materialization kind: `credit_curve`\n- Deferred scope: `basket_credit`, `structural_credit`,\
+    \ `hybrid_credit_equity`\n### `rates_bootstrap_curve` — Rates bootstrap curve\
+    \ authority\n- Model: `Rates bootstrap curve bundle`\n- Quote families: `par_rate`,\
+    \ `price`\n- Calibration workflows: `build_bootstrap_solve_request`\n- Runtime\
+    \ materialization kind: `market_curves`\n- Rates curve roles: `discount_curve`,\
+    \ `forecast_curve`\n- Deferred scope: `cross_currency_bootstrap`, `calendar_complete_bootstrap`\n\
+    \n## Lessons (ranked by relevance)\n\n### [CRITICAL] BlackScholesOperator constructor\
+    \ mismatch\n**Symptom:** TypeError: BlackScholesOperator.__init__() got an unexpected\
+    \ keyword argument 'r'.\n**Why:** The generated code treated the PDE operator\
+    \ as if it accepted scalar 'r' and 'sigma' keywords, but trellis.models.pde.operator.BlackScholesOperator\
+    \ actually expects callables '(sigma_fn, r_fn)'. The mismatch caused constructor\
+    \ failure during module build.\n**Fix:** Import BlackScholesOperator from trellis.models.pde.operator\
+    \ and pass callables, for example BlackScholesOperator(lambda s, t: sigma, lambda\
+    \ t: r). Add a signature smoke test or cookbook template to lock the constructor\
+    \ shape and keep the solver path aligned with the real API.\n\n### [CRITICAL]\
+    \ PDE price blow-up from unit/scale mismatch\n**Symptom:** Final PV magnitude\
+    \ far exceeds expected scale (machine-check: |PV| > 10 × notional) or the PDE\
+    \ route returns a boundary-like price instead of the spot price.\n**Why:** The\
+    \ generated PDE branch called theta_method_1d with the obsolete operator/s_grid/t_grid/boundary_conditions\
+    \ signature and then read the wrong element of the result instead of interpolating\
+    \ the returned solution over grid.x. The actual API is theta_method_1d(grid, operator,\
+    \ terminal_condition, theta=..., lower_bc_fn=..., upper_bc_fn=...), and it returns\
+    \ the full solution vector at t=0.\n**Fix:** Build Grid(x_min=0.0, x_max=S_max,\
+    \ n_x=n_x, T=T, n_t=n_t), construct BlackScholesOperator(lambda s, t: sigma, lambda\
+    \ t: r), call theta_method_1d(grid, op, terminal, theta=0.5, lower_bc_fn=...,\
+    \ upper_bc_fn=...), then interpolate the returned vector with np.interp(spec.spot,\
+    \ grid.x, V) before multiplying by notional.\n\n### [CRITICAL] Use exact PDE import\
+    \ paths\n**Symptom:** ImportError shows `Grid` and `theta_method_1d` are not exported\
+    \ by `trellis.models.pde`.\n**Why:** The implementation guessed PDE module exports\
+    \ instead of using the exact supported import paths. The build then failed before\
+    \ any pricing logic could run.\n**Fix:** Inspect the actual trellis PDE package\
+    \ structure and import the grid/operator/solver objects from their real modules.\
+    \ Keep the solver call isolated so module-path errors are caught immediately during\
+    \ validation.\n\n### [CRITICAL] Undefined boundary condition symbol\n**Symptom:**\
+    \ NameError: name 'absorbing' is not defined when constructing the BarrierCallSpec\
+    \ (or assigning pde_boundary_condition).\n**Why:** The code used an undefined\
+    \ Python name 'absorbing' instead of a string literal or an imported/defined constant\
+    \ for the PDE boundary condition. There was no validation or unit test to catch\
+    \ the NameError before build.\n**Fix:** Use a quoted string (e.g. 'absorbing')\
+    \ or import/define the boundary-condition constant from the PDE module; add a\
+    \ small input validation that boundary-condition values belong to the allowed\
+    \ set.\n\n### [CRITICAL] Incorrect PDE API import (Grid not exported)\n**Symptom:**\
+    \ ImportError / AttributeError: 'Grid' is not exported by trellis.models.pde (or\
+    \ module has no attribute 'Grid').\n**Why:** The pricer attempted to import or\
+    \ reference a symbol (Grid) that is not part of the public API of trellis.models.pde;\
+    \ additionally the spec contained literal unquoted identifiers and malformed defaults\
+    \ which would cause name errors. This mismatch between assumed library exports\
+    \ and the actual library surface caused the build to fail.\n**Fix:** Inspect the\
+    \ actual exported symbols in trellis.models.pde (e.g. via help() or module.__all__),\
+    \ and replace the non-exported 'Grid' usage with the correct factory/function/class\
+    \ provided by the module (or implement a local grid builder). Also correct spec\
+    \ field defaults (quote string literals) and validate names with a small import/unit\
+    \ test before full build.\n\n### [CRITICAL] Unit conversion causes extreme PV\n\
+    **Symptom:** Price sanity check triggered: |PV| > 10 * typical_notional (e.g.,\
+    \ |PV| = 9995.24 > 1000)\n**Why:** Market-data / model-input unit mismatch (most\
+    \ commonly a volatility expressed in percent vs decimal, or a rate/discount representation\
+    \ mismatch) caused the PDE operator to receive parameters off by orders of magnitude.\n\
+    **Fix:** Normalize and validate market data before passing to the PDE (convert\
+    \ vol from percent->decimal, convert rates to the operator's expected form or\
+    \ supply discount factors), add assertive checks on ranges and shapes, and run\
+    \ a small-price sanity test before accepting results.\n\n### [CRITICAL] Incorrect\
+    \ PDE imports and malformed code\n**Symptom:** ImportError: 'trellis.models.pde'\
+    \ does not export 'Grid' OR SyntaxError: unexpected indent in generated module.\n\
+    **Why:** The generator guessed an incorrect trellis export (Grid) and produced\
+    \ malformed Python (incorrect indentation) while synthesizing the PDE solver;\
+    \ the combination prevented module import/execution.\n**Fix:** Use exact, confirmed\
+    \ trellis import paths (inspect the package or __all__), construct the spatial\
+    \ grid from the actual provided API if Grid isn't exported, and validate/ lint\
+    \ generated code (check indentation) before runtime. Add a minimal unit test that\
+    \ imports and runs evaluate() to catch these errors early.\n\n\n## Generated Skills\n\
+    - [cookbook] fft_pricing: Characteristic-function pricing for European-style options\
+    \ under models such as Heston\n- [lesson] Unit conversion causes huge PV: Enforce\
+    \ and document input conventions (vol as decimal, discount curve vs zero rate\
+    \ semantics, notional scaling), derive r from discount factors via r = -ln(df)/T\
+    \ or use forward/Black76 consistently, add unit/conversi...\n\n## Stage-Aware\
+    \ Skills\n- [route_hint] vanilla_equity_theta_pde route helper: Use the selected\
+    \ route helper directly inside `evaluate()`; do not rebuild the process, engine,\
+    \ or discount glue manually.\n- [route_hint] vanilla_equity_theta_pde note 1:\
+    \ For vanilla European equity PDE routes, prefer `price_vanilla_equity_option_pde(market_state,\
+    \ spec, theta=...)` so the adapter stays thin.\n- [route_hint] vanilla_equity_theta_pde\
+    \ note 2: Map `implementation_target=theta_0.5` to `theta=0.5` and `implementation_target=theta_1.0`\
+    \ to `theta=1.0`.\n- [route_hint] vanilla_equity_theta_pde note 3: The checked-in\
+    \ helper already owns grid sizing, terminal payoff assembly, boundary conditions,\
+    \ theta-method solve, and interpolation back to spot.\n- [route_hint] vanilla_equity_theta_pde\
+    \ note 4: Use the lower-level `Grid + BlackScholesOperator + theta_method_1d`\
+    \ path only when the payoff or boundary contract genuinely differs from plain\
+    \ vanilla European call/put.\n## Retry Focus\n- Recover against the real task\
+    \ market contract: required curves, spots, and volatility surfaces must be read\
+    \ from the live market_state.\n- Do not fix actual-market failures by hard-coding\
+    \ fixture values or widening fallback defaults inside evaluate().\n## Route-Specific\
+    \ Recovery\n- Vanilla European PDE routes should stay on the checked-in helper\
+    \ surface whenever the contract is plain call/put Black-Scholes.\n- Prefer `from\
+    \ trellis.models.equity_option_pde import price_vanilla_equity_option_pde` and\
+    \ delegate to that helper from the adapter.\n- Map `implementation_target=theta_0.5`\
+    \ to `theta=0.5` and `implementation_target=theta_1.0` to `theta=1.0`.\n- Do not\
+    \ rebuild terminal intrinsic branches, boundary callables, scalar interpolation,\
+    \ or discount-to-rate glue inline when the checked-in helper already matches the\
+    \ route.\n- Use the lower-level `Grid`, `BlackScholesOperator`, and `theta_method_1d`\
+    \ primitives only if the payoff or boundary contract genuinely differs from plain\
+    \ vanilla European call/put.\n## Semantic Repair Card\n- Method family: `pde_solver`\n\
+    - Instrument type: `european_option`\n- Lane boundary: family=`pde_solver`, kind=`exact_target_binding`,\
+    \ exact_bindings=`trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
+    - Route: `vanilla_equity_theta_pde`\n- Engine family: `pde_solver`\n- Route family:\
+    \ `pde_solver`\n- Required primitives:\n  - `trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\
+    \ (route_helper)\n- Required adapters:\n  - `reuse_checked_in_vanilla_equity_pde_helper`\n\
+    - Route notes:\n  - For vanilla European equity PDE routes, prefer `price_vanilla_equity_option_pde(market_state,\
+    \ spec, theta=...)` so the adapter stays thin.\n  - Map `implementation_target=theta_0.5`\
+    \ to `theta=0.5` and `implementation_target=theta_1.0` to `theta=1.0`.\n  - The\
+    \ checked-in helper already owns grid sizing, terminal payoff assembly, boundary\
+    \ conditions, theta-method solve, and interpolation back to spot.\n  - Use the\
+    \ lower-level `Grid + BlackScholesOperator + theta_method_1d` path only when the\
+    \ payoff or boundary contract genuinely differs from plain vanilla European call/put.\n\
+    - Match the product semantics, required primitives, and approved imports exactly.\n\
+    - Return the complete module again, not only an evaluate-body fragment, patch,\
+    \ or diff.\n## Backend Lookup (Secondary To Lane Obligations)\n- Lane family:\
+    \ `pde_solver`\n- Lane plan kind: `exact_target_binding`\n- Method family: `pde_solver`\n\
+    - Route: `vanilla_equity_theta_pde`\n- Engine family: `pde_solver`\n- Required\
+    \ primitive symbols:\n  - `trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
+    - Adapter obligations:\n  - `reuse_checked_in_vanilla_equity_pde_helper`\n## Thin\
+    \ Adapter Plan\n- Target payoff class: `EuropeanOptionAnalyticalPayoff`\n- Required\
+    \ market reads:\n  - `market_state.vol_surface.black_vol(...)`\n  - `market_state.discount`\n\
+    - Required primitive calls:\n  - `trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
+    - Required adapter steps:\n  - `reuse_checked_in_vanilla_equity_pde_helper`\n\
+    - Return contract: Return a Python `float` present value from `evaluate()`.\n\
+    ## Invariant Pack\n- The generated payoff should be compatible with these deterministic\
+    \ validation checks:\n  - `check_non_negativity`\n  - `check_price_sanity`\n \
+    \ - `check_vol_sensitivity`\n  - `check_vol_monotonicity`\n## Family Route Guidance\n\
+    - For vanilla European PDE routes, prefer `price_vanilla_equity_option_pde(market_state,\
+    \ self._spec, theta=...)` from `trellis.models.equity_option_pde`.\n- Map `implementation_target=theta_0.5`\
+    \ to `theta=0.5` and `implementation_target=theta_1.0` to `theta=1.0`.\n- Keep\
+    \ the wrapper thin: delegate grid sizing, boundary conditions, terminal payoff\
+    \ assembly, theta-method solve, and interpolation back to spot to the checked-in\
+    \ helper.\n- Only fall back to direct `Grid + BlackScholesOperator + theta_method_1d`\
+    \ assembly when the payoff or boundary contract genuinely differs from plain vanilla\
+    \ European call/put.\n## Conventions\n- evaluate() returns a FLOAT — the present\
+    \ value (PV) of the instrument\n- You MUST handle all discounting internally —\
+    \ use `market_state.discount.discount(t)`\n- For forward rates: `market_state.forecast_forward_curve(self._spec.rate_index)`\n\
+    - For vol: `market_state.vol_surface.black_vol(T, strike)`\n- For discount factors:\
+    \ `market_state.discount.discount(t)`\n- `market_state.fx_rates[pair]` returns\
+    \ an `FXRate` wrapper; extract `.spot` before scalar arithmetic or process seeding\n\
+    - Schedule generation: prefer `build_payment_timeline(...)`, `build_observation_timeline(...)`,\
+    \ or `build_period_schedule(...)` for accrual/event routes; use `generate_schedule(start,\
+    \ end, freq)` only for plain date lists with no period semantics\n- Year fractions:\
+    \ `year_fraction(date1, date2, day_count)`\n- Never use wall-clock dates such\
+    \ as `date.today()` or `datetime.now()` inside `evaluate()`; derive valuation\
+    \ time from `market_state` or shared resolver outputs.\n- Black76: `black76_call(F,\
+    \ K, sigma, T)`, `black76_put(F, K, sigma, T)` — undiscounted\n- Black76 digital:\
+    \ `black76_cash_or_nothing_call(F, K, sigma, T)`, `black76_cash_or_nothing_put(F,\
+    \ K, sigma, T)` — undiscounted cash-or-nothing digitals\n- For CDS / nth-to-default:\
+    \ use `market_state.credit_curve.survival_probability(t)` and `market_state.credit_curve.hazard_rate(t)`\
+    \ on an explicit payment/default schedule; do not route credit-default pricing\
+    \ through Black76 call/put primitives.\n- For equity trees: prefer `from trellis.models.equity_option_tree\
+    \ import price_vanilla_equity_option_tree`; the lower-level lattice path is `from\
+    \ trellis.models.trees.lattice import build_spot_lattice, lattice_backward_induction`\n\
+    - For vanilla European PDE routes: prefer `from trellis.models.equity_option_pde\
+    \ import price_vanilla_equity_option_pde`; the lower-level fallback is `from trellis.models.pde.grid\
+    \ import Grid`, `from trellis.models.pde.operator import BlackScholesOperator`,\
+    \ and `from trellis.models.pde.theta_method import theta_method_1d`\n- For rate\
+    \ lattices: prefer helper surfaces such as `price_callable_bond_tree(...)`, `price_bermudan_swaption_tree(...)`,\
+    \ or `price_zcb_option_tree(...)`; the lower-level fallback is `from trellis.models.trees.lattice\
+    \ import build_rate_lattice, lattice_backward_induction`\n- For schedule-dependent\
+    \ rate lattices: `from trellis.models.trees.control import lattice_steps_from_timeline,\
+    \ resolve_lattice_exercise_policy`\n- For MC: `from trellis.models.monte_carlo\
+    \ import MonteCarloEngine`\n- For QMC accelerators: `from trellis.models.qmc import\
+    \ sobol_normals, brownian_bridge`\n- For copulas: `from trellis.models.copulas\
+    \ import GaussianCopula, FactorCopula`\n- Do not invent MonteCarloEngine method\
+    \ strings. Valid `method=` values are `euler`, `milstein`, and `exact`.\n- For\
+    \ Monte Carlo early exercise, use an approved control primitive; do not pretend\
+    \ that `MonteCarloEngine.price(...)` or `method=\"lsm\"` implements early exercise.\
+    \ Approved policy classes: `longstaff_schwartz` [implemented], `tsitsiklis_van_roy`\
+    \ [implemented], `primal_dual_mc` [implemented], `stochastic_mesh` [implemented].\
+    \ Currently implemented in Trellis: `longstaff_schwartz`, `tsitsiklis_van_roy`,\
+    \ `primal_dual_mc`, `stochastic_mesh`.\n- If you use `LaguerreBasis`, import it\
+    \ from `trellis.models.monte_carlo.schemes`, not from `trellis.models.monte_carlo.lsm`.\n\
+    - For FFT/COS pricing, characteristic functions must accept vector `u` and use\
+    \ array-safe numerics such as `numpy`, not scalar `math`/`cmath`.\n- Black76 basis:\
+    \ `black76_asset_or_nothing_call(F, K, sigma, T)`, `black76_asset_or_nothing_put(F,\
+    \ K, sigma, T)`, `black76_cash_or_nothing_call(F, K, sigma, T)`, `black76_cash_or_nothing_put(F,\
+    \ K, sigma, T)` — exact terminal basis claims.\n- For terminal vanilla payoffs,\
+    \ prefer exact basis assembly via `terminal_vanilla_from_basis(...)` from `trellis.models.analytical`.\n\
+    - For FX vanilla options, treat the route as Garman-Kohlhagen: map spot FX and\
+    \ domestic/foreign discount factors to `ResolvedGarmanKohlhagenInputs`, then prefer\
+    \ `garman_kohlhagen_price_raw(spec.option_type, resolved)` from `trellis.models.analytical.fx`;\
+    \ use explicit basis-claim assembly only when the request explicitly needs the\
+    \ decomposition.\n- For cash-or-nothing digital options, use the Black76 digital\
+    \ helpers directly; do not approximate them with vanilla call/put prices or divide\
+    \ by spot.\n- You MUST use only real, approved `trellis.*` imports from the structured\
+    \ generation plan and import registry\n- Treat the compiler-emitted lane obligations\
+    \ in the structured generation plan as the backbone of the implementation.\n-\
+    \ Reuse the listed exact backend bindings when present; otherwise build the smallest\
+    \ lane-consistent kernel that satisfies the construction steps.\n- Do not replace\
+    \ selected primitives with bespoke numerical kernels or alternative Trellis routes\
+    \ unless the plan explicitly permits a new lane implementation.\n- Do not add\
+    \ wildcard imports\n- If the approved modules do not contain what you need, reuse\
+    \ the closest existing implementation and keep the gap explicit instead of inventing\
+    \ a path\n\n## Reference implementations\n\n### Payoff protocol + Cashflows/PresentValue\
+    \ return types\n```python\n\"\"\"Payoff protocol and base classes for pricing\
+    \ instruments.\n\nEvery priceable instrument in Trellis implements the Payoff\
+    \ protocol.\nA payoff takes market data (via MarketState) and returns a present\
+    \ value.\nThis module also provides base classes for two common pricing patterns:\n\
+    \n- ResolvedInputPayoff: for analytical or tree-based pricing where market\n \
+    \ data is extracted once, then fed into a pricing formula.\n- MonteCarloPathPayoff:\
+    \ for simulation-based pricing where paths are\n  generated and payoffs are computed\
+    \ per path then averaged.\n\"\"\"\n\nfrom __future__ import annotations\n\nfrom\
+    \ abc import ABC, abstractmethod\nfrom datetime import date\nfrom typing import\
+    \ Generic, Protocol, TypeVar, runtime_c\n# [truncated reference]\n```\n\n### Date\
+    \ utilities used by generated payoffs\n```python\n\"\"\"Date utilities: day count\
+    \ conventions, schedule generation, year fractions.\"\"\"\n\nfrom __future__ import\
+    \ annotations\n\nimport calendar\nfrom collections.abc import Iterable\nfrom datetime\
+    \ import date, datetime, timedelta\nfrom typing import Union\n\nfrom trellis.core.types\
+    \ import (\n    ContractTimeline,\n    DayCountConvention,\n    EventSchedule,\n\
+    \    Frequency,\n    TimelineRole,\n)\n\nDateLike = Union[date, datetime]\nExplicitDateInput\
+    \ = ContractTimeline | EventSchedule | Iterable[DateLike | str] | str\n\n\ndef\
+    \ _to_date(d: DateLike) -> date:\n    \"\"\"Normalize ``date``/``datetime`` inputs\
+    \ to plain ``date`` objects.\"\"\"\n    if isinstance(d, datetime):\n        return\
+    \ d.date()\n    return d\n\n\ndef add_months(dt:\n# [truncated reference]\n```\n\
+    \n[omitted 8 additional reference modules]\n\n\n## Output\nReturn the COMPLETE\
+    \ Python module — copy the skeleton exactly, but replace the\n`raise NotImplementedError(...)`\
+    \ line with the actual implementation of `evaluate()`.\nDo NOT change imports,\
+    \ class names, spec fields, or the requirements property.\nOnly implement the\
+    \ evaluate() method body. You may add imports at the top.\nNo markdown fences,\
+    \ no explanation — just the Python code.\n\n## ACTUAL MARKET SMOKE FAILURES (your\
+    \ previous code had these issues):\n- Actual market state smoke test failed: name\
+    \ 'year_fraction' is not defined\n\nThe generated payoff must also run against\
+    \ the real task market_state, not just synthetic validation fixtures."
+  model: gpt-5.4-mini
+- seq: 5
   function: llm_generate_json
   stage: critic
-  prompt_hash: befa63693598d5f2813571dc1450d69f6b653e043d1f11bde5e50a6fd3848bda
-  response_text: '{"check_id": "volatility_input_usage", "description": "Volatility
-    is likely ignored or effectively bypassed in the PDE call path", "severity": "error",
-    "evidence": "The evaluate() method hard-codes theta=1.0 and never uses the docstring''s
-    theta-method comparison logic; more importantly, it passes only market_state and
-    spec into price_vanilla_equity_option_pde without any visible handling of the
-    market vol input beyond a presence check. The route contract requires the helper
-    to consume expiry_black_vol from market_state, but this implementation does not
-    verify or adapt it, so a flat-vol sensitivity test is likely to show little or
-    no response if the backend is not wired through correctly.", "remediation": "Ensure
-    the evaluated market_state carries the volatility surface in the backend-expected
-    field and that the route helper is called with the correct theta target (0.5 or
-    1.0 as intended). If the helper is not using market_state.vol_surface/expiry_black_vol,
-    fix the adapter to map the vol input explicitly.", "status": "suspect"}'
+  prompt_hash: ccb2106a9d074f5b00efa0f3ba697a8c71074eefc464ef4f1a9fb1f4942e7ccf
+  response_text: '{"check_id": "volatility_input_usage", "description": "Potential
+    volatility insensitivity / route misuse in the PDE adapter", "severity": "error",
+    "evidence": "`evaluate()` delegates to `price_vanilla_equity_option_pde(market_state,
+    spec, theta=1.0)` with no local validation or binding of the required `expiry_black_vol`
+    input, despite the compiled route contract requiring `black_vol_surface` and `expiry_black_vol`.
+    The spec object only carries spot/strike/expiry and the code never uses the imported
+    `year_fraction`, so there is a real risk the routed price is not responding to
+    volatility as intended or is using a fallback/default surface incorrectly.", "remediation":
+    "Ensure the market_state actually supplies the expiry volatility required by the
+    route contract, and add explicit validation that the pricing output changes materially
+    when flat vol is shifted from 5% to 40%. If the helper requires a richer spec,
+    pass the correct vanilla-equity spec object rather than this custom dataclass.",
+    "status": "suspect"}'
   prompt_text: "You are a quantitative model validator reviewing agent-generated pricing\
     \ code.\nYour job is to find deterministic review concerns, not to praise. Be\
     \ adversarial.\n\n## Code to review\n```python\n\"\"\"Agent-generated payoff:\
@@ -1012,7 +2027,7 @@ calls:
     \ convergence_order_diagnostic\n\nImplementation target: theta_1.0\nPreferred\
     \ method family: pde_solver\n\nImplementation target: theta_1.0.\"\"\"\n    notional:\
     \ float\n    spot: float\n    strike: float\n    expiry_date: date\n    option_type:\
-    \ str = \"'call'\"\n    day_count: DayCountConvention = DayCountConvention.ACT_365\n\
+    \ str = 'call'\n    day_count: DayCountConvention = DayCountConvention.ACT_365\n\
     \n\nclass EuropeanOptionAnalyticalPayoff:\n    \"\"\"Build a pricer for: European\
     \ call: theta-method convergence order measurement\n\nEuropean call option on\
     \ a non-dividend-paying stock.\nS0=100, K=105, T=1Y, risk-free rate r=5%, volatility\
@@ -1030,53 +2045,158 @@ calls:
     \    @property\n    def spec(self) -> EuropeanOptionSpec:\n        return self._spec\n\
     \n    @property\n    def requirements(self) -> set[str]:\n        return {\"black_vol_surface\"\
     , \"discount_curve\"}\n\n    def evaluate(self, market_state: MarketState) ->\
-    \ float:\n        spec = self._spec\n        spec = self._spec\n        from trellis.models.equity_option_pde\
-    \ import price_vanilla_equity_option_pde\n\n        if not hasattr(market_state,\
-    \ \"vol_surface\") or market_state.vol_surface is None:\n            raise ValueError(\"\
-    market_state.vol_surface is required for PDE pricing\")\n        if not hasattr(market_state,\
-    \ \"discount\") or market_state.discount is None:\n            raise ValueError(\"\
-    market_state.discount is required for PDE pricing\")\n\n        theta = 0.5 if\
-    \ \"0.5\" in type(self).__doc__ or False else 1.0\n        return float(\n   \
-    \         price_vanilla_equity_option_pde(\n                market_state,\n  \
-    \              spec,\n                theta=1.0,\n            )\n        )\n\n\
-    ```\n\n## Instrument description\nBuild a pricer for: European call: theta-method\
-    \ convergence order measurement\n\nEuropean call option on a non-dividend-paying\
-    \ stock.\nS0=100, K=105, T=1Y, risk-free rate r=5%, volatility sigma=20%.\nSolve\
-    \ with the Black-Scholes PDE operator using Crank-Nicolson\n(theta=0.5) and fully\
-    \ implicit (theta=1.0) on a 200-point spot grid\n× 100 time steps.\nMeasure convergence\
-    \ order by doubling the grid: the CN scheme should\nshow O(dt^2 + dS^2) convergence\
-    \ and the implicit scheme O(dt + dS^2).\nCompare both to the Black-Scholes analytical\
-    \ price.\n\nConstruct methods: pde_solver\nComparison targets: theta_0.5 (pde_solver),\
-    \ theta_1.0 (pde_solver), black_scholes (analytical)\nCross-validation harness:\n\
-    \  internal targets: theta_0.5, theta_1.0\n  analytical benchmark: black_scholes\n\
-    \  external targets: quantlib\nNew component: convergence_order_diagnostic\n\n\
-    Implementation target: theta_1.0\nPreferred method family: pde_solver\n\nImplementation\
-    \ target: theta_1.0\n\n## Shared Knowledge\n## Distilled Review Memory\n\n- Review\
-    \ principles:\n  - `P1`: Always calibrate rate trees to the discount curve before\
-    \ pricing\n  - `P2`: Callable bonds need issuer_call lattice control, discrete\
-    \ coupons, and exercise=par+coupon\n  - `P3`: Convert vol units at the boundary\
-    \ between market data and model\n- Review checkpoints:\n  - GRID: Use at least\
-    \ 200 spatial points and 200+ time steps. For barrier options, use non-uniform\
-    \ grid concentrated near the barrier.\n  - BOUNDARY CONDITIONS: Set V(0,t)=0 for\
-    \ calls, V(S_max,t)=S_max-K*exp(-r*(T-t)) for calls. For puts: V(0,t)=K*exp(-r*(T-t)),\
-    \ V(S_max,t)=0.\n  - STABILITY: Crank-Nicolson (theta=0.5) is second-order but\
-    \ may oscillate near discontinuities. Use Rannacher smoothing (2-4 implicit steps\
-    \ at start) for digital/barrier payoffs.\n- Canonical model grammar:\n  - `local_vol_surface_workflow`\
-    \ -> `Dupire local vol`\n  - `sabr_smile_workflow` -> `SABR smile`\n- Known failure\
-    \ traps:\n  - `BlackScholesOperator constructor mismatch` -> The generated code\
-    \ treated the PDE operator as if it accepted scalar 'r' and 'sigma' keywords,\
-    \ but trellis.models.pde.operator.BlackScholesOperator actually expects callables\
-    \ '(sigma_fn, r_fn)'. The mismatch caused constructor failure during module build.\n\
-    \  - `PDE price blow-up from unit/scale mismatch` -> The generated PDE branch\
-    \ called theta_method_1d with the obsolete operator/s_grid/t_grid/boundary_conditions\
+    \ float:\n        spec = self._spec\n        spec = self._spec\n        from trellis.core.date_utils\
+    \ import year_fraction\n        from trellis.models.equity_option_pde import price_vanilla_equity_option_pde\n\
+    \n        price = price_vanilla_equity_option_pde(market_state, spec, theta=1.0)\n\
+    \        return float(price)\n\n```\n\n## Instrument description\nBuild a pricer\
+    \ for: European call: theta-method convergence order measurement\n\nEuropean call\
+    \ option on a non-dividend-paying stock.\nS0=100, K=105, T=1Y, risk-free rate\
+    \ r=5%, volatility sigma=20%.\nSolve with the Black-Scholes PDE operator using\
+    \ Crank-Nicolson\n(theta=0.5) and fully implicit (theta=1.0) on a 200-point spot\
+    \ grid\n× 100 time steps.\nMeasure convergence order by doubling the grid: the\
+    \ CN scheme should\nshow O(dt^2 + dS^2) convergence and the implicit scheme O(dt\
+    \ + dS^2).\nCompare both to the Black-Scholes analytical price.\n\nConstruct methods:\
+    \ pde_solver\nComparison targets: theta_0.5 (pde_solver), theta_1.0 (pde_solver),\
+    \ black_scholes (analytical)\nCross-validation harness:\n  internal targets: theta_0.5,\
+    \ theta_1.0\n  analytical benchmark: black_scholes\n  external targets: quantlib\n\
+    New component: convergence_order_diagnostic\n\nImplementation target: theta_1.0\n\
+    Preferred method family: pde_solver\n\nImplementation target: theta_1.0\n\n##\
+    \ Shared Knowledge\n## Shared Review Principles\n\n- **P1**: Always calibrate\
+    \ rate trees to the discount curve before pricing\n- **P2**: Callable bonds need\
+    \ issuer_call lattice control, discrete coupons, and exercise=par+coupon\n- **P3**:\
+    \ Convert vol units at the boundary between market data and model\n- **P4**: Monte\
+    \ Carlo: use ≥10k paths, verify SE <1% of price, use Laguerre basis at high vol\
+    \ (σ ≥ 0.40) to avoid LSM polynomial bias\n- **P5**: Numerical stability: use\
+    \ theta_method_1d with BlackScholesOperator (not legacy crank_nicolson_1d), center\
+    \ COS truncation on first cumulant to prevent overflow\n- **P6**: Cross-validation:\
+    \ measure the actual gap first, then set tolerance to 2-3x the measured gap —\
+    \ never wider than 1% of price or 5bp\n- **P7**: Bermudan swaption: all exercise\
+    \ dates enter the SAME underlying swap (start=first_exercise, end=first_exercise+tenor)\
+    \ — do not create a fresh shorter swap at each exercise date\n- **P8**: OAS computation:\
+    \ keep sigma_HW (vol model) fixed during the spread root-finding loop — only shift\
+    \ the discount curve, never recompute vol from the shifted forward rate\n- **P9**:\
+    \ Separate semantic understanding, method arbitration, and numerical pricing:\
+    \ draft the contract first, choose and explain the method second, and only then\
+    \ call the pricing kernel.\n- **P10**: Bootstrap before pricing: launch with the\
+    \ repo-pinned Python and an explicit shell/workdir, validate imports and module\
+    \ compilation first, and treat interpreter mismatches, shell-launch failures,\
+    \ ModuleNotFoundError, ImportError, and SyntaxError as setup defects, not pricing\
+    \ failures.\n- **P11**: Partial requests are normal: draft the semantic contract\
+    \ first, infer the required-input checklist from the product IR and method requirements,\
+    \ and let the LLM or a mock input provider fill only the missing market-data and\
+    \ convention gaps. Never guess silently.\n\n## Product Semantics\n\n- Instrument:\
+    \ `european_option`\n- Exercise style: `european`\n- State dependence: `terminal_markov`\n\
+    - Model family: `equity_diffusion`\n- Payoff traits: `discounting`, `vol_surface_dependence`\n\
+    \n## REVIEWER CHECKPOINTS\n\n- GRID: Use at least 200 spatial points and 200+\
+    \ time steps. For barrier options, use non-uniform grid concentrated near the\
+    \ barrier.\n- BOUNDARY CONDITIONS: Set V(0,t)=0 for calls, V(S_max,t)=S_max-K*exp(-r*(T-t))\
+    \ for calls. For puts: V(0,t)=K*exp(-r*(T-t)), V(S_max,t)=0.\n- STABILITY: Crank-Nicolson\
+    \ (theta=0.5) is second-order but may oscillate near discontinuities. Use Rannacher\
+    \ smoothing (2-4 implicit steps at start) for digital/barrier payoffs.\n- PDE\
+    \ ROUTE SCOPE: Use Grid from trellis.models.pde.grid, BlackScholesOperator from\
+    \ trellis.models.pde.operator, and theta_method_1d from trellis.models.pde.theta_method.\
+    \ For American puts, pass exercise_values and exercise_fn=max. Keep lower_bc_fn\
+    \ / upper_bc_fn callables explicit for barrier and digital payoffs, and do not\
+    \ invent log_grid_pde, uniform_grid_pde, absorbing, or dirichlet helper tokens.\n\
+    \n## Canonical Model Grammar Hints\n\n### `local_vol_surface_workflow` — Dupire\
+    \ local-vol workflow\n- Model: `Dupire local vol`\n- Quote families: `implied_vol`\n\
+    - Calibration workflows: `calibrate_local_vol_surface_workflow`\n- Runtime materialization\
+    \ kind: `local_vol_surface`\n- Deferred scope: `stochastic_local_vol`, `local_vol_extrapolation_governance`\n\
+    ### `sabr_smile_workflow` — SABR smile calibration\n- Model: `SABR smile`\n- Quote\
+    \ families: `implied_vol`\n- Calibration workflows: `calibrate_sabr_smile_workflow`\n\
+    - Deferred scope: `term_structure_sabr`, `direct_market_state_materialization`\n\
+    ### `heston_smile_workflow` — Heston smile calibration\n- Model: `Heston`\n- Quote\
+    \ families: `implied_vol`\n- Calibration workflows: `calibrate_heston_smile_workflow`\n\
+    - Runtime materialization kind: `model_parameter_set`\n- Deferred scope: `term_structure_heston`,\
+    \ `hybrid_equity_rates`\n### `credit_single_name_reduced_form` — Reduced-form\
+    \ single-name CDS calibration\n- Model: `Reduced-form single-name credit`\n- Quote\
+    \ families: `spread`, `hazard`\n- Calibration workflows: `calibrate_single_name_credit_curve_workflow`\n\
+    - Runtime materialization kind: `credit_curve`\n- Deferred scope: `basket_credit`,\
+    \ `structural_credit`, `hybrid_credit_equity`\n### `rates_bootstrap_curve` — Rates\
+    \ bootstrap curve authority\n- Model: `Rates bootstrap curve bundle`\n- Quote\
+    \ families: `par_rate`, `price`\n- Calibration workflows: `build_bootstrap_solve_request`\n\
+    - Runtime materialization kind: `market_curves`\n- Rates curve roles: `discount_curve`,\
+    \ `forecast_curve`\n- Deferred scope: `cross_currency_bootstrap`, `calendar_complete_bootstrap`\n\
+    \n## Shared Failure Memory\n\n### [CRITICAL] BlackScholesOperator constructor\
+    \ mismatch\n**Symptom:** TypeError: BlackScholesOperator.__init__() got an unexpected\
+    \ keyword argument 'r'.\n**Why:** The generated code treated the PDE operator\
+    \ as if it accepted scalar 'r' and 'sigma' keywords, but trellis.models.pde.operator.BlackScholesOperator\
+    \ actually expects callables '(sigma_fn, r_fn)'. The mismatch caused constructor\
+    \ failure during module build.\n**Fix:** Import BlackScholesOperator from trellis.models.pde.operator\
+    \ and pass callables, for example BlackScholesOperator(lambda s, t: sigma, lambda\
+    \ t: r). Add a signature smoke test or cookbook template to lock the constructor\
+    \ shape and keep the solver path aligned with the real API.\n\n### [CRITICAL]\
+    \ PDE price blow-up from unit/scale mismatch\n**Symptom:** Final PV magnitude\
+    \ far exceeds expected scale (machine-check: |PV| > 10 × notional) or the PDE\
+    \ route returns a boundary-like price instead of the spot price.\n**Why:** The\
+    \ generated PDE branch called theta_method_1d with the obsolete operator/s_grid/t_grid/boundary_conditions\
     \ signature and then read the wrong element of the result instead of interpolating\
     \ the returned solution over grid.x. The actual API is theta_method_1d(grid, operator,\
     \ terminal_condition, theta=..., lower_bc_fn=..., upper_bc_fn=...), and it returns\
-    \ the full solution vector at t=0.\n\n## Generated Skills\n- [lesson] Unit conversion\
-    \ causes huge PV: Enforce and document input conventions (vol as decimal, discount\
-    \ curve vs zero rate semantics, notional scaling), derive r from discount factors\
-    \ via r = -ln(df)/T or use forward/Black76 consistently, add unit/conversi...\n\
-    \n\n## Compiled Route Contract\n- Method family: `pde_solver`\n- Instrument type:\
+    \ the full solution vector at t=0.\n**Fix:** Build Grid(x_min=0.0, x_max=S_max,\
+    \ n_x=n_x, T=T, n_t=n_t), construct BlackScholesOperator(lambda s, t: sigma, lambda\
+    \ t: r), call theta_method_1d(grid, op, terminal, theta=0.5, lower_bc_fn=...,\
+    \ upper_bc_fn=...), then interpolate the returned vector with np.interp(spec.spot,\
+    \ grid.x, V) before multiplying by notional.\n\n### [CRITICAL] Use exact PDE import\
+    \ paths\n**Symptom:** ImportError shows `Grid` and `theta_method_1d` are not exported\
+    \ by `trellis.models.pde`.\n**Why:** The implementation guessed PDE module exports\
+    \ instead of using the exact supported import paths. The build then failed before\
+    \ any pricing logic could run.\n**Fix:** Inspect the actual trellis PDE package\
+    \ structure and import the grid/operator/solver objects from their real modules.\
+    \ Keep the solver call isolated so module-path errors are caught immediately during\
+    \ validation.\n\n### [CRITICAL] Undefined boundary condition symbol\n**Symptom:**\
+    \ NameError: name 'absorbing' is not defined when constructing the BarrierCallSpec\
+    \ (or assigning pde_boundary_condition).\n**Why:** The code used an undefined\
+    \ Python name 'absorbing' instead of a string literal or an imported/defined constant\
+    \ for the PDE boundary condition. There was no validation or unit test to catch\
+    \ the NameError before build.\n**Fix:** Use a quoted string (e.g. 'absorbing')\
+    \ or import/define the boundary-condition constant from the PDE module; add a\
+    \ small input validation that boundary-condition values belong to the allowed\
+    \ set.\n\n### [CRITICAL] Incorrect PDE API import (Grid not exported)\n**Symptom:**\
+    \ ImportError / AttributeError: 'Grid' is not exported by trellis.models.pde (or\
+    \ module has no attribute 'Grid').\n**Why:** The pricer attempted to import or\
+    \ reference a symbol (Grid) that is not part of the public API of trellis.models.pde;\
+    \ additionally the spec contained literal unquoted identifiers and malformed defaults\
+    \ which would cause name errors. This mismatch between assumed library exports\
+    \ and the actual library surface caused the build to fail.\n**Fix:** Inspect the\
+    \ actual exported symbols in trellis.models.pde (e.g. via help() or module.__all__),\
+    \ and replace the non-exported 'Grid' usage with the correct factory/function/class\
+    \ provided by the module (or implement a local grid builder). Also correct spec\
+    \ field defaults (quote string literals) and validate names with a small import/unit\
+    \ test before full build.\n\n### [CRITICAL] Unit conversion causes extreme PV\n\
+    **Symptom:** Price sanity check triggered: |PV| > 10 * typical_notional (e.g.,\
+    \ |PV| = 9995.24 > 1000)\n**Why:** Market-data / model-input unit mismatch (most\
+    \ commonly a volatility expressed in percent vs decimal, or a rate/discount representation\
+    \ mismatch) caused the PDE operator to receive parameters off by orders of magnitude.\n\
+    **Fix:** Normalize and validate market data before passing to the PDE (convert\
+    \ vol from percent->decimal, convert rates to the operator's expected form or\
+    \ supply discount factors), add assertive checks on ranges and shapes, and run\
+    \ a small-price sanity test before accepting results.\n\n### [CRITICAL] Incorrect\
+    \ PDE imports and malformed code\n**Symptom:** ImportError: 'trellis.models.pde'\
+    \ does not export 'Grid' OR SyntaxError: unexpected indent in generated module.\n\
+    **Why:** The generator guessed an incorrect trellis export (Grid) and produced\
+    \ malformed Python (incorrect indentation) while synthesizing the PDE solver;\
+    \ the combination prevented module import/execution.\n**Fix:** Use exact, confirmed\
+    \ trellis import paths (inspect the package or __all__), construct the spatial\
+    \ grid from the actual provided API if Grid isn't exported, and validate/ lint\
+    \ generated code (check indentation) before runtime. Add a minimal unit test that\
+    \ imports and runs evaluate() to catch these errors early.\n\n\n## Generated Skills\n\
+    - [lesson] Unit conversion causes huge PV: Enforce and document input conventions\
+    \ (vol as decimal, discount curve vs zero rate semantics, notional scaling), derive\
+    \ r from discount factors via r = -ln(df)/T or use forward/Black76 consistently,\
+    \ add unit/conversi...\n\n## Stage-Aware Skills\n- [route_hint] vanilla_equity_theta_pde\
+    \ route helper: Use the selected route helper directly inside `evaluate()`; do\
+    \ not rebuild the process, engine, or discount glue manually.\n- [route_hint]\
+    \ vanilla_equity_theta_pde note 1: For vanilla European equity PDE routes, prefer\
+    \ `price_vanilla_equity_option_pde(market_state, spec, theta=...)` so the adapter\
+    \ stays thin.\n- [route_hint] vanilla_equity_theta_pde note 2: Map `implementation_target=theta_0.5`\
+    \ to `theta=0.5` and `implementation_target=theta_1.0` to `theta=1.0`.\n- [route_hint]\
+    \ vanilla_equity_theta_pde note 3: The checked-in helper already owns grid sizing,\
+    \ terminal payoff assembly, boundary conditions, theta-method solve, and interpolation\
+    \ back to spot.\n- [route_hint] vanilla_equity_theta_pde note 4: Use the lower-level\
+    \ `Grid + BlackScholesOperator + theta_method_1d` path only when the payoff or\
+    \ boundary contract genuinely differs from plain vanilla European call/put.\n\n\
+    \n## Compiled Route Contract\n- Method family: `pde_solver`\n- Instrument type:\
     \ `european_option`\n- Lane boundary: family=`pde_solver`, kind=`exact_target_binding`,\
     \ exact_bindings=`trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
     - Lane obligations:\n  - Lane family: `pde_solver`\n  - Plan kind: `exact_target_binding`\n\
@@ -1134,4 +2254,39 @@ calls:
     ,\n    \"remediation\": \"what to change\",\n    \"status\": \"suspect\"\n}\n\n\
     Focus on pricing errors that the deterministic checks can confirm.\nReturn at\
     \ most 3 concerns, ordered by severity.\nReturn ONLY the JSON array."
+  model: gpt-5.4-mini
+- seq: 6
+  function: llm_generate_json
+  stage: unscoped
+  prompt_hash: b68118324974453267fe8ff8cc819d63e46d64393d19419ddc63724f9def26d7
+  response_text: '{"category": "finite_differences", "title": "Missing time helper
+    variable", "mistake": "The PDE solver referenced year_fraction without defining
+    or passing it into the method.", "why": "This happens when a finite-difference
+    routine assumes a shared time-setup variable exists in scope, but the solver is
+    actually self-contained and must derive or receive all discretization inputs explicitly.
+    The mental model failure is treating grid setup as implicit state instead of making
+    the time horizon and step sizes part of the solver interface.", "detect": "Run
+    a smoke test on the solver entry point and check for NameError or any undeclared
+    grid-setup variables before calibration.", "fix": "Define the time horizon locally
+    or pass it as an explicit argument, and compute all time-step quantities from
+    that value inside the solver."}'
+  prompt_text: "You fixed these validation failures for a Build a pricer for: European\
+    \ call: theta-method convergence order measurement\n\nEuropean call option on\
+    \ a non-dividend-paying stock.\nS0=100, K=105, T=1Y, risk-free rate r=5%, volatility\
+    \ sigma=20%.\nSolve with the Black-Scholes PDE operator using Crank-Nicolson\n\
+    (theta=0.5) and fully implicit (theta=1.0) on a 200-point spot grid\n× 100 time\
+    \ steps.\nMeasure convergence order by doubling the grid: the CN scheme should\n\
+    show O(dt^2 + dS^2) convergence and the implicit scheme O(dt + dS^2).\nCompare\
+    \ both to the Black-Scholes analytical price.\n\nConstruct methods: pde_solver\n\
+    Comparison targets: theta_0.5 (pde_solver), theta_1.0 (pde_solver), black_scholes\
+    \ (analytical)\nCross-validation harness:\n  internal targets: theta_0.5, theta_1.0\n\
+    \  analytical benchmark: black_scholes\n  external targets: quantlib\nNew component:\
+    \ convergence_order_diagnostic\n\nImplementation target: theta_1.0\nPreferred\
+    \ method family: pde_solver\n\nImplementation target: theta_1.0\n(pde_solver method):\n\
+    \n- Actual market state smoke test failed: name 'year_fraction' is not defined\n\
+    \nDistill ONE concise lesson learned. Return JSON:\n{\n  \"category\": \"calibration|volatility|backward_induction|finite_differences|monte_carlo|market_data\"\
+    ,\n  \"title\": \"Short title (max 10 words)\",\n  \"mistake\": \"What went wrong\
+    \ (1 sentence)\",\n  \"why\": \"Why it happens — the mental model failure (1-2\
+    \ sentences)\",\n  \"detect\": \"How to detect this issue (1 sentence)\",\n  \"\
+    fix\": \"How to fix it (1 sentence)\"\n}\n\nOnly return JSON, no markdown."
   model: gpt-5.4-mini

--- a/cassettes/full_task/T13.yaml
+++ b/cassettes/full_task/T13.yaml
@@ -2,7 +2,7 @@ meta:
   recorded_at: '2026-04-11T00:34:30.994893+00:00'
   provider: openai
   model: gpt-5.4-mini
-  total_calls: 7
+  total_calls: 6
   name: T13
 calls:
 - seq: 0
@@ -2254,39 +2254,4 @@ calls:
     ,\n    \"remediation\": \"what to change\",\n    \"status\": \"suspect\"\n}\n\n\
     Focus on pricing errors that the deterministic checks can confirm.\nReturn at\
     \ most 3 concerns, ordered by severity.\nReturn ONLY the JSON array."
-  model: gpt-5.4-mini
-- seq: 6
-  function: llm_generate_json
-  stage: unscoped
-  prompt_hash: b68118324974453267fe8ff8cc819d63e46d64393d19419ddc63724f9def26d7
-  response_text: '{"category": "finite_differences", "title": "Missing time helper
-    variable", "mistake": "The PDE solver referenced year_fraction without defining
-    or passing it into the method.", "why": "This happens when a finite-difference
-    routine assumes a shared time-setup variable exists in scope, but the solver is
-    actually self-contained and must derive or receive all discretization inputs explicitly.
-    The mental model failure is treating grid setup as implicit state instead of making
-    the time horizon and step sizes part of the solver interface.", "detect": "Run
-    a smoke test on the solver entry point and check for NameError or any undeclared
-    grid-setup variables before calibration.", "fix": "Define the time horizon locally
-    or pass it as an explicit argument, and compute all time-step quantities from
-    that value inside the solver."}'
-  prompt_text: "You fixed these validation failures for a Build a pricer for: European\
-    \ call: theta-method convergence order measurement\n\nEuropean call option on\
-    \ a non-dividend-paying stock.\nS0=100, K=105, T=1Y, risk-free rate r=5%, volatility\
-    \ sigma=20%.\nSolve with the Black-Scholes PDE operator using Crank-Nicolson\n\
-    (theta=0.5) and fully implicit (theta=1.0) on a 200-point spot grid\n× 100 time\
-    \ steps.\nMeasure convergence order by doubling the grid: the CN scheme should\n\
-    show O(dt^2 + dS^2) convergence and the implicit scheme O(dt + dS^2).\nCompare\
-    \ both to the Black-Scholes analytical price.\n\nConstruct methods: pde_solver\n\
-    Comparison targets: theta_0.5 (pde_solver), theta_1.0 (pde_solver), black_scholes\
-    \ (analytical)\nCross-validation harness:\n  internal targets: theta_0.5, theta_1.0\n\
-    \  analytical benchmark: black_scholes\n  external targets: quantlib\nNew component:\
-    \ convergence_order_diagnostic\n\nImplementation target: theta_1.0\nPreferred\
-    \ method family: pde_solver\n\nImplementation target: theta_1.0\n(pde_solver method):\n\
-    \n- Actual market state smoke test failed: name 'year_fraction' is not defined\n\
-    \nDistill ONE concise lesson learned. Return JSON:\n{\n  \"category\": \"calibration|volatility|backward_induction|finite_differences|monte_carlo|market_data\"\
-    ,\n  \"title\": \"Short title (max 10 words)\",\n  \"mistake\": \"What went wrong\
-    \ (1 sentence)\",\n  \"why\": \"Why it happens — the mental model failure (1-2\
-    \ sentences)\",\n  \"detect\": \"How to detect this issue (1 sentence)\",\n  \"\
-    fix\": \"How to fix it (1 sentence)\"\n}\n\nOnly return JSON, no markdown."
   model: gpt-5.4-mini

--- a/cassettes/full_task/T38.yaml
+++ b/cassettes/full_task/T38.yaml
@@ -1,5 +1,5 @@
 meta:
-  recorded_at: '2026-04-10T15:36:20.163035+00:00'
+  recorded_at: '2026-04-11T00:35:05.470675+00:00'
   provider: openai
   model: gpt-5.4-mini
   total_calls: 4
@@ -9,9 +9,9 @@ calls:
   function: llm_generate
   stage: code_generation
   prompt_hash: f3f7221443896173945940705c2fd41fe6604a580fec1bb1344c7fd4dca60ecf
-  response_text: "from trellis.core.differentiable import get_numpy\n        from\
-    \ trellis.models.credit_default_swap import build_cds_schedule, price_cds_monte_carlo\n\
-    \n        np = get_numpy()\n\n        spec = self._spec\n        spread = float(spec.spread)\n\
+  response_text: "spec = self._spec\n        from trellis.core.differentiable import\
+    \ get_numpy\n        from trellis.models.credit_default_swap import build_cds_schedule,\
+    \ price_cds_monte_carlo\n\n        np = get_numpy()\n\n        spread = float(spec.spread)\n\
     \        if spread > 1.0:\n            spread *= 1e-4\n\n        schedule = build_cds_schedule(\n\
     \            spec.start_date,\n            spec.end_date,\n            spec.frequency,\n\
     \            spec.day_count,\n            time_origin=spec.start_date,\n     \
@@ -514,17 +514,18 @@ calls:
 - seq: 1
   function: llm_generate_json
   stage: critic
-  prompt_hash: 3efb04c0582dffb75be6667c4e39f4c4a37cd00a720c9fe9e5cea76f11b68e2a
-  response_text: '{"check_id": "price_non_negative", "description": "Likely sign/leg
-    orientation error for CDS PV.", "severity": "error", "evidence": "The instrument
-    spec explicitly says \"Compute the mark-to-market PV (protection leg minus premium
-    leg)\" for a protection buyer, but the implementation directly returns `price_cds_monte_carlo(...)`
-    without any visible adjustment or sign check. If the helper is buyer-side conventional,
-    a mismatched orientation would produce a negative PV in a default-free / low-spread
-    state and can violate non-negativity for the requested long protection position.",
-    "remediation": "Verify the helper''s sign convention and, if needed, flip the
-    PV to match protection buyer economics (protection leg minus premium leg) before
-    returning.", "status": "suspect"}'
+  prompt_hash: 05fb7a4264ee063668b863a0d07490a7c7049035fac16e387d377321e2703161
+  response_text: '{"check_id": "price_non_negative", "description": "Potential sign/leg-direction
+    ambiguity can produce a negative PV for the protection buyer leg decomposition.",
+    "severity": "warning", "evidence": "The contract description says to compute \"protection
+    leg minus premium leg\" for a protection buyer. However, the implementation delegates
+    entirely to `price_cds_monte_carlo(...)` without any explicit sign check, and
+    the surrounding spec repeatedly mixes \"protection buyer side\" with generic CDS
+    pricing language. If the helper returns seller-side convention or premium-minus-protection
+    convention, the result can go negative under the default market state.", "remediation":
+    "Verify the helper''s leg sign convention and explicitly map the returned value
+    to protection-buyer PV (protection leg minus premium leg) before returning it.",
+    "status": "suspect"}'
   prompt_text: "You are a quantitative model validator reviewing agent-generated pricing\
     \ code.\nYour job is to find deterministic review concerns, not to praise. Be\
     \ adversarial.\n\n## Code to review\n```python\n\"\"\"Agent-generated payoff:\
@@ -585,48 +586,48 @@ calls:
     \ = spec\n\n    @property\n    def spec(self) -> CDSSpec:\n        return self._spec\n\
     \n    @property\n    def requirements(self) -> set[str]:\n        return {\"credit_curve\"\
     , \"discount_curve\"}\n\n    def evaluate(self, market_state: MarketState) ->\
-    \ float:\n        spec = self._spec\n        from trellis.models.credit_default_swap\
-    \ import build_cds_schedule, price_cds_monte_carlo\n\n        np = get_numpy()\n\
-    \n        spec = self._spec\n        spread = float(spec.spread)\n        if spread\
-    \ > 1.0:\n            spread *= 1e-4\n\n        schedule = build_cds_schedule(\n\
-    \        spec.start_date,\n        spec.end_date,\n        spec.frequency,\n \
-    \       spec.day_count,\n        time_origin=spec.start_date,\n        )\n\n \
-    \       return float(\n        price_cds_monte_carlo(\n            notional=float(spec.notional),\n\
-    \            spread_quote=spread,\n            recovery=float(spec.recovery),\n\
-    \            schedule=schedule,\n            credit_curve=market_state.credit_curve,\n\
-    \            discount_curve=market_state.discount,\n            n_paths=int(spec.n_paths),\n\
-    \            seed=42,\n        )\n        )\n\n```\n\n## Instrument description\n\
-    Build a pricer for: CDS pricing: hazard rate MC vs survival prob analytical\n\n\
-    Standard single-name CDS, protection buyer side.\nNotional: $10,000,000.  Maturity:\
-    \ 5Y from settlement.\nPremium leg: quarterly payments, Act/360 day count.\nRunning\
-    \ CDS spread: 150 bp.  Recovery rate: 40%.\nUse the investment-grade (IG) credit\
-    \ curve from the market snapshot\n(as_of 2024-11-15) — this provides term-dependent\
-    \ hazard rates\nbootstrapped from market CDS spreads at 1Y, 3Y, 5Y, and 10Y tenors.\n\
-    Do NOT use a flat hazard rate — the model must respect the full\nhazard rate term\
-    \ structure.\nUse the USD OIS curve for risk-free discounting.\nMethod 1: Monte\
-    \ Carlo simulation of default times from the hazard curve.\nMethod 2: Analytical\
-    \ (deterministic) survival-probability integration.\nCompute the mark-to-market\
-    \ PV (protection leg minus premium leg).\n\nConstruct methods: monte_carlo\nComparison\
-    \ targets: mc_cds (monte_carlo), analytical_cds (analytical)\nCross-validation\
-    \ harness:\n  internal targets: mc_cds, analytical_cds\n  external targets: quantlib,\
-    \ financepy\nNew component: cds_pricing\n\nImplementation target: mc_cds\nPreferred\
-    \ method family: monte_carlo\n\nImplementation target: mc_cds\n\n## Shared Knowledge\n\
-    ## Distilled Review Memory\n\n- Review principles:\n  - `P1`: Always calibrate\
-    \ rate trees to the discount curve before pricing\n  - `P2`: Callable bonds need\
-    \ issuer_call lattice control, discrete coupons, and exercise=par+coupon\n  -\
-    \ `P3`: Convert vol units at the boundary between market data and model\n- Review\
-    \ checkpoints:\n  - CONVERGENCE: Use at least 10,000 paths. Verify that the standard\
-    \ error is <1% of the price. If path-dependent, use at least 100 time steps per\
-    \ year.\n  - DISCRETE OBSERVATIONS: For instruments with discrete fixing/observation\
-    \ dates (Asian options, barriers), simulate paths that pass through those exact\
-    \ dates. Do not interpolate between steps.\n  - EARLY EXERCISE: For American or\
-    \ Bermudan exercise in Monte Carlo, use an approved optimal-stopping control primitive\
-    \ instead of inventing method=\"lsm\" or treating engine.price(...) as a substitute\
-    \ for early-exercise control. Trellis currently implements longstaff_schwartz.\
-    \ Planned policy classes include tsitsiklis_van_roy, primal_dual_mc, and stochastic_mesh.\
-    \ If the control primitive uses continuation regression, the basis or estimator\
-    \ choice is explicit; LaguerreBasis is a common option, not a mandatory route\
-    \ primitive.\n- Canonical model grammar:\n  - `credit_single_name_reduced_form`\
+    \ float:\n        spec = self._spec\n        spec = self._spec\n        from trellis.core.differentiable\
+    \ import get_numpy\n        from trellis.models.credit_default_swap import build_cds_schedule,\
+    \ price_cds_monte_carlo\n\n        np = get_numpy()\n\n        spread = float(spec.spread)\n\
+    \        if spread > 1.0:\n            spread *= 1e-4\n\n        schedule = build_cds_schedule(\n\
+    \            spec.start_date,\n            spec.end_date,\n            spec.frequency,\n\
+    \            spec.day_count,\n            time_origin=spec.start_date,\n     \
+    \   )\n\n        return float(\n            price_cds_monte_carlo(\n         \
+    \       notional=float(spec.notional),\n                spread_quote=spread,\n\
+    \                recovery=float(spec.recovery),\n                schedule=schedule,\n\
+    \                credit_curve=market_state.credit_curve,\n                discount_curve=market_state.discount,\n\
+    \                n_paths=int(spec.n_paths),\n                seed=42,\n      \
+    \      )\n        )\n\n```\n\n## Instrument description\nBuild a pricer for: CDS\
+    \ pricing: hazard rate MC vs survival prob analytical\n\nStandard single-name\
+    \ CDS, protection buyer side.\nNotional: $10,000,000.  Maturity: 5Y from settlement.\n\
+    Premium leg: quarterly payments, Act/360 day count.\nRunning CDS spread: 150 bp.\
+    \  Recovery rate: 40%.\nUse the investment-grade (IG) credit curve from the market\
+    \ snapshot\n(as_of 2024-11-15) — this provides term-dependent hazard rates\nbootstrapped\
+    \ from market CDS spreads at 1Y, 3Y, 5Y, and 10Y tenors.\nDo NOT use a flat hazard\
+    \ rate — the model must respect the full\nhazard rate term structure.\nUse the\
+    \ USD OIS curve for risk-free discounting.\nMethod 1: Monte Carlo simulation of\
+    \ default times from the hazard curve.\nMethod 2: Analytical (deterministic) survival-probability\
+    \ integration.\nCompute the mark-to-market PV (protection leg minus premium leg).\n\
+    \nConstruct methods: monte_carlo\nComparison targets: mc_cds (monte_carlo), analytical_cds\
+    \ (analytical)\nCross-validation harness:\n  internal targets: mc_cds, analytical_cds\n\
+    \  external targets: quantlib, financepy\nNew component: cds_pricing\n\nImplementation\
+    \ target: mc_cds\nPreferred method family: monte_carlo\n\nImplementation target:\
+    \ mc_cds\n\n## Shared Knowledge\n## Distilled Review Memory\n\n- Review principles:\n\
+    \  - `P1`: Always calibrate rate trees to the discount curve before pricing\n\
+    \  - `P2`: Callable bonds need issuer_call lattice control, discrete coupons,\
+    \ and exercise=par+coupon\n  - `P3`: Convert vol units at the boundary between\
+    \ market data and model\n- Review checkpoints:\n  - CONVERGENCE: Use at least\
+    \ 10,000 paths. Verify that the standard error is <1% of the price. If path-dependent,\
+    \ use at least 100 time steps per year.\n  - DISCRETE OBSERVATIONS: For instruments\
+    \ with discrete fixing/observation dates (Asian options, barriers), simulate paths\
+    \ that pass through those exact dates. Do not interpolate between steps.\n  -\
+    \ EARLY EXERCISE: For American or Bermudan exercise in Monte Carlo, use an approved\
+    \ optimal-stopping control primitive instead of inventing method=\"lsm\" or treating\
+    \ engine.price(...) as a substitute for early-exercise control. Trellis currently\
+    \ implements longstaff_schwartz. Planned policy classes include tsitsiklis_van_roy,\
+    \ primal_dual_mc, and stochastic_mesh. If the control primitive uses continuation\
+    \ regression, the basis or estimator choice is explicit; LaguerreBasis is a common\
+    \ option, not a mandatory route primitive.\n- Canonical model grammar:\n  - `credit_single_name_reduced_form`\
     \ -> `Reduced-form single-name credit`\n  - `heston_smile_workflow` -> `Heston`\n\
     - Known failure traps:\n  - `MC payoff must use market_state.discount` -> The\
     \ generated Monte Carlo payoff did not call the required market_state.discount\
@@ -756,18 +757,19 @@ calls:
   function: llm_generate
   stage: code_generation
   prompt_hash: 48fb4541b102bfd9e05ff6b3e35f263c45a5b71037de9c066149e577ba66f1e8
-  response_text: "def evaluate(self, market_state: MarketState) -> float:\n    spec\
-    \ = self._spec\n\n    if market_state.discount is None:\n        raise ValueError(\"\
-    CDSPayoff requires a discount curve in market_state\")\n    if market_state.credit_curve\
-    \ is None:\n        raise ValueError(\"CDSPayoff requires a credit curve in market_state\"\
-    )\n\n    spread = float(spec.spread)\n    if spread > 1.0:\n        spread *=\
-    \ 1e-4\n\n    schedule = build_cds_schedule(\n        spec.start_date,\n     \
-    \   spec.end_date,\n        spec.frequency,\n        spec.day_count,\n       \
-    \ time_origin=spec.start_date,\n    )\n\n    return float(\n        price_cds_analytical(\n\
-    \            notional=float(spec.notional),\n            spread_quote=spread,\n\
-    \            recovery=float(spec.recovery),\n            schedule=schedule,\n\
-    \            credit_curve=market_state.credit_curve,\n            discount_curve=market_state.discount,\n\
-    \        )\n    )"
+  response_text: "spec = self._spec\n        if market_state.credit_curve is None:\n\
+    \            raise ValueError(\"CDS pricing requires market_state.credit_curve\"\
+    )\n        if market_state.discount is None:\n            raise ValueError(\"\
+    CDS pricing requires market_state.discount\")\n\n        from trellis.models.credit_default_swap\
+    \ import build_cds_schedule, price_cds_analytical\n\n        spread = spec.spread\n\
+    \        if spread > 1.0:\n            spread = spread / 10000.0\n\n        schedule\
+    \ = build_cds_schedule(\n            spec.start_date,\n            spec.end_date,\n\
+    \            spec.frequency,\n            spec.day_count,\n            time_origin=spec.start_date,\n\
+    \        )\n\n        pv = price_cds_analytical(\n            notional=spec.notional,\n\
+    \            spread_quote=spread,\n            recovery=spec.recovery,\n     \
+    \       schedule=schedule,\n            credit_curve=market_state.credit_curve,\n\
+    \            discount_curve=market_state.discount,\n        )\n        return\
+    \ float(pv)"
   prompt_text: "You are implementing the evaluate() method for `CDSPayoff` in the\
     \ Trellis pricing library.\n\n## Complete module (skeleton — everything is fixed\
     \ except evaluate)\n```python\n\"\"\"Agent-generated payoff: Build a pricer for:\
@@ -1210,17 +1212,8 @@ calls:
 - seq: 3
   function: llm_generate_json
   stage: critic
-  prompt_hash: c1901df7ad8d26d2929811c43fd391bf82b0cd3aae736c202d2075c18d4d7ed4
-  response_text: '{"check_id": "price_non_negative", "description": "The pricer can
-    return a negative PV for a protection buyer CDS when the running spread is too
-    high relative to the protection leg, and this code does not enforce any non-negativity
-    guard.", "severity": "warning", "evidence": "evaluate() directly returns price_cds_analytical(...).
-    The product is protection buyer side, and the model computes protection leg minus
-    premium leg; if the premium leg dominates under the supplied curve/spread conventions,
-    the result can be negative. There is no clamp or validation against negative PV.",
-    "remediation": "Add explicit contract validation or downstream handling for negative
-    MTM results, or confirm the sign convention and market-state inputs guarantee
-    a non-negative buyer PV under the expected scenarios.", "status": "suspect"}'
+  prompt_hash: 5d218672e8e4d1551d9b2656ffb8cf38a98f1e386991eba847c094999f769c70
+  response_text: '{"": []}'
   prompt_text: "You are a quantitative model validator reviewing agent-generated pricing\
     \ code.\nYour job is to find deterministic review concerns, not to praise. Be\
     \ adversarial.\n\n## Code to review\n```python\n\"\"\"Agent-generated payoff:\
@@ -1281,24 +1274,25 @@ calls:
     \      return self._spec\n\n    @property\n    def requirements(self) -> set[str]:\n\
     \        return {\"credit_curve\", \"discount_curve\"}\n\n    def evaluate(self,\
     \ market_state: MarketState) -> float:\n        spec = self._spec\n        spec\
-    \ = self._spec\n\n        if market_state.discount is None:\n            raise\
-    \ ValueError(\"CDSPayoff requires a discount curve in market_state\")\n      \
-    \  if market_state.credit_curve is None:\n            raise ValueError(\"CDSPayoff\
-    \ requires a credit curve in market_state\")\n\n        spread = float(spec.spread)\n\
-    \        if spread > 1.0:\n            spread *= 1e-4\n\n        schedule = build_cds_schedule(\n\
+    \ = self._spec\n        if market_state.credit_curve is None:\n            raise\
+    \ ValueError(\"CDS pricing requires market_state.credit_curve\")\n        if market_state.discount\
+    \ is None:\n            raise ValueError(\"CDS pricing requires market_state.discount\"\
+    )\n\n        from trellis.models.credit_default_swap import build_cds_schedule,\
+    \ price_cds_analytical\n\n        spread = spec.spread\n        if spread > 1.0:\n\
+    \            spread = spread / 10000.0\n\n        schedule = build_cds_schedule(\n\
     \            spec.start_date,\n            spec.end_date,\n            spec.frequency,\n\
     \            spec.day_count,\n            time_origin=spec.start_date,\n     \
-    \   )\n\n        return float(\n            price_cds_analytical(\n          \
-    \      notional=float(spec.notional),\n                spread_quote=spread,\n\
-    \                recovery=float(spec.recovery),\n                schedule=schedule,\n\
-    \                credit_curve=market_state.credit_curve,\n                discount_curve=market_state.discount,\n\
-    \            )\n        )\n\n```\n\n## Instrument description\nBuild a pricer\
-    \ for: CDS pricing: hazard rate MC vs survival prob analytical\n\nStandard single-name\
-    \ CDS, protection buyer side.\nNotional: $10,000,000.  Maturity: 5Y from settlement.\n\
-    Premium leg: quarterly payments, Act/360 day count.\nRunning CDS spread: 150 bp.\
-    \  Recovery rate: 40%.\nUse the investment-grade (IG) credit curve from the market\
-    \ snapshot\n(as_of 2024-11-15) — this provides term-dependent hazard rates\nbootstrapped\
-    \ from market CDS spreads at 1Y, 3Y, 5Y, and 10Y tenors.\nDo NOT use a flat hazard\
+    \   )\n\n        pv = price_cds_analytical(\n            notional=spec.notional,\n\
+    \            spread_quote=spread,\n            recovery=spec.recovery,\n     \
+    \       schedule=schedule,\n            credit_curve=market_state.credit_curve,\n\
+    \            discount_curve=market_state.discount,\n        )\n        return\
+    \ float(pv)\n\n```\n\n## Instrument description\nBuild a pricer for: CDS pricing:\
+    \ hazard rate MC vs survival prob analytical\n\nStandard single-name CDS, protection\
+    \ buyer side.\nNotional: $10,000,000.  Maturity: 5Y from settlement.\nPremium\
+    \ leg: quarterly payments, Act/360 day count.\nRunning CDS spread: 150 bp.  Recovery\
+    \ rate: 40%.\nUse the investment-grade (IG) credit curve from the market snapshot\n\
+    (as_of 2024-11-15) — this provides term-dependent hazard rates\nbootstrapped from\
+    \ market CDS spreads at 1Y, 3Y, 5Y, and 10Y tenors.\nDo NOT use a flat hazard\
     \ rate — the model must respect the full\nhazard rate term structure.\nUse the\
     \ USD OIS curve for risk-free discounting.\nMethod 1: Monte Carlo simulation of\
     \ default times from the hazard curve.\nMethod 2: Analytical (deterministic) survival-probability\

--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -165,6 +165,24 @@ Evals And Stress Tasks
 This is the main developer-facing evidence loop for changes to routing,
 knowledge retrieval, or generation guardrails.
 
+For the focused simple-derivative tranche, use
+``scripts/run_knowledge_light_proving.py``. That harness keeps the
+compiler-first, knowledge-light prompt surface but now emits a more explicit
+reliability summary alongside the ordinary correctness outcomes:
+
+- ``first_pass`` for task-level first-attempt success
+- ``attempts_to_success`` for successful-task attempt counts
+- ``retry_taxonomy`` for recovered successes bucketed by the triggering stage
+
+The retry taxonomy is derived from the recorded platform trace events rather
+than free-form closeout text, so a proving rerun can answer "what recovered?"
+and "which stage missed first?" from the stored artifact alone.
+
+For comparison tasks, ``attempts_to_success`` is normalized by the slowest
+successful method leg, not by summing all nested attempts. Two methods that
+both succeed on their first method-local attempt still count as a first-pass
+task-level success.
+
 Task-run artifacts now preserve analytical trace paths alongside the existing
 platform traces. When a build loop emits an analytical route, the stored task
 record keeps both the JSON trace and the rendered Markdown path, including

--- a/docs/developer/task_diagnostics.rst
+++ b/docs/developer/task_diagnostics.rst
@@ -304,6 +304,13 @@ a safe checked binding. This matters for thin-adapter families such as CDS,
 where the task may select the correct helper but still drift on keyword names
 without the signature in view.
 
+The proving summary now also records task-level ``first_pass``,
+``attempts_to_success``, and a stage-bucketed ``retry_taxonomy``. That makes
+it possible to separate "eventually succeeded after retries" from
+"succeeded on the first constructive attempt" without reopening the raw trace
+set, and it keeps recovered successes attributable to a concrete stage such as
+semantic validation rather than a generic retry count.
+
 Runtime contract failures
 -------------------------
 

--- a/docs/plans/backlog-burn-down-execution.md
+++ b/docs/plans/backlog-burn-down-execution.md
@@ -19,8 +19,14 @@ Current status:
 - `QUA-430` is complete.
 - `QUA-700` is complete.
 - `QUA-543` is complete.
+- `QUA-544` is complete with a measured `3/3` proving-success bar, `2/3`
+  task-level first-pass success, and the residual `KL01` semantic-validation
+  retry split into `QUA-779`.
 - Wave 1 is complete.
-- The next actionable ticket in queue order is `QUA-417`.
+- Wave 2 is complete.
+- `QUA-417` has been rewritten as a low-priority route-registry maintenance
+  cleanup rather than a core burn-down tranche.
+- The next actionable ticket in queue order is `QUA-429`.
 
 ## Operating Rules
 
@@ -45,12 +51,13 @@ These tickets are actionable backlog burn-down work:
 4. `QUA-430` local gate and release-gate configuration
 5. `QUA-700` canary suite closeout after replay / telemetry / gate hardening
 6. `QUA-543` stress tranche: remaining `E22` compare-ready regression
-7. `QUA-417` route registry cleanup for smaller builder obligation surfaces
-8. `QUA-544` proving runs: first-pass knowledge-light reliability
-9. `QUA-429` lesson-to-test pipeline base slice
-10. `QUA-447` semantic template follow-on for the lesson-to-test path
-11. `QUA-545` maintenance tail for residual cleanup that does not justify a
+7. `QUA-544` proving runs: first-pass knowledge-light reliability
+8. `QUA-429` lesson-to-test pipeline base slice
+9. `QUA-447` semantic template follow-on for the lesson-to-test path
+10. `QUA-545` maintenance tail for residual cleanup that does not justify a
     broader project
+11. `QUA-417` route registry cleanup: collapse redundant optional utility
+    bindings
 
 ## Out of Scope
 
@@ -90,20 +97,18 @@ Wave 1 closeout gate:
 - gate commands and release posture are documented
 - `QUA-700` is closed only after the above slices are done
 
-### Wave 2: Remaining correctness and route-surface cleanup
+### Wave 2: Remaining correctness
 
-This wave removes the highest-value remaining correctness and builder-surface
-debt once canary iteration is cheap again.
+This wave removed the highest-value remaining correctness debt once canary
+iteration was cheap again.
 
 | Order | Ticket | Expected artifact |
 | --- | --- | --- |
 | 6 | `QUA-543` | `E22` stress path restored to a compare-ready state |
-| 7 | `QUA-417` | Narrower route-registry / builder obligation surface |
 
 Wave 2 closeout gate:
 
 - the remaining stress-path regression is resolved or split cleanly
-- route-surface cleanup lands with the relevant regional validation
 
 ### Wave 3: Reliability and durable learning loop
 
@@ -112,9 +117,9 @@ to durable regression coverage.
 
 | Order | Ticket | Expected artifact |
 | --- | --- | --- |
-| 8 | `QUA-544` | Improved first-pass knowledge-light proving reliability |
-| 9 | `QUA-429` | Base lesson-to-test pipeline |
-| 10 | `QUA-447` | Semantic template follow-on on top of the base pipeline |
+| 7 | `QUA-544` | Improved first-pass knowledge-light proving reliability |
+| 8 | `QUA-429` | Base lesson-to-test pipeline |
+| 9 | `QUA-447` | Semantic template follow-on on top of the base pipeline |
 
 Wave 3 closeout gate:
 
@@ -122,11 +127,18 @@ Wave 3 closeout gate:
 - the lesson-to-test path exists end-to-end
 - semantic follow-on scope stays additive rather than reopening the base slice
 
+Current note:
+
+- `QUA-544` delivered the proving summary and route/packet hardening needed to
+  move the tranche to `3/3` success; the remaining non-first-pass retry path
+  is isolated in `QUA-779`
+
 ### Wave 4: Maintenance tail
 
 | Order | Ticket | Expected artifact |
 | --- | --- | --- |
-| 11 | `QUA-545` | Residual maintenance cleanup with explicit scope boundary |
+| 10 | `QUA-545` | Residual maintenance cleanup with explicit scope boundary |
+| 11 | `QUA-417` | Route-registry metadata compaction for optional utility bindings |
 
 ## Ticket Selection Rule
 
@@ -143,17 +155,20 @@ If a ticket has become stale because other landed work already satisfies it:
 ## Current Start Point
 
 Execution started with `QUA-458`, continued through `QUA-710`, `QUA-428`,
-`QUA-430`, the `QUA-700` umbrella closeout, and `QUA-543`, and now moves next
-to `QUA-417`.
+`QUA-430`, the `QUA-700` umbrella closeout, and `QUA-543`. `QUA-417` was
+rewritten as maintenance cleanup. `QUA-544` then improved the knowledge-light
+proving tranche to `3/3` success and split the remaining `KL01`
+semantic-validation retry into `QUA-779`, so the active queue now moves next
+to `QUA-429`.
 
 Plain-English goal:
 
-- narrow the route-registry / builder obligation surface without reopening the
-  completed stress-path recovery
+- build the base lesson-to-test pipeline now that the proving tranche is
+  stable enough to turn repeat misses into durable regression coverage
 
 Primary files and surfaces:
 
-- the route registry and builder obligation surfaces that still overexpose
-  modules or prompts
-- the generation and routing contracts that depend on that registry surface
-- regional validation around route selection and builder prompt assembly
+- lesson capture, normalization, and regression materialization surfaces
+- the proving / evaluation loops that should consume durable regression output
+- validation around the base learning-to-test path rather than proving-only
+  packet hardening

--- a/scripts/run_knowledge_light_proving.py
+++ b/scripts/run_knowledge_light_proving.py
@@ -197,7 +197,14 @@ def run_proving_set(
     print(f"\n{'=' * 60}")
     print(f"SUMMARY: {sum(1 for item in results if item.get('success'))}/{len(results)} succeeded")
     print(f"  Failure buckets: {summary['failure_buckets']}")
+    print(
+        "  First pass: "
+        f"{summary['first_pass']['first_pass_successes']}/{summary['first_pass']['tasks']} "
+        f"({summary['first_pass']['rate']:.0%})"
+    )
+    print(f"  Attempts to success: {summary['attempts_to_success']}")
     print(f"  Retry recovery: {summary['retry_recovery']}")
+    print(f"  Retry taxonomy: {summary['retry_taxonomy']}")
     print(f"  Token usage: {summary['token_usage']}")
     print(f"  Results saved to: {output_file}")
     print(f"  Summary saved to: {summary_path}")

--- a/tests/test_agent/test_codegen_guardrails.py
+++ b/tests/test_agent/test_codegen_guardrails.py
@@ -288,7 +288,10 @@ def test_american_option_route_card_mentions_equity_tree_helper():
 
 
 def test_fx_monte_carlo_route_card_mentions_fx_rate_scalar_extraction():
+    from trellis.agent.codegen_guardrails import clear_generation_plan_cache
     from trellis.agent.knowledge.decompose import decompose_to_ir
+
+    clear_generation_plan_cache()
 
     pricing_plan = PricingPlan(
         method="monte_carlo",
@@ -308,7 +311,15 @@ def test_fx_monte_carlo_route_card_mentions_fx_rate_scalar_extraction():
 
     assert "Lane obligations:" in card
     assert "Lane family: `monte_carlo`" in card
+    assert plan.primitive_plan is not None
+    assert plan.primitive_plan.route == "monte_carlo_fx_vanilla"
+    primitive_refs = {
+        f"{primitive.module}.{primitive.symbol}"
+        for primitive in plan.primitive_plan.primitives
+    }
+    assert "trellis.models.fx_vanilla.price_fx_vanilla_monte_carlo" in primitive_refs
     assert "Resolve scalar FX spot from `market_state.fx_rates[spec.fx_pair].spot`" in card
+    assert "price_fx_vanilla_monte_carlo" in card
     assert "FXRate` wrapper" in card
 
 

--- a/tests/test_agent/test_evals.py
+++ b/tests/test_agent/test_evals.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
+
+import yaml
 
 from trellis.agent.quant import PricingPlan
 
@@ -496,6 +499,97 @@ def test_summarize_task_results_reports_retry_recovery_and_reviewer_signals():
     assert summary["token_usage"]["call_count"] == 3
     assert summary["token_usage"]["calls_without_usage"] == 1
     assert summary["token_usage"]["by_stage"]["code_generation"]["total_tokens"] == 120
+
+
+def test_summarize_task_results_uses_attempts_to_success_for_comparison_tasks(tmp_path):
+    from trellis.agent.evals import summarize_task_results
+
+    def _write_platform_trace(name: str, *events: dict[str, object]) -> str:
+        trace_path = tmp_path / f"{name}.yaml"
+        trace_path.write_text(
+            yaml.safe_dump(
+                {
+                    "request_id": name,
+                    "status": "succeeded",
+                    "outcome": "build_completed",
+                },
+                sort_keys=False,
+            )
+        )
+        events_path = trace_path.with_suffix(".events.ndjson")
+        if events:
+            events_path.write_text(
+                "\n".join(json.dumps(event) for event in events) + "\n"
+            )
+        return str(trace_path)
+
+    results = [
+        {
+            "task_id": "KL01",
+            "success": True,
+            "attempts": 2,
+            "method_results": {
+                "analytical": {
+                    "success": True,
+                    "attempts": 1,
+                    "platform_trace_path": _write_platform_trace("kl01_analytical"),
+                },
+                "monte_carlo": {
+                    "success": True,
+                    "attempts": 1,
+                    "platform_trace_path": _write_platform_trace("kl01_mc"),
+                },
+            },
+        },
+        {
+            "task_id": "KL02",
+            "success": True,
+            "attempts": 3,
+            "method_results": {
+                "analytical": {
+                    "success": True,
+                    "attempts": 2,
+                    "platform_trace_path": _write_platform_trace(
+                        "kl02_analytical",
+                        {
+                            "event": "builder_attempt_failed",
+                            "status": "error",
+                            "timestamp": "2026-04-10T15:00:00+00:00",
+                            "details": {"reason": "semantic_validation"},
+                        },
+                        {
+                            "event": "builder_attempt_succeeded",
+                            "status": "ok",
+                            "timestamp": "2026-04-10T15:00:01+00:00",
+                            "details": {"attempt": 2},
+                        },
+                    ),
+                },
+                "monte_carlo": {
+                    "success": True,
+                    "attempts": 1,
+                    "platform_trace_path": _write_platform_trace("kl02_mc"),
+                },
+            },
+        },
+    ]
+
+    summary = summarize_task_results(results)
+
+    assert summary["retry_recovery"]["first_attempt_successes"] == 1
+    assert summary["retry_recovery"]["successful_after_retry"] == 1
+    assert summary["first_pass"]["successful_tasks"] == 2
+    assert summary["first_pass"]["first_pass_successes"] == 1
+    assert summary["first_pass"]["rate"] == 0.5
+    assert summary["attempts_to_success"]["average"] == 1.5
+    assert summary["attempts_to_success"]["median"] == 1.5
+    assert summary["attempts_to_success"]["max"] == 2
+    assert summary["attempts_to_success"]["distribution"] == {"1": 1, "2": 1}
+    assert summary["retry_taxonomy"]["recovered_successes"] == 1
+    assert summary["retry_taxonomy"]["unattributed_recoveries"] == 0
+    assert summary["retry_taxonomy"]["by_stage"]["semantic_validation"]["count"] == 1
+    assert summary["retry_taxonomy"]["by_stage"]["semantic_validation"]["task_ids"] == ["KL02"]
+    assert summary["retry_taxonomy"]["by_task"]["KL02"] == ["semantic_validation"]
 
 
 def test_summarize_promotion_discipline_flags_success_without_reusable_artifacts():

--- a/tests/test_agent/test_executor.py
+++ b/tests/test_agent/test_executor.py
@@ -856,8 +856,8 @@ def test_generate_skeleton_prefills_exact_binding_imports_without_generic_noise(
     from trellis.agent.planner import FieldDef, SpecSchema
 
     spec_schema = SpecSchema(
-        class_name="AmericanOptionPayoff",
-        spec_name="AmericanPutEquitySpec",
+        class_name="AmericanPutTreePayoff",
+        spec_name="AmericanPutTreeSpec",
         requirements=["discount_curve", "black_vol_surface"],
         fields=[
             FieldDef("spot", "float", "Spot"),

--- a/tests/test_agent/test_executor.py
+++ b/tests/test_agent/test_executor.py
@@ -284,9 +284,14 @@ def test_diagnose_failure_reads_related_lessons_from_canonical_signatures(monkey
     assert diagnosis.related_lessons == ["LSM high-vol bias with polynomial basis"]
 
 
-def test_generate_skeleton_quotes_string_defaults_but_keeps_symbolic_defaults():
-    from trellis.agent.executor import _generate_skeleton
+def test_generate_skeleton_normalizes_string_defaults_and_keeps_symbolic_defaults():
+    from trellis.agent.executor import _generate_skeleton, _render_spec_default_value
     from trellis.agent.planner import FieldDef, SpecSchema
+
+    assert _render_spec_default_value("str", "monte_carlo") == "'monte_carlo'"
+    assert _render_spec_default_value("str", "'american'") == "'american'"
+    assert _render_spec_default_value("str", '"put"') == "'put'"
+    assert _render_spec_default_value("str | None", "None") == "None"
 
     spec_schema = SpecSchema(
         class_name="DemoPayoff",
@@ -880,6 +885,8 @@ def test_generate_skeleton_prefills_exact_binding_imports_without_generic_noise(
         "from trellis.models.equity_option_tree import price_vanilla_equity_option_tree"
         in skeleton
     )
+    assert "option_type: str = 'put'" in skeleton
+    assert "exercise_style: str = 'american'" in skeleton
     assert "from trellis.core.date_utils import generate_schedule, year_fraction" not in skeleton
     assert "from trellis.models.black import black76_call, black76_put" not in skeleton
 

--- a/tests/test_agent/test_knowledge_light_proving.py
+++ b/tests/test_agent/test_knowledge_light_proving.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 from pathlib import Path
+
+import yaml
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -38,3 +41,81 @@ def test_select_cases_filters_requested_ids():
     selected = module._select_cases(tasks, ["KL02"])
 
     assert [task["id"] for task in selected] == ["KL02"]
+
+
+def test_run_proving_set_writes_first_pass_metrics_and_retry_taxonomy(tmp_path, monkeypatch, capsys):
+    module = _load_module()
+
+    def _write_platform_trace(name: str, *events: dict[str, object]) -> str:
+        trace_path = tmp_path / f"{name}.yaml"
+        trace_path.write_text(
+            yaml.safe_dump(
+                {
+                    "request_id": name,
+                    "status": "succeeded",
+                    "outcome": "build_completed",
+                },
+                sort_keys=False,
+            )
+        )
+        events_path = trace_path.with_suffix(".events.ndjson")
+        if events:
+            events_path.write_text(
+                "\n".join(json.dumps(event) for event in events) + "\n"
+            )
+        return str(trace_path)
+
+    fake_results = iter(
+        [
+            {
+                "task_id": "KL01",
+                "success": True,
+                "attempts": 1,
+                "platform_trace_path": _write_platform_trace("kl01"),
+            },
+            {
+                "task_id": "KL02",
+                "success": True,
+                "attempts": 2,
+                "platform_trace_path": _write_platform_trace(
+                    "kl02",
+                    {
+                        "event": "builder_attempt_failed",
+                        "status": "error",
+                        "timestamp": "2026-04-10T15:00:00+00:00",
+                        "details": {"reason": "validation"},
+                    }
+                ),
+            },
+        ]
+    )
+
+    monkeypatch.setattr(module, "build_market_state", lambda: object())
+    monkeypatch.setattr(module, "run_task", lambda *args, **kwargs: next(fake_results))
+
+    output_file = tmp_path / "knowledge_light_results.json"
+    tasks = [
+        {"id": "KL01", "title": "Case 1"},
+        {"id": "KL02", "title": "Case 2"},
+    ]
+
+    summary = module.run_proving_set(
+        tasks,
+        str(output_file),
+        model="test-model",
+        validation="standard",
+    )
+
+    summary_path = tmp_path / "knowledge_light_results_summary.json"
+    persisted = json.loads(summary_path.read_text())
+    stdout = capsys.readouterr().out
+
+    assert summary["first_pass"]["rate"] == 0.5
+    assert summary["attempts_to_success"]["distribution"] == {"1": 1, "2": 1}
+    assert summary["retry_taxonomy"]["by_stage"]["validation"]["task_ids"] == ["KL02"]
+    assert persisted["first_pass"]["first_pass_successes"] == 1
+    assert persisted["attempts_to_success"]["average"] == 1.5
+    assert persisted["retry_taxonomy"]["recovered_successes"] == 1
+    assert "First pass:" in stdout
+    assert "Attempts to success:" in stdout
+    assert "Retry taxonomy:" in stdout

--- a/tests/test_agent/test_planner.py
+++ b/tests/test_agent/test_planner.py
@@ -253,6 +253,26 @@ class TestPlanBuild:
         assert plan.spec_schema.spec_name == "FXVanillaOptionSpec"
         assert plan.payoff_class_name == "FXVanillaMonteCarloPayoff"
 
+    def test_american_put_tree_route_uses_deterministic_spec_schema(self):
+        plan = plan_build(
+            "American put: equity tree knowledge-light proving",
+            {"discount_curve", "black_vol_surface"},
+            instrument_type="american_put",
+            preferred_method="rate_tree",
+        )
+
+        assert plan.spec_schema is not None
+        assert plan.spec_schema.spec_name == "AmericanOptionSpec"
+        assert plan.payoff_class_name == "AmericanOptionPayoff"
+        assert [field.name for field in plan.spec_schema.fields] == [
+            "spot",
+            "strike",
+            "expiry_date",
+            "option_type",
+            "exercise_style",
+            "day_count",
+        ]
+
     def test_plan_gap_analysis(self):
         plan = plan_build(
             "European payer swaption",

--- a/tests/test_agent/test_planner.py
+++ b/tests/test_agent/test_planner.py
@@ -3,7 +3,7 @@
 import pytest
 
 from trellis.agent.planner import (
-    BuildPlan, BuildStep, FieldDef, SpecSchema, STATIC_SPECS, _plan_static, plan_build,
+    BuildPlan, BuildStep, FieldDef, SpecSchema, STATIC_SPECS, _infer_method_hint, _plan_static, plan_build,
 )
 
 
@@ -262,8 +262,8 @@ class TestPlanBuild:
         )
 
         assert plan.spec_schema is not None
-        assert plan.spec_schema.spec_name == "AmericanOptionSpec"
-        assert plan.payoff_class_name == "AmericanOptionPayoff"
+        assert plan.spec_schema.spec_name == "AmericanPutTreeSpec"
+        assert plan.payoff_class_name == "AmericanPutTreePayoff"
         assert [field.name for field in plan.spec_schema.fields] == [
             "spot",
             "strike",
@@ -272,6 +272,10 @@ class TestPlanBuild:
             "exercise_style",
             "day_count",
         ]
+
+    def test_infer_method_hint_does_not_match_tree_substrings_inside_other_words(self):
+        assert _infer_method_hint("main street spot-vol quote pack") is None
+        assert _infer_method_hint("american put lattice benchmark") == "rate_tree"
 
     def test_plan_gap_analysis(self):
         plan = plan_build(

--- a/tests/test_agent/test_platform_requests.py
+++ b/tests/test_agent/test_platform_requests.py
@@ -266,7 +266,7 @@ def test_compile_build_request_emits_fallback_lane_plan_for_fx_monte_carlo_route
 
     assert compiled.semantic_blueprint is None
     assert compiled.generation_plan.primitive_plan is not None
-    assert compiled.generation_plan.primitive_plan.route == "monte_carlo_paths"
+    assert compiled.generation_plan.primitive_plan.route == "monte_carlo_fx_vanilla"
     assert compiled.generation_plan.lane_family == "monte_carlo"
     assert any("FXRate" in step for step in compiled.generation_plan.lane_construction_steps)
 

--- a/tests/test_agent/test_route_registry.py
+++ b/tests/test_agent/test_route_registry.py
@@ -258,7 +258,7 @@ class TestRegistryValidation:
 
     def test_reuse_module_paths_hydrate_for_checked_in_deterministic_routes(self, registry):
         analytical_fx = find_route_by_id("analytical_garman_kohlhagen", registry)
-        monte_carlo_fx = find_route_by_id("monte_carlo_paths", registry)
+        monte_carlo_fx = find_route_by_id("monte_carlo_fx_vanilla", registry)
         analytical_quanto = find_route_by_id("quanto_adjustment_analytical", registry)
         monte_carlo_quanto = find_route_by_id("correlated_gbm_monte_carlo", registry)
 
@@ -957,6 +957,26 @@ class TestFXAnalyticalRoutes:
         assert _prim_set(new_prims) == expected_prims
 
 
+class TestFXMonteCarloRoutes:
+    FX_IR = ProductIR(instrument="fx_option", payoff_family="vanilla_option", exercise_style="european")
+    FX_PLAN = _make_plan(
+        "monte_carlo",
+        market_data={"fx_rates", "forward_curve", "discount_curve", "black_vol_surface", "spot"},
+    )
+
+    def test_fx_candidate(self, registry):
+        new = _new_routes(registry, "monte_carlo", self.FX_IR, pricing_plan=self.FX_PLAN)
+        assert "monte_carlo_fx_vanilla" in new
+
+    def test_primitives(self, registry):
+        spec = [r for r in registry.routes if r.id == "monte_carlo_fx_vanilla"][0]
+        new_prims = resolve_route_primitives(spec, self.FX_IR)
+        expected_prims = {
+            ("trellis.models.fx_vanilla", "price_fx_vanilla_monte_carlo", "route_helper"),
+        }
+        assert _prim_set(new_prims) == expected_prims
+
+
 # ---------------------------------------------------------------------------
 # Transform / PDE / Copula / Waterfall routes
 # ---------------------------------------------------------------------------
@@ -1322,6 +1342,7 @@ class TestEngineFamilyCoverage:
         "correlated_basket_monte_carlo": "monte_carlo",
         "exercise_monte_carlo": "exercise",
         "monte_carlo_paths": "monte_carlo",
+        "monte_carlo_fx_vanilla": "monte_carlo",
         "local_vol_monte_carlo": "monte_carlo",
         "qmc_sobol_paths": "qmc",
         "exercise_lattice": "lattice",

--- a/trellis/agent/evals.py
+++ b/trellis/agent/evals.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import json
 from pathlib import Path
+from statistics import median
 from typing import Any, Iterable, Mapping
 
 import yaml
@@ -603,6 +604,7 @@ def summarize_task_results(results: list[Mapping[str, Any]]) -> dict[str, Any]:
     """Summarize one task-result tranche with shared-memory-focused metrics."""
     failure_buckets: dict[str, int] = {}
     attempts: list[int] = []
+    attempts_to_success: list[int] = []
     token_usage = _empty_token_usage_summary()
     shared_knowledge_tasks = 0
     shared_knowledge_lessons = 0
@@ -610,6 +612,9 @@ def summarize_task_results(results: list[Mapping[str, Any]]) -> dict[str, Any]:
     tasks_recovered_after_review = 0
     tasks_with_multi_reviewer_issues = 0
     reviewer_agent_counts: dict[str, int] = {}
+    retry_taxonomy_by_stage: dict[str, dict[str, Any]] = {}
+    retry_taxonomy_by_task: dict[str, list[str]] = {}
+    unattributed_recoveries = 0
 
     successes = 0
     successful_after_retry = 0
@@ -621,11 +626,31 @@ def summarize_task_results(results: list[Mapping[str, Any]]) -> dict[str, Any]:
 
         if result.get("success"):
             successes += 1
-            attempt_count = int(result.get("attempts") or 0)
+            attempt_count = _result_attempts_to_success(result)
+            attempts_to_success.append(attempt_count)
             if attempt_count <= 1:
                 first_attempt_successes += 1
             elif attempt_count > 1:
                 successful_after_retry += 1
+                task_id = str(result.get("task_id") or "").strip()
+                stage_reasons = _result_retry_taxonomy_reasons(result)
+                if not stage_reasons:
+                    unattributed_recoveries += 1
+                    stage_reasons = ("unattributed",)
+                if task_id:
+                    retry_taxonomy_by_task[task_id] = list(stage_reasons)
+                for stage_reason in stage_reasons:
+                    stage_entry = retry_taxonomy_by_stage.setdefault(
+                        stage_reason,
+                        {"count": 0, "task_ids": []},
+                    )
+                    if task_id:
+                        if task_id not in stage_entry["task_ids"]:
+                            stage_entry["task_ids"].append(task_id)
+                        stage_entry["task_ids"].sort()
+                        stage_entry["count"] = len(stage_entry["task_ids"])
+                    else:
+                        stage_entry["count"] += 1
         attempts.append(int(result.get("attempts") or 0))
 
         knowledge_summaries = list(_iter_knowledge_summaries(result))
@@ -664,6 +689,33 @@ def summarize_task_results(results: list[Mapping[str, Any]]) -> dict[str, Any]:
             "successful_after_retry": successful_after_retry,
             "first_attempt_successes": first_attempt_successes,
         },
+        "first_pass": {
+            "tasks": len(results),
+            "successful_tasks": successes,
+            "first_pass_successes": first_attempt_successes,
+            "rate": round(first_attempt_successes / len(results), 2) if results else 0.0,
+            "success_rate": round(first_attempt_successes / successes, 2) if successes else 0.0,
+        },
+        "attempts_to_success": {
+            "successful_tasks": len(attempts_to_success),
+            "average": round(sum(attempts_to_success) / len(attempts_to_success), 2)
+            if attempts_to_success
+            else 0.0,
+            "median": round(float(median(attempts_to_success)), 2)
+            if attempts_to_success
+            else 0.0,
+            "max": max(attempts_to_success) if attempts_to_success else 0,
+            "distribution": {
+                str(attempt): attempts_to_success.count(attempt)
+                for attempt in sorted(set(attempts_to_success))
+            },
+        },
+        "retry_taxonomy": {
+            "recovered_successes": successful_after_retry,
+            "unattributed_recoveries": unattributed_recoveries,
+            "by_stage": dict(sorted(retry_taxonomy_by_stage.items())),
+            "by_task": dict(sorted(retry_taxonomy_by_task.items())),
+        },
         "reviewer_signals": {
             "tasks_with_reviewer_issues": tasks_with_reviewer_issues,
             "tasks_with_multi_reviewer_issues": tasks_with_multi_reviewer_issues,
@@ -677,6 +729,59 @@ def summarize_task_results(results: list[Mapping[str, Any]]) -> dict[str, Any]:
         "promotion_discipline": summarize_promotion_discipline(results),
         "token_usage": token_usage,
     }
+
+
+def _result_attempts_to_success(result: Mapping[str, Any]) -> int:
+    """Return the task-level attempts-to-success count, normalizing comparison tasks."""
+    method_results = result.get("method_results")
+    if isinstance(method_results, Mapping):
+        method_attempts = [
+            max(int(payload.get("attempts") or 0), 0)
+            for payload in method_results.values()
+            if isinstance(payload, Mapping)
+        ]
+        if method_attempts:
+            return max(method_attempts)
+    return max(int(result.get("attempts") or 0), 0)
+
+
+def _result_retry_taxonomy_reasons(result: Mapping[str, Any]) -> tuple[str, ...]:
+    """Return the stable retry-stage reasons that explain one recovered success."""
+    reasons: list[str] = []
+    method_results = result.get("method_results")
+    if isinstance(method_results, Mapping):
+        for payload in method_results.values():
+            if not isinstance(payload, Mapping):
+                continue
+            if max(int(payload.get("attempts") or 0), 0) <= 1:
+                continue
+            reasons.extend(_payload_retry_taxonomy_reasons(payload))
+    elif _result_attempts_to_success(result) > 1:
+        reasons.extend(_payload_retry_taxonomy_reasons(result))
+    return tuple(dict.fromkeys(reason for reason in reasons if reason))
+
+
+def _payload_retry_taxonomy_reasons(payload: Mapping[str, Any]) -> tuple[str, ...]:
+    """Load ordered distinct builder retry reasons from one payload trace."""
+    trace_path = str(payload.get("platform_trace_path") or "").strip()
+    if not trace_path:
+        return ()
+
+    try:
+        from trellis.agent.platform_traces import load_platform_trace_events
+
+        events = load_platform_trace_events(trace_path)
+    except Exception:
+        return ()
+
+    reasons: list[str] = []
+    for event in events:
+        if event.event != "builder_attempt_failed":
+            continue
+        reason = str((event.details or {}).get("reason") or "").strip()
+        if reason:
+            reasons.append(reason)
+    return tuple(dict.fromkeys(reasons))
 
 
 def summarize_promotion_discipline(results: list[Mapping[str, Any]]) -> dict[str, Any]:

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -145,6 +145,12 @@ def _render_spec_default_value(field_type: str, default: str) -> str:
     if "str" in normalized_type:
         if default == "None":
             return "None"
+        try:
+            parsed_default = ast.literal_eval(default)
+        except (SyntaxError, ValueError):
+            parsed_default = default
+        if isinstance(parsed_default, str):
+            return repr(parsed_default)
         return repr(default)
     return default
 

--- a/trellis/agent/knowledge/canonical/routes.yaml
+++ b/trellis/agent/knowledge/canonical/routes.yaml
@@ -388,7 +388,6 @@ routes:
     route_family: monte_carlo
     status: promoted
     confidence: 1.0
-    reuse_module_paths: [instruments/_agent/fxvanillamontecarlo.py]
     score_hints:
       non_european_penalty: -2.0
       penalize_when_market_data: {local_vol_surface: -3.0}
@@ -454,6 +453,46 @@ routes:
       - when: default
         primitives: []
         adapters: []
+
+  - id: monte_carlo_fx_vanilla
+    engine_family: monte_carlo
+    route_family: monte_carlo
+    status: promoted
+    confidence: 1.0
+    reuse_module_paths: [instruments/_agent/fxvanillamontecarlo.py]
+    score_hints:
+      bonus_when_market_data: {fx_rates: 4.0, forward_curve: 4.0}
+      payoff_family_bonus: {vanilla_option: 1.0}
+      non_european_penalty: -2.0
+    match:
+      methods: [monte_carlo]
+      exclude_instruments: [quanto_option, cds, nth_to_default, basket_option]
+      required_market_data: [fx_rates, forward_curve]
+    admissibility:
+      control_styles: [identity]
+      event_support: automatic
+      phase_sensitivity: default_phase_order_only
+      multicurrency_support: native_payout_with_fx
+      supported_outputs: [price, scenario_pnl]
+      supports_sensitivity_outputs: true
+      supported_state_tags: [pathwise_only, terminal_markov, recombining_safe, schedule_state]
+      supported_process_families: [gbm_1d]
+      supported_path_requirement_kinds: [terminal_only, full_path, event_snapshots, event_replay, reducer_state]
+      supports_calibration: true
+    primitives:
+      - module: trellis.models.fx_vanilla
+        symbol: price_fx_vanilla_monte_carlo
+        role: route_helper
+    adapters: []
+    notes:
+      - "For vanilla European FX options on the Monte Carlo lane, prefer `trellis.models.fx_vanilla.price_fx_vanilla_monte_carlo(...)`."
+      - "Treat the generated route as a thin adapter over the checked FX helper; do not rebuild GBM drift, curve resolution, or payoff discounting inline."
+    market_data_access:
+      required:
+        discount_curve: [market_state.discount]
+        forward_curve: [market_state.forward_curve, market_state.forecast_curves]
+        black_vol_surface: [market_state.vol_surface]
+        spot: [market_state.spot, market_state.underlier_spots, market_state.fx_rates]
 
   - id: local_vol_monte_carlo
     engine_family: monte_carlo

--- a/trellis/agent/planner.py
+++ b/trellis/agent/planner.py
@@ -309,6 +309,19 @@ SPECIALIZED_SPECS: dict[str, SpecSchema] = {
             FieldDef("n_steps", "int", "Number of Monte Carlo time steps", "252"),
         ],
     ),
+    "american_put_tree": SpecSchema(
+        class_name="AmericanOptionPayoff",
+        spec_name="AmericanOptionSpec",
+        requirements=["discount_curve", "black_vol_surface"],
+        fields=[
+            FieldDef("spot", "float", "Current spot price"),
+            FieldDef("strike", "float", "Option strike price"),
+            FieldDef("expiry_date", "date", "Option expiry date"),
+            FieldDef("option_type", "str", "Option type: 'call' or 'put'", "'put'"),
+            FieldDef("exercise_style", "str", "Exercise style for the checked lattice helper", "'american'"),
+            FieldDef("day_count", "DayCountConvention", "Day count convention", "DayCountConvention.ACT_365"),
+        ],
+    ),
     "quanto_option_analytical": SpecSchema(
         class_name="QuantoOptionAnalyticalPayoff",
         spec_name="QuantoOptionSpec",
@@ -392,6 +405,7 @@ _SPECIALIZED_SPEC_ALLOWED_INSTRUMENTS: dict[str, frozenset[str]] = {
     "cds_monte_carlo": frozenset({"", "cds", "credit_default_swap"}),
     "fx_vanilla_analytical": frozenset({"", "european_option"}),
     "fx_vanilla_monte_carlo": frozenset({"", "european_option"}),
+    "american_put_tree": frozenset({"", "american_put"}),
     "quanto_option_analytical": frozenset({"", "quanto_option"}),
     "quanto_option_monte_carlo": frozenset({"", "quanto_option"}),
     "european_option_analytical": frozenset({"", "european_option"}),
@@ -568,6 +582,13 @@ def _select_specialized_spec(
             return SPECIALIZED_SPECS["fx_vanilla_monte_carlo"]
         return SPECIALIZED_SPECS["fx_vanilla_analytical"]
 
+    if _allowed("american_put_tree") and (
+        normalized_instrument == "american_put"
+        or ("american" in desc_lower and "put" in desc_lower)
+    ):
+        if method_hint == "rate_tree":
+            return SPECIALIZED_SPECS["american_put_tree"]
+
     if _allowed("european_local_vol_monte_carlo") and (
         "local vol" in desc_lower or "local_vol_surface" in normalized_requirements
     ):
@@ -605,6 +626,8 @@ def _infer_method_hint(desc_lower: str, *, preferred_method: str | None = None) 
         normalized = preferred_method.strip().lower().replace("-", "_").replace(" ", "_")
         if normalized in {"monte_carlo", "mc"}:
             return "monte_carlo"
+        if normalized in {"rate_tree", "tree", "lattice"}:
+            return "rate_tree"
         if normalized in {"analytical", "garman_kohlhagen", "gk_analytical"}:
             return "analytical"
     preferred_match = re.search(r"preferred method family:\s*([a-zA-Z_]+)", desc_lower)
@@ -614,6 +637,8 @@ def _infer_method_hint(desc_lower: str, *, preferred_method: str | None = None) 
         return "monte_carlo"
     if "monte carlo" in desc_lower or " monte_carlo" in desc_lower:
         return "monte_carlo"
+    if "rate_tree" in desc_lower or "tree" in desc_lower or "lattice" in desc_lower:
+        return "rate_tree"
     if "analytical" in desc_lower or "garman_kohlhagen" in desc_lower:
         return "analytical"
     return None

--- a/trellis/agent/planner.py
+++ b/trellis/agent/planner.py
@@ -310,8 +310,8 @@ SPECIALIZED_SPECS: dict[str, SpecSchema] = {
         ],
     ),
     "american_put_tree": SpecSchema(
-        class_name="AmericanOptionPayoff",
-        spec_name="AmericanOptionSpec",
+        class_name="AmericanPutTreePayoff",
+        spec_name="AmericanPutTreeSpec",
         requirements=["discount_curve", "black_vol_surface"],
         fields=[
             FieldDef("spot", "float", "Current spot price"),
@@ -637,7 +637,7 @@ def _infer_method_hint(desc_lower: str, *, preferred_method: str | None = None) 
         return "monte_carlo"
     if "monte carlo" in desc_lower or " monte_carlo" in desc_lower:
         return "monte_carlo"
-    if "rate_tree" in desc_lower or "tree" in desc_lower or "lattice" in desc_lower:
+    if "rate_tree" in desc_lower or re.search(r"\b(?:rate[_ ]tree|binomial tree|tree|lattice)\b", desc_lower):
         return "rate_tree"
     if "analytical" in desc_lower or "garman_kohlhagen" in desc_lower:
         return "analytical"


### PR DESCRIPTION
## Summary
- add first-pass, attempts-to-success, and retry-taxonomy reporting to the knowledge-light proving summary
- harden the first-pass proving packet for the American tree and FX Monte Carlo lanes, and normalize specialized string defaults in executor skeletons
- refresh the replay-backed full-task canary cassettes and sync the developer docs / backlog mirror for QUA-544

## Validation
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_executor.py tests/test_agent/test_build_loop.py tests/test_agent/test_planner.py tests/test_agent/test_codegen_guardrails.py tests/test_agent/test_route_registry.py tests/test_agent/test_platform_requests.py tests/test_agent/test_evals.py tests/test_agent/test_knowledge_light_proving.py -q
- PYTHONHASHSEED=0 /Users/steveyang/miniforge3/bin/python3 scripts/run_knowledge_light_proving.py --output /tmp/qua544_knowledge_light_results_after_default_fix.json
- PYTHONHASHSEED=0 /Users/steveyang/miniforge3/bin/python3 scripts/record_cassettes.py --task T13
- PYTHONHASHSEED=0 /Users/steveyang/miniforge3/bin/python3 scripts/record_cassettes.py --task T38
- PYTHONHASHSEED=0 /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_contracts/test_canary_replay_contracts.py -q
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/ -x -q -m "not integration"