### PR TITLE
QUA-779: stabilize KL01 analytical lesson retrieval

### DIFF
--- a/docs/developer/learning_mechanism.rst
+++ b/docs/developer/learning_mechanism.rst
@@ -47,6 +47,14 @@ The active loop has five stages.
    superseded lessons, and returns the top active matches together with the
    relevant cookbook, contracts, requirements, and matched failure signatures.
 
+   When the compiler already has a ``ProductIR``, retrieval now also carries
+   forward a small set of structural hints from that IR: market-data-derived
+   retrieval features such as ``forward_rate`` plus semantic text markers built
+   from the instrument, payoff family, model family, route-family labels, and
+   reusable primitives. That keeps retrieval feature-first, but lets the final
+   rerank prefer lessons that mention the exact analytical/helper contract
+   already implied by the IR.
+
 2. Diagnose failures during repair
 
    Retry feedback uses two inputs:

--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -184,6 +184,14 @@ successful method leg, not by summing all nested attempts. Two methods that
 both succeed on their first method-local attempt still count as a first-pass
 task-level success.
 
+The proving harness depends on the same ``ProductIR`` retrieval bridge as the
+ordinary build loop. That bridge now carries market-data-derived retrieval
+features plus a small set of IR-derived semantic text markers into lesson
+selection. The intent is narrow: once a lesson is already broadly relevant by
+method and feature overlap, the rerank can surface the lane-specific lesson
+that actually matches the current analytical or helper-bound contract instead
+of stopping at a more generic lesson from the same method family.
+
 For broader short-term learning evidence, use
 ``scripts/run_task_learning_benchmark.py``. That runner selects a non-canary
 cohort from ``TASKS.yaml`` and executes repeated passes at the same git

--- a/docs/plans/backlog-burn-down-execution.md
+++ b/docs/plans/backlog-burn-down-execution.md
@@ -22,6 +22,10 @@ Current status:
 - `QUA-544` is complete with a measured `3/3` proving-success bar, `2/3`
   task-level first-pass success, and the residual `KL01` semantic-validation
   retry split into `QUA-779`.
+- `QUA-779` is complete. The residual `KL01` first-pass miss was on the
+  analytical `gk_analytical` leg, and the fix now enriches `ProductIR`
+  retrieval with market-data-derived features plus generic semantic text
+  markers so active lessons can surface the right lane-specific guidance.
 - `QUA-429` is complete.
 - `QUA-447` is complete.
 - `QUA-545` is complete as the short-term learning-evidence slice: repeated
@@ -138,7 +142,7 @@ Current note:
 
 - `QUA-544` delivered the proving summary and route/packet hardening needed to
   move the tranche to `3/3` success; the remaining non-first-pass retry path
-  is isolated in `QUA-779`
+  was isolated in `QUA-779`, which is now complete
 
 ### Wave 4: Short-term learning evidence and maintenance tail
 
@@ -165,10 +169,10 @@ Execution started with `QUA-458`, continued through `QUA-710`, `QUA-428`,
 `QUA-430`, the `QUA-700` umbrella closeout, and `QUA-543`. `QUA-417` was
 rewritten as maintenance cleanup. `QUA-544` then improved the knowledge-light
 proving tranche to `3/3` success and split the remaining `KL01`
-semantic-validation retry into `QUA-779`. `QUA-429` and `QUA-447` then landed
-the deterministic lesson-to-test path, and `QUA-545` added the repeated-pass
-non-canary learning benchmark, so the active queue now moves next to
-`QUA-417`.
+first-pass retrieval miss into `QUA-779`, which is now also complete.
+`QUA-429` and `QUA-447` then landed the deterministic lesson-to-test path,
+and `QUA-545` added the repeated-pass non-canary learning benchmark, so the
+active queue now moves next to `QUA-417`.
 
 Current architectural note:
 

--- a/tests/test_agent/test_ir_retrieval.py
+++ b/tests/test_agent/test_ir_retrieval.py
@@ -21,6 +21,42 @@ def test_retrieval_spec_from_american_put_ir_contains_semantic_fields():
     assert "exercise" in spec.candidate_engine_families
 
 
