### PR TITLE
knowledge: materialize lessons into regression payloads

### DIFF
--- a/docs/developer/learning_mechanism.rst
+++ b/docs/developer/learning_mechanism.rst
@@ -133,6 +133,26 @@ The prompt surface therefore reuses:
 - modeling requirements
 - matched failure signatures
 
+Deterministic Lesson-To-Test Projection
+---------------------------------------
+
+Validated and promoted lessons now also feed a separate deterministic
+materialization seam in ``trellis.agent.knowledge.lesson_to_test``.
+
+That layer does not mutate the canonical lesson store and does not ask the
+model to write tests. Instead it:
+
+- classifies one active lesson into a regression-template family
+- attaches a stable target-test-file hint plus assertion and fixture focus
+- renders a reviewable pytest-style fragment for the lesson
+- ignores ``candidate`` and ``archived`` lessons so low-confidence guidance
+  does not silently become regression authority
+
+The base template families cover generic codegen, method-contract, convention,
+and dependency-resilience failures. Semantic, lowering, bridge, and
+route-boundary failures refine that same deterministic layer rather than
+creating a separate prompt-only path.
+
 Observability And Audit
 -----------------------
 

--- a/docs/plans/backlog-burn-down-execution.md
+++ b/docs/plans/backlog-burn-down-execution.md
@@ -22,11 +22,14 @@ Current status:
 - `QUA-544` is complete with a measured `3/3` proving-success bar, `2/3`
   task-level first-pass success, and the residual `KL01` semantic-validation
   retry split into `QUA-779`.
+- `QUA-429` is complete.
+- `QUA-447` is complete.
 - Wave 1 is complete.
 - Wave 2 is complete.
+- Wave 3 is complete.
 - `QUA-417` has been rewritten as a low-priority route-registry maintenance
   cleanup rather than a core burn-down tranche.
-- The next actionable ticket in queue order is `QUA-429`.
+- The next actionable ticket in queue order is `QUA-545`.
 
 ## Operating Rules
 
@@ -158,8 +161,11 @@ Execution started with `QUA-458`, continued through `QUA-710`, `QUA-428`,
 `QUA-430`, the `QUA-700` umbrella closeout, and `QUA-543`. `QUA-417` was
 rewritten as maintenance cleanup. `QUA-544` then improved the knowledge-light
 proving tranche to `3/3` success and split the remaining `KL01`
-semantic-validation retry into `QUA-779`, so the active queue now moves next
-to `QUA-429`.
+semantic-validation retry into `QUA-779`. `QUA-429` then added the base
+deterministic lesson-to-test seam for validated/promoted lessons, and
+`QUA-447` extended that seam with semantic, lowering, bridge, and
+route-boundary template families, so the active queue now moves next to
+`QUA-545`.
 
 Current architectural note:
 

--- a/docs/quant/knowledge_maintenance.rst
+++ b/docs/quant/knowledge_maintenance.rst
@@ -45,6 +45,11 @@ manual edit target. Retrieval also suppresses lessons that are marked as
 ``supersedes`` links as metadata so retrieval can prune stale lessons before it
 hydrates full lesson payloads from disk.
 
+Validated and promoted lessons can also be projected into deterministic
+regression payloads through ``trellis.agent.knowledge.lesson_to_test``. That
+projection is reviewable and read-only with respect to the canonical lesson
+store: candidate lessons stay excluded until they clear the promotion gate.
+
 Replay and reflection traces now persist a ``lesson_contract`` validation
 report plus a ``lesson_promotion_outcome`` field, so a task run can show the
 contract that was accepted or rejected before promotion.

--- a/tests/test_agent/test_lesson_to_test.py
+++ b/tests/test_agent/test_lesson_to_test.py
@@ -229,3 +229,24 @@ def test_materialize_route_boundary_regression_from_wrapper_signature_drift():
     assert payload.template_family == "route_boundary_regression"
     assert payload.target_test_file == "tests/test_agent/test_semantic_validators.py"
     assert "route_helper_signature_preserved" in payload.assertion_focus
