### PR TITLE
Route surfaces: thin rate-tree helper routes

### DIFF
--- a/docs/developer/dsl_system_design_review.md
+++ b/docs/developer/dsl_system_design_review.md
@@ -205,6 +205,16 @@ loops, survival/default plumbing, copula initialization, and tranche-loss
 projection are no longer carried as route-card instructions once the checked
 helpers already own that surface.
 
+The rate-tree cohort now follows the same discipline. ``exercise_lattice``,
+``rate_tree_backward_induction``, ``zcb_option_rate_tree``, and
+``zcb_option_analytical`` still expose the backend binding and the validation
+surface, but they no longer supply prompt-level lattice or short-rate
+construction guidance when the checked helper already owns that assembly. The
+semantic drafting boundary is also stricter here: an explicit ``instrument_type``
+such as ``zcb_option`` now blocks fallback drafting into a generic
+``vanilla_option`` contract when the prose only happens to contain generic
+``option`` language.
+
 The Monte Carlo compiler now has the matching bounded family surface for the
 next migration tranche:
 

--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -476,6 +476,10 @@ runtime contract, or ``ProductIR`` already supplies the family. Description
 heuristics remain only as the final fallback when no structural family signal
 exists yet. The residual text-pattern table is intentionally narrower now:
 generic ``bond`` and ``swap`` wording no longer produce a family on their own,
+and an explicit family such as ``zcb_option`` no longer gets silently redrafted
+into a generic ``vanilla_option`` semantic contract just because the request
+text contains phrases like ``European call option``. That keeps exact helper
+binding on the intended family-first path for the short-rate comparison cohort.
 so ingress fallback only fires for phrases that still correspond to defended
 task families rather than widening broad desk summaries into a pricing schema.
 

--- a/docs/plans/route-registry-minimization.md
+++ b/docs/plans/route-registry-minimization.md
@@ -268,10 +268,14 @@ The active route-card retirement queue is now tracked under umbrella
    `exercise_lattice`, `rate_tree_backward_induction`,
    `zcb_option_rate_tree`, `zcb_option_analytical`
    Validation cohort: `T01`, `T04`, `T05`, `T17`
+   Closeout status: route cards thinned and helper-signature enforcement landed;
+   `T01` and `T05` recovered, `T17` carries forward to `QUA-783`, and the
+   residual `T04` comparison mismatch is tracked in `QUA-786` outside this
+   route-surface workstream
 4. `QUA-783` analytical / PDE / FFT routes:
    `analytical_black76`, `vanilla_equity_theta_pde`, `pde_theta_1d`,
    `transform_fft`
-   Validation cohort: `T13`, `T39`, `T53`, `T73`, `T94`, `E21`, `E22`, `T103`
+   Validation cohort: `T13`, `T17`, `T39`, `T53`, `T73`, `T94`, `E21`, `E22`, `T103`
 5. `QUA-784` generic Monte Carlo and basket routes:
    `monte_carlo_paths`, `correlated_basket_monte_carlo`
    Validation cohort: `T37`, `T53`, `T102`, `T104`, `T126`, `E21`, `E22`, `E24`, `E26`
@@ -309,7 +313,7 @@ Status mirror last synced: `2026-04-12`
 | `QUA-732` | Compatibility cleanup: retire redundant route aliases after migrated-family adoption | Done |
 | `QUA-778` | Route surfaces: FX and quanto exact-helper routes stop emitting procedural authority | Done |
 | `QUA-782` | Route surfaces: credit and copula routes retire procedural authority behind backend helpers | Done |
-| `QUA-781` | Route surfaces: rate-tree routes retire procedural authority and stay task-backed | Backlog |
+| `QUA-781` | Route surfaces: rate-tree routes retire procedural authority and stay task-backed | Done |
 | `QUA-783` | Route surfaces: analytical Black76, PDE, and FFT routes retire procedural guidance | Backlog |
 | `QUA-784` | Route surfaces: generic Monte Carlo and basket routes collapse to family-first metadata | Backlog |
 | `QUA-785` | Route inventory: audit metadata-first residual route cards against representative tasks | Backlog |

--- a/docs/quant/lattice_algebra.rst
+++ b/docs/quant/lattice_algebra.rst
@@ -335,6 +335,7 @@ The checked helper-backed lattice routes remain:
 
 - ``trellis.models.callable_bond_tree.price_callable_bond_tree``
 - ``trellis.models.bermudan_swaption_tree.price_bermudan_swaption_tree``
+- ``trellis.models.zcb_option_tree.price_zcb_option_tree``
 
 Target API Design
 -----------------

--- a/docs/quant/pricing_stack.rst
+++ b/docs/quant/pricing_stack.rst
@@ -247,6 +247,12 @@ generic exotics runtime. The callable-bond slice now also projects callable
 analytics directly off that tree boundary: effective ``oas_duration`` plus a
 callable-specific scenario ladder that compares callable price, straight-bond
 reference price, and embedded call option value under parallel rate shocks.
+The same route-thinning rule now also applies to the short-rate ZCB-option
+cohort. ``zcb_option_rate_tree`` and ``zcb_option_analytical`` remain as
+backend-binding identities for the checked Hull-White tree and Jamshidian
+helpers, but the route cards no longer carry lattice-construction or
+short-rate-input assembly instructions once the helper surface already owns
+that work.
 
 Below those public callable wrappers, the reusable coupon/event/control layer
 now lives in ``trellis.models.short_rate_fixed_income``. Coupon schedule

--- a/tests/test_agent/test_codegen_guardrails.py
+++ b/tests/test_agent/test_codegen_guardrails.py
@@ -229,6 +229,62 @@ def test_generation_route_card_for_quanto_exact_helper_stays_helper_only():
     assert "apply_quanto_adjustment_terms" not in text
 
 
