### PR TITLE
QUA-545: add repeated-pass non-canary learning benchmark

### DIFF
--- a/docs/developer/learning_mechanism.rst
+++ b/docs/developer/learning_mechanism.rst
@@ -149,6 +149,40 @@ That makes the learning mechanism auditable. A later reviewer can see not just
 that a lesson exists, but how it was captured, whether the contract passed, and
 whether it stayed candidate, validated, promoted, or duplicate.
 
+Short-Term Learning Benchmark
+-----------------------------
+
+The near-term learning claim for Trellis is narrower than autonomous library
+development.
+
+Today the honest claim is:
+
+- repeated runs can carry forward validated or promoted knowledge
+- that carry-forward can reduce failures, retries, elapsed time, and token use
+- the effect can be measured without changing the underlying code revision
+
+That is what ``scripts/run_task_learning_benchmark.py`` measures.
+
+The benchmark uses a non-canary cohort from ``TASKS.yaml`` and repeated passes
+at a fixed git revision. By default it also forces fresh builds so the score
+is not dominated by trivial adapter reuse. The report records:
+
+- success and failure deltas across passes
+- task-level ``first_pass`` and ``attempts_to_success``
+- stage-level ``retry_taxonomy``
+- elapsed time and token usage
+- shared-knowledge and lesson-promotion signals
+- attribution buckets for:
+
+  * knowledge-assisted improvements
+  * residual knowledge gaps
+  * residual implementation gaps
+  * residual market/provider noise
+
+That benchmark is the short-term learning milestone because it tests whether
+the platform gets better at rerunning broader tasks with knowledge it has
+already captured.
+
 Current Boundaries
 ------------------
 
@@ -159,6 +193,8 @@ still limits:
 - the executor retry path captures candidate lessons but does not auto-promote them
 - task reruns and human review are still needed to confirm whether a captured
   lesson should become stable guidance
+- the repeated-pass benchmark measures knowledge reuse only; it does not prove
+  autonomous code authoring or autonomous primitive implementation
 
 Those limits are intentional. They keep the learning loop explicit and
 reviewable rather than silently mutating policy.

--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -50,6 +50,7 @@ The repo ships a small task-operations toolchain:
 - ``scripts/run_tasks.py``: run a contiguous task block or all pending tasks
 - ``scripts/rerun_ids.py``: re-run specific task ids
 - ``scripts/benchmark_tasks.py``: benchmark cached generated payoffs without rebuilding
+- ``scripts/run_task_learning_benchmark.py``: run repeated non-canary passes at a fixed revision and emit a learning scorecard
 - ``scripts/remediate.py``: analyze failures, categorize knowledge gaps, and patch common knowledge issues
 - ``scripts/evaluate_shared_memory.py``: compare two task-result tranches and render a shared-memory improvement report
 - ``scripts/should_run_canary.py``: decide whether current local changes justify the focused core canary gate
@@ -182,6 +183,52 @@ For comparison tasks, ``attempts_to_success`` is normalized by the slowest
 successful method leg, not by summing all nested attempts. Two methods that
 both succeed on their first method-local attempt still count as a first-pass
 task-level success.
+
+For broader short-term learning evidence, use
+``scripts/run_task_learning_benchmark.py``. That runner selects a non-canary
+cohort from ``TASKS.yaml`` and executes repeated passes at the same git
+revision. The benchmark is asking a narrower question than a canary or stress
+gate:
+
+- do later passes fail less often?
+- do first-pass success and attempts-to-success improve?
+- do elapsed time and token usage fall?
+- do those improvements line up with reused knowledge signals?
+
+The runner defaults to ``fresh_build=True``. That is deliberate. Reusing
+admitted adapters would swamp the signal and turn the benchmark into a warm
+cache measurement instead of a knowledge-carry-forward measurement. Reuse mode
+still exists, but only when you explicitly want warm-path operational data.
+
+Each pass writes:
+
+- a raw task-result file under ``task_runs/learning_benchmarks/raw/``
+- a pass summary JSON beside that raw file
+- a Markdown plus JSON scorecard under ``task_runs/learning_benchmarks/reports/``
+
+The scorecard reports:
+
+- success and failure counts
+- task-level ``first_pass``
+- ``attempts_to_success``
+- ``retry_taxonomy``
+- elapsed-time totals
+- token-usage totals
+- shared-knowledge reuse signals
+- attribution buckets separating knowledge-assisted improvements from residual
+  knowledge gaps, implementation gaps, and market/provider noise
+
+Use it like this:
+
+.. code-block:: bash
+
+   /Users/steveyang/miniforge3/bin/python3 scripts/run_task_learning_benchmark.py --limit 10 --passes 2
+
+If you want to inspect the selected cohort first:
+
+.. code-block:: bash
+
+   /Users/steveyang/miniforge3/bin/python3 scripts/run_task_learning_benchmark.py --list-tasks --limit 10
 
 Task-run artifacts now preserve analytical trace paths alongside the existing
 platform traces. When a build loop emits an analytical route, the stored task

--- a/docs/plans/backlog-burn-down-execution.md
+++ b/docs/plans/backlog-burn-down-execution.md
@@ -9,7 +9,7 @@ This program turns the audited backlog into a strict execution order with
 reviewable delivery slices, validation gates, and closeout rules that match
 `AGENTS.md`.
 
-Status mirror last synced: `2026-04-10`
+Status mirror last synced: `2026-04-11`
 
 Current status:
 
@@ -22,11 +22,18 @@ Current status:
 - `QUA-544` is complete with a measured `3/3` proving-success bar, `2/3`
   task-level first-pass success, and the residual `KL01` semantic-validation
   retry split into `QUA-779`.
+- `QUA-429` is complete.
+- `QUA-447` is complete.
+- `QUA-545` is complete as the short-term learning-evidence slice: repeated
+  non-canary passes, a fixed-revision scorecard, and explicit attribution for
+  knowledge-assisted improvements versus residual gaps.
 - Wave 1 is complete.
 - Wave 2 is complete.
+- Wave 3 is complete.
+- Wave 4 is complete except for the low-priority `QUA-417` maintenance tail.
 - `QUA-417` has been rewritten as a low-priority route-registry maintenance
   cleanup rather than a core burn-down tranche.
-- The next actionable ticket in queue order is `QUA-429`.
+- The next actionable ticket in queue order is `QUA-417`.
 
 ## Operating Rules
 