+
+
+def test_rendered_fragment_sanitizes_title_rationale_and_test_name():
+    from trellis.agent.knowledge.lesson_to_test import materialize_lesson_regression
+
+    payload = materialize_lesson_regression(
+        _lesson(
+            lesson_id="9 weird.lesson-id",
+            title='Odd """title"""\nwith newline',
+            category="market_data",
+            symptom="single-line symptom",
+            root_cause="single-line root cause",
+            fix='Preserve a thin fallback boundary\nand keep the """guard""" visible.',
+        )
+    )
+
+    assert payload is not None
+    assert 'def test_n_9_weird_lesson_id_odd_title_with_newline():' in payload.rendered_fragment
+    assert 'Odd \\"\\"\\"title\\"\\"\\" with newline' in payload.rendered_fragment
+    assert '"""Regression guard for 9 weird.lesson-id: Odd \\"\\"\\"title\\"\\"\\" with newline."""' in payload.rendered_fragment
+    assert "\nwith newline" not in payload.rendered_fragment

--- a/tests/test_agent/test_lesson_to_test.py
+++ b/tests/test_agent/test_lesson_to_test.py
@@ -1,0 +1,231 @@
+"""Tests for deterministic lesson-to-regression payload materialization."""
+
+from __future__ import annotations
+
+from trellis.agent.knowledge.schema import AppliesWhen, Lesson, LessonStatus, Severity
+
+
+def _lesson(
+    *,
+    lesson_id: str = "lesson_001",
+    title: str = "Lesson title",
+    category: str = "numerical",
+    status: LessonStatus = LessonStatus.PROMOTED,
+    method: tuple[str, ...] = ("analytical",),
+    features: tuple[str, ...] = ("discounting",),
+    instrument: tuple[str, ...] = ("european_option",),
+    symptom: str = "symptom",
+    root_cause: str = "root cause",
+    fix: str = "fix",
+    source_trace: str | None = "/tmp/trace.yaml",
+) -> Lesson:
+    return Lesson(
+        id=lesson_id,
+        title=title,
+        severity=Severity.HIGH,
+        category=category,
+        applies_when=AppliesWhen(
+            method=method,
+            features=features,
+            instrument=instrument,
+        ),
+        symptom=symptom,
+        root_cause=root_cause,
+        fix=fix,
+        validation="validation",
+        confidence=0.9,
+        status=status,
+        source_trace=source_trace,
+    )
+
+
+def test_materialize_base_regression_payload_for_promoted_numerical_lesson():
+    from trellis.agent.knowledge.lesson_to_test import materialize_lesson_regression
+
+    payload = materialize_lesson_regression(
+        _lesson(
+            lesson_id="num_030",
+            title="Payoff code generation indentation error",
+            category="numerical",
+            symptom="Generated payoff module fails to import due to SyntaxError.",
+            root_cause="Template indentation and compile validation were missing.",
+            fix="Dedent templates and compile generated modules before import.",
+        )
+    )
+
+    assert payload is not None
+    assert payload.lesson_id == "num_030"
+    assert payload.template_family == "codegen_safety_regression"
+    assert payload.target_test_file == "tests/test_agent/test_executor.py"
+    assert "generated_module_compiles" in payload.assertion_focus
+    assert "compile_generated_module" in payload.fixture_hints
+    assert "test_num_030_payoff_code_generation_indentation_error" in payload.rendered_fragment
+
+
+def test_materialize_lesson_regression_ignores_candidate_lessons():
+    from trellis.agent.knowledge.lesson_to_test import materialize_lesson_regression
+
+    payload = materialize_lesson_regression(
+        _lesson(
+            lesson_id="md_130",
+            category="market_data",
+            status=LessonStatus.CANDIDATE,
+        )
+    )
+
+    assert payload is None
+
+
+def test_materialize_store_regressions_only_uses_validated_or_promoted_lessons(monkeypatch):
+    from trellis.agent.knowledge.lesson_to_test import materialize_store_regressions
+    from trellis.agent.knowledge.schema import LessonIndex
+    from trellis.agent.knowledge.store import KnowledgeStore
+
+    store = KnowledgeStore()
+    store._lesson_index = [
+        LessonIndex(
+            id="candidate_lesson",
+            title="Candidate lesson",
+            severity=Severity.MEDIUM,
+            category="market_data",
+            applies_when=AppliesWhen(method=("analytical",), features=("discount_curve",)),
+            status=LessonStatus.CANDIDATE,
+        ),
+        LessonIndex(
+            id="validated_lesson",
+            title="Validated lesson",
+            severity=Severity.HIGH,
+            category="convention",
+            applies_when=AppliesWhen(method=("credit",), features=("credit_risk",)),
+            status=LessonStatus.VALIDATED,
+        ),
+        LessonIndex(
+            id="promoted_lesson",
+            title="Promoted lesson",
+            severity=Severity.HIGH,
+            category="numerical",
+            applies_when=AppliesWhen(method=("analytical",), features=("discounting",)),
+            status=LessonStatus.PROMOTED,
+        ),
+    ]
+
+    def fake_load(lesson_id: str) -> Lesson:
+        if lesson_id == "candidate_lesson":
+            return _lesson(
+                lesson_id=lesson_id,
+                category="market_data",
+                status=LessonStatus.CANDIDATE,
+            )
+        if lesson_id == "validated_lesson":
+            return _lesson(
+                lesson_id=lesson_id,
+                category="convention",
+                status=LessonStatus.VALIDATED,
+                method=("credit",),
+                features=("credit_risk",),
+                fix="Add the missing convention contract and unit normalization.",
+            )
+        return _lesson(
+            lesson_id=lesson_id,
+            category="numerical",
+            status=LessonStatus.PROMOTED,
+            fix="Compile generated modules before import.",
+        )
+
+    monkeypatch.setattr(store, "_load_lesson", fake_load)
+
+    payloads = materialize_store_regressions(store)
+
+    assert [payload.lesson_id for payload in payloads] == ["promoted_lesson", "validated_lesson"]
+
+
+def test_materialize_semantic_contract_regression_from_missing_contract_fields():
+    from trellis.agent.knowledge.lesson_to_test import materialize_lesson_regression
+
+    payload = materialize_lesson_regression(
+        _lesson(
+            lesson_id="sem_006",
+            title="missing semantic contract fields",
+            category="semantic",
+            method=("knowledge_artifact",),
+            features=("underlier_structure", "payoff_rule", "settlement_rule"),
+            instrument=("structured_note",),
+            symptom="missing contract fields: underlier_structure, payoff_rule, settlement_rule",
+            root_cause="semantic validation could not proceed because required contract fields were absent",
+            fix="Define the smallest new semantic concept before adding any wrapper or route helper.",
+        )
+    )
+
+    assert payload is not None
+    assert payload.template_family == "semantic_contract_regression"
+    assert payload.target_test_file == "tests/test_agent/test_semantic_contracts.py"
+    assert "semantic_contract_fields_present" in payload.assertion_focus
+
+
+def test_materialize_bridge_fallback_regression_from_thin_wrapper_guidance():
+    from trellis.agent.knowledge.lesson_to_test import materialize_lesson_regression
+
+    payload = materialize_lesson_regression(
+        _lesson(
+            lesson_id="sem_018",
+            title="keep canonical concept",
+            category="semantic",
+            method=("knowledge_artifact",),
+            features=("underlier_structure", "payoff_rule", "settlement_rule"),
+            instrument=("american_put",),
+            symptom="missing contract fields: underlier_structure, payoff_rule, settlement_rule",
+            root_cause="compatibility naming drift hid the canonical concept boundary",
+            fix="Keep the canonical concept and surface the compatibility name as a thin wrapper.",
+        )
+    )
+
+    assert payload is not None
+    assert payload.template_family == "bridge_fallback_regression"
+    assert payload.target_test_file == "tests/test_agent/test_checkpoints.py"
+    assert "compatibility_bridge_preserved" in payload.assertion_focus
+
+
+def test_materialize_lowering_admissibility_regression_from_exact_backend_gap():
+    from trellis.agent.knowledge.lesson_to_test import materialize_lesson_regression
+
+    payload = materialize_lesson_regression(
+        _lesson(
+            lesson_id="con_037",
+            title="Missing CDS convention contract",
+            category="convention",
+            method=("credit",),
+            features=("credit_risk", "discounting"),
+            instrument=(),
+            symptom="Lane `credit` has no exact backend binding and no constructive steps.",
+            root_cause="The compiler cannot safely assemble par-spread logic without the lane contract.",
+            fix="Bind the credit lane to a constructive route or exact backend contract before generation.",
+        )
+    )
+
+    assert payload is not None
+    assert payload.template_family == "lowering_admissibility_regression"
+    assert payload.target_test_file == "tests/test_agent/test_platform_requests.py"
+    assert "lowering_gate_blocks_unsupported_lane" in payload.assertion_focus
+
+
+def test_materialize_route_boundary_regression_from_wrapper_signature_drift():
+    from trellis.agent.knowledge.lesson_to_test import materialize_lesson_regression
+
+    payload = materialize_lesson_regression(
+        _lesson(
+            lesson_id="con_046",
+            title="Wrong product shape contract",
+            category="convention",
+            method=("copula",),
+            features=("credit_risk", "path_dependent"),
+            instrument=(),
+            symptom="price_nth_to_default_basket() got an unexpected keyword argument 'market_state'",
+            root_cause="The route wrapper signature did not match the pricing kernel boundary.",
+            fix="Define an explicit tranche payoff adapter with the exact pricing kernel signature and remove unsupported market_state plumbing.",
+        )
+    )
+
+    assert payload is not None
+    assert payload.template_family == "route_boundary_regression"
+    assert payload.target_test_file == "tests/test_agent/test_semantic_validators.py"
+    assert "route_helper_signature_preserved" in payload.assertion_focus