+def test_generation_route_card_for_zcb_option_analytical_stays_helper_only():
+    from trellis.agent.knowledge.decompose import decompose_to_ir
+
+    pricing_plan = PricingPlan(
+        method="analytical",
+        method_modules=["trellis.models.zcb_option"],
+        required_market_data={"discount_curve", "black_vol_surface"},
+        model_to_build="zcb_option",
+        reasoning="test",
+    )
+
+    plan = build_generation_plan(
+        pricing_plan=pricing_plan,
+        instrument_type="zcb_option",
+        inspected_modules=("trellis.models.zcb_option",),
+        product_ir=decompose_to_ir(
+            "ZCB option: Ho-Lee vs HW tree vs Jamshidian analytical",
+            instrument_type="zcb_option",
+        ),
+    )
+
+    text = render_generation_route_card(plan)
+
+    assert "price_zcb_option_jamshidian" in text
+    assert "resolve_zcb_option_hw_inputs" not in text
+    assert "zcb_option_hw_raw" not in text
+
+
+def test_generation_route_card_for_zcb_option_tree_stays_helper_only():
+    from trellis.agent.knowledge.decompose import decompose_to_ir
+
+    pricing_plan = PricingPlan(
+        method="rate_tree",
+        method_modules=["trellis.models.zcb_option_tree"],
+        required_market_data={"discount_curve", "black_vol_surface"},
+        model_to_build="zcb_option",
+        reasoning="test",
+    )
+
+    plan = build_generation_plan(
+        pricing_plan=pricing_plan,
+        instrument_type="zcb_option",
+        inspected_modules=("trellis.models.zcb_option_tree",),
+        product_ir=decompose_to_ir(
+            "ZCB option: Ho-Lee vs HW tree vs Jamshidian analytical",
+            instrument_type="zcb_option",
+        ),
+    )
+
+    text = render_generation_route_card(plan)
+
+    assert "price_zcb_option_tree" in text
+    assert "build_generic_lattice" not in text
+    assert "MODEL_REGISTRY" not in text
+
+
 def test_review_contract_card_renders_wrapper_route_and_validation_scope():
     compiled = compile_build_request(
         "European equity call on AAPL with strike 120 and expiry 2025-11-15",

--- a/tests/test_agent/test_platform_requests.py
+++ b/tests/test_agent/test_platform_requests.py
@@ -256,6 +256,38 @@ def test_compile_build_request_emits_fallback_lane_plan_for_american_tree_route(
     assert "price_vanilla_equity_option_tree" in " ".join(compiled.generation_plan.lane_construction_steps)
 
 
+def test_compile_build_request_keeps_explicit_zcb_option_off_generic_vanilla_semantics():
+    from trellis.agent.platform_requests import compile_build_request
+
+    compiled = compile_build_request(
+        (
+            "Build a pricer for: ZCB option: Ho-Lee vs HW tree vs Jamshidian analytical\n\n"
+            "European call option on a zero-coupon bond.\n"
+            "Settlement / valuation date: 2024-11-15.\n"
+            "Option expiry: 2027-11-15.\n"
+            "Underlying bond maturity: 2033-11-15.\n"
+            "Strike: 63 per 100 face (= 0.63 per unit face).\n"
+            "Face / notional: 100.\n"
+            "Shared short-rate comparison regime:\n"
+            "- flat discount curve at 5%\n"
+            "- flat short-rate volatility sigma = 0.01\n"
+            "- Hull-White mean reversion a = 0.1\n"
+            "- Ho-Lee uses the same sigma with zero mean reversion\n\n"
+            "Construct methods: rate_tree\n"
+            "Comparison targets: ho_lee_tree (rate_tree), hull_white_tree (rate_tree), jamshidian (analytical)"
+        ),
+        instrument_type="zcb_option",
+        preferred_method="rate_tree",
+    )
+
+    assert compiled.semantic_contract is None
+    assert compiled.product_ir is not None
+    assert compiled.product_ir.instrument == "zcb_option"
+    assert compiled.generation_plan is not None
+    assert compiled.generation_plan.primitive_plan is not None
+    assert compiled.generation_plan.primitive_plan.route == "zcb_option_rate_tree"
+
+
 def test_compile_build_request_emits_fallback_lane_plan_for_fx_monte_carlo_route():
     from trellis.agent.platform_requests import compile_build_request
 

--- a/tests/test_agent/test_primitive_planning.py
+++ b/tests/test_agent/test_primitive_planning.py
@@ -340,6 +340,7 @@ def test_builds_zcb_option_analytical_plan():
     assert plan.primitive_plan.route == "zcb_option_analytical"
     primitive_symbols = {primitive.symbol for primitive in plan.primitive_plan.primitives}
     assert primitive_symbols == {"price_zcb_option_jamshidian"}
+    assert plan.primitive_plan.adapters == ()
 
 
 def test_builds_zcb_option_rate_tree_plan():
@@ -368,6 +369,7 @@ def test_builds_zcb_option_rate_tree_plan():
     assert plan.primitive_plan.route == "zcb_option_rate_tree"
     primitive_symbols = {primitive.symbol for primitive in plan.primitive_plan.primitives}
     assert primitive_symbols == {"price_zcb_option_tree"}
+    assert plan.primitive_plan.adapters == ()
 
 
 def test_builds_exercise_lattice_plan_for_callable_bond():

--- a/tests/test_agent/test_rate_tree_generation.py
+++ b/tests/test_agent/test_rate_tree_generation.py
@@ -171,6 +171,35 @@ def test_callable_artifact_prices_plausibly_against_reference_tree():
     assert abs(artifact_price - reference_price) / reference_price < 0.05
 
 
+def test_callable_artifact_works_with_calibrated_model_parameters_only():
+    sys.path.insert(0, str(ROOT))
+    mod = import_module("trellis.instruments._agent.callablebond")
+    settle = date(2024, 11, 15)
+    market_state = MarketState(
+        as_of=settle,
+        settlement=settle,
+        discount=YieldCurve.flat(0.05, max_tenor=31.0),
+        model_parameters={
+            "model_family": "hull_white",
+            "mean_reversion": 0.03,
+            "sigma": 0.004,
+        },
+    )
+    spec = mod.CallableBondSpec(
+        notional=100.0,
+        coupon=0.05,
+        start_date=settle,
+        end_date=date(2034, 11, 15),
+        call_dates=(
+            date(2027, 11, 15),
+            date(2029, 11, 15),
+            date(2031, 11, 15),
+        ),
+    )
+
+    assert price_payoff(mod.CallableBondPayoff(spec), market_state) > 0.0
+
+
 def test_bermudan_artifact_prices_plausibly_against_reference_tree():
     sys.path.insert(0, str(ROOT))
     from tests.test_tasks.test_t04_bermudan_swaption import (
@@ -231,3 +260,29 @@ def test_bermudan_artifact_prices_plausibly_against_reference_tree():
     )
 
     assert abs(artifact_price - reference_price) / reference_price < 0.20
+
+
+def test_zcb_artifact_normalizes_quoted_option_type():
+    sys.path.insert(0, str(ROOT))
+    mod = import_module("trellis.instruments._agent.zcboption")
+    settle = date(2024, 11, 15)
+    market_state = MarketState(
+        as_of=settle,
+        settlement=settle,
+        discount=YieldCurve.flat(0.05, max_tenor=12.0),
+        vol_surface=FlatVol(0.20),
+        model_parameters={
+            "model_family": "hull_white",
+            "mean_reversion": 0.1,
+            "sigma": 0.01,
+        },
+    )
+    spec = mod.ZCBOptionSpec(
+        notional=100.0,
+        strike=63.0,
+        expiry_date=date(2027, 11, 15),
+        bond_maturity_date=date(2033, 11, 15),
+        option_type="'call'",
+    )
+
+    assert price_payoff(mod.ZCBOptionPayoff(spec), market_state) > 0.0

--- a/tests/test_agent/test_route_registry.py
+++ b/tests/test_agent/test_route_registry.py
@@ -762,6 +762,11 @@ class TestRateTreeRoutes:
         }
         assert _prim_set(new_prims) == expected_prims
 
+    def test_callable_bond_helper_route_is_thin(self, registry):
+        spec = [r for r in registry.routes if r.id == "exercise_lattice"][0]
+        notes = resolve_route_notes(spec, self.CALLABLE_IR)
+        assert notes == ()
+
     def test_puttable_bond_primitives(self, registry):
         spec = [r for r in registry.routes if r.id == "exercise_lattice"][0]
         new_prims = resolve_route_primitives(spec, self.PUTTABLE_IR)
@@ -778,6 +783,11 @@ class TestRateTreeRoutes:
         }
         assert _prim_set(new_prims) == expected_prims
 
+    def test_bermudan_swaption_helper_route_is_thin(self, registry):
+        spec = [r for r in registry.routes if r.id == "exercise_lattice"][0]
+        notes = resolve_route_notes(spec, self.BERMUDAN_IR)
+        assert notes == ()
+
     def test_rate_tree_swaption_primitives(self, registry):
         spec = [r for r in registry.routes if r.id == "rate_tree_backward_induction"][0]
         new_prims = resolve_route_primitives(spec, self.EUROPEAN_SWAPTION_IR)
@@ -786,10 +796,10 @@ class TestRateTreeRoutes:
         }
         assert _prim_set(new_prims) == expected_prims
 
-    def test_rate_tree_swaption_notes_pin_helper_backed_route(self, registry):
+    def test_rate_tree_swaption_helper_route_is_thin(self, registry):
         spec = [r for r in registry.routes if r.id == "rate_tree_backward_induction"][0]
         notes = resolve_route_notes(spec, self.EUROPEAN_SWAPTION_IR)
-        assert any("price_swaption_tree" in note for note in notes)
+        assert notes == ()
 
     def test_backward_induction_engine_family(self, registry):
         spec = [r for r in registry.routes if r.id == "rate_tree_backward_induction"][0]
@@ -872,11 +882,10 @@ class TestAnalyticalRoutes:
         }
         assert _prim_set(new_prims) == expected_prims
 
-    def test_zcb_notes_pin_resolved_jamshidian_lane(self, registry):
+    def test_zcb_analytical_route_is_thin(self, registry):
         spec = [r for r in registry.routes if r.id == "zcb_option_analytical"][0]
         notes = resolve_route_notes(spec, self.ZCB_IR)
-        assert any("resolve_zcb_option_hw_inputs" in note for note in notes)
-        assert any("zcb_option_hw_raw" in note for note in notes)
+        assert notes == ()
 
     def test_admissibility_rejects_pathwise_state_tags_on_black76(self, registry):
         from dataclasses import replace
@@ -927,6 +936,28 @@ class TestZCBRateTreeRoutes:
             ("trellis.models.zcb_option_tree", "price_zcb_option_tree", "route_helper"),
         }
         assert _prim_set(new_prims) == expected_prims
+
+    def test_zcb_rate_tree_route_is_thin(self, registry):
+        spec = [r for r in registry.routes if r.id == "zcb_option_rate_tree"][0]
+        notes = resolve_route_notes(spec, self.IR)
+        assert notes == ()
+
+
+def test_rate_tree_routes_keep_backend_binding_metadata_only(registry):
+    exercise = find_route_by_id("exercise_lattice", registry)
+    backward = find_route_by_id("rate_tree_backward_induction", registry)
+    zcb_tree = find_route_by_id("zcb_option_rate_tree", registry)
+    zcb_analytical = find_route_by_id("zcb_option_analytical", registry)
+
+    assert exercise is not None
+    assert backward is not None
+    assert zcb_tree is not None
+    assert zcb_analytical is not None
+
+    assert zcb_tree.adapters == ()
+    assert zcb_tree.notes == ()
+    assert zcb_analytical.adapters == ()
+    assert zcb_analytical.notes == ()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_agent/test_semantic_contracts.py
+++ b/tests/test_agent/test_semantic_contracts.py
@@ -215,6 +215,22 @@ def test_ranked_observation_basket_emits_typed_semantic_surface():
     assert contract.product.event_machine is not None
 
 
