### PR TITLE
docs: rescue paper series workspace

### DIFF
--- a/docs/paper/README.md
+++ b/docs/paper/README.md
@@ -1,0 +1,49 @@
+# Trellis Paper Workspace
+
+This workspace is the starting point for a paper series on Trellis.
+
+The repo uses `docs/`, not `doc/`, so the paper workspace lives under
+`docs/paper/`.
+
+## Recommended shape
+
+The strongest framing today is a three-part series:
+
+1. request-to-outcome compiler and semantic pipeline
+2. mathematical and computational substrate
+3. governed knowledge loop and the path to real learning
+
+If later you want only two papers, merge Parts II and III.
+
+## Why three parts is better right now
+
+- Part I is already a strong systems/compiler story.
+- Part II is already a strong quantitative-methods story.
+- Part III is important, but the repo is more honest as "governed reflection,
+  retrieval, promotion, and future closed-loop learning" than as "the system
+  already learns robustly in production."
+
+## Workspace layout
+
+- `series-plan.md`: repo-grounded paper strategy and writing order
+- `common/preamble.tex`: shared LaTeX packages and macros
+- `artifacts/`: figures, tables, exported traces, benchmark snapshots
+- `part1-request-to-outcome/main.tex`: Part I draft entrypoint
+- `part2-computational-lanes/main.tex`: Part II draft entrypoint
+- `part3-learning-loop/main.tex`: Part III draft entrypoint
+
+## Authoring rules
+
+- Keep the core claim consistent across all papers: the LLM is not in the
+  deterministic pricing hot path.
+- Distinguish clearly between shipped architecture, active transition work,
+  and future roadmap.
+- Use `LIMITATIONS.md` as a guardrail against overclaiming numerical or
+  learning maturity.
+- Prefer repo-grounded figures and traces over aspirational diagrams.
+
+## Suggested next move
+
+Write Part I first, because it defines the vocabulary the other papers reuse:
+`PlatformRequest`, `SemanticContract`, `ValuationContext`, `ProductIR`,
+family IRs, admissibility, validation, and traces.

--- a/docs/paper/artifacts/README.md
+++ b/docs/paper/artifacts/README.md
@@ -1,0 +1,21 @@
+# Paper Artifacts
+
+Put paper-specific assets here.
+
+Recommended organization:
+
+- exported figures from repo-grounded diagrams
+- benchmark tables and CSV snapshots
+- task/canary trace excerpts
+- rendered architecture diagrams used in the LaTeX papers
+
+Suggested subfolders to create as needed:
+
+- `figures/`
+- `tables/`
+- `traces/`
+- `benchmarks/`
+- `notes/`
+
+Keep assets reproducible where possible. If an artifact is derived from repo
+data or traces, include a short provenance note beside it.