@@ -54,8 +61,8 @@ These tickets are actionable backlog burn-down work:
 7. `QUA-544` proving runs: first-pass knowledge-light reliability
 8. `QUA-429` lesson-to-test pipeline base slice
 9. `QUA-447` semantic template follow-on for the lesson-to-test path
-10. `QUA-545` maintenance tail for residual cleanup that does not justify a
-    broader project
+10. `QUA-545` short-term learning evidence: repeated non-canary passes and a
+    knowledge-reuse scorecard
 11. `QUA-417` route registry cleanup: collapse redundant optional utility
     bindings
 
@@ -133,11 +140,11 @@ Current note:
   move the tranche to `3/3` success; the remaining non-first-pass retry path
   is isolated in `QUA-779`
 
-### Wave 4: Maintenance tail
+### Wave 4: Short-term learning evidence and maintenance tail
 
 | Order | Ticket | Expected artifact |
 | --- | --- | --- |
-| 10 | `QUA-545` | Residual maintenance cleanup with explicit scope boundary |
+| 10 | `QUA-545` | Non-canary multi-pass learning scorecard with explicit attribution |
 | 11 | `QUA-417` | Route-registry metadata compaction for optional utility bindings |
 
 ## Ticket Selection Rule
@@ -158,8 +165,10 @@ Execution started with `QUA-458`, continued through `QUA-710`, `QUA-428`,
 `QUA-430`, the `QUA-700` umbrella closeout, and `QUA-543`. `QUA-417` was
 rewritten as maintenance cleanup. `QUA-544` then improved the knowledge-light
 proving tranche to `3/3` success and split the remaining `KL01`
-semantic-validation retry into `QUA-779`, so the active queue now moves next
-to `QUA-429`.
+semantic-validation retry into `QUA-779`. `QUA-429` and `QUA-447` then landed
+the deterministic lesson-to-test path, and `QUA-545` added the repeated-pass
+non-canary learning benchmark, so the active queue now moves next to
+`QUA-417`.
 
 Current architectural note:
 
@@ -172,19 +181,22 @@ Current architectural note:
   or promoted lessons into regression payloads
 - `QUA-447` remains the semantic-specific follow-on for lowering, validation,
   bridge, and route-boundary template families
+- `QUA-545` is the short-term learning-evidence slice: repeated non-canary
+  passes at a fixed revision, fresh-build-by-default execution, and honest
+  attribution of what improved because of reusable knowledge versus what still
+  needs implementation work
 
 Plain-English goal:
 
-- build the base lesson-to-test pipeline now that the proving tranche is
-  stable enough to turn repeat misses into durable regression coverage
+- keep the last backlog tail focused on low-priority route cleanup now that the
+  short-term learning benchmark exists and the broader learning loop can be
+  measured directly
 
 Primary files and surfaces:
 
-- `trellis/agent/knowledge/promotion.py`
-- `trellis/agent/knowledge/store.py`
-- `trellis/agent/knowledge/reflect.py`
-- `trellis/agent/test_resolution.py`
-- `trellis/agent/executor.py` for resolved-failure provenance into the lesson
-  pipeline
-- a new deterministic lesson-to-test materialization surface and its
-  `tests/test_agent/` coverage
+- `trellis/agent/task_learning_benchmark.py`
+- `scripts/run_task_learning_benchmark.py`
+- `docs/developer/task_and_eval_loops.rst`
+- `docs/developer/learning_mechanism.rst`
+- `tests/test_agent/test_task_learning_benchmark.py`
+- `tests/test_agent/test_task_learning_benchmark_runner.py`