+def test_explicit_zcb_option_instrument_does_not_draft_generic_vanilla_option():
+    contract = _draft_contract(
+        (
+            "European call option on a zero-coupon bond. "
+            "Settlement / valuation date: 2024-11-15. "
+            "Option expiry: 2027-11-15. "
+            "Underlying bond maturity: 2033-11-15. "
+            "Strike: 63 per 100 face (= 0.63 per unit face). "
+            "Face / notional: 100."
+        ),
+        instrument_type="zcb_option",
+    )
+
+    assert contract is None
+
+
 def test_range_accrual_trade_entry_contract_validates_and_surfaces_term_fields():
     from trellis.agent.semantic_contract_validation import validate_semantic_contract
     from trellis.agent.semantic_contract_compiler import compile_semantic_contract

--- a/tests/test_agent/test_semantic_validators.py
+++ b/tests/test_agent/test_semantic_validators.py
@@ -272,6 +272,142 @@ def evaluate(self, market_state):
         findings = validator.validate(source, _make_plan("quanto_adjustment_analytical"), spec)
         assert any(f.category == "route_helper_signature_mismatch" for f in findings)
 
+    def test_flags_callable_bond_tree_helper_signature_mismatch(self, registry):
+        spec = [r for r in registry.routes if r.id == "exercise_lattice"][0]
+        callable_ir = ProductIR(
+            instrument="callable_bond",
+            payoff_family="callable_fixed_income",
+            exercise_style="issuer_call",
+            model_family="short_rate",
+        )
+        spec = replace(spec, primitives=resolve_route_primitives(spec, callable_ir))
+        source = '''
+from trellis.models.callable_bond_tree import price_callable_bond_tree
+
+def evaluate(self, market_state):
+    return price_callable_bond_tree(spec=self._spec, market_state=market_state, maturity=5.0)
+'''
+        validator = AlgorithmContractValidator()
+        findings = validator.validate(source, _make_plan("exercise_lattice", "lattice"), spec)
+        assert any(f.category == "route_helper_signature_mismatch" for f in findings)
+
+    def test_accepts_callable_bond_tree_helper_surface(self, registry):
+        spec = [r for r in registry.routes if r.id == "exercise_lattice"][0]
+        callable_ir = ProductIR(
+            instrument="callable_bond",
+            payoff_family="callable_fixed_income",
+            exercise_style="issuer_call",
+            model_family="short_rate",
+        )
+        spec = replace(spec, primitives=resolve_route_primitives(spec, callable_ir))
+        source = '''
+from trellis.models.callable_bond_tree import price_callable_bond_tree
+
+def evaluate(self, market_state):
+    return price_callable_bond_tree(market_state, self._spec, model="hull_white", sigma=0.01)
+'''
+        validator = AlgorithmContractValidator()
+        findings = validator.validate(source, _make_plan("exercise_lattice", "lattice"), spec)
+        assert not any(f.category == "route_helper_signature_mismatch" for f in findings)
+
+    def test_flags_rate_tree_swaption_helper_signature_mismatch(self, registry):
+        spec = [r for r in registry.routes if r.id == "rate_tree_backward_induction"][0]
+        swaption_ir = ProductIR(
+            instrument="swaption",
+            payoff_family="swaption",
+            exercise_style="european",
+            model_family="interest_rate",
+        )
+        spec = replace(spec, primitives=resolve_route_primitives(spec, swaption_ir))
+        source = '''
+from trellis.models.rate_style_swaption_tree import price_swaption_tree
+
+def evaluate(self, market_state):
+    return price_swaption_tree(spec=self._spec, market_state=market_state, exercise_steps=12)
+'''
+        validator = AlgorithmContractValidator()
+        findings = validator.validate(source, _make_plan("rate_tree_backward_induction", "lattice"), spec)
+        assert any(f.category == "route_helper_signature_mismatch" for f in findings)
+
+    def test_accepts_rate_tree_swaption_helper_surface(self, registry):
+        spec = [r for r in registry.routes if r.id == "rate_tree_backward_induction"][0]
+        swaption_ir = ProductIR(
+            instrument="swaption",
+            payoff_family="swaption",
+            exercise_style="european",
+            model_family="interest_rate",
+        )
+        spec = replace(spec, primitives=resolve_route_primitives(spec, swaption_ir))
+        source = '''
+from trellis.models.rate_style_swaption_tree import price_swaption_tree
+
+def evaluate(self, market_state):
+    return price_swaption_tree(market_state, self._spec, model="hull_white", mean_reversion=0.05)
+'''
+        validator = AlgorithmContractValidator()
+        findings = validator.validate(source, _make_plan("rate_tree_backward_induction", "lattice"), spec)
+        assert not any(f.category == "route_helper_signature_mismatch" for f in findings)
+
+    def test_flags_zcb_option_tree_helper_signature_mismatch(self, registry):
+        spec = [r for r in registry.routes if r.id == "zcb_option_rate_tree"][0]
+        zcb_ir = ProductIR(
+            instrument="zcb_option",
+            payoff_family="zcb_option",
+            exercise_style="european",
+        )
+        spec = replace(spec, primitives=resolve_route_primitives(spec, zcb_ir))
+        source = '''
+from trellis.models.zcb_option_tree import price_zcb_option_tree
+
+def evaluate(self, market_state):
+    return price_zcb_option_tree(self._spec, market_state, steps=100)
+'''
+        validator = AlgorithmContractValidator()
+        findings = validator.validate(source, _make_plan("zcb_option_rate_tree", "lattice"), spec)
+        assert any(f.category == "route_helper_signature_mismatch" for f in findings)
+
+    def test_accepts_zcb_option_tree_helper_surface(self, registry):
+        spec = [r for r in registry.routes if r.id == "zcb_option_rate_tree"][0]
+        zcb_ir = ProductIR(
+            instrument="zcb_option",
+            payoff_family="zcb_option",
+            exercise_style="european",
+        )
+        spec = replace(spec, primitives=resolve_route_primitives(spec, zcb_ir))
+        source = '''
+from trellis.models.zcb_option_tree import price_zcb_option_tree
+
+def evaluate(self, market_state):
+    return price_zcb_option_tree(market_state, self._spec, model="ho_lee", n_steps=200)
+'''
+        validator = AlgorithmContractValidator()
+        findings = validator.validate(source, _make_plan("zcb_option_rate_tree", "lattice"), spec)
+        assert not any(f.category == "route_helper_signature_mismatch" for f in findings)
+
+    def test_flags_zcb_option_jamshidian_helper_signature_mismatch(self, registry):
+        spec = [r for r in registry.routes if r.id == "zcb_option_analytical"][0]
+        source = '''
+from trellis.models.zcb_option import price_zcb_option_jamshidian
+
+def evaluate(self, market_state):
+    return price_zcb_option_jamshidian(self._spec, market_state, strike=0.63)
+'''
+        validator = AlgorithmContractValidator()
+        findings = validator.validate(source, _make_plan("zcb_option_analytical"), spec)
+        assert any(f.category == "route_helper_signature_mismatch" for f in findings)
+
+    def test_accepts_zcb_option_jamshidian_helper_surface(self, registry):
+        spec = [r for r in registry.routes if r.id == "zcb_option_analytical"][0]
+        source = '''
+from trellis.models.zcb_option import price_zcb_option_jamshidian
+
+def evaluate(self, market_state):
+    return price_zcb_option_jamshidian(market_state, self._spec, mean_reversion=0.1)
+'''
+        validator = AlgorithmContractValidator()
+        findings = validator.validate(source, _make_plan("zcb_option_analytical"), spec)
+        assert not any(f.category == "route_helper_signature_mismatch" for f in findings)
+
     def test_flags_credit_default_swap_analytical_helper_signature_mismatch(self, registry):
         spec = [r for r in registry.routes if r.id == "credit_default_swap_analytical"][0]
         source = '''
@@ -309,6 +445,25 @@ def evaluate(self, market_state):
         validator = AlgorithmContractValidator()
         findings = validator.validate(source, _make_plan("credit_default_swap_analytical"), spec)
         assert not any(f.category == "route_helper_signature_mismatch" for f in findings)
+
+    def test_rejects_credit_default_swap_analytical_positional_calls(self, registry):
+        spec = [r for r in registry.routes if r.id == "credit_default_swap_analytical"][0]
+        source = '''
+from trellis.models.credit_default_swap import price_cds_analytical
+
+def evaluate(self, market_state):
+    return price_cds_analytical(
+        self._spec.notional,
+        self._spec.spread_quote,
+        self._spec.recovery,
+        schedule,
+        market_state.credit_curve,
+        market_state.discount_curve,
+    )
+'''
+        validator = AlgorithmContractValidator()
+        findings = validator.validate(source, _make_plan("credit_default_swap_analytical"), spec)
+        assert any(f.category == "route_helper_signature_mismatch" for f in findings)
 
     def test_flags_credit_default_swap_monte_carlo_helper_signature_mismatch(self, registry):
         spec = [r for r in registry.routes if r.id == "credit_default_swap_monte_carlo"][0]
@@ -351,6 +506,26 @@ def evaluate(self, market_state):
         findings = validator.validate(source, _make_plan("credit_default_swap_monte_carlo", "monte_carlo"), spec)
         assert not any(f.category == "route_helper_signature_mismatch" for f in findings)
 
+    def test_rejects_credit_default_swap_monte_carlo_positional_calls(self, registry):
+        spec = [r for r in registry.routes if r.id == "credit_default_swap_monte_carlo"][0]
+        source = '''
+from trellis.models.credit_default_swap import price_cds_monte_carlo
+
+def evaluate(self, market_state):
+    return price_cds_monte_carlo(
+        self._spec.notional,
+        self._spec.spread_quote,
+        self._spec.recovery,
+        schedule,
+        market_state.credit_curve,
+        market_state.discount_curve,
+        self._spec.n_paths,
+    )
+'''
+        validator = AlgorithmContractValidator()
+        findings = validator.validate(source, _make_plan("credit_default_swap_monte_carlo", "monte_carlo"), spec)
+        assert any(f.category == "route_helper_signature_mismatch" for f in findings)
+
     def test_flags_nth_to_default_helper_signature_mismatch(self, registry):
         spec = [r for r in registry.routes if r.id == "nth_to_default_monte_carlo"][0]
         source = '''