--- a/docs/paper/common/preamble.tex
+++ b/docs/paper/common/preamble.tex
@@ -1,0 +1,36 @@
+\usepackage[margin=1in]{geometry}
+\usepackage[T1]{fontenc}
+\usepackage[utf8]{inputenc}
+\usepackage{lmodern}
+\usepackage{microtype}
+\usepackage{amsmath,amssymb,amsthm,mathtools}
+\usepackage{booktabs}
+\usepackage{array}
+\usepackage{longtable}
+\usepackage{graphicx}
+\usepackage{xcolor}
+\usepackage{hyperref}
+\usepackage[nameinlink,noabbrev]{cleveref}
+\usepackage{enumitem}
+\usepackage{listings}
+\usepackage{csquotes}
+
+\hypersetup{
+    colorlinks=true,
+    linkcolor=blue,
+    citecolor=blue,
+    urlcolor=blue
+}
+
+\setlist[itemize]{leftmargin=1.5em}
+\setlist[enumerate]{leftmargin=1.75em}
+
+\newcommand{\trellis}{\textsc{Trellis}}
+\newcommand{\platformrequest}{\texttt{PlatformRequest}}
+\newcommand{\semanticcontract}{\texttt{SemanticContract}}
+\newcommand{\valuationcontext}{\texttt{ValuationContext}}
+\newcommand{\productir}{\texttt{ProductIR}}
+\newcommand{\eventprogramir}{\texttt{EventProgramIR}}
+\newcommand{\controlprogramir}{\texttt{ControlProgramIR}}
+\newcommand{\familyir}{family IR}
+\newcommand{\code}[1]{\texttt{#1}}

--- a/docs/paper/part1-request-to-outcome/main.tex
+++ b/docs/paper/part1-request-to-outcome/main.tex
@@ -1,0 +1,106 @@
+\documentclass[11pt]{article}
+\input{../common/preamble.tex}
+
+\title{Trellis I: A Request-to-Outcome Compiler for Agent-Assisted Derivatives Pricing}
+\author{Draft}
+\date{\today}
+
+\begin{document}
+\maketitle
+
+\begin{abstract}
+This paper should explain how \trellis{} turns ambiguous pricing requests into
+defensible deterministic pricing outcomes. The central claim is that
+agent-pricing becomes viable when the LLM is constrained to semantic parsing,
+planning, and guarded artifact generation around a typed compiler and a
+deterministic numerical runtime, rather than being placed in the pricing hot
+path.
+\end{abstract}
+
+\tableofcontents
+
+\section{Introduction}
+
+\subsection{Problem}
+Explain why naive prompt-to-code pricing is unsafe for quantitative finance.
+
+\subsection{Contribution}
+State the compiler thesis clearly:
+\begin{itemize}
+    \item unified request normalization
+    \item typed semantic compilation
+    \item admissibility and lowering before pricing
+    \item deterministic validation and traceability
+\end{itemize}
+
+\section{From Front Doors to a Canonical Request}
+
+Cover:
+\begin{itemize}
+    \item \code{ask(...)}
+    \item \code{Session}
+    \item \code{Pipeline}
+    \item structured user-defined products
+    \item comparison and task-runner flows
+\end{itemize}
+
+Key objects:
+\begin{itemize}
+    \item \platformrequest{}
+    \item \code{CompiledPlatformRequest}
+    \item \code{ExecutionPlan}
+\end{itemize}
+
+\section{Semantic Compilation}
+
+Cover:
+\begin{itemize}
+    \item \semanticcontract{}
+    \item semantic validation
+    \item \valuationcontext{}
+    \item required data and market binding
+    \item \productir{}
+\end{itemize}
+
+\section{Admissibility, Lowering, and Route Selection}
+
+Cover:
+\begin{itemize}
+    \item route registry and build gate
+    \item \eventprogramir{} and \controlprogramir{}
+    \item lowering onto bounded family IRs
+    \item helper-backed deterministic routes
+\end{itemize}
+
+\section{Validation and Traces}
+
+Cover:
+\begin{itemize}
+    \item validation as a compiled contract
+    \item deterministic checks versus residual model review
+    \item canonical trace surfaces and replayability
+\end{itemize}
+
+\section{Case Studies}
+
+Suggested cases:
+\begin{itemize}
+    \item one direct deterministic pricing request
+    \item one guarded build path
+    \item one comparison-task path
+\end{itemize}
+
+\section{What This Paper Does Not Claim}
+
+\begin{itemize}
+    \item the LLM does not perform deterministic pricing
+    \item the compiler does not imply universal numerical support
+    \item unsupported capability remains bounded by documented limitations
+\end{itemize}
+
+\section{Conclusion}
+
+Restate the main result: the meaningful innovation is a governed semantic
+compiler around deterministic quantitative engines.
+
+\end{document}

--- a/docs/paper/part2-computational-lanes/main.tex
+++ b/docs/paper/part2-computational-lanes/main.tex
@@ -1,0 +1,85 @@
+\documentclass[11pt]{article}
+\input{../common/preamble.tex}
+
+\title{Trellis II: Mathematical and Computational Lanes for Semantic Derivatives Pricing}
+\author{Draft}
+\date{\today}
+
+\begin{document}
+\maketitle
+
+\begin{abstract}
+This paper should explain the mathematical and computational substrate that
+lets one semantic request lower onto multiple deterministic pricing families.
+The main claim is that \trellis{} succeeds by combining contract algebra,
+event/control compilation, bounded family IRs, and reusable numerical kernels
+rather than by relying on a single universal solver representation.
+\end{abstract}
+
+\tableofcontents
+
+\section{Introduction}
+
+Frame the paper as the bridge between rich product semantics and bounded
+numerical execution.
+
+\section{Why Bounded Family IRs}
+
+Explain why the system does not use one monolithic universal pricing IR.
+
+\section{Contract Algebra and Analytical Support}
+
+Cover:
+\begin{itemize}
+    \item contracts as syntax
+    \item valuation as semantics
+    \item semantics-preserving rewrites
+    \item reusable analytical kernels
+\end{itemize}
+
+\section{Event and Control as Numerical Interface}
+
+Cover:
+\begin{itemize}
+    \item \eventprogramir{}
+    \item \controlprogramir{}
+    \item how shared semantic programs project into family-specific forms
+\end{itemize}
+
+\section{Family Lanes}
+
+Suggested subsections:
+\begin{itemize}
+    \item analytical
+    \item exercise lattice
+    \item PDE
+    \item event-aware Monte Carlo
+    \item transforms
+    \item basket credit / copula
+\end{itemize}
+
+\section{Calibration and Market Binding}
+
+Explain how model binding, quote regimes, calibration surfaces, and market
+context stay explicit rather than route-local.
+
+\section{Case Studies}
+
+Suggested cases:
+\begin{itemize}
+    \item transform family hardening
+    \item event-aware Monte Carlo swaption path
+    \item short-rate helper extraction
+\end{itemize}
+
+\section{Support Boundary and Limitations}
+
+Use \code{LIMITATIONS.md} directly to keep the paper honest about current
+coverage, especially for calibration, risk, xVA, and performance.
+
+\section{Conclusion}
+
+Restate the main result: the computational novelty lies in family-specific
+semantic lowering onto deterministic quantitative kernels.
+
+\end{document}

--- a/docs/paper/part3-learning-loop/main.tex
+++ b/docs/paper/part3-learning-loop/main.tex
@@ -1,0 +1,93 @@
+\documentclass[11pt]{article}
+\input{../common/preamble.tex}
+
+\title{Trellis III: Governed Knowledge, Reflection, and the Path to a Learning Pricing Agent}
+\author{Draft}
+\date{\today}
+
+\begin{document}
+\maketitle
+
+\begin{abstract}
+This paper should present the Trellis knowledge layer honestly: the repo
+already contains a governed architecture for retrieval, reflection, promotion,
+trace capture, and durable regression materialization, but the full
+self-improving learning loop is still an active milestone rather than a fully
+landed claim. The contribution is therefore governance for learning in a
+quantitative pricing system.
+\end{abstract}
+
+\tableofcontents
+
+\section{Introduction}
+
+Frame the problem: pricing agents need memory, but naive memory is unsafe in a
+numerical library.
+
+\section{Knowledge Assets}
+
+Cover:
+\begin{itemize}
+    \item principles
+    \item decompositions
+    \item cookbooks
+    \item data contracts
+    \item method requirements
+    \item lessons
+    \item import registry
+    \item traces and promotion candidates
+\end{itemize}
+
+\section{Retrieval and Grounding}
+
+Cover:
+\begin{itemize}
+    \item \code{KnowledgeStore}
+    \item prompt formatting and artifact selection
+    \item anti-hallucination controls
+\end{itemize}
+
+\section{Reflection and Promotion}
+
+Cover:
+\begin{itemize}
+    \item post-build reflection
+    \item lesson capture and promotion states
+    \item cookbook candidates
+    \item route and adapter lifecycle artifacts
+    \item lesson-to-test seam
+\end{itemize}
+
+\section{Platform Traces, Remediation, and Reliability}
+
+Explain how platform traces and task/runtime artifacts support debugging,
+auditing, and future learning evaluation.
+
+\section{Current Reality Versus Future Loop}
+
+Be explicit about the split:
+\begin{itemize}
+    \item implemented now: retrieval, reflection, promotion, traces,
+    partial closed-loop seams
+    \item not yet a mature claim: robust autonomous learning that reliably
+    improves first-pass pricing quality over time
+\end{itemize}
+
+\section{Evaluation Plan for the True Learning Loop}
+
+Suggested metrics:
+\begin{itemize}
+    \item first-pass success rate
+    \item repeated-failure suppression
+    \item lesson-to-test conversion rate
+    \item promotion precision
+    \item stale-artifact detection quality
+\end{itemize}
+
+\section{Conclusion}
+
+Restate the main result: Trellis already has a governed memory architecture,
+and that governance is the necessary precursor to a credible learning pricing
+agent.
+
+\end{document}

--- a/docs/paper/series-plan.md
+++ b/docs/paper/series-plan.md
@@ -1,0 +1,267 @@
+# Trellis Paper Series Plan
+
+## Recommendation
+
+Write a three-part series now, with a clean fallback to two papers later.
+
+The core novelty is not "LLMs price derivatives." The core novelty is that
+Trellis makes agent-pricing possible by compiling ambiguous requests into
+typed semantic objects, narrowing them through admissibility and lowering, and
+then executing only deterministic numerical machinery in the pricing hot path.
+
+That gives you a paper program with three distinct contributions:
+
+1. a compiler/systems contribution
+2. a mathematical and computational-methods contribution
+3. a knowledge-governance and learning-systems contribution
+
+## Proposed series thesis
+
+Trellis is best presented as a governed semantic compiler for quantitative
+finance, not as a generic code-generation agent. The system works because it
+combines:
+
+- contract algebra and typed product semantics
+- DSL-style lowering onto bounded numerical families
+- reusable deterministic mathematical engines
+- a governed knowledge layer for retrieval, reflection, promotion, and audit
+
+The series should repeatedly state one architectural rule:
+
+> the agent handles ambiguity, compilation, and maintenance; deterministic
+> numerical engines handle valuation.
+
+## Recommended paper split
+
+### Part I
+
+**Working title:** `Trellis I: A Request-to-Outcome Compiler for Agent-Assisted Derivatives Pricing`
+
+**Main question:** How can a natural-language or structured pricing request be
+turned into a defensible deterministic pricing outcome?
+
+**Primary thesis:** Agent-pricing is viable when the system compiles requests
+through typed semantic contracts, valuation context, route admissibility, and
+family lowering before any pricing call is executed.
+
+**Core sections:**
+
+1. Problem statement: why naive prompt-to-code pricing is unsafe.
+2. Unified front door:
+   `ask`, `Session`, `Pipeline`, structured product specs, task runner.
+3. Canonical request layer:
+   `PlatformRequest`, `CompiledPlatformRequest`, `ExecutionPlan`.
+4. Semantic compilation:
+   `SemanticContract`, semantic validation, `ValuationContext`,
+   `RequiredDataSpec`, `MarketBindingSpec`, `ProductIR`.
+5. Admissibility and lowering:
+   route registry, build gate, `EventProgramIR`, `ControlProgramIR`,
+   family-specific IR emission.
+6. Validation contract and traceability:
+   deterministic checks, compiled validation, canonical traces.
+7. Case studies:
+   one direct deterministic path and one guarded build path.
+
+**Innovation angle:** This is a pricing compiler paper with an LLM at the
+edges, not a free-form agent paper.
+
+**Primary repo sources:**
+
+- `ARCHITECTURE.md`
+- `docs/quant/pricing_stack.rst`
+- `docs/developer/overview.rst`
+- `docs/agent/workflow_diagrams.md`
+- `docs/developer/implementation_journey_prompt_to_price.md`
+- `docs/design_validation_contract_loop.md`
+- `trellis/agent/platform_requests.py`
+- `trellis/agent/semantic_contracts.py`
+- `trellis/agent/family_lowering_ir.py`
+
+### Part II
+
+**Working title:** `Trellis II: Mathematical and Computational Lanes for Semantic Derivatives Pricing`
+
+**Main question:** What mathematical and computational abstractions let one
+semantic request compile onto multiple pricing families without collapsing into
+product-specific formula sprawl?
+
+**Primary thesis:** Trellis works because it narrows rich financial semantics
+onto bounded numerical families rather than forcing one universal solver IR.
+
+**Core sections:**
+
+1. Why bounded family IRs beat a monolithic universal pricing IR.
+2. Contract algebra and analytical support:
+   contracts as syntax, valuation as semantics, sound rewrites, reusable
+   kernels.
+3. Event/control programs as the bridge from product semantics to numerics.
+4. Family lanes:
+   analytical, exercise lattice, PDE, event-aware Monte Carlo, transforms,
+   basket credit / copula.
+5. Calibration and market-binding surfaces as governed numerical context.
+6. Case studies:
+   transform family hardening, event-aware Monte Carlo, callable/short-rate
+   routes, basket credit.
+7. Honest support boundary:
+   use `LIMITATIONS.md` to mark what remains incomplete.
+
+**Innovation angle:** The novelty is the composition of semantic contracts,
+family IRs, and deterministic kernels across multiple pricing regimes.
+
+**Primary repo sources:**
+
+- `docs/design_analytical_support_contract_algebra.md`
+- `docs/quant/pricing_stack.rst`
+- `docs/plans/event-aware-monte-carlo-lane.md`
+- `docs/plans/transform-family-ir-and-admissibility-hardening.md`
+- `docs/plans/semantic-contract-registry-and-short-rate-claim-generalization.md`
+- `LIMITATIONS.md`
+- `trellis/agent/family_lowering_ir.py`
+- `trellis/agent/lane_obligations.py`
+- `trellis/models/`
+
+### Part III
+
+**Working title:** `Trellis III: Governed Knowledge, Reflection, and the Path to a Learning Pricing Agent`
+
+**Main question:** How should a pricing agent improve over time without
+letting free-form learning corrupt a numerical library?
+
+**Primary thesis:** Trellis already has a governed memory and reflection
+architecture; the real contribution is disciplined retrieval, promotion, and
+auditability, with full autonomous learning presented as an explicit next
+phase rather than a completed claim.
+
+**Core sections:**
+
+1. Why a pricing agent needs governed memory rather than raw conversational
+   history.
+2. Knowledge assets:
+   principles, decompositions, cookbooks, contracts, requirements, lessons,
+   import registry, traces.
+3. Retrieval and prompt grounding:
+   `KnowledgeStore`, prompt formatting, anti-hallucination controls.
+4. Reflection and promotion:
+   post-build reflection, lesson capture, cookbook candidates,
+   promotion candidates, lesson-to-test seam.
+5. Platform traces, remediation, and reliability measurement.
+6. What is implemented now versus what is not yet true.
+7. Roadmap to the real learning loop:
+   durable improvement, automatic regression materialization, scorer training,
+   validator promotion, and evidence standards.
+
+**Innovation angle:** The contribution is governance for agent improvement in
+quant software, not merely another memory feature.
+
+**Primary repo sources:**
+
+- `docs/platform_loop_workstream.md`
+- `docs/plans/backlog-burn-down-execution.md`
+- `docs/plans/lesson-store-refactor.md`
+- `trellis/agent/knowledge/store.py`
+- `trellis/agent/knowledge/retrieval.py`
+- `trellis/agent/knowledge/reflect.py`
+- `trellis/agent/knowledge/promotion.py`
+- `trellis/agent/knowledge/autonomous.py`
+- `trellis/agent/task_runtime.py`
+
+## Cross-paper narrative
+
+Each paper should defend one layer, while reusing a shared vocabulary.
+
+### Shared vocabulary
+
+- `PlatformRequest`
+- `SemanticContract`
+- `ValuationContext`
+- `ProductIR`
+- `EventProgramIR`
+- `ControlProgramIR`
+- family IR
+- admissibility
+- helper-backed numerical route
+- knowledge trace
+- promotion candidate
+
+### Cross-paper dependency
+
+- Part I defines the compiler and runtime vocabulary.
+- Part II explains why the compiler can target multiple mathematical lanes.
+- Part III explains how the system remembers, critiques, and eventually
+  improves those lanes without weakening deterministic guarantees.
+
+## Two-paper fallback
+
+If you want only two papers, keep Part I unchanged and merge Parts II and III
+into:
+
+`Trellis II: Mathematical Substrate, Governed Knowledge, and the Path to Learning`
+
+That merged version should still separate:
+
+- shipped numerical/compiler architecture
+- shipped knowledge governance
+- future autonomous learning loop
+
+## What not to overclaim
+
+- Do not claim that Trellis already has a fully effective autonomous learning
+  loop. The repo shows retrieval, reflection, promotion, traces, and some
+  closed-loop seams, but your own note is right: the real execution of the
+  learning loop is not yet the main mature contribution.
+- Do not claim universal solver coverage. The system is intentionally built on
+  bounded family IRs and helper-backed routes.
+- Do not claim desk-complete risk, calibration, or xVA support; anchor those
+  limits in `LIMITATIONS.md`.
+
+## Artifact backlog
+
+Store all figures, tables, and exported evidence under `docs/paper/artifacts/`.
+
+### Figures to prepare
+
+1. Unified request-to-outcome pipeline.
+2. Semantic compile and lowering stack.
+3. Family IR map: analytical / lattice / PDE / MC / transforms / credit.
+4. Knowledge lifecycle: retrieve -> build -> reflect -> promote -> test.
+5. Validation contract loop and trace surfaces.
+
+### Tables to prepare
+
+1. Front-door to canonical-request mapping.
+2. Semantic object inventory and responsibility split.
+3. Family IRs and supported numerical obligations.
+4. Current proven families versus open limitations.
+5. Knowledge asset types and lifecycle states.
+
+### Case studies to prepare
+
+1. Transform lane hardening (`T39`, `T40`).
+2. Event-aware Monte Carlo and swaption comparison recovery (`T73`).
+3. Short-rate helper extraction under callable/bond and Bermudan flows.
+4. One lesson-to-test or promotion-candidate example for Part III.
+
+## Recommended writing order
+
+1. Finish Part I outline into prose first.
+2. Draft Part II while the compiler vocabulary is still fresh.
+3. Draft Part III last, after choosing exactly how candidly to frame the
+   learning loop as present capability versus roadmap.
+
+## Near-term execution plan
+
+### Week 1
+
+- lock the series thesis and paper titles
+- export the first two core architecture figures
+- write Part I introduction and system overview
+
+### Week 2
+
+- draft Part II sections on contract algebra and family IRs
+- collect one numerical case study per lane you want to feature
+
+### Week 3
+
+- draft Part III with explicit "current state" and "future loop" split
+- add the cross-paper introduction/conclusion language for a coherent series


### PR DESCRIPTION
## Summary
- rescue the local `docs/paper/` workspace from the dropped stash
- preserve the paper series structure and LaTeX sources on a dedicated docs branch

## Validation
- docs-only change
- no tests run