--- a/trellis/agent/knowledge/lesson_to_test.py
+++ b/trellis/agent/knowledge/lesson_to_test.py
@@ -1,0 +1,355 @@
+"""Deterministic lesson-to-regression payload materialization."""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+from trellis.agent.knowledge.schema import (
+    AppliesWhen,
+    Lesson,
+    LessonRegressionPayload,
+    LessonRegressionTemplate,
+    LessonStatus,
+)
+from trellis.agent.knowledge.store import KnowledgeStore
+
+_ELIGIBLE_STATUSES = {
+    LessonStatus.PROMOTED,
+    LessonStatus.VALIDATED,
+}
+
+_BASE_CATEGORY_FAMILIES = {
+    "market_data": "dependency_resilience_regression",
+    "numerical": "codegen_safety_regression",
+    "monte_carlo": "method_contract_regression",
+    "finite_differences": "method_contract_regression",
+    "backward_induction": "method_contract_regression",
+    "convention": "data_contract_regression",
+    "volatility": "data_contract_regression",
+    "calibration": "data_contract_regression",
+    "credit_risk": "data_contract_regression",
+    "contract": "data_contract_regression",
+    "testing": "harness_regression",
+}
+
+_ROUTE_BOUNDARY_MARKERS = (
+    "unexpected keyword argument 'market_state'",
+    "pricing kernel signature",
+    "route_helper",
+    "route helper signature",
+    "route helper not called",
+    "exact binding",
+    "helper-backed route",
+    "wrapper signature",
+    "route authority",
+)
+
+_BRIDGE_FALLBACK_MARKERS = (
+    "compatibility name",
+    "canonical concept",
+    "thin wrapper",
+    "compatibility bridge",
+    "thin compatibility wrapper",
+    "fallback drift",
+    "bridge drift",
+)
+
+_LOWERING_ADMISSIBILITY_MARKERS = (
+    "no exact backend binding",
+    "no constructive steps",
+    "route admissibility failed",
+    "admissibility",
+    "constructive route",
+    "unsupported lane",
+    "decision=clarification",
+)
+
+_SEMANTIC_CONTRACT_MARKERS = (
+    "missing contract fields",
+    "semantic_product_shape",
+    "underlier_structure",
+    "payoff_rule",
+    "settlement_rule",
+    "observation_schedule",
+    "selection_scope",
+    "selection_operator",
+    "lock_rule",
+    "semantic validation",
+    "semantic contract",
+)
+
+_TEMPLATES = {
+    "dependency_resilience_regression": LessonRegressionTemplate(
+        family="dependency_resilience_regression",
+        target_test_file="tests/test_agent/test_task_runtime.py",
+        description="Guard transient dependency failure handling and fallback behavior.",
+        assertion_focus=(
+            "external_request_retry_present",
+            "fallback_path_prevents_hard_abort",
+        ),
+        fixture_hints=(
+            "simulate_transient_dependency_failure",
+            "task_runtime_retry_policy",
+        ),
+        tags=("knowledge", "resilience"),
+    ),
+    "codegen_safety_regression": LessonRegressionTemplate(
+        family="codegen_safety_regression",
+        target_test_file="tests/test_agent/test_executor.py",
+        description="Guard generated-source syntax and compile-time validation.",
+        assertion_focus=(
+            "generated_module_compiles",
+            "syntax_guard_present",
+        ),
+        fixture_hints=(
+            "compile_generated_module",
+            "generated_source_smoke",
+        ),
+        tags=("knowledge", "codegen"),
+    ),
+    "method_contract_regression": LessonRegressionTemplate(
+        family="method_contract_regression",
+        target_test_file="tests/test_agent/test_executor.py",
+        description="Guard helper usage and runtime method contracts.",
+        assertion_focus=(
+            "runtime_contract_preserved",
+            "helper_invocation_shape_preserved",
+        ),
+        fixture_hints=(
+            "assemble_generation_plan",
+            "method_contract_smoke",
+        ),
+        tags=("knowledge", "method"),
+    ),
+    "data_contract_regression": LessonRegressionTemplate(
+        family="data_contract_regression",
+        target_test_file="tests/test_agent/test_knowledge_store.py",
+        description="Guard data contracts, unit normalization, and convention retrieval.",
+        assertion_focus=(
+            "data_contract_present",
+            "normalization_guard_present",
+        ),
+        fixture_hints=(
+            "retrieve_for_task",
+            "knowledge_contract_fixture",
+        ),
+        tags=("knowledge", "contract"),
+    ),
+    "harness_regression": LessonRegressionTemplate(
+        family="harness_regression",
+        target_test_file="tests/test_agent/test_reflect_loop.py",
+        description="Guard the learning loop and deterministic knowledge artifact capture.",
+        assertion_focus=(
+            "lesson_pipeline_remains_deterministic",
+            "knowledge_artifact_provenance_preserved",
+        ),
+        fixture_hints=(
+            "reflect_on_build",
+            "knowledge_root_fixture",
+        ),
+        tags=("knowledge", "harness"),
+    ),
+    "semantic_contract_regression": LessonRegressionTemplate(
+        family="semantic_contract_regression",
+        target_test_file="tests/test_agent/test_semantic_contracts.py",
+        description="Guard typed semantic contract fields and semantic validation boundaries.",
+        assertion_focus=(
+            "semantic_contract_fields_present",
+            "semantic_validation_blocks_missing_shape",
+        ),
+        fixture_hints=(
+            "compile_semantic_contract",
+            "validate_semantics",
+        ),
+        tags=("knowledge", "semantic"),
+    ),
+    "lowering_admissibility_regression": LessonRegressionTemplate(
+        family="lowering_admissibility_regression",
+        target_test_file="tests/test_agent/test_platform_requests.py",
+        description="Guard lowering and admissibility boundaries before generation.",
+        assertion_focus=(
+            "lowering_gate_blocks_unsupported_lane",
+            "constructive_plan_required_for_lane",
+        ),
+        fixture_hints=(
+            "compile_build_request",
+            "fallback_lane_plan_fixture",
+        ),
+        tags=("knowledge", "lowering"),
+    ),
+    "route_boundary_regression": LessonRegressionTemplate(
+        family="route_boundary_regression",
+        target_test_file="tests/test_agent/test_semantic_validators.py",
+        description="Guard route-helper and exact-binding authority boundaries.",
+        assertion_focus=(
+            "route_helper_signature_preserved",
+            "unsupported_wrapper_plumbing_blocked",
+        ),
+        fixture_hints=(
+            "validate_algorithm_contract",
+            "route_helper_contract_fixture",
+        ),
+        tags=("knowledge", "route"),
+    ),
+    "bridge_fallback_regression": LessonRegressionTemplate(
+        family="bridge_fallback_regression",
+        target_test_file="tests/test_agent/test_checkpoints.py",
+        description="Guard compatibility bridges and thin-wrapper fallback drift.",
+        assertion_focus=(
+            "compatibility_bridge_preserved",
+            "fallback_drift_detected",
+        ),
+        fixture_hints=(
+            "semantic_checkpoint_fixture",
+            "platform_trace_boundary",
+        ),
+        tags=("knowledge", "bridge"),
+    ),
+}
+
+
+def classify_lesson_regression_family(lesson: Lesson) -> str | None:
+    """Return the deterministic regression-template family for one lesson."""
+    if lesson.status not in _ELIGIBLE_STATUSES:
+        return None
+
+    text = _lesson_text(lesson)
+    if _contains_any(text, _ROUTE_BOUNDARY_MARKERS):
+        return "route_boundary_regression"
+    if _contains_any(text, _BRIDGE_FALLBACK_MARKERS):
+        return "bridge_fallback_regression"
+    if _contains_any(text, _LOWERING_ADMISSIBILITY_MARKERS):
+        return "lowering_admissibility_regression"
+    if (
+        lesson.category in {"semantic", "semantic_contract"}
+        or _contains_any(text, _SEMANTIC_CONTRACT_MARKERS)
+    ):
+        return "semantic_contract_regression"
+    return _BASE_CATEGORY_FAMILIES.get(lesson.category, "data_contract_regression")
+
+
+def materialize_lesson_regression(lesson: Lesson) -> LessonRegressionPayload | None:
+    """Materialize one deterministic regression payload from a lesson."""
+    family = classify_lesson_regression_family(lesson)
+    if family is None:
+        return None
+    template = _TEMPLATES[family]
+    rationale = _build_rationale(lesson, template)
+    payload = LessonRegressionPayload(
+        lesson_id=lesson.id,
+        lesson_title=lesson.title,
+        lesson_category=lesson.category,
+        lesson_status=lesson.status,
+        template_family=template.family,
+        target_test_file=template.target_test_file,
+        applies_when=lesson.applies_when,
+        rationale=rationale,
+        assertion_focus=template.assertion_focus,
+        fixture_hints=template.fixture_hints,
+        tags=template.tags,
+        source_trace=lesson.source_trace,
+    )
+    return LessonRegressionPayload(
+        lesson_id=payload.lesson_id,
+        lesson_title=payload.lesson_title,
+        lesson_category=payload.lesson_category,
+        lesson_status=payload.lesson_status,
+        template_family=payload.template_family,
+        target_test_file=payload.target_test_file,
+        applies_when=payload.applies_when,
+        rationale=payload.rationale,
+        assertion_focus=payload.assertion_focus,
+        fixture_hints=payload.fixture_hints,
+        tags=payload.tags,
+        source_trace=payload.source_trace,
+        rendered_fragment=render_lesson_regression_fragment(payload),
+    )
+
+
+def materialize_lesson_regressions(
+    lessons: Iterable[Lesson],
+) -> tuple[LessonRegressionPayload, ...]:
+    """Materialize regression payloads for all eligible lessons."""
+    payloads: list[LessonRegressionPayload] = []
+    for lesson in lessons:
+        payload = materialize_lesson_regression(lesson)
+        if payload is not None:
+            payloads.append(payload)
+    return tuple(payloads)
+
+
+def materialize_store_regressions(
+    store: KnowledgeStore,
+    *,
+    lesson_ids: tuple[str, ...] | None = None,
+) -> tuple[LessonRegressionPayload, ...]:
+    """Materialize deterministic regression payloads from store-backed lessons."""
+    lessons = store.list_lessons(lesson_ids=lesson_ids)
+    return materialize_lesson_regressions(lessons)
+
+
+def render_lesson_regression_fragment(payload: LessonRegressionPayload) -> str:
+    """Render one reviewable pytest-style regression fragment."""
+    test_name = _test_name(payload.lesson_id, payload.lesson_title)
+    methods = ", ".join(f"`{item}`" for item in payload.applies_when.method) or "`any`"
+    features = ", ".join(f"`{item}`" for item in payload.applies_when.features) or "`none`"
+    instruments = ", ".join(f"`{item}`" for item in payload.applies_when.instrument) or "`generic`"
+    lines = [
+        f"def {test_name}():",
+        f'    """Regression guard for {payload.lesson_id}: {payload.lesson_title}."""',
+        f"    # Template family: `{payload.template_family}`",
+        f"    # Target file hint: `{payload.target_test_file}`",
+        f"    # Applies when: method={methods}; features={features}; instrument={instruments}",
+        f"    # Rationale: {payload.rationale}",
+    ]
+    if payload.assertion_focus:
+        lines.append("    # Assertion focus:")
+        lines.extend(
+            f"    # - {assertion}" for assertion in payload.assertion_focus
+        )
+    if payload.fixture_hints:
+        lines.append("    # Fixture hints:")
+        lines.extend(
+            f"    # - {fixture}" for fixture in payload.fixture_hints
+        )
+    return "\n".join(lines)
+
+
+def _build_rationale(
+    lesson: Lesson,
+    template: LessonRegressionTemplate,
+) -> str:
+    method = ", ".join(lesson.applies_when.method) or "any method"
+    features = ", ".join(lesson.applies_when.features[:4]) or "generic features"
+    return (
+        f"{template.description} Triggered by {method} on {features}; "
+        f"encode the lesson fix as a deterministic guard instead of relying on replayed reflection."
+    )
+
+
+def _lesson_text(lesson: Lesson) -> str:
+    fragments = [
+        lesson.title,
+        lesson.category,
+        lesson.symptom,
+        lesson.root_cause,
+        lesson.fix,
+        lesson.validation,
+        *lesson.applies_when.method,
+        *lesson.applies_when.features,
+        *lesson.applies_when.instrument,
+    ]
+    return " ".join(fragment for fragment in fragments if fragment).lower()
+
+
+def _contains_any(text: str, markers: tuple[str, ...]) -> bool:
+    return any(marker in text for marker in markers)
+
+
+def _test_name(lesson_id: str, title: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "_", title.lower()).strip("_")
+    slug = re.sub(r"_+", "_", slug)
+    if not slug:
+        slug = "lesson_regression"
+    return f"test_{lesson_id}_{slug}"