@@ -392,6 +567,27 @@ def evaluate(self, market_state):
         validator = AlgorithmContractValidator()
         findings = validator.validate(source, _make_plan("nth_to_default_monte_carlo", "monte_carlo"), spec)
         assert not any(f.category == "route_helper_signature_mismatch" for f in findings)
+
+    def test_rejects_nth_to_default_positional_calls(self, registry):
+        spec = [r for r in registry.routes if r.id == "nth_to_default_monte_carlo"][0]
+        source = '''
+from trellis.instruments.nth_to_default import price_nth_to_default_basket
+
+def evaluate(self, market_state):
+    return price_nth_to_default_basket(
+        self._spec.notional,
+        len(self._spec.reference_entities),
+        self._spec.nth_default,
+        self._spec.horizon,
+        self._spec.correlation,
+        self._spec.recovery,
+        market_state.credit_curve,
+        market_state.discount_curve,
+    )
+'''
+        validator = AlgorithmContractValidator()
+        findings = validator.validate(source, _make_plan("nth_to_default_monte_carlo", "monte_carlo"), spec)
+        assert any(f.category == "route_helper_signature_mismatch" for f in findings)
 
     def test_flags_credit_basket_tranche_helper_signature_mismatch(self, registry):
         spec = [r for r in registry.routes if r.id == "copula_loss_distribution"][0]

--- a/tests/test_agent/test_semantic_validators.py
+++ b/tests/test_agent/test_semantic_validators.py
@@ -310,6 +310,25 @@ def evaluate(self, market_state):
         findings = validator.validate(source, _make_plan("exercise_lattice", "lattice"), spec)
         assert not any(f.category == "route_helper_signature_mismatch" for f in findings)
 