--- a/scripts/run_task_learning_benchmark.py
+++ b/scripts/run_task_learning_benchmark.py
@@ -1,0 +1,313 @@
+"""Run the repeated non-canary task-learning benchmark at a fixed revision.
+
+Usage:
+    /Users/steveyang/miniforge3/bin/python3 scripts/run_task_learning_benchmark.py
+    /Users/steveyang/miniforge3/bin/python3 scripts/run_task_learning_benchmark.py --list-tasks
+    /Users/steveyang/miniforge3/bin/python3 scripts/run_task_learning_benchmark.py T13 T14 --passes 3
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault("LLM_PROVIDER", "openai")
+
+from trellis.agent.config import load_env
+from trellis.agent.evals import summarize_task_results
+from trellis.agent.task_learning_benchmark import (
+    build_task_learning_benchmark_report,
+    load_canary_task_ids,
+    save_task_learning_benchmark_report,
+    select_task_learning_cohort,
+)
+from trellis.agent.task_runtime import build_market_state, load_tasks, run_task
+from trellis.cli_paths import resolve_repo_path
+
+load_env()
+
+
+DEFAULT_OUTPUT_ROOT = ROOT / "task_runs" / "learning_benchmarks"
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "task_ids",
+        nargs="*",
+        help="Optional explicit task ids. Defaults to the pending non-canary cohort.",
+    )
+    parser.add_argument("--passes", type=int, default=2)
+    parser.add_argument("--model", default="gpt-5.4-mini")
+    parser.add_argument("--validation", default="standard")
+    parser.add_argument("--limit", type=int)
+    parser.add_argument(
+        "--include-done",
+        action="store_true",
+        help="Include tasks already marked done in TASKS.yaml.",
+    )
+    parser.add_argument(
+        "--knowledge-light",
+        action="store_true",
+        help="Use the compiler-first minimal knowledge profile.",
+    )
+    parser.add_argument(
+        "--reuse",
+        action="store_true",
+        help="Allow adapter reuse. By default the benchmark uses fresh builds to isolate knowledge carry-forward.",
+    )
+    parser.add_argument("--list-tasks", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--output-root")
+    parser.add_argument("--report-name", default="non_canary_task_learning")
+    return parser.parse_args(argv)
+
+
+def build_learning_tasks(
+    *,
+    requested_ids: list[str] | None = None,
+    include_done: bool = False,
+    limit: int | None = None,
+) -> list[dict[str, Any]]:
+    """Return the selected non-canary task-learning cohort."""
+    all_tasks = load_tasks(status=None)
+    allowed_statuses = ("pending", "done") if include_done else ("pending",)
+    selected = select_task_learning_cohort(
+        all_tasks,
+        canary_task_ids=load_canary_task_ids(),
+        allowed_statuses=allowed_statuses,
+        requested_ids=requested_ids,
+        limit=limit,
+    )
+    if requested_ids:
+        requested = {
+            str(task_id).strip()
+            for task_id in requested_ids
+            if str(task_id).strip()
+        }
+        selected_ids = {str(task.get("id") or "").strip() for task in selected}
+        missing = sorted(requested - selected_ids)
+        if missing:
+            raise ValueError(
+                "Requested task ids are not in the selected non-canary cohort: "
+                + ", ".join(missing)
+            )
+    return selected
+
+
+def run_learning_benchmark(
+    tasks: list[dict[str, Any]],
+    *,
+    benchmark_name: str,
+    cohort_name: str = "non_canary_pending",
+    output_root: Path,
+    passes: int,
+    model: str,
+    validation: str,
+    fresh_build: bool,
+    knowledge_light: bool,
+) -> dict[str, Any]:
+    """Run repeated passes for one non-canary task cohort and save the report."""
+    output_root.mkdir(parents=True, exist_ok=True)
+    raw_root = output_root / "raw"
+    report_root = output_root / "reports"
+    raw_root.mkdir(parents=True, exist_ok=True)
+    report_root.mkdir(parents=True, exist_ok=True)
+
+    git_revision = _git_revision()
+    pass_runs: list[dict[str, Any]] = []
+
+    print(f"\n{'#' * 72}")
+    print(f"# Task learning benchmark: {benchmark_name}")
+    print(f"# Git revision: {git_revision}")
+    print(f"# Tasks: {', '.join(task['id'] for task in tasks)}")
+    print(f"# Passes: {passes}")
+    print(f"# Fresh build: {fresh_build}")
+    print(f"# Knowledge light: {knowledge_light}")
+    print(f"# Validation: {validation}")
+    print(f"# Started: {datetime.now().isoformat()}")
+    print(f"{'#' * 72}")
+
+    for pass_number in range(1, passes + 1):
+        label = f"pass_{pass_number}"
+        output_path = raw_root / f"{benchmark_name}_{label}.json"
+        summary_path = raw_root / f"{benchmark_name}_{label}_summary.json"
+        print(f"\nPass {pass_number}/{passes}: {label}", flush=True)
+        results = _run_learning_pass(
+            tasks,
+            model=model,
+            validation=validation,
+            benchmark_name=benchmark_name,
+            git_revision=git_revision,
+            pass_number=pass_number,
+            fresh_build=fresh_build,
+            knowledge_light=knowledge_light,
+        )
+        output_path.write_text(json.dumps(results, indent=2, default=str))
+        summary = summarize_task_results(results)
+        summary_path.write_text(json.dumps(summary, indent=2, default=str))
+        pass_runs.append(
+            {
+                "pass_number": pass_number,
+                "label": label,
+                "fresh_build": fresh_build,
+                "knowledge_profile": "knowledge_light" if knowledge_light else "default",
+                "model": model,
+                "validation": validation,
+                "results": results,
+                "results_path": str(output_path),
+                "summary_path": str(summary_path),
+            }
+        )
+        print(
+            "  Summary: "
+            f"{summary['totals']['successes']}/{summary['totals']['tasks']} success, "
+            f"first-pass={summary['first_pass']['rate']:.0%}, "
+            f"avg-attempts-to-success={summary['attempts_to_success']['average']}, "
+            f"tokens={summary['token_usage']['total_tokens']}"
+        )
+
+    report = build_task_learning_benchmark_report(
+        benchmark_name=benchmark_name,
+        cohort_name=cohort_name,
+        git_revision=git_revision,
+        tasks=tasks,
+        pass_runs=pass_runs,
+        notes=[
+            "Fresh-build passes isolate knowledge carry-forward from adapter reuse."
+            if fresh_build
+            else "Reuse mode was enabled, so adapter reuse may contribute to improvements.",
+            "This benchmark measures short-term learning evidence, not autonomous code development.",
+        ],
+    )
+    artifacts = save_task_learning_benchmark_report(
+        report,
+        root=report_root,
+        stem=benchmark_name,
+    )
+    print(f"\nSaved learning benchmark report to {artifacts.json_path}")
+    print(f"Saved learning benchmark markdown to {artifacts.text_path}")
+    return {
+        "report": report,
+        "report_json_path": artifacts.json_path,
+        "report_md_path": artifacts.text_path,
+        "pass_runs": pass_runs,
+    }
+
+
+def _run_learning_pass(
+    tasks: list[dict[str, Any]],
+    *,
+    model: str,
+    validation: str,
+    benchmark_name: str,
+    git_revision: str,
+    pass_number: int,
+    fresh_build: bool,
+    knowledge_light: bool,
+) -> list[dict[str, Any]]:
+    market_state = build_market_state()
+    results: list[dict[str, Any]] = []
+
+    for index, task in enumerate(tasks, start=1):
+        print(f"  [{index}/{len(tasks)}] {task['id']}: {task['title']}", flush=True)
+        result = run_task(
+            task,
+            market_state,
+            model=model,
+            force_rebuild=fresh_build,
+            fresh_build=fresh_build,
+            knowledge_profile="knowledge_light" if knowledge_light else None,
+            validation=validation,
+        )
+        payload = dict(result)
+        payload["learning_benchmark_name"] = benchmark_name
+        payload["learning_benchmark_pass"] = pass_number
+        payload["learning_benchmark_git_revision"] = git_revision
+        payload["learning_benchmark_fresh_build"] = fresh_build
+        payload["learning_benchmark_knowledge_profile"] = (
+            "knowledge_light" if knowledge_light else "default"
+        )
+        results.append(payload)
+        status = "OK" if payload.get("success") else "FAIL"
+        print(
+            f"    [{status}] attempts={payload.get('attempts', 0)} "
+            f"elapsed={(payload.get('elapsed_seconds') or 0):.1f}s"
+        )
+
+    return results
+
+
+def _git_revision() -> str:
+    completed = subprocess.run(
+        ["git", "rev-parse", "--short", "HEAD"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    revision = completed.stdout.strip()
+    return revision or "unknown"
+
+
+def main(argv: list[str]) -> int:
+    args = _parse_args(argv)
+    try:
+        tasks = build_learning_tasks(
+            requested_ids=args.task_ids or None,
+            include_done=args.include_done,
+            limit=args.limit,
+        )
+    except ValueError as exc:
+        print(str(exc))
+        return 2
+
+    if args.list_tasks:
+        for task in tasks:
+            print(f"{task['id']}: {task['title']}")
+        return 0
+    if not tasks:
+        print("No tasks selected for the non-canary learning benchmark.")
+        return 1
+    if args.dry_run:
+        print(json.dumps(tasks, indent=2))
+        return 0
+    if args.passes < 2:
+        print("Pass count must be at least 2 for a learning benchmark.")
+        return 2
+
+    cohort_name = (
+        "explicit_non_canary_selection"
+        if args.task_ids
+        else ("non_canary_pending_plus_done" if args.include_done else "non_canary_pending")
+    )
+
+    output_root = Path(
+        resolve_repo_path(args.output_root, DEFAULT_OUTPUT_ROOT)
+    )
+    run_learning_benchmark(
+        tasks,
+        benchmark_name=args.report_name,
+        cohort_name=cohort_name,
+        output_root=output_root,
+        passes=args.passes,
+        model=args.model,
+        validation=args.validation,
+        fresh_build=not args.reuse,
+        knowledge_light=args.knowledge_light,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_agent/test_task_learning_benchmark.py
+++ b/tests/test_agent/test_task_learning_benchmark.py
@@ -203,3 +203,55 @@ def test_build_task_learning_benchmark_report_tracks_pass_deltas_and_attribution
     assert artifacts.json_path.exists()
     assert artifacts.text_path.exists()
 
+
+def test_build_task_learning_benchmark_report_ignores_non_reuse_knowledge_metadata():
+    from trellis.agent.task_learning_benchmark import build_task_learning_benchmark_report
+
+    tasks = [_task("T13", "European call PDE")]
+    pass_one = [
+        {
+            **_result(
+                task_id="T13",
+                success=False,
+                attempts=2,
+                elapsed_seconds=10.0,
+                error="build failed",
+                total_tokens=120,
+            ),
+            "knowledge_summary": {
+                "instrument": "european_option",
+                "lesson_count": 0,
+                "prompt_sizes": {"builder": {"compact_chars": 180}},
+            },
+        }
+    ]
+    pass_two = [
+        {
+            **_result(
+                task_id="T13",
+                success=True,
+                attempts=1,
+                elapsed_seconds=4.0,
+                total_tokens=80,
+            ),
+            "knowledge_summary": {
+                "instrument": "european_option",
+                "lesson_count": 0,
+                "prompt_sizes": {"builder": {"compact_chars": 160}},
+            },
+        }
+    ]
+
+    report = build_task_learning_benchmark_report(
+        benchmark_name="non_canary_task_learning",
+        cohort_name="non_canary_pending",
+        git_revision="abc1234",
+        tasks=tasks,
+        pass_runs=[
+            {"pass_number": 1, "label": "pass_1", "results": pass_one},
+            {"pass_number": 2, "label": "pass_2", "results": pass_two},
+        ],
+    )
+
+    assert report["attribution"]["knowledge_assisted_improvements"]["task_ids"] == []
+    assert report["attribution"]["unexplained_improvements"]["task_ids"] == ["T13"]

--- a/tests/test_agent/test_task_learning_benchmark.py
+++ b/tests/test_agent/test_task_learning_benchmark.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+
+def _task(task_id: str, title: str, *, status: str = "pending") -> dict[str, str]:
+    return {"id": task_id, "title": title, "status": status}
+
+
+def _result(
+    *,
+    task_id: str,
+    success: bool,
+    attempts: int,
+    elapsed_seconds: float = 0.0,
+    error: str | None = None,
+    knowledge_gaps: list[str] | None = None,
+    lesson_ids: list[str] | None = None,
+    cookbook_enriched: bool = False,
+    promotion_candidate_saved: str | None = None,
+    total_tokens: int = 0,
+) -> dict:
+    return {
+        "task_id": task_id,
+        "success": success,
+        "attempts": attempts,
+        "elapsed_seconds": elapsed_seconds,
+        "error": error,
+        "knowledge_gaps": knowledge_gaps or [],
+        "knowledge_summary": {"lesson_ids": lesson_ids or []},
+        "reflection": {
+            "lesson_captured": lesson_ids or [],
+            "cookbook_enriched": cookbook_enriched,
+            "promotion_candidate_saved": promotion_candidate_saved,
+        },
+        "artifacts": {
+            "platform_request_ids": [],
+            "platform_trace_paths": [],
+            "analytical_trace_paths": [],
+            "analytical_trace_text_paths": [],
+            "knowledge_trace_paths": [],
+            "cookbook_candidate_paths": [],
+            "promotion_candidate_paths": [],
+            "knowledge_gap_log_paths": [],
+        },
+        "token_usage_summary": {
+            "call_count": 1,
+            "calls_with_usage": 1,
+            "calls_without_usage": 0,
+            "prompt_tokens": max(total_tokens - 10, 0),
+            "completion_tokens": min(total_tokens, 10),
+            "total_tokens": total_tokens,
+            "by_stage": {},
+            "by_provider": {},
+        },
+    }
+
+
+def test_select_task_learning_cohort_excludes_canaries_and_blocked_tasks_by_default():
+    from trellis.agent.task_learning_benchmark import select_task_learning_cohort
+
+    tasks = [
+        _task("T01", "Canary lattice task"),
+        _task("T13", "Pending non-canary PDE task"),
+        _task("T14", "Blocked non-canary task", status="blocked"),
+        _task("T15", "Done non-canary task", status="done"),
+    ]
+
+    selected = select_task_learning_cohort(
+        tasks,
+        canary_task_ids={"T01"},
+    )
+
+    assert [task["id"] for task in selected] == ["T13"]
+
+
+def test_select_task_learning_cohort_can_include_done_tasks_and_requested_ids():
+    from trellis.agent.task_learning_benchmark import select_task_learning_cohort
+
+    tasks = [
+        _task("T13", "Pending task"),
+        _task("T15", "Done task", status="done"),
+        _task("T16", "Another pending task"),
+    ]
+
+    selected = select_task_learning_cohort(
+        tasks,
+        canary_task_ids=set(),
+        allowed_statuses=("pending", "done"),
+        requested_ids=("T15", "T16"),
+    )
+
+    assert [task["id"] for task in selected] == ["T15", "T16"]
+
+
+def test_build_task_learning_benchmark_report_tracks_pass_deltas_and_attribution(tmp_path):
+    from trellis.agent.task_learning_benchmark import (
+        build_task_learning_benchmark_report,
+        render_task_learning_benchmark_report,
+        save_task_learning_benchmark_report,
+    )
+
+    tasks = [
+        _task("T13", "European call PDE"),
+        _task("T14", "American put"),
+        _task("T15", "Barrier call"),
+    ]
+    pass_one = [
+        _result(
+            task_id="T13",
+            success=False,
+            attempts=2,
+            elapsed_seconds=11.0,
+            error="build failed",
+            knowledge_gaps=["missing_cookbook"],
+            total_tokens=220,
+        ),
+        _result(
+            task_id="T14",
+            success=False,
+            attempts=1,
+            elapsed_seconds=7.0,
+            error="MissingCapabilityError: missing market data discount_curve",
+            total_tokens=120,
+        ),
+        _result(
+            task_id="T15",
+            success=False,
+            attempts=2,
+            elapsed_seconds=13.0,
+            error="semantic validation failed",
+            total_tokens=180,
+        ),
+    ]
+    pass_two = [
+        _result(
+            task_id="T13",
+            success=True,
+            attempts=1,
+            elapsed_seconds=4.0,
+            lesson_ids=["lesson-13"],
+            cookbook_enriched=True,
+            promotion_candidate_saved="/tmp/promotion.yaml",
+            total_tokens=90,
+        ),
+        _result(
+            task_id="T14",
+            success=False,
+            attempts=1,
+            elapsed_seconds=6.0,
+            error="MissingCapabilityError: missing market data discount_curve",
+            total_tokens=100,
+        ),
+        _result(
+            task_id="T15",
+            success=False,
+            attempts=2,
+            elapsed_seconds=10.0,
+            error="semantic validation failed",
+            total_tokens=150,
+        ),
+    ]
+
+    report = build_task_learning_benchmark_report(
+        benchmark_name="non_canary_task_learning",
+        cohort_name="non_canary_pending",
+        git_revision="abc1234",
+        tasks=tasks,
+        pass_runs=[
+            {
+                "pass_number": 1,
+                "label": "pass_1",
+                "results": pass_one,
+                "results_path": "/tmp/pass_1.json",
+            },
+            {
+                "pass_number": 2,
+                "label": "pass_2",
+                "results": pass_two,
+                "results_path": "/tmp/pass_2.json",
+            },
+        ],
+        notes=["Fresh-build passes isolate knowledge carry-forward from adapter reuse."],
+    )
+
+    assert report["passes"][0]["summary"]["totals"]["successes"] == 0
+    assert report["passes"][1]["summary"]["totals"]["successes"] == 1
+    assert report["pairwise_comparisons"][0]["comparison"]["task_transitions"]["improved"] == 1
+    assert report["pairwise_comparisons"][0]["deltas"]["elapsed_seconds_total"] == -11.0
+    assert report["pairwise_comparisons"][0]["deltas"]["token_usage_total"] == -180
+    assert report["attribution"]["knowledge_assisted_improvements"]["task_ids"] == ["T13"]
+    assert report["attribution"]["residual_market_or_provider_noise"]["task_ids"] == ["T14"]
+    assert report["attribution"]["residual_implementation_gaps"]["task_ids"] == ["T15"]
+
+    rendered = render_task_learning_benchmark_report(report)
+    assert "Task Learning Benchmark" in rendered
+    assert "Knowledge-assisted improvements" in rendered
+    assert "Residual implementation gaps" in rendered
+
+    artifacts = save_task_learning_benchmark_report(
+        report,
+        root=tmp_path,
+        stem="non_canary_task_learning",
+    )
+    assert artifacts.json_path.exists()
+    assert artifacts.text_path.exists()
+

--- a/tests/test_agent/test_task_learning_benchmark_runner.py
+++ b/tests/test_agent/test_task_learning_benchmark_runner.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = ROOT / "scripts" / "run_task_learning_benchmark.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "run_task_learning_benchmark",
+        SCRIPT_PATH,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_run_learning_benchmark_writes_pass_outputs_and_report(tmp_path, monkeypatch, capsys):
+    module = _load_module()
+
+    fake_results = iter(
+        [
+            {
+                "task_id": "T13",
+                "success": False,
+                "attempts": 2,
+                "elapsed_seconds": 9.0,
+                "error": "build failed",
+                "knowledge_gaps": ["missing_cookbook"],
+                "knowledge_summary": {"lesson_ids": []},
+                "reflection": {},
+                "token_usage_summary": {"total_tokens": 200},
+            },
+            {
+                "task_id": "T14",
+                "success": False,
+                "attempts": 1,
+                "elapsed_seconds": 6.0,
+                "error": "MissingCapabilityError: missing market data discount_curve",
+                "knowledge_gaps": [],
+                "knowledge_summary": {"lesson_ids": []},
+                "reflection": {},
+                "token_usage_summary": {"total_tokens": 110},
+            },
+            {
+                "task_id": "T13",
+                "success": True,
+                "attempts": 1,
+                "elapsed_seconds": 4.0,
+                "knowledge_gaps": [],
+                "knowledge_summary": {"lesson_ids": ["lesson-13"]},
+                "reflection": {
+                    "lesson_captured": ["lesson-13"],
+                    "cookbook_enriched": True,
+                },
+                "token_usage_summary": {"total_tokens": 90},
+            },
+            {
+                "task_id": "T14",
+                "success": False,
+                "attempts": 1,
+                "elapsed_seconds": 5.0,
+                "error": "MissingCapabilityError: missing market data discount_curve",
+                "knowledge_gaps": [],
+                "knowledge_summary": {"lesson_ids": []},
+                "reflection": {},
+                "token_usage_summary": {"total_tokens": 100},
+            },
+        ]
+    )
+
+    monkeypatch.setattr(module, "build_market_state", lambda: object())
+    monkeypatch.setattr(module, "run_task", lambda *args, **kwargs: next(fake_results))
+    monkeypatch.setattr(module, "_git_revision", lambda: "abc1234")
+
+    tasks = [
+        {"id": "T13", "title": "European call PDE", "status": "pending"},
+        {"id": "T14", "title": "American put", "status": "pending"},
+    ]
+
+    artifacts = module.run_learning_benchmark(
+        tasks,
+        benchmark_name="non_canary_task_learning",
+        output_root=tmp_path,
+        passes=2,
+        model="test-model",
+        validation="standard",
+        fresh_build=True,
+        knowledge_light=False,
+    )
+
+    report = json.loads(artifacts["report_json_path"].read_text())
+    pass_one_results = json.loads((tmp_path / "raw" / "non_canary_task_learning_pass_1.json").read_text())
+    pass_two_summary = json.loads((tmp_path / "raw" / "non_canary_task_learning_pass_2_summary.json").read_text())
+    stdout = capsys.readouterr().out
+
+    assert len(pass_one_results) == 2
+    assert report["git_revision"] == "abc1234"
+    assert report["passes"][0]["fresh_build"] is True
+    assert report["passes"][1]["summary"]["first_pass"]["first_pass_successes"] == 1
+    assert pass_two_summary["totals"]["successes"] == 1
+    assert "Pass 1/2" in stdout
+    assert "Pass 2/2" in stdout
+    assert "Saved learning benchmark report" in stdout

--- a/trellis/agent/task_learning_benchmark.py
+++ b/trellis/agent/task_learning_benchmark.py
@@ -370,8 +370,16 @@ def _empty_attribution() -> dict[str, Any]:
 def _result_has_knowledge_signal(result: Mapping[str, Any]) -> bool:
     knowledge_summary = result.get("knowledge_summary") or {}
     if isinstance(knowledge_summary, Mapping):
-        if any(_normalize_strings(value) for value in knowledge_summary.values()):
-            return True
+        explicit_summary_keys = (
+            "lesson_ids",
+            "lesson_titles",
+            "selected_artifact_ids",
+            "selected_artifact_titles",
+            "selected_artifacts_by_audience",
+        )
+        for key in explicit_summary_keys:
+            if _normalize_strings(knowledge_summary.get(key)):
+                return True
     reflection = result.get("reflection") or {}
     if not isinstance(reflection, Mapping):
         return False

--- a/trellis/agent/task_learning_benchmark.py
+++ b/trellis/agent/task_learning_benchmark.py
@@ -1,0 +1,446 @@
+"""Repeated-pass task-learning benchmark helpers."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from trellis.agent.evals import classify_task_result, compare_task_runs, summarize_task_results
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CANARY_TASKS_MANIFEST = ROOT / "CANARY_TASKS.yaml"
+DEFAULT_REPORT_ROOT = ROOT / "task_runs" / "learning_benchmarks" / "reports"
+
+
+@dataclass(frozen=True)
+class TaskLearningBenchmarkArtifacts:
+    """Persisted files for one task-learning benchmark report."""
+
+    report: dict[str, Any]
+    json_path: Path
+    text_path: Path
+
+
+def load_canary_task_ids(path: Path | None = None) -> set[str]:
+    """Load the curated canary task ids used to exclude benchmark tasks."""
+    manifest_path = path or CANARY_TASKS_MANIFEST
+    if not manifest_path.exists():
+        return set()
+    payload = yaml.safe_load(manifest_path.read_text()) or {}
+    return {
+        str(entry.get("id") or "").strip()
+        for entry in payload.get("canary_set") or ()
+        if isinstance(entry, Mapping) and str(entry.get("id") or "").strip()
+    }
+
+
+def select_task_learning_cohort(
+    tasks: Sequence[Mapping[str, Any]],
+    *,
+    canary_task_ids: set[str],
+    allowed_statuses: Sequence[str] = ("pending",),
+    requested_ids: Sequence[str] | None = None,
+    limit: int | None = None,
+) -> list[dict[str, Any]]:
+    """Select the short-term learning cohort from the pricing-task inventory."""
+    allowed = {str(status).strip().lower() for status in allowed_statuses if str(status).strip()}
+    requested = {
+        str(task_id).strip()
+        for task_id in (requested_ids or ())
+        if str(task_id).strip()
+    }
+
+    selected: list[dict[str, Any]] = []
+    for task in tasks:
+        task_id = str(task.get("id") or "").strip()
+        if not task_id or task_id in canary_task_ids:
+            continue
+        status = str(task.get("status") or "").strip().lower()
+        if allowed and status not in allowed:
+            continue
+        if requested and task_id not in requested:
+            continue
+        selected.append(dict(task))
+        if limit is not None and len(selected) >= max(limit, 0):
+            break
+    return selected
+
+
+def build_task_learning_benchmark_report(
+    *,
+    benchmark_name: str,
+    cohort_name: str,
+    git_revision: str,
+    tasks: Sequence[Mapping[str, Any]],
+    pass_runs: Sequence[Mapping[str, Any]],
+    notes: Sequence[str] | None = None,
+) -> dict[str, Any]:
+    """Build a repeated-pass learning report for one non-canary cohort."""
+    normalized_passes: list[dict[str, Any]] = []
+    raw_results_by_pass: list[list[Mapping[str, Any]]] = []
+
+    for raw_pass in sorted(pass_runs, key=lambda item: int(item.get("pass_number") or 0)):
+        results = list(raw_pass.get("results") or [])
+        raw_results_by_pass.append(results)
+        elapsed_total = round(
+            sum(float(result.get("elapsed_seconds") or 0.0) for result in results),
+            2,
+        )
+        summary = summarize_task_results(results)
+        normalized_passes.append(
+            {
+                "pass_number": int(raw_pass.get("pass_number") or 0),
+                "label": str(raw_pass.get("label") or f"pass_{len(normalized_passes) + 1}"),
+                "fresh_build": bool(raw_pass.get("fresh_build")),
+                "knowledge_profile": str(raw_pass.get("knowledge_profile") or "default"),
+                "model": str(raw_pass.get("model") or ""),
+                "validation": str(raw_pass.get("validation") or ""),
+                "results_path": str(raw_pass.get("results_path") or ""),
+                "summary_path": str(raw_pass.get("summary_path") or ""),
+                "result_count": len(results),
+                "task_ids": [
+                    str(result.get("task_id") or "").strip()
+                    for result in results
+                    if str(result.get("task_id") or "").strip()
+                ],
+                "elapsed_seconds_total": elapsed_total,
+                "elapsed_seconds_average": round(elapsed_total / len(results), 2) if results else 0.0,
+                "summary": summary,
+            }
+        )
+
+    pairwise_comparisons: list[dict[str, Any]] = []
+    for previous, current, previous_results, current_results in zip(
+        normalized_passes,
+        normalized_passes[1:],
+        raw_results_by_pass,
+        raw_results_by_pass[1:],
+    ):
+        pairwise_comparisons.append(
+            _build_pass_comparison(
+                previous=previous,
+                current=current,
+                previous_results=previous_results,
+                current_results=current_results,
+            )
+        )
+
+    overall_comparison = (
+        _build_pass_comparison(
+            previous=normalized_passes[0],
+            current=normalized_passes[-1],
+            previous_results=raw_results_by_pass[0],
+            current_results=raw_results_by_pass[-1],
+        )
+        if len(normalized_passes) >= 2
+        else {}
+    )
+    attribution = (
+        _build_learning_attribution(
+            baseline_results=raw_results_by_pass[0],
+            latest_results=raw_results_by_pass[-1],
+        )
+        if raw_results_by_pass
+        else _empty_attribution()
+    )
+
+    return {
+        "benchmark_name": benchmark_name,
+        "cohort_name": cohort_name,
+        "git_revision": git_revision,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "task_ids": [str(task.get("id") or "") for task in tasks],
+        "task_titles": {
+            str(task.get("id") or ""): str(task.get("title") or "")
+            for task in tasks
+        },
+        "pass_count": len(normalized_passes),
+        "passes": normalized_passes,
+        "pairwise_comparisons": pairwise_comparisons,
+        "overall_comparison": overall_comparison,
+        "attribution": attribution,
+        "notes": list(notes or ()),
+    }
+
+
+def render_task_learning_benchmark_report(report: Mapping[str, Any]) -> str:
+    """Render one repeated-pass learning scorecard as Markdown."""
+    lines = [
+        f"# Task Learning Benchmark: `{report['benchmark_name']}`",
+        f"- Cohort: `{report.get('cohort_name', '')}`",
+        f"- Git revision: `{report.get('git_revision', '')}`",
+        f"- Passes: `{report.get('pass_count', 0)}`",
+        f"- Tasks: {', '.join(f'`{task_id}`' for task_id in report.get('task_ids', []))}",
+    ]
+    if report.get("notes"):
+        lines.extend(["", "## Notes"])
+        lines.extend(f"- {note}" for note in report["notes"])
+
+    lines.extend(["", "## Pass Summaries"])
+    for learning_pass in report.get("passes") or []:
+        summary = learning_pass["summary"]
+        lines.extend(
+            [
+                "",
+                f"### Pass {learning_pass['pass_number']}: `{learning_pass['label']}`",
+                f"- Success: `{summary['totals']['successes']}/{summary['totals']['tasks']}`",
+                f"- First-pass rate: `{summary['first_pass']['rate']:.0%}`",
+                f"- Attempts-to-success average: `{summary['attempts_to_success']['average']}`",
+                f"- Retry recoveries: `{summary['retry_taxonomy']['recovered_successes']}`",
+                f"- Elapsed seconds: `{learning_pass['elapsed_seconds_total']}`",
+                f"- Token usage: `{summary['token_usage']['total_tokens']}`",
+                f"- Shared-knowledge tasks: `{summary['shared_knowledge']['tasks_with_shared_context']}`",
+                f"- Results path: `{learning_pass.get('results_path', '')}`",
+            ]
+        )
+
+    if report.get("pairwise_comparisons"):
+        lines.extend(["", "## Pass Deltas"])
+        for comparison in report["pairwise_comparisons"]:
+            deltas = comparison["deltas"]
+            transition = comparison["comparison"]["task_transitions"]
+            lines.extend(
+                [
+                    "",
+                    f"### Pass {comparison['from_pass']} -> Pass {comparison['to_pass']}",
+                    f"- Improved: `{transition['improved']}`",
+                    f"- Regressed: `{transition['regressed']}`",
+                    f"- Unchanged: `{transition['unchanged']}`",
+                    f"- Success delta: `{deltas['successes']:+d}`",
+                    f"- First-pass rate delta: `{deltas['first_pass_rate']:+.2f}`",
+                    f"- Attempts-to-success delta: `{deltas['attempts_to_success_average']:+.2f}`",
+                    f"- Elapsed seconds delta: `{deltas['elapsed_seconds_total']:+.2f}`",
+                    f"- Token usage delta: `{deltas['token_usage_total']:+d}`",
+                ]
+            )
+
+    attribution = dict(report.get("attribution") or {})
+    lines.extend(
+        [
+            "",
+            "## Attribution",
+            f"- Knowledge-assisted improvements: {', '.join(_format_task_ids(attribution.get('knowledge_assisted_improvements', {}).get('task_ids') or [])) or 'none'}",
+            f"- Residual knowledge gaps: {', '.join(_format_task_ids(attribution.get('residual_knowledge_gaps', {}).get('task_ids') or [])) or 'none'}",
+            f"- Residual implementation gaps: {', '.join(_format_task_ids(attribution.get('residual_implementation_gaps', {}).get('task_ids') or [])) or 'none'}",
+            f"- Residual market/provider noise: {', '.join(_format_task_ids(attribution.get('residual_market_or_provider_noise', {}).get('task_ids') or [])) or 'none'}",
+            f"- Unexplained improvements: {', '.join(_format_task_ids(attribution.get('unexplained_improvements', {}).get('task_ids') or [])) or 'none'}",
+        ]
+    )
+
+    return "\n".join(lines) + "\n"
+
+
+def save_task_learning_benchmark_report(
+    report: Mapping[str, Any],
+    *,
+    root: Path | None = None,
+    stem: str,
+) -> TaskLearningBenchmarkArtifacts:
+    """Persist one task-learning report as JSON plus Markdown."""
+    output_root = root or DEFAULT_REPORT_ROOT
+    output_root.mkdir(parents=True, exist_ok=True)
+    json_path = output_root / f"{stem}.json"
+    text_path = output_root / f"{stem}.md"
+    payload = dict(report)
+    json_path.write_text(json.dumps(payload, indent=2, sort_keys=True, default=str))
+    text_path.write_text(render_task_learning_benchmark_report(payload))
+    return TaskLearningBenchmarkArtifacts(report=payload, json_path=json_path, text_path=text_path)
+
+
+def _build_pass_comparison(
+    *,
+    previous: Mapping[str, Any],
+    current: Mapping[str, Any],
+    previous_results: Sequence[Mapping[str, Any]],
+    current_results: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    comparison = compare_task_runs(list(previous_results), list(current_results))
+    return {
+        "from_pass": int(previous.get("pass_number") or 0),
+        "to_pass": int(current.get("pass_number") or 0),
+        "comparison": comparison,
+        "deltas": {
+            "successes": (
+                int(current["summary"]["totals"]["successes"])
+                - int(previous["summary"]["totals"]["successes"])
+            ),
+            "first_pass_rate": round(
+                float(current["summary"]["first_pass"]["rate"])
+                - float(previous["summary"]["first_pass"]["rate"]),
+                2,
+            ),
+            "attempts_to_success_average": round(
+                float(current["summary"]["attempts_to_success"]["average"])
+                - float(previous["summary"]["attempts_to_success"]["average"]),
+                2,
+            ),
+            "elapsed_seconds_total": round(
+                float(current.get("elapsed_seconds_total") or 0.0)
+                - float(previous.get("elapsed_seconds_total") or 0.0),
+                2,
+            ),
+            "token_usage_total": (
+                int(current["summary"]["token_usage"]["total_tokens"])
+                - int(previous["summary"]["token_usage"]["total_tokens"])
+            ),
+        },
+    }
+
+
+def _build_learning_attribution(
+    *,
+    baseline_results: Sequence[Mapping[str, Any]],
+    latest_results: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    baseline_by_id = {
+        str(result.get("task_id") or "").strip(): result
+        for result in baseline_results
+        if str(result.get("task_id") or "").strip()
+    }
+    latest_by_id = {
+        str(result.get("task_id") or "").strip(): result
+        for result in latest_results
+        if str(result.get("task_id") or "").strip()
+    }
+
+    improved: list[str] = []
+    knowledge_assisted: list[str] = []
+    unexplained: list[str] = []
+    residual_knowledge: list[str] = []
+    residual_implementation: list[str] = []
+    residual_market_noise: list[str] = []
+
+    for task_id in sorted(set(baseline_by_id) | set(latest_by_id)):
+        baseline = baseline_by_id.get(task_id, {})
+        latest = latest_by_id.get(task_id, {})
+        if _transition_rank(classify_task_result(latest)) < _transition_rank(classify_task_result(baseline)):
+            improved.append(task_id)
+            if _result_has_knowledge_signal(latest):
+                knowledge_assisted.append(task_id)
+            else:
+                unexplained.append(task_id)
+        if latest and not latest.get("success"):
+            if _result_is_market_or_provider_noise(latest):
+                residual_market_noise.append(task_id)
+            elif latest.get("knowledge_gaps"):
+                residual_knowledge.append(task_id)
+            else:
+                residual_implementation.append(task_id)
+
+    return {
+        "improved_tasks": {"count": len(improved), "task_ids": improved},
+        "knowledge_assisted_improvements": {
+            "count": len(knowledge_assisted),
+            "task_ids": knowledge_assisted,
+        },
+        "unexplained_improvements": {"count": len(unexplained), "task_ids": unexplained},
+        "residual_knowledge_gaps": {
+            "count": len(residual_knowledge),
+            "task_ids": residual_knowledge,
+        },
+        "residual_implementation_gaps": {
+            "count": len(residual_implementation),
+            "task_ids": residual_implementation,
+        },
+        "residual_market_or_provider_noise": {
+            "count": len(residual_market_noise),
+            "task_ids": residual_market_noise,
+        },
+    }
+
+
+def _empty_attribution() -> dict[str, Any]:
+    return {
+        "improved_tasks": {"count": 0, "task_ids": []},
+        "knowledge_assisted_improvements": {"count": 0, "task_ids": []},
+        "unexplained_improvements": {"count": 0, "task_ids": []},
+        "residual_knowledge_gaps": {"count": 0, "task_ids": []},
+        "residual_implementation_gaps": {"count": 0, "task_ids": []},
+        "residual_market_or_provider_noise": {"count": 0, "task_ids": []},
+    }
+
+
+def _result_has_knowledge_signal(result: Mapping[str, Any]) -> bool:
+    knowledge_summary = result.get("knowledge_summary") or {}
+    if isinstance(knowledge_summary, Mapping):
+        if any(_normalize_strings(value) for value in knowledge_summary.values()):
+            return True
+    reflection = result.get("reflection") or {}
+    if not isinstance(reflection, Mapping):
+        return False
+    if reflection.get("cookbook_enriched"):
+        return True
+    if int(reflection.get("lessons_attributed") or 0) > 0:
+        return True
+    for key in (
+        "lesson_captured",
+        "cookbook_candidate_saved",
+        "promotion_candidate_saved",
+        "knowledge_trace_saved",
+    ):
+        if _normalize_strings(reflection.get(key)):
+            return True
+    return False
+
+
+def _result_is_market_or_provider_noise(result: Mapping[str, Any]) -> bool:
+    bucket = classify_task_result(result)
+    if bucket in {"missing_market_data", "timeout", "llm_response"}:
+        return True
+
+    fragments = [
+        str(result.get("error") or ""),
+        *[str(item) for item in (result.get("failures") or ())],
+    ]
+    text = "\n".join(fragment for fragment in fragments if fragment).lower()
+    return any(pattern in text for pattern in ("rate limit", "quota", "provider", "missing market data"))
+
+
+def _transition_rank(bucket: str) -> int:
+    return {
+        "success": 0,
+        "missing_market_data": 5,
+        "timeout": 6,
+        "llm_response": 6,
+        "semantic_validation": 4,
+        "import_validation": 4,
+        "comparison_failed": 4,
+        "comparison_insufficient_results": 4,
+        "build_failure": 4,
+        "blocked": 4,
+        "missing": 7,
+    }.get(str(bucket or "").strip(), 4)
+
+
+def _normalize_strings(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        text = value.strip()
+        return [text] if text else []
+    if isinstance(value, Mapping):
+        return _normalize_strings(list(value.values()))
+    if isinstance(value, (list, tuple, set)):
+        items: list[str] = []
+        for item in value:
+            items.extend(_normalize_strings(item))
+        deduped: list[str] = []
+        seen: set[str] = set()
+        for item in items:
+            if item and item not in seen:
+                seen.add(item)
+                deduped.append(item)
+        return deduped
+    text = str(value).strip()
+    return [text] if text else []
+
+
+def _format_task_ids(task_ids: Sequence[str]) -> list[str]:
+    return [str(task_id) for task_id in task_ids if str(task_id).strip()]


### PR DESCRIPTION
## Summary
- add a repeated-pass non-canary learning benchmark surface and runner
- emit JSON/Markdown scorecards with pass-to-pass deltas and attribution
- document the short-term learning benchmark and sync the backlog mirror

## Validation
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_task_learning_benchmark.py tests/test_agent/test_task_learning_benchmark_runner.py -q
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_task_learning_benchmark.py tests/test_agent/test_task_learning_benchmark_runner.py tests/test_agent/test_reliability_benchmark.py tests/test_agent/test_evals.py -q
- /Users/steveyang/miniforge3/bin/python3 -m py_compile trellis/agent/task_learning_benchmark.py scripts/run_task_learning_benchmark.py
- /Users/steveyang/miniforge3/bin/python3 scripts/run_task_learning_benchmark.py --list-tasks --limit 3

## Caveat
- this PR implements the benchmark surface and docs but does not spend tokens on a full live multi-pass non-canary cohort run