--- a/trellis/agent/knowledge/lesson_to_test.py
+++ b/trellis/agent/knowledge/lesson_to_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 import re
 from typing import Iterable
 
@@ -250,19 +251,8 @@ def materialize_lesson_regression(lesson: Lesson) -> LessonRegressionPayload | N
         tags=template.tags,
         source_trace=lesson.source_trace,
     )
-    return LessonRegressionPayload(
-        lesson_id=payload.lesson_id,
-        lesson_title=payload.lesson_title,
-        lesson_category=payload.lesson_category,
-        lesson_status=payload.lesson_status,
-        template_family=payload.template_family,
-        target_test_file=payload.target_test_file,
-        applies_when=payload.applies_when,
-        rationale=payload.rationale,
-        assertion_focus=payload.assertion_focus,
-        fixture_hints=payload.fixture_hints,
-        tags=payload.tags,
-        source_trace=payload.source_trace,
+    return replace(
+        payload,
         rendered_fragment=render_lesson_regression_fragment(payload),
     )
 
@@ -295,13 +285,17 @@ def render_lesson_regression_fragment(payload: LessonRegressionPayload) -> str:
     methods = ", ".join(f"`{item}`" for item in payload.applies_when.method) or "`any`"
     features = ", ".join(f"`{item}`" for item in payload.applies_when.features) or "`none`"
     instruments = ", ".join(f"`{item}`" for item in payload.applies_when.instrument) or "`generic`"
+    docstring_text = _sanitize_fragment_text(
+        f"Regression guard for {payload.lesson_id}: {payload.lesson_title}."
+    )
+    rationale = _sanitize_fragment_text(payload.rationale)
     lines = [
         f"def {test_name}():",
-        f'    """Regression guard for {payload.lesson_id}: {payload.lesson_title}."""',
+        f'    """{docstring_text}"""',
         f"    # Template family: `{payload.template_family}`",
         f"    # Target file hint: `{payload.target_test_file}`",
         f"    # Applies when: method={methods}; features={features}; instrument={instruments}",
-        f"    # Rationale: {payload.rationale}",
+        f"    # Rationale: {rationale}",
     ]
     if payload.assertion_focus:
         lines.append("    # Assertion focus:")
@@ -347,9 +341,23 @@ def _contains_any(text: str, markers: tuple[str, ...]) -> bool:
     return any(marker in text for marker in markers)
 
 
+def _identifier_fragment(value: str, *, fallback: str) -> str:
+    fragment = re.sub(r"[^a-z0-9_]+", "_", value.lower()).strip("_")
+    fragment = re.sub(r"_+", "_", fragment)
+    if not fragment:
+        fragment = fallback
+    if fragment[0].isdigit():
+        fragment = f"n_{fragment}"
+    return fragment
+
+
+def _sanitize_fragment_text(value: str) -> str:
+    sanitized = str(value).replace('"""', '\\"\\"\\"')
+    sanitized = re.sub(r"\s+", " ", sanitized).strip()
+    return sanitized
+
+
 def _test_name(lesson_id: str, title: str) -> str:
-    slug = re.sub(r"[^a-z0-9]+", "_", title.lower()).strip("_")
-    slug = re.sub(r"_+", "_", slug)
-    if not slug:
-        slug = "lesson_regression"
-    return f"test_{lesson_id}_{slug}"
+    lesson_id_slug = _identifier_fragment(lesson_id, fallback="lesson")
+    slug = _identifier_fragment(title, fallback="lesson_regression")
+    return f"test_{lesson_id_slug}_{slug}"

--- a/trellis/agent/knowledge/schema.py
+++ b/trellis/agent/knowledge/schema.py
@@ -221,7 +221,7 @@ class LessonRegressionTemplate:
 
 @dataclass(frozen=True)
 class LessonRegressionPayload:
-    """Materialized regression payload derived from a validated lesson."""
+    """Materialized regression payload derived from a validated or promoted lesson."""
 
     lesson_id: str
     lesson_title: str

--- a/trellis/agent/knowledge/schema.py
+++ b/trellis/agent/knowledge/schema.py
@@ -208,6 +208,37 @@ class Lesson:
 
 
 @dataclass(frozen=True)
+class LessonRegressionTemplate:
+    """Deterministic regression-template metadata for one lesson family."""
+
+    family: str
+    target_test_file: str
+    description: str = ""
+    assertion_focus: tuple[str, ...] = ()
+    fixture_hints: tuple[str, ...] = ()
+    tags: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class LessonRegressionPayload:
+    """Materialized regression payload derived from a validated lesson."""
+
+    lesson_id: str
+    lesson_title: str
+    lesson_category: str
+    lesson_status: LessonStatus
+    template_family: str
+    target_test_file: str
+    applies_when: AppliesWhen
+    rationale: str
+    assertion_focus: tuple[str, ...] = ()
+    fixture_hints: tuple[str, ...] = ()
+    tags: tuple[str, ...] = ()
+    source_trace: str | None = None
+    rendered_fragment: str = ""
+
+
+@dataclass(frozen=True)
 class AdapterLifecycleRecord:
     """Lifecycle metadata for an adapter family or fresh-build replacement."""
 

--- a/trellis/agent/knowledge/store.py
+++ b/trellis/agent/knowledge/store.py
@@ -699,6 +699,54 @@ class KnowledgeStore:
         self._lessons_cache[lesson_id] = lesson
         return lesson
 
+    def list_lessons(
+        self,
+        *,
+        lesson_ids: tuple[str, ...] | None = None,
+        statuses: tuple[LessonStatus, ...] = (
+            LessonStatus.PROMOTED,
+            LessonStatus.VALIDATED,
+        ),
+    ) -> tuple[Lesson, ...]:
+        """Return hydrated lessons filtered by id and lifecycle state.
+
+        The ordering is stable for downstream deterministic consumers:
+        promoted lessons first, then validated lessons, then by severity and id.
+        """
+        allowed_statuses = {status for status in statuses}
+        selected_ids = {
+            str(lesson_id).strip()
+            for lesson_id in (lesson_ids or ())
+            if str(lesson_id).strip()
+        }
+        status_priority = {
+            LessonStatus.PROMOTED: 0,
+            LessonStatus.VALIDATED: 1,
+            LessonStatus.CANDIDATE: 2,
+            LessonStatus.ARCHIVED: 3,
+        }
+        eligible = [
+            index
+            for index in self._lesson_index
+            if index.status in allowed_statuses
+            and (not selected_ids or index.id in selected_ids)
+        ]
+        ordered = sorted(
+            eligible,
+            key=lambda index: (
+                status_priority.get(index.status, 99),
+                _SEVERITY_ORDER.get(index.severity, 99),
+                index.id,
+            ),
+        )
+        hydrated: list[Lesson] = []
+        for index in ordered:
+            lesson = self._load_lesson(index.id)
+            if lesson is None or lesson.status not in allowed_statuses:
+                continue
+            hydrated.append(lesson)
+        return tuple(hydrated)
+
     # --------------------------------------------------------------------- #
     # Warm tier: cookbooks
     # --------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary
- add the deterministic lesson-to-test materialization pipeline for validated/promoted lessons
- extend it with semantic, lowering, bridge, and route-boundary template families
- document the new learning-loop seam and sync the backlog mirror

## Validation
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_lesson_to_test.py -q
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_knowledge_store.py -q
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_semantic_contracts.py tests/test_agent/test_semantic_validators.py tests/test_agent/test_platform_requests.py tests/test_agent/test_checkpoints.py -q
- /Users/steveyang/miniforge3/bin/python3 scripts/remediate.py --analyze-only

## Notes
- full `pytest tests/ -x -q -m "not integration"` in the dirty local worktree hit an unrelated T13 replay failure caused by local uncommitted `_agent` / trace state
- the previously failing T13 replay passes in a temporary clean worktree at this branch commit (`69b6f0f8`)