+    def test_rejects_callable_bond_tree_positional_optional_argument(self, registry):
+        spec = [r for r in registry.routes if r.id == "exercise_lattice"][0]
+        callable_ir = ProductIR(
+            instrument="callable_bond",
+            payoff_family="callable_fixed_income",
+            exercise_style="issuer_call",
+            model_family="short_rate",
+        )
+        spec = replace(spec, primitives=resolve_route_primitives(spec, callable_ir))
+        source = '''
+from trellis.models.callable_bond_tree import price_callable_bond_tree
+
+def evaluate(self, market_state):
+    return price_callable_bond_tree(market_state, self._spec, "hull_white")
+'''
+        validator = AlgorithmContractValidator()
+        findings = validator.validate(source, _make_plan("exercise_lattice", "lattice"), spec)
+        assert any(f.category == "route_helper_signature_mismatch" for f in findings)
+
     def test_flags_rate_tree_swaption_helper_signature_mismatch(self, registry):
         spec = [r for r in registry.routes if r.id == "rate_tree_backward_induction"][0]
         swaption_ir = ProductIR(
@@ -407,6 +426,18 @@ def evaluate(self, market_state):
         validator = AlgorithmContractValidator()
         findings = validator.validate(source, _make_plan("zcb_option_analytical"), spec)
         assert not any(f.category == "route_helper_signature_mismatch" for f in findings)
+
+    def test_rejects_zcb_option_jamshidian_positional_optional_argument(self, registry):
+        spec = [r for r in registry.routes if r.id == "zcb_option_analytical"][0]
+        source = '''
+from trellis.models.zcb_option import price_zcb_option_jamshidian
+
+def evaluate(self, market_state):
+    return price_zcb_option_jamshidian(market_state, self._spec, 0.1)
+'''
+        validator = AlgorithmContractValidator()
+        findings = validator.validate(source, _make_plan("zcb_option_analytical"), spec)
+        assert any(f.category == "route_helper_signature_mismatch" for f in findings)
 
     def test_flags_credit_default_swap_analytical_helper_signature_mismatch(self, registry):
         spec = [r for r in registry.routes if r.id == "credit_default_swap_analytical"][0]

--- a/trellis/agent/knowledge/canonical/routes.yaml
+++ b/trellis/agent/knowledge/canonical/routes.yaml
@@ -568,10 +568,7 @@ routes:
             symbol: price_callable_bond_tree
             role: route_helper
         adapters: []
-        notes:
-          - "Use `trellis.models.callable_bond_tree.price_callable_bond_tree(...)` directly inside `evaluate()` for callable or puttable bond tree routes."
-          - "Treat callable-bond tree generation as a thin adapter over the checked-in helper; do not rebuild lattice assembly, coupon maps, or exercise-step logic inline."
-          - "Keep volatility access explicit in the adapter with `market_state.vol_surface.black_vol(...)` before passing control to the helper."
+        notes: []
       - when:
           payoff_family: swaption
           exercise_style: [bermudan]
@@ -581,10 +578,7 @@ routes:
             symbol: price_bermudan_swaption_tree
             role: route_helper
         adapters: []
-        notes:
-          - "Use `trellis.models.bermudan_swaption_tree.price_bermudan_swaption_tree(...)` directly inside `evaluate()` for Bermudan swaption tree routes."
-          - "Treat Bermudan swaption tree generation as a thin adapter over the checked-in helper; do not rebuild swap-value rollback, fixed-leg maps, or exercise-step logic inline."
-          - "Keep volatility access explicit in the adapter with `market_state.vol_surface.black_vol(...)` before passing control to the helper."
+        notes: []
       - when: default
         primitives:
           - module: trellis.models.trees.lattice
@@ -621,17 +615,8 @@ routes:
             symbol: lattice_steps_from_timeline
             role: step_mapper
             required: false
-        adapters:
-          - map_cashflows_and_exercise_dates_to_tree_steps
-          - resolve_schedule_dependent_lattice_control_policy
-        notes:
-          - "Use lattice_backward_induction with a checked-in lattice exercise policy for callable, puttable, and Bermudan products."
-          - "Keep volatility access explicit in the adapter with `market_state.vol_surface.black_vol(...)` before converting Black vol into the rate-tree volatility parameter."
-          - "For model-specific calibrated trees such as BDT or explicit Hull-White comparisons, import `build_generic_lattice` from `trellis.models.trees.lattice` and `MODEL_REGISTRY` from `trellis.models.trees.models`."
-          - "Use `market_state.discount.zero_rate(...)`, not `market_state.zero_rate(...)`, when reading the short-rate seed from the market state."
-          - "Prefer the checked-in product-specific helper when one exists, such as `price_callable_bond_tree(...)` for callable bonds or `price_bermudan_swaption_tree(...)` for Bermudan swaptions."
-          - "Prefer resolve_lattice_exercise_policy(...) so issuer-call, holder-put, and Bermudan semantics stay explicit instead of repeating exercise_type/exercise_fn conventions inline."
-          - "Treat `trellis.models.trees.control` as the lattice-timeline facade: timeline builders live there alongside `lattice_step_from_time(...)` and `lattice_steps_from_timeline(...)`."
+        adapters: []
+        notes: []
     market_data_access:
       required:
         discount_curve: [market_state.discount]
@@ -671,10 +656,7 @@ routes:
             symbol: price_swaption_tree
             role: route_helper
         adapters: []
-        notes:
-          - "For single-exercise European rate-style swaptions on the rate-tree route, prefer `trellis.models.rate_style_swaption_tree.price_swaption_tree(...)`."
-          - "Treat the rate-tree swaption build as a thin adapter over the checked-in helper; do not rebuild exercise-step selection, swap rollback, or lattice payoff glue inline."
-          - "The checked-in helper assumes the live forward-starting European surface where `spec.swap_start == spec.expiry_date`."
+        notes: []
       - when: default
         primitives:
           - module: trellis.models.trees.lattice
@@ -683,13 +665,8 @@ routes:
           - module: trellis.models.trees.lattice
             symbol: lattice_backward_induction
             role: backward_induction
-        adapters:
-          - map_cashflows_and_exercise_dates_to_tree_steps
-        notes:
-          - "Use calibrated rate-tree primitives for scheduled early-exercise products."
-          - "The real Hull-White convenience-builder contract is `build_rate_lattice(r0, sigma_hw, mean_reversion, T, n_steps, discount_curve=market_state.discount)`."
-          - "Do not invent keyword-only variants such as `maturity=...`, `steps=...`, or `market_state=...` when calling `build_rate_lattice(...)`."
-          - "For explicit model selection, prefer `build_generic_lattice(MODEL_REGISTRY[\"hull_white\"|\"ho_lee\"|\"bdt\"], r0=..., sigma=..., a=..., T=..., n_steps=..., discount_curve=market_state.discount)`."
+        adapters: []
+        notes: []
     market_data_access:
       required:
         discount_curve: [market_state.discount]
@@ -718,13 +695,8 @@ routes:
       - module: trellis.models.zcb_option_tree
         symbol: price_zcb_option_tree
         role: route_helper
-    adapters:
-      - reuse_checked_in_zcb_option_tree_helper
-    notes:
-      - "For zero-coupon bond option trees, prefer `price_zcb_option_tree(market_state, spec, model=\"ho_lee\"|\"hull_white\")` so the adapter stays thin."
-      - "Map `implementation_target=ho_lee_tree` to `model=\"ho_lee\"` and `implementation_target=hull_white_tree` to `model=\"hull_white\"`."
-      - "If you must drop to lower-level lattice assembly, import `build_generic_lattice` from `trellis.models.trees.lattice` and `MODEL_REGISTRY` from `trellis.models.trees.models`."
-      - "When building the lower-level tree directly, use `MODEL_REGISTRY[\"ho_lee\"]` or `MODEL_REGISTRY[\"hull_white\"]`, seed `r0` from `market_state.discount.zero_rate(...)`, read vol from `market_state.vol_surface.black_vol(...)`, and cover the full `spec.bond_maturity_date` horizon."
+    adapters: []
+    notes: []
     market_data_access:
       required:
         discount_curve: [market_state.discount]
@@ -890,14 +862,8 @@ routes:
       - module: trellis.models.zcb_option
         symbol: price_zcb_option_jamshidian
         role: route_helper
-    adapters:
-      - reuse_checked_in_zcb_option_analytical_helper
-    notes:
-      - "For European zero-coupon bond option analytics, prefer `price_zcb_option_jamshidian(market_state, spec, mean_reversion=...)` from `trellis.models.zcb_option`."
-      - "If you need the resolved-input lane under that wrapper, use `resolve_zcb_option_hw_inputs(...)` from `trellis.models.zcb_option`, then delegate the traced kernel to `zcb_option_hw_raw(...)` from `trellis.models.analytical.jamshidian`."
-      - "Do not fall back to Black76 on a forward bond price when the request explicitly asks for Jamshidian / Hull-White."
-      - "Normalize strike quotes to unit face before the closed-form kernel: treat `63` on `100` face as `0.63`."
-      - "Use `spec.expiry_date` and `spec.bond_maturity_date`; the underlying bond maturity must be strictly after expiry."
+    adapters: []
+    notes: []
     market_data_access:
       required:
         discount_curve: [market_state.discount]

--- a/trellis/agent/semantic_contracts.py
+++ b/trellis/agent/semantic_contracts.py
@@ -4677,6 +4677,16 @@ def _normalize_instrument_alias(instrument_type: str | None) -> str:
     return str(instrument_type or "").strip().lower().replace(" ", "_")
 
 
+_GENERIC_SEMANTIC_DRAFT_ALIASES = frozenset({
+    "",
+    "option",
+    "product",
+    "instrument",
+    "derivative",
+    "security",
+})
+
+
 def _matches_semantic_draft_profile(
     text: str,
     instrument_type: str | None,
@@ -4686,8 +4696,11 @@ def _matches_semantic_draft_profile(
     """Return whether request text/instrument matches one declarative drafting profile."""
     lower = text.lower()
     normalized_instrument = _normalize_instrument_alias(instrument_type)
-    if normalized_instrument and normalized_instrument in profile.instrument_aliases:
-        return True
+    if normalized_instrument:
+        if normalized_instrument in profile.instrument_aliases:
+            return True
+        if normalized_instrument not in _GENERIC_SEMANTIC_DRAFT_ALIASES:
+            return False
     if any(cue in lower for cue in profile.negative_cues):
         return False
     return any(cue in lower for cue in profile.positive_cues)

--- a/trellis/agent/semantic_validators/algorithm_contract.py
+++ b/trellis/agent/semantic_validators/algorithm_contract.py
@@ -115,6 +115,7 @@ _EXACT_HELPER_SIGNATURES = {
     },
     "price_vanilla_equity_option_tree": {
         "min_positional_args": 2,
+        "max_positional_args": 2,
         "required_parameters": ("market_state", "spec"),
         "required_keyword_groups": (frozenset({"market_state", "spec"}),),
         "allowed_keywords": frozenset({"market_state", "spec", "model", "n_steps"}),
@@ -130,6 +131,7 @@ _EXACT_HELPER_SIGNATURES = {
     },
     "price_callable_bond_tree": {
         "min_positional_args": 2,
+        "max_positional_args": 2,
         "required_parameters": ("market_state", "spec"),
         "required_keyword_groups": (frozenset({"market_state", "spec"}),),
         "allowed_keywords": frozenset({"market_state", "spec", "model", "mean_reversion", "sigma", "n_steps"}),
@@ -146,6 +148,7 @@ _EXACT_HELPER_SIGNATURES = {
     },
     "price_bermudan_swaption_tree": {
         "min_positional_args": 2,
+        "max_positional_args": 2,
         "required_parameters": ("market_state", "spec"),
         "required_keyword_groups": (frozenset({"market_state", "spec"}),),
         "allowed_keywords": frozenset({"market_state", "spec", "model", "mean_reversion", "sigma", "n_steps"}),
@@ -162,6 +165,7 @@ _EXACT_HELPER_SIGNATURES = {
     },
     "price_swaption_tree": {
         "min_positional_args": 2,
+        "max_positional_args": 2,
         "required_parameters": ("market_state", "spec"),
         "required_keyword_groups": (frozenset({"market_state", "spec"}),),
         "allowed_keywords": frozenset({"market_state", "spec", "model", "mean_reversion", "sigma", "n_steps"}),
@@ -178,6 +182,7 @@ _EXACT_HELPER_SIGNATURES = {
     },
     "price_fx_vanilla_analytical": {
         "min_positional_args": 2,
+        "max_positional_args": 2,
         "required_parameters": ("market_state", "spec"),
         "required_keyword_groups": (frozenset({"market_state", "spec"}),),
         "allowed_keywords": frozenset({"market_state", "spec"}),
@@ -193,6 +198,7 @@ _EXACT_HELPER_SIGNATURES = {
     },
     "price_fx_vanilla_monte_carlo": {
         "min_positional_args": 2,
+        "max_positional_args": 2,
         "required_parameters": ("market_state", "spec"),
         "required_keyword_groups": (frozenset({"market_state", "spec"}),),
         "allowed_keywords": frozenset({"market_state", "spec", "seed"}),
@@ -249,6 +255,7 @@ _EXACT_HELPER_SIGNATURES = {
     },
     "price_credit_basket_tranche": {
         "min_positional_args": 2,
+        "max_positional_args": 2,
         "required_parameters": ("market_state", "spec"),
         "required_keyword_groups": (frozenset({"market_state", "spec"}),),
         "allowed_keywords": frozenset({
@@ -272,6 +279,7 @@ _EXACT_HELPER_SIGNATURES = {
     },
     "price_zcb_option_tree": {
         "min_positional_args": 2,
+        "max_positional_args": 2,
         "required_parameters": ("market_state", "spec"),
         "required_keyword_groups": (frozenset({"market_state", "spec"}),),
         "allowed_keywords": frozenset({"market_state", "spec", "model", "mean_reversion", "sigma", "n_steps"}),
@@ -288,6 +296,7 @@ _EXACT_HELPER_SIGNATURES = {
     },
     "price_zcb_option_jamshidian": {
         "min_positional_args": 2,
+        "max_positional_args": 2,
         "required_parameters": ("market_state", "spec"),
         "required_keyword_groups": (frozenset({"market_state", "spec"}),),
         "allowed_keywords": frozenset({"market_state", "spec", "mean_reversion"}),
@@ -570,6 +579,10 @@ def _call_satisfies_required_surface(
     keyword_surface_ok: bool,
 ) -> bool:
     """Return whether one helper call satisfies the declared required surface."""
+    max_positional_args = signature.get("max_positional_args")
+    if max_positional_args is not None and len(call.args) > int(max_positional_args):
+        return False
+
     if bool(signature.get("keyword_only")) and call.args:
         return False
 

--- a/trellis/agent/semantic_validators/algorithm_contract.py
+++ b/trellis/agent/semantic_validators/algorithm_contract.py
@@ -42,6 +42,7 @@ _DISCOUNT_PATTERNS = (
 _EXACT_HELPER_SIGNATURES = {
     "price_cds_analytical": {
         "min_positional_args": 0,
+        "keyword_only": True,
         "required_parameters": (
             "notional",
             "spread_quote",
@@ -77,6 +78,7 @@ _EXACT_HELPER_SIGNATURES = {
     },
     "price_cds_monte_carlo": {
         "min_positional_args": 0,
+        "keyword_only": True,
         "required_parameters": (
             "notional",
             "spread_quote",
@@ -126,6 +128,54 @@ _EXACT_HELPER_SIGNATURES = {
             "`expiry_date`, and optional exercise fields instead of inventing helper keywords."
         ),
     },
+    "price_callable_bond_tree": {
+        "min_positional_args": 2,
+        "required_parameters": ("market_state", "spec"),
+        "required_keyword_groups": (frozenset({"market_state", "spec"}),),
+        "allowed_keywords": frozenset({"market_state", "spec", "model", "mean_reversion", "sigma", "n_steps"}),
+        "required_positional_markers": (
+            frozenset({"market_state"}),
+            frozenset({"spec", "_spec"}),
+        ),
+        "message": (
+            "`price_callable_bond_tree(...)` expects `(market_state, spec, *, "
+            "model=..., mean_reversion=..., sigma=..., n_steps=...)`. "
+            "Pass the live market state and original callable/puttable bond spec "
+            "instead of inventing lattice-builder keywords."
+        ),
+    },
+    "price_bermudan_swaption_tree": {
+        "min_positional_args": 2,
+        "required_parameters": ("market_state", "spec"),
+        "required_keyword_groups": (frozenset({"market_state", "spec"}),),
+        "allowed_keywords": frozenset({"market_state", "spec", "model", "mean_reversion", "sigma", "n_steps"}),
+        "required_positional_markers": (
+            frozenset({"market_state"}),
+            frozenset({"spec", "_spec"}),
+        ),
+        "message": (
+            "`price_bermudan_swaption_tree(...)` expects `(market_state, spec, *, "
+            "model=..., mean_reversion=..., sigma=..., n_steps=...)`. "
+            "Pass the live market state and the original Bermudan swaption spec "
+            "instead of rebuilding lattice rollback or exercise glue inline."
+        ),
+    },
+    "price_swaption_tree": {
+        "min_positional_args": 2,
+        "required_parameters": ("market_state", "spec"),
+        "required_keyword_groups": (frozenset({"market_state", "spec"}),),
+        "allowed_keywords": frozenset({"market_state", "spec", "model", "mean_reversion", "sigma", "n_steps"}),
+        "required_positional_markers": (
+            frozenset({"market_state"}),
+            frozenset({"spec", "_spec"}),
+        ),
+        "message": (
+            "`price_swaption_tree(...)` expects `(market_state, spec, *, "
+            "model=..., mean_reversion=..., sigma=..., n_steps=...)`. "
+            "Pass the live market state and the original European rate-style swaption spec "
+            "instead of inventing exercise-step or lattice-builder keywords."
+        ),
+    },
     "price_fx_vanilla_analytical": {
         "min_positional_args": 2,
         "required_parameters": ("market_state", "spec"),
@@ -158,6 +208,7 @@ _EXACT_HELPER_SIGNATURES = {
     },
     "price_nth_to_default_basket": {
         "min_positional_args": 0,
+        "keyword_only": True,
         "required_parameters": (
             "notional",
             "n_names",
@@ -217,6 +268,37 @@ _EXACT_HELPER_SIGNATURES = {
             "copula_family=..., degrees_of_freedom=..., n_paths=..., seed=...)`. "
             "Pass the live market state and original tranche spec instead of "
             "rebuilding copula loss plumbing inline."
+        ),
+    },
+    "price_zcb_option_tree": {
+        "min_positional_args": 2,
+        "required_parameters": ("market_state", "spec"),
+        "required_keyword_groups": (frozenset({"market_state", "spec"}),),
+        "allowed_keywords": frozenset({"market_state", "spec", "model", "mean_reversion", "sigma", "n_steps"}),
+        "required_positional_markers": (
+            frozenset({"market_state"}),
+            frozenset({"spec", "_spec"}),
+        ),
+        "message": (
+            "`price_zcb_option_tree(...)` expects `(market_state, spec, *, "
+            "model=..., mean_reversion=..., sigma=..., n_steps=...)`. "
+            "Pass the live market state and original ZCB-option spec instead of "
+            "inventing direct lattice-builder keywords."
+        ),
+    },
+    "price_zcb_option_jamshidian": {
+        "min_positional_args": 2,
+        "required_parameters": ("market_state", "spec"),
+        "required_keyword_groups": (frozenset({"market_state", "spec"}),),
+        "allowed_keywords": frozenset({"market_state", "spec", "mean_reversion"}),
+        "required_positional_markers": (
+            frozenset({"market_state"}),
+            frozenset({"spec", "_spec"}),
+        ),
+        "message": (
+            "`price_zcb_option_jamshidian(...)` expects `(market_state, spec, *, "
+            "mean_reversion=...)`. Pass the live market state and original ZCB-option "
+            "spec instead of resolved inputs or ad hoc strike plumbing."
         ),
     },
     "price_quanto_option_analytical_from_market_state": {
@@ -488,6 +570,9 @@ def _call_satisfies_required_surface(
     keyword_surface_ok: bool,
 ) -> bool:
     """Return whether one helper call satisfies the declared required surface."""
+    if bool(signature.get("keyword_only")) and call.args:
+        return False
+
     required_parameters = tuple(str(item) for item in signature.get("required_parameters", ()) or ())
     positional_markers = tuple(signature.get("required_positional_markers", ()) or ())
 

--- a/trellis/instruments/_agent/bermudanswaption.py
+++ b/trellis/instruments/_agent/bermudanswaption.py
@@ -17,10 +17,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import date
 
-from trellis.core.date_utils import generate_schedule, year_fraction
 from trellis.core.market_state import MarketState
 from trellis.core.types import DayCountConvention, Frequency
-from trellis.models.black import black76_call, black76_put
+from trellis.models.rate_style_swaption import price_bermudan_swaption_black76_lower_bound
 
 
 
@@ -77,8 +76,4 @@ Implementation target: black76_european_lower_bound."""
 
     def evaluate(self, market_state: MarketState) -> float:
         spec = self._spec
-        spec = self._spec
-        from trellis.models.rate_style_swaption import price_bermudan_swaption_black76_lower_bound
-
-        # Thin analytical adapter: delegate to the checked-in route helper.
         return float(price_bermudan_swaption_black76_lower_bound(market_state, spec))

--- a/trellis/instruments/_agent/callablebond.py
+++ b/trellis/instruments/_agent/callablebond.py
@@ -72,15 +72,13 @@ Implementation target: hw_rate_tree."""
 
     @property
     def requirements(self) -> set[str]:
-        return {"black_vol_surface", "discount_curve"}
+        return {"discount_curve"}
 
     def evaluate(self, market_state: MarketState) -> float:
         spec = self._spec
 
         if market_state.discount is None:
             raise ValueError("CallableBondPayoff requires a discount curve in market_state")
-        if market_state.vol_surface is None:
-            raise ValueError("CallableBondPayoff requires a black vol surface in market_state")
 
         # Thin adapter to the checked-in callable bond tree helper.
         return float(

--- a/trellis/instruments/_agent/callablebond.py
+++ b/trellis/instruments/_agent/callablebond.py
@@ -1,15 +1,5 @@
 """Agent-generated payoff: Build a pricer for: Callable bond: HW rate PDE (PSOR) vs HW tree
 
-Price a 10-year callable bond paying a 5% semi-annual coupon, par $100,
-callable at par on any coupon date after year 3.
-Use the USD OIS discount curve from the market snapshot (as_of 2024-11-15).
-Hull-White model: mean reversion a=0.05, short-rate vol sigma=0.01.
-Method 1: solve the HW rate PDE backward in time using PSOR to
-enforce the call constraint (issuer calls when continuation value > par).
-Method 2: Hull-White trinomial/binomial rate tree for comparison.
-Both methods should agree within 1%.
-Compute callable bond price and option-adjusted spread (OAS).
-
 Construct methods: pde_solver, rate_tree
 Comparison targets: hw_pde_psor (pde_solver), hw_rate_tree (rate_tree)
 Cross-validation harness:
@@ -37,16 +27,6 @@ from trellis.models.callable_bond_tree import price_callable_bond_tree
 class CallableBondSpec:
     """Specification for Build a pricer for: Callable bond: HW rate PDE (PSOR) vs HW tree
 
-Price a 10-year callable bond paying a 5% semi-annual coupon, par $100,
-callable at par on any coupon date after year 3.
-Use the USD OIS discount curve from the market snapshot (as_of 2024-11-15).
-Hull-White model: mean reversion a=0.05, short-rate vol sigma=0.01.
-Method 1: solve the HW rate PDE backward in time using PSOR to
-enforce the call constraint (issuer calls when continuation value > par).
-Method 2: Hull-White trinomial/binomial rate tree for comparison.
-Both methods should agree within 1%.
-Compute callable bond price and option-adjusted spread (OAS).
-
 Construct methods: pde_solver, rate_tree
 Comparison targets: hw_pde_psor (pde_solver), hw_rate_tree (rate_tree)
 Cross-validation harness:
@@ -70,16 +50,6 @@ Implementation target: hw_rate_tree."""
 
 class CallableBondPayoff:
     """Build a pricer for: Callable bond: HW rate PDE (PSOR) vs HW tree
-
-Price a 10-year callable bond paying a 5% semi-annual coupon, par $100,
-callable at par on any coupon date after year 3.
-Use the USD OIS discount curve from the market snapshot (as_of 2024-11-15).
-Hull-White model: mean reversion a=0.05, short-rate vol sigma=0.01.
-Method 1: solve the HW rate PDE backward in time using PSOR to
-enforce the call constraint (issuer calls when continuation value > par).
-Method 2: Hull-White trinomial/binomial rate tree for comparison.
-Both methods should agree within 1%.
-Compute callable bond price and option-adjusted spread (OAS).
 
 Construct methods: pde_solver, rate_tree
 Comparison targets: hw_pde_psor (pde_solver), hw_rate_tree (rate_tree)
@@ -106,4 +76,17 @@ Implementation target: hw_rate_tree."""
 
     def evaluate(self, market_state: MarketState) -> float:
         spec = self._spec
-        return float(price_callable_bond_tree(market_state, spec, model="hull_white"))
+
+        if market_state.discount is None:
+            raise ValueError("CallableBondPayoff requires a discount curve in market_state")
+        if market_state.vol_surface is None:
+            raise ValueError("CallableBondPayoff requires a black vol surface in market_state")
+
+        # Thin adapter to the checked-in callable bond tree helper.
+        return float(
+            price_callable_bond_tree(
+                market_state,
+                spec,
+                model="hull_white",
+            )
+        )

--- a/trellis/instruments/_agent/puttablebond.py
+++ b/trellis/instruments/_agent/puttablebond.py
@@ -69,7 +69,7 @@ Implementation target: callable_tree_symmetry."""
 
     @property
     def requirements(self) -> set[str]:
-        return {"black_vol_surface", "discount_curve"}
+        return {"discount_curve"}
 
     def evaluate(self, market_state: MarketState) -> float:
         spec = self._spec

--- a/trellis/instruments/_agent/puttablebond.py
+++ b/trellis/instruments/_agent/puttablebond.py
@@ -16,11 +16,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import date
 
-from trellis.core.date_utils import generate_schedule, year_fraction
 from trellis.core.market_state import MarketState
 from trellis.core.types import DayCountConvention, Frequency
-from trellis.models.black import black76_call, black76_put
-from trellis.models.trees.lattice import build_rate_lattice, lattice_backward_induction
+from trellis.models.callable_bond_tree import price_callable_bond_tree
+
 
 
 @dataclass(frozen=True)
@@ -73,172 +72,12 @@ Implementation target: callable_tree_symmetry."""
         return {"black_vol_surface", "discount_curve"}
 
     def evaluate(self, market_state: MarketState) -> float:
-        try:
-            from trellis.models.callable_bond_tree import price_callable_bond_tree
-            return float(price_callable_bond_tree(market_state, self._spec, model="hull_white"))
-        except Exception:
-            pass
-
         spec = self._spec
-        as_of = market_state.as_of
 
-        # Generate coupon schedule
-        coupon_dates = generate_schedule(spec.start_date, spec.end_date, spec.frequency)
-
-        # Filter to future coupon dates
-        future_coupon_dates = [d for d in coupon_dates if d > as_of]
-
-        if not future_coupon_dates:
-            return 0.0
-
-        # Determine coupon period length for coupon amount calculation
-        freq_per_year = {
-            Frequency.ANNUAL: 1,
-            Frequency.SEMI_ANNUAL: 2,
-            Frequency.QUARTERLY: 4,
-            Frequency.MONTHLY: 12,
-        }.get(spec.frequency, 2)
-
-        coupon_amount = spec.notional * spec.coupon / freq_per_year
-
-        # Maturity time in years from as_of
-        T_mat = year_fraction(as_of, spec.end_date, spec.day_count)
-
-        if T_mat <= 0.0:
-            return 0.0
-
-        # Get short rate vol from vol surface
-        # Use a representative tenor (e.g., T_mat / 2 or 1 year)
-        vol_tenor = max(T_mat / 2.0, 0.25)
-        try:
-            sigma = market_state.vol_surface.black_vol(vol_tenor, spec.put_price / spec.notional)
-        except Exception:
-            try:
-                sigma = market_state.vol_surface.black_vol(vol_tenor, 1.0)
-            except Exception:
-                sigma = 0.10  # fallback
-
-        # Get short rate seed from discount curve
-        try:
-            r0 = market_state.discount.zero_rate(min(1.0, T_mat))
-        except Exception:
-            r0 = 0.05
-
-        # Build rate lattice
-        n_steps = max(int(T_mat * 52), 20)  # weekly steps
-        dt = T_mat / n_steps
-
-        try:
-            rate_lattice = build_rate_lattice(
-                r0=r0,
-                sigma=sigma,
-                T=T_mat,
-                n_steps=n_steps,
-                discount_curve=market_state.discount,
+        return float(
+            price_callable_bond_tree(
+                market_state,
+                spec,
                 model="hull_white",
             )
-        except Exception:
-            try:
-                rate_lattice = build_rate_lattice(
-                    r0=r0,
-                    sigma=sigma,
-                    T=T_mat,
-                    n_steps=n_steps,
-                    discount_curve=market_state.discount,
-                )
-            except Exception:
-                # Fallback: price as straight bond + put option value
-                pv = 0.0
-                for d in future_coupon_dates:
-                    t = year_fraction(as_of, d, spec.day_count)
-                    if t > 0:
-                        df = market_state.discount.discount(t)
-                        pv += coupon_amount * df
-                t_mat = year_fraction(as_of, spec.end_date, spec.day_count)
-                if t_mat > 0:
-                    df_mat = market_state.discount.discount(t_mat)
-                    pv += spec.notional * df_mat
-                return float(pv)
-
-        # Map coupon dates to tree steps
-        def date_to_step(d: date) -> int:
-            t = year_fraction(as_of, d, spec.day_count)
-            step = int(round(t / dt))
-            return max(0, min(step, n_steps))
-
-        # Build cashflow map: step -> cashflow amount
-        cashflow_map: dict[int, float] = {}
-        for d in future_coupon_dates:
-            step = date_to_step(d)
-            cashflow_map[step] = cashflow_map.get(step, 0.0) + coupon_amount
-
-        # Add notional at maturity
-        mat_step = n_steps
-        cashflow_map[mat_step] = cashflow_map.get(mat_step, 0.0) + spec.notional
-
-        # Map put dates to exercise steps
-        put_steps = set()
-        for pd in spec.put_dates:
-            if pd > as_of:
-                put_steps.add(date_to_step(pd))
-
-        # Define cashflow_at_node function
-        def cashflow_at_node(step: int, node: int) -> float:
-            return cashflow_map.get(step, 0.0)
-
-        # Define exercise function for puttable bond (holder's put: exercise_fn=max)
-        # Holder exercises put when put_price > continuation value
-        # => bond value = max(put_price, continuation_value)
-        put_price_scaled = spec.put_price * spec.notional / 100.0 if spec.put_price <= 100.0 else spec.put_price
-
-        def exercise_fn(step: int, node: int, continuation: float) -> float:
-            if step in put_steps:
-                return max(put_price_scaled, continuation)
-            return continuation
-
-        # Run backward induction
-        try:
-            # Try with exercise_steps parameter
-            exercise_steps = sorted(put_steps)
-            pv = lattice_backward_induction(
-                rate_lattice=rate_lattice,
-                cashflow_at_node=cashflow_at_node,
-                exercise_type="bermudan",
-                exercise_steps=exercise_steps,
-                put_call="put",
-                exercise_price=put_price_scaled,
-                T=T_mat,
-                n_steps=n_steps,
-                dt=dt,
-            )
-        except TypeError:
-            try:
-                pv = lattice_backward_induction(
-                    rate_lattice=rate_lattice,
-                    cashflow_at_node=cashflow_at_node,
-                    exercise_fn=exercise_fn,
-                    T=T_mat,
-                    n_steps=n_steps,
-                    dt=dt,
-                )
-            except TypeError:
-                try:
-                    pv = lattice_backward_induction(
-                        rate_lattice,
-                        cashflow_at_node,
-                        exercise_fn,
-                    )
-                except Exception:
-                    # Final fallback: straight bond price
-                    pv = 0.0
-                    for d in future_coupon_dates:
-                        t = year_fraction(as_of, d, spec.day_count)
-                        if t > 0:
-                            df = market_state.discount.discount(t)
-                            pv += coupon_amount * df
-                    t_mat = year_fraction(as_of, spec.end_date, spec.day_count)
-                    if t_mat > 0:
-                        df_mat = market_state.discount.discount(t_mat)
-                        pv += spec.notional * df_mat
-
-        return float(pv)
+        )

--- a/trellis/instruments/_agent/zcboption.py
+++ b/trellis/instruments/_agent/zcboption.py
@@ -32,6 +32,7 @@ from datetime import date
 
 from trellis.core.market_state import MarketState
 from trellis.core.types import DayCountConvention
+from trellis.models.resolution.short_rate_claims import resolve_discount_bond_option_type
 from trellis.models.zcb_option import price_zcb_option_jamshidian
 
 
@@ -113,11 +114,13 @@ Implementation target: jamshidian."""
 
     def evaluate(self, market_state: MarketState) -> float:
         spec = self._spec
-        if spec.option_type.lower() not in {"call", "put"}:
-            raise ValueError(f"Unsupported option_type: {spec.option_type!r}")
+        option_type = resolve_discount_bond_option_type(spec)
 
         if spec.bond_maturity_date <= spec.expiry_date:
             raise ValueError("bond_maturity_date must be strictly after expiry_date")
+
+        if option_type not in {"call", "put"}:
+            raise ValueError(f"Unsupported option_type: {spec.option_type!r}")
 
         try:
             return float(

--- a/trellis/instruments/_agent/zcboption.py
+++ b/trellis/instruments/_agent/zcboption.py
@@ -1,11 +1,16 @@
 """Agent-generated payoff: Build a pricer for: ZCB option: Ho-Lee vs HW tree vs Jamshidian analytical
 
-Price a 1Y European option on a zero-coupon bond maturing at T=5Y.
-Face value $100, strike price $88. Hull-White model: mean reversion
-a=0.1, short-rate vol sigma=0.01, initial short rate r0=0.05.
-Flat yield curve at 5%.
-Cross-validate Ho-Lee tree, Hull-White tree, and Jamshidian analytical
-decomposition.  All three should agree within 2%.
+European call option on a zero-coupon bond.
+Settlement / valuation date: 2024-11-15.
+Option expiry: 2027-11-15.
+Underlying bond maturity: 2033-11-15.
+Strike: 63 per 100 face (= 0.63 per unit face).
+Face / notional: 100.
+Shared short-rate comparison regime:
+- flat discount curve at 5%
+- flat short-rate volatility sigma = 0.01
+- Hull-White mean reversion a = 0.1
+- Ho-Lee uses the same sigma with zero mean reversion
 
 Construct methods: rate_tree
 Comparison targets: ho_lee_tree (rate_tree), hull_white_tree (rate_tree), jamshidian (analytical)
@@ -35,12 +40,17 @@ from trellis.models.zcb_option import price_zcb_option_jamshidian
 class ZCBOptionSpec:
     """Specification for Build a pricer for: ZCB option: Ho-Lee vs HW tree vs Jamshidian analytical
 
-Price a 1Y European option on a zero-coupon bond maturing at T=5Y.
-Face value $100, strike price $88. Hull-White model: mean reversion
-a=0.1, short-rate vol sigma=0.01, initial short rate r0=0.05.
-Flat yield curve at 5%.
-Cross-validate Ho-Lee tree, Hull-White tree, and Jamshidian analytical
-decomposition.  All three should agree within 2%.
+European call option on a zero-coupon bond.
+Settlement / valuation date: 2024-11-15.
+Option expiry: 2027-11-15.
+Underlying bond maturity: 2033-11-15.
+Strike: 63 per 100 face (= 0.63 per unit face).
+Face / notional: 100.
+Shared short-rate comparison regime:
+- flat discount curve at 5%
+- flat short-rate volatility sigma = 0.01
+- Hull-White mean reversion a = 0.1
+- Ho-Lee uses the same sigma with zero mean reversion
 
 Construct methods: rate_tree
 Comparison targets: ho_lee_tree (rate_tree), hull_white_tree (rate_tree), jamshidian (analytical)
@@ -59,18 +69,23 @@ Implementation target: jamshidian."""
     expiry_date: date
     bond_maturity_date: date
     day_count: DayCountConvention = DayCountConvention.ACT_365
-    option_type: str = "'call'"
+    option_type: str = 'call'
 
 
 class ZCBOptionPayoff:
     """Build a pricer for: ZCB option: Ho-Lee vs HW tree vs Jamshidian analytical
 
-Price a 1Y European option on a zero-coupon bond maturing at T=5Y.
-Face value $100, strike price $88. Hull-White model: mean reversion
-a=0.1, short-rate vol sigma=0.01, initial short rate r0=0.05.
-Flat yield curve at 5%.
-Cross-validate Ho-Lee tree, Hull-White tree, and Jamshidian analytical
-decomposition.  All three should agree within 2%.
+European call option on a zero-coupon bond.
+Settlement / valuation date: 2024-11-15.
+Option expiry: 2027-11-15.
+Underlying bond maturity: 2033-11-15.
+Strike: 63 per 100 face (= 0.63 per unit face).
+Face / notional: 100.
+Shared short-rate comparison regime:
+- flat discount curve at 5%
+- flat short-rate volatility sigma = 0.01
+- Hull-White mean reversion a = 0.1
+- Ho-Lee uses the same sigma with zero mean reversion
 
 Construct methods: rate_tree
 Comparison targets: ho_lee_tree (rate_tree), hull_white_tree (rate_tree), jamshidian (analytical)
@@ -98,25 +113,20 @@ Implementation target: jamshidian."""
 
     def evaluate(self, market_state: MarketState) -> float:
         spec = self._spec
-
-        # Resolve and validate the required market data.
-        if market_state.discount is None:
-            raise ValueError("ZCBOptionPayoff requires a discount curve in market_state")
-        if market_state.vol_surface is None:
-            raise ValueError("ZCBOptionPayoff requires a black vol surface in market_state")
-        if market_state.as_of is None:
-            raise ValueError("ZCBOptionPayoff requires market_state.as_of to be set")
+        if spec.option_type.lower() not in {"call", "put"}:
+            raise ValueError(f"Unsupported option_type: {spec.option_type!r}")
 
         if spec.bond_maturity_date <= spec.expiry_date:
             raise ValueError("bond_maturity_date must be strictly after expiry_date")
 
-        option_type = str(spec.option_type).strip().strip("'").strip('"').lower()
-        if option_type not in {"call", "put"}:
-            raise ValueError("option_type must be 'call' or 'put'")
-
-        # Prefer the checked-in analytical helper for Jamshidian pricing.
         try:
-            return float(price_zcb_option_jamshidian(market_state, spec, mean_reversion=0.1))
+            return float(
+                price_zcb_option_jamshidian(
+                    market_state,
+                    spec,
+                    mean_reversion=0.1,
+                )
+            )
         except TypeError:
-            # Fallback for helper variants that do not accept mean_reversion as a keyword.
+            # Fallback for implementations that infer mean reversion from market/model state.
             return float(price_zcb_option_jamshidian(market_state, spec))


### PR DESCRIPTION
## Summary
- thin the rate-tree route cards so they only surface backend binding and validation metadata
- enforce exact helper signatures for callable bond, Bermudan swaption, and ZCB option helper-backed routes
- keep explicit `zcb_option` requests off generic vanilla semantic drafting and document the carry-forward regressions

## Testing
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_route_registry.py tests/test_agent/test_primitive_planning.py tests/test_agent/test_codegen_guardrails.py tests/test_agent/test_semantic_validators.py tests/test_agent/test_semantic_contracts.py tests/test_agent/test_platform_requests.py -q
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_skill_index.py tests/test_agent/test_prompts.py tests/test_agent/test_lite_review.py tests/test_agent/test_rate_tree_generation.py tests/test_agent/test_lattice_admissibility.py -q
- /Users/steveyang/miniforge3/bin/python3 -m py_compile trellis/agent/semantic_contracts.py trellis/agent/semantic_validators/algorithm_contract.py trellis/instruments/_agent/bermudanswaption.py trellis/instruments/_agent/callablebond.py trellis/instruments/_agent/puttablebond.py trellis/instruments/_agent/zcboption.py

## Live task evidence
- T01 passed
- T05 passed
- T04 reduced to a non-route comparison mismatch (tracked in QUA-786)
- T17 carried forward to QUA-783 for the PDE lane