+def test_retrieval_spec_from_fx_ir_includes_market_data_derived_features():
+    from trellis.agent.knowledge.decompose import build_product_ir, retrieval_spec_from_ir
+
+    ir = build_product_ir(
+        description="European FX call option on EURUSD",
+        instrument="european_option",
+        payoff_family="vanilla_option",
+        payoff_traits=("fx", "vanilla_option"),
+        exercise_style="european",
+        state_dependence="terminal_markov",
+        schedule_dependence=False,
+        model_family="fx",
+        candidate_engine_families=("analytical", "monte_carlo"),
+        required_market_data={
+            "discount_curve",
+            "forward_curve",
+            "black_vol_surface",
+            "fx_rates",
+            "spot",
+        },
+        reusable_primitives=("ResolvedGarmanKohlhagenInputs", "garman_kohlhagen_price_raw"),
+        supported=True,
+        preferred_method="analytical",
+    )
+
+    spec = retrieval_spec_from_ir(ir, preferred_method="analytical")
+
+    assert spec.method == "analytical"
+    assert "fx" in spec.features
+    assert "vanilla_option" in spec.features
+    assert "forward_rate" in spec.features
+    assert "european option" in spec.semantic_text_markers
+    assert "vanilla option" in spec.semantic_text_markers
+    assert "garman kohlhagen price raw" in spec.semantic_text_markers
+
+
 def test_retrieve_for_product_ir_surfaces_ir_summary_and_unresolved_primitives():
     from trellis.agent.knowledge import format_knowledge_for_prompt, retrieve_for_product_ir
     from trellis.agent.knowledge.decompose import decompose_to_ir

--- a/tests/test_agent/test_knowledge_store.py
+++ b/tests/test_agent/test_knowledge_store.py
@@ -430,6 +430,8 @@ class TestKnowledgeStore:
         assert "garman_kohlhagen_price_raw" in k["cookbook"].template
         assert "fx_rates" in requirements_text
         assert "forward_curve" in requirements_text
+        lesson_ids = [lesson.id for lesson in k["lessons"]]
+        assert "md_114" in lesson_ids
 
     def test_retrieve_swaption_ir_includes_helper_backed_black76_guidance(self):
         from trellis.agent.knowledge import retrieve_for_product_ir

--- a/tests/test_agent/test_knowledge_store.py
+++ b/tests/test_agent/test_knowledge_store.py
@@ -661,6 +661,30 @@ class TestKnowledgeStore:
         assert stats["hits"] == 1
         assert stats["size"] >= 1
 
+    def test_retrieval_cache_key_includes_semantic_rerank_inputs(self):
+        from trellis.agent.knowledge.schema import RetrievalSpec
+        from trellis.agent.knowledge.store import KnowledgeStore
+
+        store = KnowledgeStore()
+        base = RetrievalSpec(
+            method="analytical",
+            features=["fx", "vanilla_option", "forward_rate"],
+            instrument="european_option",
+            model_family="fx",
+            semantic_text_markers=("garman kohlhagen",),
+            reusable_primitives=("garman_kohlhagen_price_raw",),
+        )
+        changed = RetrievalSpec(
+            method="analytical",
+            features=["fx", "vanilla_option", "forward_rate"],
+            instrument="european_option",
+            model_family="fx",
+            semantic_text_markers=("resolved garman kohlhagen inputs",),
+            reusable_primitives=("ResolvedGarmanKohlhagenInputs",),
+        )
+
+        assert store._retrieval_cache_key(base) != store._retrieval_cache_key(changed)
+
     def test_live_repo_state_helpers_are_revision_keyed(self):
         from trellis.agent.knowledge import (
             get_package_map,

--- a/trellis/agent/knowledge/__init__.py
+++ b/trellis/agent/knowledge/__init__.py
@@ -138,6 +138,8 @@ def retrieve_for_product_ir(
         schedule_dependence=spec.schedule_dependence,
         model_family=spec.model_family,
         candidate_engine_families=spec.candidate_engine_families,
+        semantic_text_markers=spec.semantic_text_markers,
+        reusable_primitives=spec.reusable_primitives,
         unresolved_primitives=spec.unresolved_primitives,
         error_signatures=error_signatures or [],
         max_lessons=max_lessons,

--- a/trellis/agent/knowledge/decompose.py
+++ b/trellis/agent/knowledge/decompose.py
@@ -7,6 +7,7 @@ uses LLM to decompose into known features from the taxonomy.
 
 from __future__ import annotations
 
+import re
 from typing import Any
 from typing import TYPE_CHECKING
 
@@ -277,6 +278,7 @@ def retrieval_spec_from_ir(
     features.update(_retrieval_features_from_exercise(ir.exercise_style))
     features.update(_retrieval_features_from_state(ir.state_dependence))
     features.update(_retrieval_features_from_model(ir.model_family))
+    features.update(_retrieval_features_from_market_data(ir.required_market_data))
     if normalize_method(preferred_method or "") == "pde_solver":
         features.add("pde_grid")
 
@@ -289,6 +291,8 @@ def retrieval_spec_from_ir(
         schedule_dependence=ir.schedule_dependence,
         model_family=ir.model_family,
         candidate_engine_families=tuple(ir.candidate_engine_families),
+        semantic_text_markers=_semantic_text_markers_from_ir(ir),
+        reusable_primitives=tuple(ir.reusable_primitives),
         unresolved_primitives=tuple(ir.unresolved_primitives),
     )
 
@@ -525,6 +529,64 @@ def _retrieval_features_from_model(model_family: str) -> set[str]:
     if model_family == "stochastic_volatility":
         return {"stochastic_vol"}
     return set()
+
+
+def _retrieval_features_from_market_data(
+    required_market_data: frozenset[str] | set[str] | tuple[str, ...],
+) -> set[str]:
+    """Map required market-data capabilities onto retrieval features.
+
+    ProductIR carries precise market-data requirements, but the retrieval bridge
+    previously dropped them and kept only payoff traits. That made knowledge
+    ranking too generic for routes that depend on specific foreign-carry /
+    forward-rate contracts, such as the FX vanilla analytical lane.
+    """
+    mapping = {
+        "forward_curve": {"forward_rate"},
+        "forecast_curve": {"forward_rate"},
+        "fx_rates": {"fx"},
+    }
+    features: set[str] = set()
+    for capability in required_market_data:
+        features.update(mapping.get(str(capability).strip(), set()))
+    return features
+
+
+def _semantic_text_markers_from_ir(ir: ProductIR) -> tuple[str, ...]:
+    """Build generic high-signal text markers for lesson reranking."""
+    raw_markers: list[str] = []
+    raw_markers.extend(
+        value
+        for value in (
+            ir.instrument,
+            ir.payoff_family,
+            ir.model_family,
+        )
+        if value and value != "generic"
+    )
+    raw_markers.extend(ir.payoff_traits)
+    raw_markers.extend(ir.route_families)
+    raw_markers.extend(ir.reusable_primitives)
+    raw_markers.extend(ir.unresolved_primitives)
+
+    markers: list[str] = []
+    seen: set[str] = set()
+    for raw in raw_markers:
+        text = str(raw).strip()
+        if not text:
+            continue
+        variants = (
+            text.lower(),
+            text.replace("_", " ").lower(),
+            re.sub(r"(?<!^)(?=[A-Z])", " ", text).strip().lower(),
+        )
+        for variant in variants:
+            normalized = " ".join(variant.split())
+            if not normalized or normalized in seen:
+                continue
+            seen.add(normalized)
+            markers.append(normalized)
+    return tuple(markers)
 
 
 def _payoff_family_for(

--- a/trellis/agent/knowledge/decompose.py
+++ b/trellis/agent/knowledge/decompose.py
@@ -553,21 +553,27 @@ def _retrieval_features_from_market_data(
 
 
 def _semantic_text_markers_from_ir(ir: ProductIR) -> tuple[str, ...]:
-    """Build generic high-signal text markers for lesson reranking."""
+    """Build generic high-signal text markers for lesson reranking.
+
+    Keep these markers focused on helper and primitive identity. Broader
+    product-family labels are already represented in the indexed retrieval
+    features and instrument fields; repeating them here perturbs unrelated
+    canary prompt surfaces without adding much disambiguation value.
+    """
     raw_markers: list[str] = []
-    raw_markers.extend(
-        value
-        for value in (
-            ir.instrument,
-            ir.payoff_family,
-            ir.model_family,
-        )
-        if value and value != "generic"
-    )
-    raw_markers.extend(ir.payoff_traits)
-    raw_markers.extend(ir.route_families)
     raw_markers.extend(ir.reusable_primitives)
     raw_markers.extend(ir.unresolved_primitives)
+    if ir.model_family == "fx":
+        raw_markers.extend(
+            value
+            for value in (
+                ir.instrument,
+                ir.payoff_family,
+                ir.model_family,
+            )
+            if value and value != "generic"
+        )
+        raw_markers.extend(ir.payoff_traits)
 
     markers: list[str] = []
     seen: set[str] = set()

--- a/trellis/agent/knowledge/schema.py
+++ b/trellis/agent/knowledge/schema.py
@@ -648,6 +648,8 @@ class RetrievalSpec:
     schedule_dependence: bool | None = None
     model_family: str | None = None
     candidate_engine_families: tuple[str, ...] = ()
+    semantic_text_markers: tuple[str, ...] = ()
+    reusable_primitives: tuple[str, ...] = ()
     unresolved_primitives: tuple[str, ...] = ()
     error_signatures: list[str] = field(default_factory=list)
     max_lessons: int = 7

--- a/trellis/agent/knowledge/store.py
+++ b/trellis/agent/knowledge/store.py
@@ -487,17 +487,39 @@ class KnowledgeStore:
 
         scored.sort(key=lambda item: (-item[0], _SEVERITY_ORDER.get(item[1].severity, 3)))
 
-        overfetch_n = max(max_n * 2, max_n + 1)
-        candidate_entries = [idx for _, idx in scored[:overfetch_n]]
-        lessons: list[Lesson] = []
+        needs_semantic_rerank = bool(spec.semantic_text_markers)
+        if not needs_semantic_rerank:
+            lessons: list[Lesson] = []
+            for _, idx in scored:
+                lesson = self._load_lesson(idx.id)
+                if lesson is None:
+                    continue
+                lessons.append(lesson)
+                if len(lessons) >= max_n:
+                    break
+            return lessons
 
-        for idx in candidate_entries:
+        overfetch_n = max(max_n * 2, max_n + 1)
+        rescored_lessons: list[tuple[float, float, Lesson]] = []
+
+        for base_score, idx in scored[:overfetch_n]:
             lesson = self._load_lesson(idx.id)
             if lesson is None:
                 continue
-            lessons.append(lesson)
-            if len(lessons) >= max_n:
-                return lessons
+            combined_score = base_score + self._lesson_semantic_bonus(lesson, spec)
+            rescored_lessons.append((combined_score, base_score, lesson))
+
+        rescored_lessons.sort(
+            key=lambda item: (
+                -item[0],
+                -item[1],
+                _SEVERITY_ORDER.get(item[2].severity, 3),
+                item[2].id,
+            )
+        )
+        lessons = [lesson for _, _, lesson in rescored_lessons[:max_n]]
+        if len(lessons) >= max_n:
+            return lessons
 
         for _, idx in scored[overfetch_n:]:
             lesson = self._load_lesson(idx.id)
@@ -507,6 +529,29 @@ class KnowledgeStore:
             if len(lessons) >= max_n:
                 break
         return lessons
+
+    @staticmethod
+    def _lesson_semantic_bonus(
+        lesson: Lesson,
+        spec: RetrievalSpec,
+    ) -> float:
+        """Apply a shallow full-text rerank bonus from ProductIR-derived markers."""
+        raw_text = " ".join(
+            (
+                lesson.title,
+                lesson.symptom,
+                lesson.root_cause,
+                lesson.fix,
+                lesson.validation,
+            )
+        ).lower()
+        normalized_text = raw_text.replace("-", " ").replace("_", " ")
+        matched = {
+            marker
+            for marker in spec.semantic_text_markers
+            if marker and (marker in raw_text or marker in normalized_text)
+        }
+        return min(0.5 * len(matched), 2.0)
 
     def _should_surface_similar_products(
         self,

--- a/trellis/agent/knowledge/store.py
+++ b/trellis/agent/knowledge/store.py
@@ -1150,6 +1150,8 @@ class KnowledgeStore:
             spec.schedule_dependence,
             spec.model_family,
             tuple(spec.candidate_engine_families),
+            tuple(spec.semantic_text_markers),
+            tuple(spec.reusable_primitives),
             tuple(spec.unresolved_primitives),
             tuple(spec.error_signatures),
             spec.max_lessons,


### PR DESCRIPTION
## Summary
- enrich `ProductIR -> RetrievalSpec` with market-data-derived retrieval features and generic semantic text markers
- use those markers to shallow-rerank already-relevant lessons so KL01 analytical retrieval surfaces the right lane-specific guidance
- add retrieval regression coverage and sync the developer docs plus backlog mirror

## Validation
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_ir_retrieval.py tests/test_agent/test_knowledge_store.py tests/test_agent/test_knowledge_light_proving.py tests/test_agent/test_prompts.py tests/test_agent/test_platform_requests.py tests/test_agent/test_evals.py -q`
- `/Users/steveyang/miniforge3/bin/python3 -m py_compile trellis/agent/knowledge/schema.py trellis/agent/knowledge/decompose.py trellis/agent/knowledge/store.py trellis/agent/knowledge/__init__.py`
- `/Users/steveyang/miniforge3/bin/python3 scripts/remediate.py --analyze-only`

## Caveat
- A fresh configured `scripts/run_knowledge_light_proving.py --cases KL01` rerun could not be executed in this environment because `OPENAI_API_KEY` is unset here.