### PR TITLE
Route surfaces: thin analytical, PDE, and FFT helper cards

### DIFF
--- a/cassettes/full_task/T13.yaml
+++ b/cassettes/full_task/T13.yaml
@@ -1,5 +1,5 @@
 meta:
-  recorded_at: '2026-04-12T08:02:11.581812+00:00'
+  recorded_at: '2026-04-12T08:14:00.121990+00:00'
   provider: openai
   model: gpt-5.4-mini
   total_calls: 4
@@ -8,15 +8,12 @@ calls:
 - seq: 0
   function: llm_generate
   stage: code_generation
-  prompt_hash: 8cae9d77a526e6551e8963663319be59de7791ab735277e00d4aa66d879dd956
-  response_text: "spec = self._spec\n        from trellis.models.equity_option_pde\
-    \ import price_vanilla_equity_option_pde\n\n        if spec.option_type not in\
-    \ {\"call\", \"put\"}:\n            raise ValueError(f\"Unsupported option_type:\
-    \ {spec.option_type!r}\")\n\n        if market_state.vol_surface is None:\n  \
-    \          raise ValueError(\"market_state.vol_surface is required for PDE pricing\"\
-    )\n        if market_state.discount is None:\n            raise ValueError(\"\
-    market_state.discount is required for PDE pricing\")\n\n        return float(price_vanilla_equity_option_pde(market_state,\
-    \ spec, theta=0.5))"
+  prompt_hash: 2a64647692922bb86ead207f5c5e25b8e2721a4ea9021cfee65e8932d0b6d140
+  response_text: "from trellis.models.equity_option_pde import price_vanilla_equity_option_pde\n\
+    \n        spec = self._spec\n        if spec.option_type.lower() not in {\"call\"\
+    , \"put\"}:\n            raise ValueError(f\"Unsupported option_type: {spec.option_type!r}\"\
+    )\n\n        return float(price_vanilla_equity_option_pde(market_state, spec,\
+    \ theta=0.5))"
   prompt_text: "You are implementing the evaluate() method for `EuropeanOptionAnalyticalPayoff`\
     \ in the Trellis pricing library.\n\n## Complete module (skeleton — everything\
     \ is fixed except evaluate)\n```python\n\"\"\"Agent-generated payoff: Build a\
@@ -197,15 +194,13 @@ calls:
     \ n_t=n_t), construct BlackScholesOperator(lambda s, t: sigma, lambda t: r), call\
     \ theta_method_1d(grid, op, terminal, theta=0.5, lower_bc_fn=..., upper_bc_fn=...),\
     \ then interpolate the returned vector with np.interp(spec.spot, grid.x, V) before\
-    \ multiplying by notional.\n- Stale adapters: `trellis.instruments._agent.fxvanillaanalytical`,\
-    \ `trellis.instruments._agent.fxvanillamontecarlo`\n\n## Generated Skills\n- [cookbook]\
-    \ fft_pricing: Characteristic-function pricing for European-style options under\
-    \ models such as Heston\n- [lesson] Unit conversion causes huge PV: Enforce and\
-    \ document input conventions (vol as decimal, discount curve vs zero rate semantics,\
-    \ notional scaling), derive r from discount factors via r = -ln(df)/T or use forward/Black76\
-    \ consistently, add unit/conversi...\n## Structured Lane Card\n- Method family:\
-    \ `pde_solver`\n- Instrument type: `european_option`\n- Lane boundary: family=`pde_solver`,\
-    \ kind=`exact_target_binding`, exact_bindings=`trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
+    \ multiplying by notional.\n\n## Generated Skills\n- [cookbook] fft_pricing: Characteristic-function\
+    \ pricing for European-style options under models such as Heston\n- [lesson] Unit\
+    \ conversion causes huge PV: Enforce and document input conventions (vol as decimal,\
+    \ discount curve vs zero rate semantics, notional scaling), derive r from discount\
+    \ factors via r = -ln(df)/T or use forward/Black76 consistently, add unit/conversi...\n\
+    ## Structured Lane Card\n- Method family: `pde_solver`\n- Instrument type: `european_option`\n\
+    - Lane boundary: family=`pde_solver`, kind=`exact_target_binding`, exact_bindings=`trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
     - Lane obligations:\n  - Lane family: `pde_solver`\n  - Plan kind: `exact_target_binding`\n\
     \  - Market bindings: `black_vol_surface`, `discount_curve`\n  - State obligations:\
     \ `spot`, `strike`, `expiry`, `expiry_black_vol`\n  - Exact backend bindings:\n\
@@ -370,18 +365,22 @@ calls:
 - seq: 1
   function: llm_generate_json
   stage: critic
-  prompt_hash: b8e33c8f6ba8b2da6a10a19604c7b36537fabe611f318ff69d0d7bee18714393
-  response_text: '{"check_id": "volatility_input_usage", "description": "Volatility
-    is not actually wired from the market state into the PDE pricer call, so the price
-    may be insensitive to volatility changes.", "severity": "error", "evidence": "`evaluate()`
-    only checks that `market_state.vol_surface` is not None and then calls `price_vanilla_equity_option_pde(market_state,
-    spec, theta=0.5)`. There is no explicit extraction or forwarding of a flat vol/expiry
-    vol to the solver, despite the route contract requiring `expiry_black_vol`. If
-    the backend helper does not infer it from the surface shape, the pricing result
-    can become effectively decoupled from vol.", "remediation": "Populate the expected
-    PDE market-state fields explicitly before calling the helper, including the expiry
-    volatility from the surface, and verify the backend receives the intended sigma
-    input.", "status": "suspect"}'
+  prompt_hash: c5ee52114675b0788354000d53d529708f33eb71f179655b5c3ae63b0ebefb90
+  response_text: '{"check_id": "volatility_input_usage", "description": "The PDE pricer
+    likely ignores or mishandles volatility/state inputs because the spec is never
+    populated from the instrument description and the code delegates directly to the
+    backend with no explicit construction of the required market state fields.", "severity":
+    "warning", "evidence": "`EuropeanOptionSpec` only stores `notional, spot, strike,
+    expiry_date, option_type, day_count`; there is no volatility field, and `evaluate()`
+    simply calls `price_vanilla_equity_option_pde(market_state, spec, theta=0.5)`
+    without any local wiring of `black_vol_surface` or `expiry_black_vol`. Under the
+    compiled route contract, the backend requires `black_vol_surface`, `discount_curve`,
+    `spot`, `strike`, `expiry`, and `expiry_black_vol`. If the generated market state
+    does not supply these consistently, the price will be effectively insensitive
+    to volatility or fail route validation.", "remediation": "Extend the spec/market-state
+    plumbing to explicitly carry and bind the flat volatility surface and expiry vol
+    into the PDE backend inputs, and verify the route helper receives the required
+    fields.", "status": "suspect"}'
   prompt_text: "You are a quantitative model validator reviewing agent-generated pricing\
     \ code.\nYour job is to find deterministic review concerns, not to praise. Be\
     \ adversarial.\n\n## Code to review\n```python\n\"\"\"Agent-generated payoff:\
@@ -433,13 +432,9 @@ calls:
     \    @property\n    def spec(self) -> EuropeanOptionSpec:\n        return self._spec\n\
     \n    @property\n    def requirements(self) -> set[str]:\n        return {\"black_vol_surface\"\
     , \"discount_curve\"}\n\n    def evaluate(self, market_state: MarketState) ->\
-    \ float:\n        spec = self._spec\n        spec = self._spec\n        from trellis.models.equity_option_pde\
-    \ import price_vanilla_equity_option_pde\n\n        if spec.option_type not in\
-    \ {\"call\", \"put\"}:\n            raise ValueError(f\"Unsupported option_type:\
-    \ {spec.option_type!r}\")\n\n        if market_state.vol_surface is None:\n  \
-    \          raise ValueError(\"market_state.vol_surface is required for PDE pricing\"\
-    )\n        if market_state.discount is None:\n            raise ValueError(\"\
-    market_state.discount is required for PDE pricing\")\n\n        return float(price_vanilla_equity_option_pde(market_state,\
+    \ float:\n        spec = self._spec\n        spec = self._spec\n        if spec.option_type.lower()\
+    \ not in {\"call\", \"put\"}:\n            raise ValueError(f\"Unsupported option_type:\
+    \ {spec.option_type!r}\")\n\n        return float(price_vanilla_equity_option_pde(market_state,\
     \ spec, theta=0.5))\n\n```\n\n## Instrument description\nBuild a pricer for: European\
     \ call: theta-method convergence order measurement\n\nEuropean call option on\
     \ a non-dividend-paying stock.\nS0=100, K=105, T=1Y, risk-free rate r=5%, volatility\
@@ -473,13 +468,12 @@ calls:
     \ signature and then read the wrong element of the result instead of interpolating\
     \ the returned solution over grid.x. The actual API is theta_method_1d(grid, operator,\
     \ terminal_condition, theta=..., lower_bc_fn=..., upper_bc_fn=...), and it returns\
-    \ the full solution vector at t=0.\n- Stale adapters: `trellis.instruments._agent.fxvanillaanalytical`,\
-    \ `trellis.instruments._agent.fxvanillamontecarlo`\n\n## Generated Skills\n- [lesson]\
-    \ Unit conversion causes huge PV: Enforce and document input conventions (vol\
-    \ as decimal, discount curve vs zero rate semantics, notional scaling), derive\
-    \ r from discount factors via r = -ln(df)/T or use forward/Black76 consistently,\
-    \ add unit/conversi...\n\n\n## Compiled Route Contract\n- Method family: `pde_solver`\n\
-    - Instrument type: `european_option`\n- Lane boundary: family=`pde_solver`, kind=`exact_target_binding`,\
+    \ the full solution vector at t=0.\n\n## Generated Skills\n- [lesson] Unit conversion\
+    \ causes huge PV: Enforce and document input conventions (vol as decimal, discount\
+    \ curve vs zero rate semantics, notional scaling), derive r from discount factors\
+    \ via r = -ln(df)/T or use forward/Black76 consistently, add unit/conversi...\n\
+    \n\n## Compiled Route Contract\n- Method family: `pde_solver`\n- Instrument type:\
+    \ `european_option`\n- Lane boundary: family=`pde_solver`, kind=`exact_target_binding`,\
     \ exact_bindings=`trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
     - Lane obligations:\n  - Lane family: `pde_solver`\n  - Plan kind: `exact_target_binding`\n\
     \  - Market bindings: `black_vol_surface`, `discount_curve`\n  - State obligations:\
@@ -524,16 +518,58 @@ calls:
 - seq: 2
   function: llm_generate
   stage: code_generation
-  prompt_hash: 0ab1b878e381be1e438e3b85ea47eba2cddb7318bc7b1aab53b284984b4e78b3
-  response_text: "spec = self._spec\n\n        from trellis.models.equity_option_pde\
-    \ import price_vanilla_equity_option_pde\n\n        if market_state.vol_surface\
-    \ is None:\n            raise ValueError(\"market_state.vol_surface is required\
-    \ for PDE pricing\")\n        if market_state.discount is None:\n            raise\
-    \ ValueError(\"market_state.discount is required for PDE pricing\")\n\n      \
-    \  if spec.option_type not in {\"call\", \"put\"}:\n            raise ValueError(f\"\
-    Unsupported option_type: {spec.option_type!r}\")\n\n        pv = price_vanilla_equity_option_pde(\n\
-    \            market_state,\n            spec,\n            theta=1.0,\n      \
-    \  )\n        return float(pv)"
+  prompt_hash: aa9e8e8aecd2e3f05aa0fe6bcd60915b4c332bfc498c5b90a8e4654b8c0d04de
+  response_text: "\"\"\"Agent-generated payoff: Build a pricer for: European call:\
+    \ theta-method convergence order measurement\n\nEuropean call option on a non-dividend-paying\
+    \ stock.\nS0=100, K=105, T=1Y, risk-free rate r=5%, volatility sigma=20%.\nSolve\
+    \ with the Black-Scholes PDE operator using Crank-Nicolson\n(theta=0.5) and fully\
+    \ implicit (theta=1.0) on a 200-point spot grid\n× 100 time steps.\nMeasure convergence\
+    \ order by doubling the grid: the CN scheme should\nshow O(dt^2 + dS^2) convergence\
+    \ and the implicit scheme O(dt + dS^2).\nCompare both to the Black-Scholes analytical\
+    \ price.\n\nConstruct methods: pde_solver\nComparison targets: theta_0.5 (pde_solver),\
+    \ theta_1.0 (pde_solver), black_scholes (analytical)\nCross-validation harness:\n\
+    \  internal targets: theta_0.5, theta_1.0\n  analytical benchmark: black_scholes\n\
+    \  external targets: quantlib\nNew component: convergence_order_diagnostic\n\n\
+    Implementation target: theta_1.0\nPreferred method family: pde_solver\n\nImplementation\
+    \ target: theta_1.0.\"\"\"\n\nfrom __future__ import annotations\n\nfrom dataclasses\
+    \ import dataclass\nfrom datetime import date\n\nfrom trellis.core.market_state\
+    \ import MarketState\nfrom trellis.core.types import DayCountConvention\nfrom\
+    \ trellis.models.equity_option_pde import price_vanilla_equity_option_pde\n\n\n\
+    \n@dataclass(frozen=True)\nclass EuropeanOptionSpec:\n    \"\"\"Specification\
+    \ for Build a pricer for: European call: theta-method convergence order measurement\n\
+    \nEuropean call option on a non-dividend-paying stock.\nS0=100, K=105, T=1Y, risk-free\
+    \ rate r=5%, volatility sigma=20%.\nSolve with the Black-Scholes PDE operator\
+    \ using Crank-Nicolson\n(theta=0.5) and fully implicit (theta=1.0) on a 200-point\
+    \ spot grid\n× 100 time steps.\nMeasure convergence order by doubling the grid:\
+    \ the CN scheme should\nshow O(dt^2 + dS^2) convergence and the implicit scheme\
+    \ O(dt + dS^2).\nCompare both to the Black-Scholes analytical price.\n\nConstruct\
+    \ methods: pde_solver\nComparison targets: theta_0.5 (pde_solver), theta_1.0 (pde_solver),\
+    \ black_scholes (analytical)\nCross-validation harness:\n  internal targets: theta_0.5,\
+    \ theta_1.0\n  analytical benchmark: black_scholes\n  external targets: quantlib\n\
+    New component: convergence_order_diagnostic\n\nImplementation target: theta_1.0\n\
+    Preferred method family: pde_solver\n\nImplementation target: theta_1.0.\"\"\"\
+    \n    notional: float\n    spot: float\n    strike: float\n    expiry_date: date\n\
+    \    option_type: str = 'call'\n    day_count: DayCountConvention = DayCountConvention.ACT_365\n\
+    \n\nclass EuropeanOptionAnalyticalPayoff:\n    \"\"\"Build a pricer for: European\
+    \ call: theta-method convergence order measurement\n\nEuropean call option on\
+    \ a non-dividend-paying stock.\nS0=100, K=105, T=1Y, risk-free rate r=5%, volatility\
+    \ sigma=20%.\nSolve with the Black-Scholes PDE operator using Crank-Nicolson\n\
+    (theta=0.5) and fully implicit (theta=1.0) on a 200-point spot grid\n× 100 time\
+    \ steps.\nMeasure convergence order by doubling the grid: the CN scheme should\n\
+    show O(dt^2 + dS^2) convergence and the implicit scheme O(dt + dS^2).\nCompare\
+    \ both to the Black-Scholes analytical price.\n\nConstruct methods: pde_solver\n\
+    Comparison targets: theta_0.5 (pde_solver), theta_1.0 (pde_solver), black_scholes\
+    \ (analytical)\nCross-validation harness:\n  internal targets: theta_0.5, theta_1.0\n\
+    \  analytical benchmark: black_scholes\n  external targets: quantlib\nNew component:\
+    \ convergence_order_diagnostic\n\nImplementation target: theta_1.0\nPreferred\
+    \ method family: pde_solver\n\nImplementation target: theta_1.0.\"\"\"\n\n   \
+    \ def __init__(self, spec: EuropeanOptionSpec):\n        self._spec = spec\n\n\
+    \    @property\n    def spec(self) -> EuropeanOptionSpec:\n        return self._spec\n\
+    \n    @property\n    def requirements(self) -> set[str]:\n        return {\"black_vol_surface\"\
+    , \"discount_curve\"}\n\n    def evaluate(self, market_state: MarketState) ->\
+    \ float:\n        spec = self._spec\n        return float(\n            price_vanilla_equity_option_pde(\n\
+    \                market_state,\n                spec,\n                theta=1.0,\n\
+    \            )\n        )"
   prompt_text: "You are implementing the evaluate() method for `EuropeanOptionAnalyticalPayoff`\
     \ in the Trellis pricing library.\n\n## Complete module (skeleton — everything\
     \ is fixed except evaluate)\n```python\n\"\"\"Agent-generated payoff: Build a\
@@ -714,15 +750,13 @@ calls:
     \ n_t=n_t), construct BlackScholesOperator(lambda s, t: sigma, lambda t: r), call\
     \ theta_method_1d(grid, op, terminal, theta=0.5, lower_bc_fn=..., upper_bc_fn=...),\
     \ then interpolate the returned vector with np.interp(spec.spot, grid.x, V) before\
-    \ multiplying by notional.\n- Stale adapters: `trellis.instruments._agent.fxvanillaanalytical`,\
-    \ `trellis.instruments._agent.fxvanillamontecarlo`\n\n## Generated Skills\n- [cookbook]\
-    \ fft_pricing: Characteristic-function pricing for European-style options under\
-    \ models such as Heston\n- [lesson] Unit conversion causes huge PV: Enforce and\
-    \ document input conventions (vol as decimal, discount curve vs zero rate semantics,\
-    \ notional scaling), derive r from discount factors via r = -ln(df)/T or use forward/Black76\
-    \ consistently, add unit/conversi...\n## Structured Lane Card\n- Method family:\
-    \ `pde_solver`\n- Instrument type: `european_option`\n- Lane boundary: family=`pde_solver`,\
-    \ kind=`exact_target_binding`, exact_bindings=`trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
+    \ multiplying by notional.\n\n## Generated Skills\n- [cookbook] fft_pricing: Characteristic-function\
+    \ pricing for European-style options under models such as Heston\n- [lesson] Unit\
+    \ conversion causes huge PV: Enforce and document input conventions (vol as decimal,\
+    \ discount curve vs zero rate semantics, notional scaling), derive r from discount\
+    \ factors via r = -ln(df)/T or use forward/Black76 consistently, add unit/conversi...\n\
+    ## Structured Lane Card\n- Method family: `pde_solver`\n- Instrument type: `european_option`\n\
+    - Lane boundary: family=`pde_solver`, kind=`exact_target_binding`, exact_bindings=`trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
     - Lane obligations:\n  - Lane family: `pde_solver`\n  - Plan kind: `exact_target_binding`\n\
     \  - Market bindings: `black_vol_surface`, `discount_curve`\n  - State obligations:\
     \ `spot`, `strike`, `expiry`, `expiry_black_vol`\n  - Exact backend bindings:\n\
@@ -887,18 +921,19 @@ calls:
 - seq: 3
   function: llm_generate_json
   stage: critic
-  prompt_hash: b3ff96220ec052577de760b03b322ad1ef549f7f393c89c5404cf510927f066d
-  response_text: '{"check_id": "volatility_input_usage", "description": "The pricer
-    does not expose or pass the required PDE resolution controls from the instrument
-    description, so the valuation path may be effectively insensitive to the intended
-    convergence setup and comparison targets.", "severity": "warning", "evidence":
-    "`evaluate()` hard-codes `theta=1.0` and never passes `n_x`, `n_t`, or `s_max_multiplier`
-    to `price_vanilla_equity_option_pde`, despite the route contract specifying these
-    exact backend bindings and the instrument being about grid-doubling convergence.
-    The code also ignores the Crank–Nicolson target (`theta=0.5`) entirely.", "remediation":
-    "Plumb the PDE solver controls through the instrument interface and provide separate
-    evaluation paths for `theta=0.5` and `theta=1.0`, including grid-size parameters
-    needed for convergence diagnostics.", "status": "suspect"}'
+  prompt_hash: b91fc4607ae31a7dac3d88185dba5b197a250f5d4e064ab30b82cb41ef290c33
+  response_text: '{"check_id": "volatility_input_usage", "description": "Volatility
+    may be effectively ignored or miswired in the PDE route because the wrapper only
+    passes `market_state` and `spec` to a generic backend helper without any explicit
+    linkage to the required `expiry_black_vol` state.", "severity": "warning", "evidence":
+    "`evaluate()` calls `price_vanilla_equity_option_pde(market_state, spec, theta=1.0)`
+    directly, while the compiled route contract explicitly requires the `expiry_black_vol`
+    state obligation and warns about prior operator-signature mismatch / unit-scale
+    drift. There is no code here that verifies the backend is consuming the volatility
+    from `market_state` rather than defaulting or dropping it.", "remediation": "Ensure
+    the market state passed into `price_vanilla_equity_option_pde` contains and uses
+    the expiry volatility, and add an explicit sanity check that price changes materially
+    when vol is varied.", "status": "suspect"}'
   prompt_text: "You are a quantitative model validator reviewing agent-generated pricing\
     \ code.\nYour job is to find deterministic review concerns, not to praise. Be\
     \ adversarial.\n\n## Code to review\n```python\n\"\"\"Agent-generated payoff:\
@@ -950,55 +985,47 @@ calls:
     \    @property\n    def spec(self) -> EuropeanOptionSpec:\n        return self._spec\n\
     \n    @property\n    def requirements(self) -> set[str]:\n        return {\"black_vol_surface\"\
     , \"discount_curve\"}\n\n    def evaluate(self, market_state: MarketState) ->\
-    \ float:\n        spec = self._spec\n        spec = self._spec\n\n        from\
-    \ trellis.models.equity_option_pde import price_vanilla_equity_option_pde\n\n\
-    \        if market_state.vol_surface is None:\n            raise ValueError(\"\
-    market_state.vol_surface is required for PDE pricing\")\n        if market_state.discount\
-    \ is None:\n            raise ValueError(\"market_state.discount is required for\
-    \ PDE pricing\")\n\n        if spec.option_type not in {\"call\", \"put\"}:\n\
-    \            raise ValueError(f\"Unsupported option_type: {spec.option_type!r}\"\
-    )\n\n        pv = price_vanilla_equity_option_pde(\n            market_state,\n\
-    \            spec,\n            theta=1.0,\n        )\n        return float(pv)\n\
-    \n```\n\n## Instrument description\nBuild a pricer for: European call: theta-method\
-    \ convergence order measurement\n\nEuropean call option on a non-dividend-paying\
-    \ stock.\nS0=100, K=105, T=1Y, risk-free rate r=5%, volatility sigma=20%.\nSolve\
-    \ with the Black-Scholes PDE operator using Crank-Nicolson\n(theta=0.5) and fully\
-    \ implicit (theta=1.0) on a 200-point spot grid\n× 100 time steps.\nMeasure convergence\
-    \ order by doubling the grid: the CN scheme should\nshow O(dt^2 + dS^2) convergence\
-    \ and the implicit scheme O(dt + dS^2).\nCompare both to the Black-Scholes analytical\
-    \ price.\n\nConstruct methods: pde_solver\nComparison targets: theta_0.5 (pde_solver),\
-    \ theta_1.0 (pde_solver), black_scholes (analytical)\nCross-validation harness:\n\
-    \  internal targets: theta_0.5, theta_1.0\n  analytical benchmark: black_scholes\n\
-    \  external targets: quantlib\nNew component: convergence_order_diagnostic\n\n\
-    Implementation target: theta_1.0\nPreferred method family: pde_solver\n\nImplementation\
-    \ target: theta_1.0\n\n## Shared Knowledge\n## Distilled Review Memory\n\n- Review\
-    \ principles:\n  - `P1`: Always calibrate rate trees to the discount curve before\
-    \ pricing\n  - `P2`: Callable bonds need issuer_call lattice control, discrete\
-    \ coupons, and exercise=par+coupon\n  - `P3`: Convert vol units at the boundary\
-    \ between market data and model\n- Review checkpoints:\n  - GRID: Use at least\
-    \ 200 spatial points and 200+ time steps. For barrier options, use non-uniform\
-    \ grid concentrated near the barrier.\n  - BOUNDARY CONDITIONS: Set V(0,t)=0 for\
-    \ calls, V(S_max,t)=S_max-K*exp(-r*(T-t)) for calls. For puts: V(0,t)=K*exp(-r*(T-t)),\
-    \ V(S_max,t)=0.\n  - STABILITY: Crank-Nicolson (theta=0.5) is second-order but\
-    \ may oscillate near discontinuities. Use Rannacher smoothing (2-4 implicit steps\
-    \ at start) for digital/barrier payoffs.\n- Canonical model grammar:\n  - `local_vol_surface_workflow`\
-    \ -> `Dupire local vol`\n  - `sabr_smile_workflow` -> `SABR smile`\n- Known failure\
-    \ traps:\n  - `BlackScholesOperator constructor mismatch` -> The generated code\
-    \ treated the PDE operator as if it accepted scalar 'r' and 'sigma' keywords,\
-    \ but trellis.models.pde.operator.BlackScholesOperator actually expects callables\
-    \ '(sigma_fn, r_fn)'. The mismatch caused constructor failure during module build.\n\
-    \  - `PDE price blow-up from unit/scale mismatch` -> The generated PDE branch\
-    \ called theta_method_1d with the obsolete operator/s_grid/t_grid/boundary_conditions\
+    \ float:\n        spec = self._spec\n        return float(\n            price_vanilla_equity_option_pde(\n\
+    \                market_state,\n                spec,\n                theta=1.0,\n\
+    \            )\n        )\n```\n\n## Instrument description\nBuild a pricer for:\
+    \ European call: theta-method convergence order measurement\n\nEuropean call option\
+    \ on a non-dividend-paying stock.\nS0=100, K=105, T=1Y, risk-free rate r=5%, volatility\
+    \ sigma=20%.\nSolve with the Black-Scholes PDE operator using Crank-Nicolson\n\
+    (theta=0.5) and fully implicit (theta=1.0) on a 200-point spot grid\n× 100 time\
+    \ steps.\nMeasure convergence order by doubling the grid: the CN scheme should\n\
+    show O(dt^2 + dS^2) convergence and the implicit scheme O(dt + dS^2).\nCompare\
+    \ both to the Black-Scholes analytical price.\n\nConstruct methods: pde_solver\n\
+    Comparison targets: theta_0.5 (pde_solver), theta_1.0 (pde_solver), black_scholes\
+    \ (analytical)\nCross-validation harness:\n  internal targets: theta_0.5, theta_1.0\n\
+    \  analytical benchmark: black_scholes\n  external targets: quantlib\nNew component:\
+    \ convergence_order_diagnostic\n\nImplementation target: theta_1.0\nPreferred\
+    \ method family: pde_solver\n\nImplementation target: theta_1.0\n\n## Shared Knowledge\n\
+    ## Distilled Review Memory\n\n- Review principles:\n  - `P1`: Always calibrate\
+    \ rate trees to the discount curve before pricing\n  - `P2`: Callable bonds need\
+    \ issuer_call lattice control, discrete coupons, and exercise=par+coupon\n  -\
+    \ `P3`: Convert vol units at the boundary between market data and model\n- Review\
+    \ checkpoints:\n  - GRID: Use at least 200 spatial points and 200+ time steps.\
+    \ For barrier options, use non-uniform grid concentrated near the barrier.\n \
+    \ - BOUNDARY CONDITIONS: Set V(0,t)=0 for calls, V(S_max,t)=S_max-K*exp(-r*(T-t))\
+    \ for calls. For puts: V(0,t)=K*exp(-r*(T-t)), V(S_max,t)=0.\n  - STABILITY: Crank-Nicolson\
+    \ (theta=0.5) is second-order but may oscillate near discontinuities. Use Rannacher\
+    \ smoothing (2-4 implicit steps at start) for digital/barrier payoffs.\n- Canonical\
+    \ model grammar:\n  - `local_vol_surface_workflow` -> `Dupire local vol`\n  -\
+    \ `sabr_smile_workflow` -> `SABR smile`\n- Known failure traps:\n  - `BlackScholesOperator\
+    \ constructor mismatch` -> The generated code treated the PDE operator as if it\
+    \ accepted scalar 'r' and 'sigma' keywords, but trellis.models.pde.operator.BlackScholesOperator\
+    \ actually expects callables '(sigma_fn, r_fn)'. The mismatch caused constructor\
+    \ failure during module build.\n  - `PDE price blow-up from unit/scale mismatch`\
+    \ -> The generated PDE branch called theta_method_1d with the obsolete operator/s_grid/t_grid/boundary_conditions\
     \ signature and then read the wrong element of the result instead of interpolating\
     \ the returned solution over grid.x. The actual API is theta_method_1d(grid, operator,\
     \ terminal_condition, theta=..., lower_bc_fn=..., upper_bc_fn=...), and it returns\
-    \ the full solution vector at t=0.\n- Stale adapters: `trellis.instruments._agent.fxvanillaanalytical`,\
-    \ `trellis.instruments._agent.fxvanillamontecarlo`\n\n## Generated Skills\n- [lesson]\
-    \ Unit conversion causes huge PV: Enforce and document input conventions (vol\
-    \ as decimal, discount curve vs zero rate semantics, notional scaling), derive\
-    \ r from discount factors via r = -ln(df)/T or use forward/Black76 consistently,\
-    \ add unit/conversi...\n\n\n## Compiled Route Contract\n- Method family: `pde_solver`\n\
-    - Instrument type: `european_option`\n- Lane boundary: family=`pde_solver`, kind=`exact_target_binding`,\
+    \ the full solution vector at t=0.\n\n## Generated Skills\n- [lesson] Unit conversion\
+    \ causes huge PV: Enforce and document input conventions (vol as decimal, discount\
+    \ curve vs zero rate semantics, notional scaling), derive r from discount factors\
+    \ via r = -ln(df)/T or use forward/Black76 consistently, add unit/conversi...\n\
+    \n\n## Compiled Route Contract\n- Method family: `pde_solver`\n- Instrument type:\
+    \ `european_option`\n- Lane boundary: family=`pde_solver`, kind=`exact_target_binding`,\
     \ exact_bindings=`trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
     - Lane obligations:\n  - Lane family: `pde_solver`\n  - Plan kind: `exact_target_binding`\n\
     \  - Market bindings: `black_vol_surface`, `discount_curve`\n  - State obligations:\

--- a/cassettes/full_task/T13.yaml
+++ b/cassettes/full_task/T13.yaml
@@ -1,5 +1,5 @@
 meta:
-  recorded_at: '2026-04-12T04:12:58.817719+00:00'
+  recorded_at: '2026-04-12T08:02:11.581812+00:00'
   provider: openai
   model: gpt-5.4-mini
   total_calls: 4
@@ -8,12 +8,15 @@ calls:
 - seq: 0
   function: llm_generate
   stage: code_generation
-  prompt_hash: 6197fcb39b14239a94033474adabc4fc9ff165d3541c3677a5215aa29ea6d480
-  response_text: "from trellis.models.equity_option_pde import price_vanilla_equity_option_pde\n\
-    \n        theta = 0.5\n        option_type = (spec.option_type or \"call\").lower()\n\
-    \        if option_type not in {\"call\", \"put\"}:\n            raise ValueError(f\"\
-    Unsupported option_type: {spec.option_type!r}\")\n\n        pv = price_vanilla_equity_option_pde(market_state,\
-    \ spec, theta=theta)\n        return float(pv)"
+  prompt_hash: 8cae9d77a526e6551e8963663319be59de7791ab735277e00d4aa66d879dd956
+  response_text: "spec = self._spec\n        from trellis.models.equity_option_pde\
+    \ import price_vanilla_equity_option_pde\n\n        if spec.option_type not in\
+    \ {\"call\", \"put\"}:\n            raise ValueError(f\"Unsupported option_type:\
+    \ {spec.option_type!r}\")\n\n        if market_state.vol_surface is None:\n  \
+    \          raise ValueError(\"market_state.vol_surface is required for PDE pricing\"\
+    )\n        if market_state.discount is None:\n            raise ValueError(\"\
+    market_state.discount is required for PDE pricing\")\n\n        return float(price_vanilla_equity_option_pde(market_state,\
+    \ spec, theta=0.5))"
   prompt_text: "You are implementing the evaluate() method for `EuropeanOptionAnalyticalPayoff`\
     \ in the Trellis pricing library.\n\n## Complete module (skeleton — everything\
     \ is fixed except evaluate)\n```python\n\"\"\"Agent-generated payoff: Build a\
@@ -131,19 +134,22 @@ calls:
     \ import HullWhitePDEOperator`\n- Notes:\n  - Vanilla European equity PDE routes\
     \ should prefer the checked-in helper `price_vanilla_equity_option_pde(...)`\n\
     \  - Use theta_method_1d, NOT legacy crank_nicolson_1d or implicit_fd_1d\n####\
-    \ fft\n- Module: `trellis.models.transforms`\n- Key imports:\n  - `from trellis.models.transforms\
-    \ import fft_price, cos_price`\n- Notes:\n  - fft_price expects CF of log(S_T)\
-    \ — include log(S0)\n  - cos_price expects CF of log(S_T/S0) — log-return only\n\
-    #### copulas\n- Module: `trellis.models.copulas`\n- Key imports:\n  - `from trellis.models.copulas\
-    \ import GaussianCopula, StudentTCopula, FactorCopula`\n#### analytical\n- Module:\
-    \ `trellis.models.zcb_option`\n- Key imports:\n  - `from trellis.models.zcb_option\
-    \ import resolve_zcb_option_hw_inputs, price_zcb_option_jamshidian`\n  - `from\
-    \ trellis.models.analytical.jamshidian import ResolvedJamshidianInputs, zcb_option_hw_raw`\n\
-    \  - `from trellis.models.analytical import zcb_option_hw`\n  - `from trellis.models.analytical\
-    \ import terminal_vanilla_from_basis`\n  - `from trellis.models.rate_style_swaption\
-    \ import ResolvedSwaptionBlack76Inputs, resolve_swaption_black76_inputs, price_swaption_black76_raw,\
-    \ price_bermudan_swaption_black76_lower_bound`\n#### calibration\n- Module: `trellis.models.calibration`\n\
-    - Key imports:\n  - `from trellis.models.calibration import implied_vol, implied_vol_jaeckel`\n\
+    \ fft\n- Module: `trellis.models.transforms.fft_pricer`\n- Key imports:\n  - `from\
+    \ trellis.models.transforms.fft_pricer import fft_price`\n  - `from trellis.models.transforms.cos_method\
+    \ import cos_price`\n- Notes:\n  - Concrete transform helpers live in submodules;\
+    \ do not import `trellis.models.transforms` directly.\n  - fft_price expects CF\
+    \ of log(S_T) — include log(S0)\n#### copulas\n- Module: `trellis.models.copulas.factor`\n\
+    - Key imports:\n  - `from trellis.models.copulas.factor import FactorCopula`\n\
+    \  - `from trellis.models.copulas.gaussian import GaussianCopula`\n  - `from trellis.models.copulas.student_t\
+    \ import StudentTCopula`\n#### analytical\n- Module: `trellis.models.zcb_option`\n\
+    - Key imports:\n  - `from trellis.models.zcb_option import resolve_zcb_option_hw_inputs,\
+    \ price_zcb_option_jamshidian`\n  - `from trellis.models.analytical.jamshidian\
+    \ import ResolvedJamshidianInputs, zcb_option_hw_raw`\n  - `from trellis.models.analytical\
+    \ import zcb_option_hw`\n  - `from trellis.models.analytical import terminal_vanilla_from_basis`\n\
+    \  - `from trellis.models.rate_style_swaption import ResolvedSwaptionBlack76Inputs,\
+    \ resolve_swaption_black76_inputs, price_swaption_black76_raw, price_bermudan_swaption_black76_lower_bound`\n\
+    #### calibration\n- Module: `trellis.models.calibration`\n- Key imports:\n  -\
+    \ `from trellis.models.calibration import implied_vol, implied_vol_jaeckel`\n\
     \  - `from trellis.models.calibration import RatesCalibrationResult, calibrate_cap_floor_black_vol,\
     \ calibrate_swaption_black_vol, swaption_terms`\n  - `from trellis.models.calibration\
     \ import calibrate_sabr`\n  - `from trellis.models.calibration import dupire_local_vol`\n\
@@ -191,13 +197,15 @@ calls:
     \ n_t=n_t), construct BlackScholesOperator(lambda s, t: sigma, lambda t: r), call\
     \ theta_method_1d(grid, op, terminal, theta=0.5, lower_bc_fn=..., upper_bc_fn=...),\
     \ then interpolate the returned vector with np.interp(spec.spot, grid.x, V) before\
-    \ multiplying by notional.\n\n## Generated Skills\n- [cookbook] fft_pricing: Characteristic-function\
-    \ pricing for European-style options under models such as Heston\n- [lesson] Unit\
-    \ conversion causes huge PV: Enforce and document input conventions (vol as decimal,\
-    \ discount curve vs zero rate semantics, notional scaling), derive r from discount\
-    \ factors via r = -ln(df)/T or use forward/Black76 consistently, add unit/conversi...\n\
-    ## Structured Lane Card\n- Method family: `pde_solver`\n- Instrument type: `european_option`\n\
-    - Lane boundary: family=`pde_solver`, kind=`exact_target_binding`, exact_bindings=`trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
+    \ multiplying by notional.\n- Stale adapters: `trellis.instruments._agent.fxvanillaanalytical`,\
+    \ `trellis.instruments._agent.fxvanillamontecarlo`\n\n## Generated Skills\n- [cookbook]\
+    \ fft_pricing: Characteristic-function pricing for European-style options under\
+    \ models such as Heston\n- [lesson] Unit conversion causes huge PV: Enforce and\
+    \ document input conventions (vol as decimal, discount curve vs zero rate semantics,\
+    \ notional scaling), derive r from discount factors via r = -ln(df)/T or use forward/Black76\
+    \ consistently, add unit/conversi...\n## Structured Lane Card\n- Method family:\
+    \ `pde_solver`\n- Instrument type: `european_option`\n- Lane boundary: family=`pde_solver`,\
+    \ kind=`exact_target_binding`, exact_bindings=`trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
     - Lane obligations:\n  - Lane family: `pde_solver`\n  - Plan kind: `exact_target_binding`\n\
     \  - Market bindings: `black_vol_surface`, `discount_curve`\n  - State obligations:\
     \ `spot`, `strike`, `expiry`, `expiry_black_vol`\n  - Exact backend bindings:\n\
@@ -215,22 +223,6 @@ calls:
     \ - `trellis.models.equity_option_pde.price_vanilla_equity_option_pde` (route_helper)\n\
     \  - Resolved instructions:\n    - [hard_constraint] Use the route helper directly\
     \ inside `evaluate()`; do not rebuild the process, engine, or discount glue manually.\n\
-    \    - [historical_note] For vanilla European equity PDE routes, prefer `price_vanilla_equity_option_pde(market_state,\
-    \ spec, theta=...)` so the adapter stays thin.\n    - [historical_note] Map `implementation_target=theta_0.5`\
-    \ to `theta=0.5` and `implementation_target=theta_1.0` to `theta=1.0`.\n    -\
-    \ [historical_note] The checked-in helper already owns grid sizing, terminal payoff\
-    \ assembly, boundary conditions, theta-method solve, and interpolation back to\
-    \ spot.\n    - [historical_note] Use the lower-level `Grid + BlackScholesOperator\
-    \ + theta_method_1d` path only when the payoff or boundary contract genuinely\
-    \ differs from plain vanilla European call/put.\n  - Required adapters:\n    -\
-    \ `reuse_checked_in_vanilla_equity_pde_helper`\n  - Backend notes:\n    - For\
-    \ vanilla European equity PDE routes, prefer `price_vanilla_equity_option_pde(market_state,\
-    \ spec, theta=...)` so the adapter stays thin.\n    - Map `implementation_target=theta_0.5`\
-    \ to `theta=0.5` and `implementation_target=theta_1.0` to `theta=1.0`.\n    -\
-    \ The checked-in helper already owns grid sizing, terminal payoff assembly, boundary\
-    \ conditions, theta-method solve, and interpolation back to spot.\n    - Use the\
-    \ lower-level `Grid + BlackScholesOperator + theta_method_1d` path only when the\
-    \ payoff or boundary contract genuinely differs from plain vanilla European call/put.\n\
     - Primary modules to inspect/reuse:\n  - `trellis.models.pde.theta_method`\n-\
     \ Post-build test targets:\n  - `tests/test_agent/test_build_loop.py`\n- Instruction\
     \ precedence: follow the lane obligations in this card first. Treat backend route/helper\
@@ -242,11 +234,9 @@ calls:
     \ To Lane Obligations)\n- Lane family: `pde_solver`\n- Lane plan kind: `exact_target_binding`\n\
     - Method family: `pde_solver`\n- Route: `vanilla_equity_theta_pde`\n- Engine family:\
     \ `pde_solver`\n- Required primitive symbols:\n  - `trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
-    - Adapter obligations:\n  - `reuse_checked_in_vanilla_equity_pde_helper`\n## Thin\
-    \ Adapter Plan\n- Target payoff class: `EuropeanOptionAnalyticalPayoff`\n- Required\
-    \ market reads:\n  - `market_state.vol_surface.black_vol(...)`\n  - `market_state.discount`\n\
+    ## Thin Adapter Plan\n- Target payoff class: `EuropeanOptionAnalyticalPayoff`\n\
+    - Required market reads:\n  - `market_state.vol_surface.black_vol(...)`\n  - `market_state.discount`\n\
     - Required primitive calls:\n  - `trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
-    - Required adapter steps:\n  - `reuse_checked_in_vanilla_equity_pde_helper`\n\
     - Return contract: Return a Python `float` present value from `evaluate()`.\n\
     ## Invariant Pack\n- The generated payoff should be compatible with these deterministic\
     \ validation checks:\n  - `check_non_negativity`\n  - `check_price_sanity`\n \
@@ -380,26 +370,18 @@ calls:
 - seq: 1
   function: llm_generate_json
   stage: critic
-  prompt_hash: fd8b82824485c6f9a40c1267ee0611f929ef90a395b34a496babd4fe02671fb7
-  response_text: '{"status": "suspect", "concerns": [{"check_id": "volatility_input_usage",
-    "description": "The implementation hardcodes a theta-method PDE call without any
-    explicit volatility plumbing in the adapter, so pricing may be insensitive to
-    the market volatility input if the backend helper is not correctly consuming `black_vol_surface`.",
-    "severity": "error", "evidence": "The adapter only forwards `market_state` and
-    `spec` into `price_vanilla_equity_option_pde(...)` and never references vol directly;
-    given the stated boundary contract, any mismatch in the helper''s expected market-state
-    fields would make the price effectively vol-blind.", "remediation": "Verify the
-    backend helper is reading the required `expiry_black_vol`/`black_vol_surface`
-    from `market_state`; if not, wire the volatility surface explicitly into the pricing
-    path or use the exact expected market-state schema.", "status": "suspect"}, {"check_id":
-    "price_non_negative", "description": "There is no explicit safeguard against negative
-    PDE output, so a boundary/interop mismatch could return a negative option value.",
-    "severity": "warning", "evidence": "The code returns `float(pv)` directly from
-    `price_vanilla_equity_option_pde(...)` with no sanity clamp or validation, and
-    the imported helper is assumed rather than asserted to respect call-option positivity.",
-    "remediation": "Add post-price sanity validation or confirm the helper is contractually
-    guaranteed to return a non-negative vanilla call PV under the default market state.",
-    "status": "suspect"}]}'
+  prompt_hash: b8e33c8f6ba8b2da6a10a19604c7b36537fabe611f318ff69d0d7bee18714393
+  response_text: '{"check_id": "volatility_input_usage", "description": "Volatility
+    is not actually wired from the market state into the PDE pricer call, so the price
+    may be insensitive to volatility changes.", "severity": "error", "evidence": "`evaluate()`
+    only checks that `market_state.vol_surface` is not None and then calls `price_vanilla_equity_option_pde(market_state,
+    spec, theta=0.5)`. There is no explicit extraction or forwarding of a flat vol/expiry
+    vol to the solver, despite the route contract requiring `expiry_black_vol`. If
+    the backend helper does not infer it from the surface shape, the pricing result
+    can become effectively decoupled from vol.", "remediation": "Populate the expected
+    PDE market-state fields explicitly before calling the helper, including the expiry
+    volatility from the surface, and verify the backend receives the intended sigma
+    input.", "status": "suspect"}'
   prompt_text: "You are a quantitative model validator reviewing agent-generated pricing\
     \ code.\nYour job is to find deterministic review concerns, not to praise. Be\
     \ adversarial.\n\n## Code to review\n```python\n\"\"\"Agent-generated payoff:\
@@ -451,30 +433,33 @@ calls:
     \    @property\n    def spec(self) -> EuropeanOptionSpec:\n        return self._spec\n\
     \n    @property\n    def requirements(self) -> set[str]:\n        return {\"black_vol_surface\"\
     , \"discount_curve\"}\n\n    def evaluate(self, market_state: MarketState) ->\
-    \ float:\n        spec = self._spec\n        theta = 0.5\n        option_type\
-    \ = (spec.option_type or \"call\").lower()\n        if option_type not in {\"\
-    call\", \"put\"}:\n            raise ValueError(f\"Unsupported option_type: {spec.option_type!r}\"\
-    )\n\n        pv = price_vanilla_equity_option_pde(market_state, spec, theta=theta)\n\
-    \        return float(pv)\n\n```\n\n## Instrument description\nBuild a pricer\
-    \ for: European call: theta-method convergence order measurement\n\nEuropean call\
-    \ option on a non-dividend-paying stock.\nS0=100, K=105, T=1Y, risk-free rate\
-    \ r=5%, volatility sigma=20%.\nSolve with the Black-Scholes PDE operator using\
-    \ Crank-Nicolson\n(theta=0.5) and fully implicit (theta=1.0) on a 200-point spot\
-    \ grid\n× 100 time steps.\nMeasure convergence order by doubling the grid: the\
-    \ CN scheme should\nshow O(dt^2 + dS^2) convergence and the implicit scheme O(dt\
-    \ + dS^2).\nCompare both to the Black-Scholes analytical price.\n\nConstruct methods:\
-    \ pde_solver\nComparison targets: theta_0.5 (pde_solver), theta_1.0 (pde_solver),\
-    \ black_scholes (analytical)\nCross-validation harness:\n  internal targets: theta_0.5,\
-    \ theta_1.0\n  analytical benchmark: black_scholes\n  external targets: quantlib\n\
-    New component: convergence_order_diagnostic\n\nImplementation target: theta_0.5\n\
-    Preferred method family: pde_solver\n\nImplementation target: theta_0.5\n\n##\
-    \ Shared Knowledge\n## Distilled Review Memory\n\n- Review principles:\n  - `P1`:\
-    \ Always calibrate rate trees to the discount curve before pricing\n  - `P2`:\
-    \ Callable bonds need issuer_call lattice control, discrete coupons, and exercise=par+coupon\n\
-    \  - `P3`: Convert vol units at the boundary between market data and model\n-\
-    \ Review checkpoints:\n  - GRID: Use at least 200 spatial points and 200+ time\
-    \ steps. For barrier options, use non-uniform grid concentrated near the barrier.\n\
-    \  - BOUNDARY CONDITIONS: Set V(0,t)=0 for calls, V(S_max,t)=S_max-K*exp(-r*(T-t))\
+    \ float:\n        spec = self._spec\n        spec = self._spec\n        from trellis.models.equity_option_pde\
+    \ import price_vanilla_equity_option_pde\n\n        if spec.option_type not in\
+    \ {\"call\", \"put\"}:\n            raise ValueError(f\"Unsupported option_type:\
+    \ {spec.option_type!r}\")\n\n        if market_state.vol_surface is None:\n  \
+    \          raise ValueError(\"market_state.vol_surface is required for PDE pricing\"\
+    )\n        if market_state.discount is None:\n            raise ValueError(\"\
+    market_state.discount is required for PDE pricing\")\n\n        return float(price_vanilla_equity_option_pde(market_state,\
+    \ spec, theta=0.5))\n\n```\n\n## Instrument description\nBuild a pricer for: European\
+    \ call: theta-method convergence order measurement\n\nEuropean call option on\
+    \ a non-dividend-paying stock.\nS0=100, K=105, T=1Y, risk-free rate r=5%, volatility\
+    \ sigma=20%.\nSolve with the Black-Scholes PDE operator using Crank-Nicolson\n\
+    (theta=0.5) and fully implicit (theta=1.0) on a 200-point spot grid\n× 100 time\
+    \ steps.\nMeasure convergence order by doubling the grid: the CN scheme should\n\
+    show O(dt^2 + dS^2) convergence and the implicit scheme O(dt + dS^2).\nCompare\
+    \ both to the Black-Scholes analytical price.\n\nConstruct methods: pde_solver\n\
+    Comparison targets: theta_0.5 (pde_solver), theta_1.0 (pde_solver), black_scholes\
+    \ (analytical)\nCross-validation harness:\n  internal targets: theta_0.5, theta_1.0\n\
+    \  analytical benchmark: black_scholes\n  external targets: quantlib\nNew component:\
+    \ convergence_order_diagnostic\n\nImplementation target: theta_0.5\nPreferred\
+    \ method family: pde_solver\n\nImplementation target: theta_0.5\n\n## Shared Knowledge\n\
+    ## Distilled Review Memory\n\n- Review principles:\n  - `P1`: Always calibrate\
+    \ rate trees to the discount curve before pricing\n  - `P2`: Callable bonds need\
+    \ issuer_call lattice control, discrete coupons, and exercise=par+coupon\n  -\
+    \ `P3`: Convert vol units at the boundary between market data and model\n- Review\
+    \ checkpoints:\n  - GRID: Use at least 200 spatial points and 200+ time steps.\
+    \ For barrier options, use non-uniform grid concentrated near the barrier.\n \
+    \ - BOUNDARY CONDITIONS: Set V(0,t)=0 for calls, V(S_max,t)=S_max-K*exp(-r*(T-t))\
     \ for calls. For puts: V(0,t)=K*exp(-r*(T-t)), V(S_max,t)=0.\n  - STABILITY: Crank-Nicolson\
     \ (theta=0.5) is second-order but may oscillate near discontinuities. Use Rannacher\
     \ smoothing (2-4 implicit steps at start) for digital/barrier payoffs.\n- Canonical\
@@ -488,12 +473,13 @@ calls:
     \ signature and then read the wrong element of the result instead of interpolating\
     \ the returned solution over grid.x. The actual API is theta_method_1d(grid, operator,\
     \ terminal_condition, theta=..., lower_bc_fn=..., upper_bc_fn=...), and it returns\
-    \ the full solution vector at t=0.\n\n## Generated Skills\n- [lesson] Unit conversion\
-    \ causes huge PV: Enforce and document input conventions (vol as decimal, discount\
-    \ curve vs zero rate semantics, notional scaling), derive r from discount factors\
-    \ via r = -ln(df)/T or use forward/Black76 consistently, add unit/conversi...\n\
-    \n\n## Compiled Route Contract\n- Method family: `pde_solver`\n- Instrument type:\
-    \ `european_option`\n- Lane boundary: family=`pde_solver`, kind=`exact_target_binding`,\
+    \ the full solution vector at t=0.\n- Stale adapters: `trellis.instruments._agent.fxvanillaanalytical`,\
+    \ `trellis.instruments._agent.fxvanillamontecarlo`\n\n## Generated Skills\n- [lesson]\
+    \ Unit conversion causes huge PV: Enforce and document input conventions (vol\
+    \ as decimal, discount curve vs zero rate semantics, notional scaling), derive\
+    \ r from discount factors via r = -ln(df)/T or use forward/Black76 consistently,\
+    \ add unit/conversi...\n\n\n## Compiled Route Contract\n- Method family: `pde_solver`\n\
+    - Instrument type: `european_option`\n- Lane boundary: family=`pde_solver`, kind=`exact_target_binding`,\
     \ exact_bindings=`trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
     - Lane obligations:\n  - Lane family: `pde_solver`\n  - Plan kind: `exact_target_binding`\n\
     \  - Market bindings: `black_vol_surface`, `discount_curve`\n  - State obligations:\
@@ -512,22 +498,6 @@ calls:
     \ - `trellis.models.equity_option_pde.price_vanilla_equity_option_pde` (route_helper)\n\
     \  - Resolved instructions:\n    - [hard_constraint] Use the route helper directly\
     \ inside `evaluate()`; do not rebuild the process, engine, or discount glue manually.\n\
-    \    - [historical_note] For vanilla European equity PDE routes, prefer `price_vanilla_equity_option_pde(market_state,\
-    \ spec, theta=...)` so the adapter stays thin.\n    - [historical_note] Map `implementation_target=theta_0.5`\
-    \ to `theta=0.5` and `implementation_target=theta_1.0` to `theta=1.0`.\n    -\
-    \ [historical_note] The checked-in helper already owns grid sizing, terminal payoff\
-    \ assembly, boundary conditions, theta-method solve, and interpolation back to\
-    \ spot.\n    - [historical_note] Use the lower-level `Grid + BlackScholesOperator\
-    \ + theta_method_1d` path only when the payoff or boundary contract genuinely\
-    \ differs from plain vanilla European call/put.\n  - Required adapters:\n    -\
-    \ `reuse_checked_in_vanilla_equity_pde_helper`\n  - Backend notes:\n    - For\
-    \ vanilla European equity PDE routes, prefer `price_vanilla_equity_option_pde(market_state,\
-    \ spec, theta=...)` so the adapter stays thin.\n    - Map `implementation_target=theta_0.5`\
-    \ to `theta=0.5` and `implementation_target=theta_1.0` to `theta=1.0`.\n    -\
-    \ The checked-in helper already owns grid sizing, terminal payoff assembly, boundary\
-    \ conditions, theta-method solve, and interpolation back to spot.\n    - Use the\
-    \ lower-level `Grid + BlackScholesOperator + theta_method_1d` path only when the\
-    \ payoff or boundary contract genuinely differs from plain vanilla European call/put.\n\
     - Approved modules in scope:\n  - `trellis.core.date_utils`\n  - `trellis.core.differentiable`\n\
     \  - `trellis.core.market_state`\n  - `trellis.core.payoff`\n  - `trellis.core.types`\n\
     \  - `trellis.models.black`\n  - `trellis.models.equity_option_pde`\n  - `trellis.models.pde`\n\
@@ -554,12 +524,16 @@ calls:
 - seq: 2
   function: llm_generate
   stage: code_generation
-  prompt_hash: 8e039b86d1bc1edf4c59ba3560080cfcca289bef296bcd00d2459ccd5c177204
-  response_text: "from trellis.models.equity_option_pde import price_vanilla_equity_option_pde\n\
-    \n        # Thin adapter to the checked-in vanilla equity PDE helper.\n      \
-    \  # The helper owns grid sizing, boundary conditions, theta-method solve,\n \
-    \       # and interpolation back to the spot.\n        return float(price_vanilla_equity_option_pde(market_state,\
-    \ spec, theta=1.0))"
+  prompt_hash: 0ab1b878e381be1e438e3b85ea47eba2cddb7318bc7b1aab53b284984b4e78b3
+  response_text: "spec = self._spec\n\n        from trellis.models.equity_option_pde\
+    \ import price_vanilla_equity_option_pde\n\n        if market_state.vol_surface\
+    \ is None:\n            raise ValueError(\"market_state.vol_surface is required\
+    \ for PDE pricing\")\n        if market_state.discount is None:\n            raise\
+    \ ValueError(\"market_state.discount is required for PDE pricing\")\n\n      \
+    \  if spec.option_type not in {\"call\", \"put\"}:\n            raise ValueError(f\"\
+    Unsupported option_type: {spec.option_type!r}\")\n\n        pv = price_vanilla_equity_option_pde(\n\
+    \            market_state,\n            spec,\n            theta=1.0,\n      \
+    \  )\n        return float(pv)"
   prompt_text: "You are implementing the evaluate() method for `EuropeanOptionAnalyticalPayoff`\
     \ in the Trellis pricing library.\n\n## Complete module (skeleton — everything\
     \ is fixed except evaluate)\n```python\n\"\"\"Agent-generated payoff: Build a\
@@ -677,19 +651,22 @@ calls:
     \ import HullWhitePDEOperator`\n- Notes:\n  - Vanilla European equity PDE routes\
     \ should prefer the checked-in helper `price_vanilla_equity_option_pde(...)`\n\
     \  - Use theta_method_1d, NOT legacy crank_nicolson_1d or implicit_fd_1d\n####\
-    \ fft\n- Module: `trellis.models.transforms`\n- Key imports:\n  - `from trellis.models.transforms\
-    \ import fft_price, cos_price`\n- Notes:\n  - fft_price expects CF of log(S_T)\
-    \ — include log(S0)\n  - cos_price expects CF of log(S_T/S0) — log-return only\n\
-    #### copulas\n- Module: `trellis.models.copulas`\n- Key imports:\n  - `from trellis.models.copulas\
-    \ import GaussianCopula, StudentTCopula, FactorCopula`\n#### analytical\n- Module:\
-    \ `trellis.models.zcb_option`\n- Key imports:\n  - `from trellis.models.zcb_option\
-    \ import resolve_zcb_option_hw_inputs, price_zcb_option_jamshidian`\n  - `from\
-    \ trellis.models.analytical.jamshidian import ResolvedJamshidianInputs, zcb_option_hw_raw`\n\
-    \  - `from trellis.models.analytical import zcb_option_hw`\n  - `from trellis.models.analytical\
-    \ import terminal_vanilla_from_basis`\n  - `from trellis.models.rate_style_swaption\
-    \ import ResolvedSwaptionBlack76Inputs, resolve_swaption_black76_inputs, price_swaption_black76_raw,\
-    \ price_bermudan_swaption_black76_lower_bound`\n#### calibration\n- Module: `trellis.models.calibration`\n\
-    - Key imports:\n  - `from trellis.models.calibration import implied_vol, implied_vol_jaeckel`\n\
+    \ fft\n- Module: `trellis.models.transforms.fft_pricer`\n- Key imports:\n  - `from\
+    \ trellis.models.transforms.fft_pricer import fft_price`\n  - `from trellis.models.transforms.cos_method\
+    \ import cos_price`\n- Notes:\n  - Concrete transform helpers live in submodules;\
+    \ do not import `trellis.models.transforms` directly.\n  - fft_price expects CF\
+    \ of log(S_T) — include log(S0)\n#### copulas\n- Module: `trellis.models.copulas.factor`\n\
+    - Key imports:\n  - `from trellis.models.copulas.factor import FactorCopula`\n\
+    \  - `from trellis.models.copulas.gaussian import GaussianCopula`\n  - `from trellis.models.copulas.student_t\
+    \ import StudentTCopula`\n#### analytical\n- Module: `trellis.models.zcb_option`\n\
+    - Key imports:\n  - `from trellis.models.zcb_option import resolve_zcb_option_hw_inputs,\
+    \ price_zcb_option_jamshidian`\n  - `from trellis.models.analytical.jamshidian\
+    \ import ResolvedJamshidianInputs, zcb_option_hw_raw`\n  - `from trellis.models.analytical\
+    \ import zcb_option_hw`\n  - `from trellis.models.analytical import terminal_vanilla_from_basis`\n\
+    \  - `from trellis.models.rate_style_swaption import ResolvedSwaptionBlack76Inputs,\
+    \ resolve_swaption_black76_inputs, price_swaption_black76_raw, price_bermudan_swaption_black76_lower_bound`\n\
+    #### calibration\n- Module: `trellis.models.calibration`\n- Key imports:\n  -\
+    \ `from trellis.models.calibration import implied_vol, implied_vol_jaeckel`\n\
     \  - `from trellis.models.calibration import RatesCalibrationResult, calibrate_cap_floor_black_vol,\
     \ calibrate_swaption_black_vol, swaption_terms`\n  - `from trellis.models.calibration\
     \ import calibrate_sabr`\n  - `from trellis.models.calibration import dupire_local_vol`\n\
@@ -737,13 +714,15 @@ calls:
     \ n_t=n_t), construct BlackScholesOperator(lambda s, t: sigma, lambda t: r), call\
     \ theta_method_1d(grid, op, terminal, theta=0.5, lower_bc_fn=..., upper_bc_fn=...),\
     \ then interpolate the returned vector with np.interp(spec.spot, grid.x, V) before\
-    \ multiplying by notional.\n\n## Generated Skills\n- [cookbook] fft_pricing: Characteristic-function\
-    \ pricing for European-style options under models such as Heston\n- [lesson] Unit\
-    \ conversion causes huge PV: Enforce and document input conventions (vol as decimal,\
-    \ discount curve vs zero rate semantics, notional scaling), derive r from discount\
-    \ factors via r = -ln(df)/T or use forward/Black76 consistently, add unit/conversi...\n\
-    ## Structured Lane Card\n- Method family: `pde_solver`\n- Instrument type: `european_option`\n\
-    - Lane boundary: family=`pde_solver`, kind=`exact_target_binding`, exact_bindings=`trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
+    \ multiplying by notional.\n- Stale adapters: `trellis.instruments._agent.fxvanillaanalytical`,\
+    \ `trellis.instruments._agent.fxvanillamontecarlo`\n\n## Generated Skills\n- [cookbook]\
+    \ fft_pricing: Characteristic-function pricing for European-style options under\
+    \ models such as Heston\n- [lesson] Unit conversion causes huge PV: Enforce and\
+    \ document input conventions (vol as decimal, discount curve vs zero rate semantics,\
+    \ notional scaling), derive r from discount factors via r = -ln(df)/T or use forward/Black76\
+    \ consistently, add unit/conversi...\n## Structured Lane Card\n- Method family:\
+    \ `pde_solver`\n- Instrument type: `european_option`\n- Lane boundary: family=`pde_solver`,\
+    \ kind=`exact_target_binding`, exact_bindings=`trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
     - Lane obligations:\n  - Lane family: `pde_solver`\n  - Plan kind: `exact_target_binding`\n\
     \  - Market bindings: `black_vol_surface`, `discount_curve`\n  - State obligations:\
     \ `spot`, `strike`, `expiry`, `expiry_black_vol`\n  - Exact backend bindings:\n\
@@ -761,22 +740,6 @@ calls:
     \ - `trellis.models.equity_option_pde.price_vanilla_equity_option_pde` (route_helper)\n\
     \  - Resolved instructions:\n    - [hard_constraint] Use the route helper directly\
     \ inside `evaluate()`; do not rebuild the process, engine, or discount glue manually.\n\
-    \    - [historical_note] For vanilla European equity PDE routes, prefer `price_vanilla_equity_option_pde(market_state,\
-    \ spec, theta=...)` so the adapter stays thin.\n    - [historical_note] Map `implementation_target=theta_0.5`\
-    \ to `theta=0.5` and `implementation_target=theta_1.0` to `theta=1.0`.\n    -\
-    \ [historical_note] The checked-in helper already owns grid sizing, terminal payoff\
-    \ assembly, boundary conditions, theta-method solve, and interpolation back to\
-    \ spot.\n    - [historical_note] Use the lower-level `Grid + BlackScholesOperator\
-    \ + theta_method_1d` path only when the payoff or boundary contract genuinely\
-    \ differs from plain vanilla European call/put.\n  - Required adapters:\n    -\
-    \ `reuse_checked_in_vanilla_equity_pde_helper`\n  - Backend notes:\n    - For\
-    \ vanilla European equity PDE routes, prefer `price_vanilla_equity_option_pde(market_state,\
-    \ spec, theta=...)` so the adapter stays thin.\n    - Map `implementation_target=theta_0.5`\
-    \ to `theta=0.5` and `implementation_target=theta_1.0` to `theta=1.0`.\n    -\
-    \ The checked-in helper already owns grid sizing, terminal payoff assembly, boundary\
-    \ conditions, theta-method solve, and interpolation back to spot.\n    - Use the\
-    \ lower-level `Grid + BlackScholesOperator + theta_method_1d` path only when the\
-    \ payoff or boundary contract genuinely differs from plain vanilla European call/put.\n\
     - Primary modules to inspect/reuse:\n  - `trellis.models.pde.theta_method`\n-\
     \ Post-build test targets:\n  - `tests/test_agent/test_build_loop.py`\n- Instruction\
     \ precedence: follow the lane obligations in this card first. Treat backend route/helper\
@@ -788,11 +751,9 @@ calls:
     \ To Lane Obligations)\n- Lane family: `pde_solver`\n- Lane plan kind: `exact_target_binding`\n\
     - Method family: `pde_solver`\n- Route: `vanilla_equity_theta_pde`\n- Engine family:\
     \ `pde_solver`\n- Required primitive symbols:\n  - `trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
-    - Adapter obligations:\n  - `reuse_checked_in_vanilla_equity_pde_helper`\n## Thin\
-    \ Adapter Plan\n- Target payoff class: `EuropeanOptionAnalyticalPayoff`\n- Required\
-    \ market reads:\n  - `market_state.vol_surface.black_vol(...)`\n  - `market_state.discount`\n\
+    ## Thin Adapter Plan\n- Target payoff class: `EuropeanOptionAnalyticalPayoff`\n\
+    - Required market reads:\n  - `market_state.vol_surface.black_vol(...)`\n  - `market_state.discount`\n\
     - Required primitive calls:\n  - `trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
-    - Required adapter steps:\n  - `reuse_checked_in_vanilla_equity_pde_helper`\n\
     - Return contract: Return a Python `float` present value from `evaluate()`.\n\
     ## Invariant Pack\n- The generated payoff should be compatible with these deterministic\
     \ validation checks:\n  - `check_non_negativity`\n  - `check_price_sanity`\n \
@@ -926,17 +887,18 @@ calls:
 - seq: 3
   function: llm_generate_json
   stage: critic
-  prompt_hash: 545a41a824b9e6fe20e4dddd64a9dec50a7e5aa084d0ed1556438e65e1d961f6
-  response_text: '{"check_id": "volatility_input_usage", "description": "Volatility
-    may be effectively ignored because the implementation binds only spot/strike/expiry
-    and relies on a helper whose volatility sourcing is opaque.", "severity": "warning",
-    "evidence": "`evaluate()` forwards `market_state` and `spec` directly to `price_vanilla_equity_option_pde(...)`
-    with `theta=1.0`, but this wrapper exposes no explicit volatility plumbing and
-    the review memory flags a known failure mode where PDE code becomes volatility-insensitive
-    or misbinds the surface/curve inputs.", "remediation": "Verify that `market_state`
-    actually contains and forwards the black vol surface into the PDE helper, and
-    that the helper uses it in the operator coefficients rather than falling back
-    to a default or constant volatility.", "status": "suspect"}'
+  prompt_hash: b3ff96220ec052577de760b03b322ad1ef549f7f393c89c5404cf510927f066d
+  response_text: '{"check_id": "volatility_input_usage", "description": "The pricer
+    does not expose or pass the required PDE resolution controls from the instrument
+    description, so the valuation path may be effectively insensitive to the intended
+    convergence setup and comparison targets.", "severity": "warning", "evidence":
+    "`evaluate()` hard-codes `theta=1.0` and never passes `n_x`, `n_t`, or `s_max_multiplier`
+    to `price_vanilla_equity_option_pde`, despite the route contract specifying these
+    exact backend bindings and the instrument being about grid-doubling convergence.
+    The code also ignores the Crank–Nicolson target (`theta=0.5`) entirely.", "remediation":
+    "Plumb the PDE solver controls through the instrument interface and provide separate
+    evaluation paths for `theta=0.5` and `theta=1.0`, including grid-size parameters
+    needed for convergence diagnostics.", "status": "suspect"}'
   prompt_text: "You are a quantitative model validator reviewing agent-generated pricing\
     \ code.\nYour job is to find deterministic review concerns, not to praise. Be\
     \ adversarial.\n\n## Code to review\n```python\n\"\"\"Agent-generated payoff:\
@@ -988,10 +950,15 @@ calls:
     \    @property\n    def spec(self) -> EuropeanOptionSpec:\n        return self._spec\n\
     \n    @property\n    def requirements(self) -> set[str]:\n        return {\"black_vol_surface\"\
     , \"discount_curve\"}\n\n    def evaluate(self, market_state: MarketState) ->\
-    \ float:\n        spec = self._spec\n        # Thin adapter to the checked-in\
-    \ vanilla equity PDE helper.\n        # The helper owns grid sizing, boundary\
-    \ conditions, theta-method solve,\n        # and interpolation back to the spot.\n\
-    \        return float(price_vanilla_equity_option_pde(market_state, spec, theta=1.0))\n\
+    \ float:\n        spec = self._spec\n        spec = self._spec\n\n        from\
+    \ trellis.models.equity_option_pde import price_vanilla_equity_option_pde\n\n\
+    \        if market_state.vol_surface is None:\n            raise ValueError(\"\
+    market_state.vol_surface is required for PDE pricing\")\n        if market_state.discount\
+    \ is None:\n            raise ValueError(\"market_state.discount is required for\
+    \ PDE pricing\")\n\n        if spec.option_type not in {\"call\", \"put\"}:\n\
+    \            raise ValueError(f\"Unsupported option_type: {spec.option_type!r}\"\
+    )\n\n        pv = price_vanilla_equity_option_pde(\n            market_state,\n\
+    \            spec,\n            theta=1.0,\n        )\n        return float(pv)\n\
     \n```\n\n## Instrument description\nBuild a pricer for: European call: theta-method\
     \ convergence order measurement\n\nEuropean call option on a non-dividend-paying\
     \ stock.\nS0=100, K=105, T=1Y, risk-free rate r=5%, volatility sigma=20%.\nSolve\
@@ -1025,12 +992,13 @@ calls:
     \ signature and then read the wrong element of the result instead of interpolating\
     \ the returned solution over grid.x. The actual API is theta_method_1d(grid, operator,\
     \ terminal_condition, theta=..., lower_bc_fn=..., upper_bc_fn=...), and it returns\
-    \ the full solution vector at t=0.\n\n## Generated Skills\n- [lesson] Unit conversion\
-    \ causes huge PV: Enforce and document input conventions (vol as decimal, discount\
-    \ curve vs zero rate semantics, notional scaling), derive r from discount factors\
-    \ via r = -ln(df)/T or use forward/Black76 consistently, add unit/conversi...\n\
-    \n\n## Compiled Route Contract\n- Method family: `pde_solver`\n- Instrument type:\
-    \ `european_option`\n- Lane boundary: family=`pde_solver`, kind=`exact_target_binding`,\
+    \ the full solution vector at t=0.\n- Stale adapters: `trellis.instruments._agent.fxvanillaanalytical`,\
+    \ `trellis.instruments._agent.fxvanillamontecarlo`\n\n## Generated Skills\n- [lesson]\
+    \ Unit conversion causes huge PV: Enforce and document input conventions (vol\
+    \ as decimal, discount curve vs zero rate semantics, notional scaling), derive\
+    \ r from discount factors via r = -ln(df)/T or use forward/Black76 consistently,\
+    \ add unit/conversi...\n\n\n## Compiled Route Contract\n- Method family: `pde_solver`\n\
+    - Instrument type: `european_option`\n- Lane boundary: family=`pde_solver`, kind=`exact_target_binding`,\
     \ exact_bindings=`trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
     - Lane obligations:\n  - Lane family: `pde_solver`\n  - Plan kind: `exact_target_binding`\n\
     \  - Market bindings: `black_vol_surface`, `discount_curve`\n  - State obligations:\
@@ -1049,22 +1017,6 @@ calls:
     \ - `trellis.models.equity_option_pde.price_vanilla_equity_option_pde` (route_helper)\n\
     \  - Resolved instructions:\n    - [hard_constraint] Use the route helper directly\
     \ inside `evaluate()`; do not rebuild the process, engine, or discount glue manually.\n\
-    \    - [historical_note] For vanilla European equity PDE routes, prefer `price_vanilla_equity_option_pde(market_state,\
-    \ spec, theta=...)` so the adapter stays thin.\n    - [historical_note] Map `implementation_target=theta_0.5`\
-    \ to `theta=0.5` and `implementation_target=theta_1.0` to `theta=1.0`.\n    -\
-    \ [historical_note] The checked-in helper already owns grid sizing, terminal payoff\
-    \ assembly, boundary conditions, theta-method solve, and interpolation back to\
-    \ spot.\n    - [historical_note] Use the lower-level `Grid + BlackScholesOperator\
-    \ + theta_method_1d` path only when the payoff or boundary contract genuinely\
-    \ differs from plain vanilla European call/put.\n  - Required adapters:\n    -\
-    \ `reuse_checked_in_vanilla_equity_pde_helper`\n  - Backend notes:\n    - For\
-    \ vanilla European equity PDE routes, prefer `price_vanilla_equity_option_pde(market_state,\
-    \ spec, theta=...)` so the adapter stays thin.\n    - Map `implementation_target=theta_0.5`\
-    \ to `theta=0.5` and `implementation_target=theta_1.0` to `theta=1.0`.\n    -\
-    \ The checked-in helper already owns grid sizing, terminal payoff assembly, boundary\
-    \ conditions, theta-method solve, and interpolation back to spot.\n    - Use the\
-    \ lower-level `Grid + BlackScholesOperator + theta_method_1d` path only when the\
-    \ payoff or boundary contract genuinely differs from plain vanilla European call/put.\n\
     - Approved modules in scope:\n  - `trellis.core.date_utils`\n  - `trellis.core.differentiable`\n\
     \  - `trellis.core.market_state`\n  - `trellis.core.payoff`\n  - `trellis.core.types`\n\
     \  - `trellis.models.black`\n  - `trellis.models.equity_option_pde`\n  - `trellis.models.pde`\n\

--- a/cassettes/full_task/T38.yaml
+++ b/cassettes/full_task/T38.yaml
@@ -1,5 +1,5 @@
 meta:
-  recorded_at: '2026-04-12T05:22:45.154999+00:00'
+  recorded_at: '2026-04-12T08:06:00.723462+00:00'
   provider: openai
   model: gpt-5.4-mini
   total_calls: 4
@@ -8,10 +8,10 @@ calls:
 - seq: 0
   function: llm_generate
   stage: code_generation
-  prompt_hash: 4bd3925e6c575383db296fbfb127b484d268f49f8ae183cc057a119ddb65a27e
+  prompt_hash: 60746e4aa23cd856cbe6da02db4a814b49d876620e4e540f803c2fac2235c8d2
   response_text: "from trellis.core.differentiable import get_numpy\n        from\
     \ trellis.models.credit_default_swap import build_cds_schedule, price_cds_monte_carlo\n\
-    \n        np = get_numpy()\n\n        spec = self._spec\n\n        spread = float(spec.spread)\n\
+    \n        np = get_numpy()\n        spec = self._spec\n\n        spread = float(spec.spread)\n\
     \        if spread > 1.0:\n            spread *= 1e-4\n\n        schedule = build_cds_schedule(\n\
     \            spec.start_date,\n            spec.end_date,\n            spec.frequency,\n\
     \            day_count=spec.day_count,\n            time_origin=spec.start_date,\n\
@@ -150,19 +150,22 @@ calls:
     \ import HullWhitePDEOperator`\n- Notes:\n  - Vanilla European equity PDE routes\
     \ should prefer the checked-in helper `price_vanilla_equity_option_pde(...)`\n\
     \  - Use theta_method_1d, NOT legacy crank_nicolson_1d or implicit_fd_1d\n####\
-    \ fft\n- Module: `trellis.models.transforms`\n- Key imports:\n  - `from trellis.models.transforms\
-    \ import fft_price, cos_price`\n- Notes:\n  - fft_price expects CF of log(S_T)\
-    \ — include log(S0)\n  - cos_price expects CF of log(S_T/S0) — log-return only\n\
-    #### copulas\n- Module: `trellis.models.copulas`\n- Key imports:\n  - `from trellis.models.copulas\
-    \ import GaussianCopula, StudentTCopula, FactorCopula`\n#### analytical\n- Module:\
-    \ `trellis.models.zcb_option`\n- Key imports:\n  - `from trellis.models.zcb_option\
-    \ import resolve_zcb_option_hw_inputs, price_zcb_option_jamshidian`\n  - `from\
-    \ trellis.models.analytical.jamshidian import ResolvedJamshidianInputs, zcb_option_hw_raw`\n\
-    \  - `from trellis.models.analytical import zcb_option_hw`\n  - `from trellis.models.analytical\
-    \ import terminal_vanilla_from_basis`\n  - `from trellis.models.rate_style_swaption\
-    \ import ResolvedSwaptionBlack76Inputs, resolve_swaption_black76_inputs, price_swaption_black76_raw,\
-    \ price_bermudan_swaption_black76_lower_bound`\n#### calibration\n- Module: `trellis.models.calibration`\n\
-    - Key imports:\n  - `from trellis.models.calibration import implied_vol, implied_vol_jaeckel`\n\
+    \ fft\n- Module: `trellis.models.transforms.fft_pricer`\n- Key imports:\n  - `from\
+    \ trellis.models.transforms.fft_pricer import fft_price`\n  - `from trellis.models.transforms.cos_method\
+    \ import cos_price`\n- Notes:\n  - Concrete transform helpers live in submodules;\
+    \ do not import `trellis.models.transforms` directly.\n  - fft_price expects CF\
+    \ of log(S_T) — include log(S0)\n#### copulas\n- Module: `trellis.models.copulas.factor`\n\
+    - Key imports:\n  - `from trellis.models.copulas.factor import FactorCopula`\n\
+    \  - `from trellis.models.copulas.gaussian import GaussianCopula`\n  - `from trellis.models.copulas.student_t\
+    \ import StudentTCopula`\n#### analytical\n- Module: `trellis.models.zcb_option`\n\
+    - Key imports:\n  - `from trellis.models.zcb_option import resolve_zcb_option_hw_inputs,\
+    \ price_zcb_option_jamshidian`\n  - `from trellis.models.analytical.jamshidian\
+    \ import ResolvedJamshidianInputs, zcb_option_hw_raw`\n  - `from trellis.models.analytical\
+    \ import zcb_option_hw`\n  - `from trellis.models.analytical import terminal_vanilla_from_basis`\n\
+    \  - `from trellis.models.rate_style_swaption import ResolvedSwaptionBlack76Inputs,\
+    \ resolve_swaption_black76_inputs, price_swaption_black76_raw, price_bermudan_swaption_black76_lower_bound`\n\
+    #### calibration\n- Module: `trellis.models.calibration`\n- Key imports:\n  -\
+    \ `from trellis.models.calibration import implied_vol, implied_vol_jaeckel`\n\
     \  - `from trellis.models.calibration import RatesCalibrationResult, calibrate_cap_floor_black_vol,\
     \ calibrate_swaption_black_vol, swaption_terms`\n  - `from trellis.models.calibration\
     \ import calibrate_sabr`\n  - `from trellis.models.calibration import dupire_local_vol`\n\
@@ -215,7 +218,8 @@ calls:
     \ the payoff as a thin adapter that calls trellis.core.differentiable.get_numpy\
     \ to obtain numpy arrays, perform all pathwise computations in numpy, and ensure\
     \ the payoff returns a 1D array of shape (n_paths,). Follow other assembly constraints\
-    \ (no banned imports, correct output shape).\n\n## Generated Skills\n- [lesson]\
+    \ (no banned imports, correct output shape).\n- Stale adapters: `trellis.instruments._agent.fxvanillaanalytical`,\
+    \ `trellis.instruments._agent.fxvanillamontecarlo`\n\n## Generated Skills\n- [lesson]\
     \ NthToDefaultPayoff analytical must use Gaussian copula integration, not independent\
     \ binomial: Use the Gaussian copula conditional independence formula (integrate\
     \ over common factor Z). This is the analytical counterpart of the GaussianCopula\
@@ -476,8 +480,19 @@ calls:
 - seq: 1
   function: llm_generate_json
   stage: critic
-  prompt_hash: 1c216c57885af4cbf579218de034b39d60383b05bfda3ab4c212d4aa00fc1050
-  response_text: '{"errors": []}'
+  prompt_hash: 2b4022f9661d8c0d7c5ea6c06961758bfdb330bc5720269aa3c611e2675017e8
+  response_text: '{"check_id": "price_non_negative", "description": "CDS PV sign is
+    likely inverted for a protection buyer, making negative MTM plausible under the
+    default market state.", "severity": "error", "evidence": "The instrument spec
+    explicitly says ''protection buyer side'' and ''Compute the mark-to-market PV
+    (protection leg minus premium leg).'' However the implementation just forwards
+    to `price_cds_monte_carlo(...)` with `spread_quote=spread` and returns its raw
+    output without any sign normalization or side handling. If the backend helper
+    interprets the quoted spread as a premium paid by the buyer, the returned value
+    can be negative by construction for an out-of-the-money CDS.", "remediation":
+    "Verify and enforce the protection-buyer payoff convention at the route boundary;
+    if the backend returns seller PV or premium-minus-protection, flip the sign before
+    returning.", "status": "suspect"}'
   prompt_text: "You are a quantitative model validator reviewing agent-generated pricing\
     \ code.\nYour job is to find deterministic review concerns, not to praise. Be\
     \ adversarial.\n\n## Code to review\n```python\n\"\"\"Agent-generated payoff:\
@@ -540,7 +555,7 @@ calls:
     , \"discount_curve\"}\n\n    def evaluate(self, market_state: MarketState) ->\
     \ float:\n        spec = self._spec\n        from trellis.models.credit_default_swap\
     \ import build_cds_schedule, price_cds_monte_carlo\n\n        np = get_numpy()\n\
-    \n        spec = self._spec\n\n        spread = float(spec.spread)\n        if\
+    \        spec = self._spec\n\n        spread = float(spec.spread)\n        if\
     \ spread > 1.0:\n            spread *= 1e-4\n\n        schedule = build_cds_schedule(\n\
     \        spec.start_date,\n        spec.end_date,\n        spec.frequency,\n \
     \       day_count=spec.day_count,\n        time_origin=spec.start_date,\n    \
@@ -590,6 +605,7 @@ calls:
     \ was implemented as ordinary numpy/opaque operations and did not adapt to the\
     \ selected assembly's required semantic primitive (trellis.core.differentiable.get_numpy).\
     \ The payoff also risked returning the wrong shape (e.g. (n_paths, n_steps+1)).\n\
+    - Stale adapters: `trellis.instruments._agent.fxvanillaanalytical`, `trellis.instruments._agent.fxvanillamontecarlo`\n\
     \n## Generated Skills\n- [lesson] NthToDefaultPayoff analytical must use Gaussian\
     \ copula integration, not independent binomial: Use the Gaussian copula conditional\
     \ independence formula (integrate over common factor Z). This is the analytical\
@@ -672,20 +688,20 @@ calls:
 - seq: 2
   function: llm_generate
   stage: code_generation
-  prompt_hash: bac7dd495f76399c2205d60e4048a8469a25b33d9169a71da75957419721daef
-  response_text: "spec = self._spec\n        if market_state.credit_curve is None:\n\
-    \            raise ValueError(\"CDS pricing requires market_state.credit_curve\"\
-    )\n        if market_state.discount is None:\n            raise ValueError(\"\
-    CDS pricing requires market_state.discount\")\n\n        from trellis.models.credit_default_swap\
-    \ import build_cds_schedule, price_cds_analytical\n\n        spread = spec.spread\n\
-    \        if spread > 1.0:\n            spread = spread / 10000.0\n\n        schedule\
-    \ = build_cds_schedule(\n            spec.start_date,\n            spec.end_date,\n\
-    \            spec.frequency,\n            spec.day_count,\n            time_origin=spec.start_date,\n\
-    \        )\n\n        return float(\n            price_cds_analytical(\n     \
-    \           notional=spec.notional,\n                spread_quote=spread,\n  \
-    \              recovery=spec.recovery,\n                schedule=schedule,\n \
-    \               credit_curve=market_state.credit_curve,\n                discount_curve=market_state.discount,\n\
-    \            )\n        )"
+  prompt_hash: 1a5a6cde692fe9d37f1d11b364768785aa34963d43028b9f7178c6b6caa912aa
+  response_text: "spec = self._spec\n\n        credit_curve = getattr(market_state,\
+    \ \"credit_curve\", None)\n        discount_curve = getattr(market_state, \"discount\"\
+    , None)\n        if credit_curve is None:\n            raise ValueError(\"CDSPayoff\
+    \ requires market_state.credit_curve\")\n        if discount_curve is None:\n\
+    \            raise ValueError(\"CDSPayoff requires market_state.discount\")\n\n\
+    \        spread = spec.spread\n        if spread > 1.0:\n            spread *=\
+    \ 1e-4\n\n        schedule = build_cds_schedule(\n            spec.start_date,\n\
+    \            spec.end_date,\n            spec.frequency,\n            spec.day_count,\n\
+    \            time_origin=spec.start_date,\n        )\n\n        return float(\n\
+    \            price_cds_analytical(\n                notional=spec.notional,\n\
+    \                spread_quote=spread,\n                recovery=spec.recovery,\n\
+    \                schedule=schedule,\n                credit_curve=credit_curve,\n\
+    \                discount_curve=discount_curve,\n            )\n        )"
   prompt_text: "You are implementing the evaluate() method for `CDSPayoff` in the\
     \ Trellis pricing library.\n\n## Complete module (skeleton — everything is fixed\
     \ except evaluate)\n```python\n\"\"\"Agent-generated payoff: Build a pricer for:\
@@ -812,19 +828,22 @@ calls:
     \ import HullWhitePDEOperator`\n- Notes:\n  - Vanilla European equity PDE routes\
     \ should prefer the checked-in helper `price_vanilla_equity_option_pde(...)`\n\
     \  - Use theta_method_1d, NOT legacy crank_nicolson_1d or implicit_fd_1d\n####\
-    \ fft\n- Module: `trellis.models.transforms`\n- Key imports:\n  - `from trellis.models.transforms\
-    \ import fft_price, cos_price`\n- Notes:\n  - fft_price expects CF of log(S_T)\
-    \ — include log(S0)\n  - cos_price expects CF of log(S_T/S0) — log-return only\n\
-    #### copulas\n- Module: `trellis.models.copulas`\n- Key imports:\n  - `from trellis.models.copulas\
-    \ import GaussianCopula, StudentTCopula, FactorCopula`\n#### analytical\n- Module:\
-    \ `trellis.models.zcb_option`\n- Key imports:\n  - `from trellis.models.zcb_option\
-    \ import resolve_zcb_option_hw_inputs, price_zcb_option_jamshidian`\n  - `from\
-    \ trellis.models.analytical.jamshidian import ResolvedJamshidianInputs, zcb_option_hw_raw`\n\
-    \  - `from trellis.models.analytical import zcb_option_hw`\n  - `from trellis.models.analytical\
-    \ import terminal_vanilla_from_basis`\n  - `from trellis.models.rate_style_swaption\
-    \ import ResolvedSwaptionBlack76Inputs, resolve_swaption_black76_inputs, price_swaption_black76_raw,\
-    \ price_bermudan_swaption_black76_lower_bound`\n#### calibration\n- Module: `trellis.models.calibration`\n\
-    - Key imports:\n  - `from trellis.models.calibration import implied_vol, implied_vol_jaeckel`\n\
+    \ fft\n- Module: `trellis.models.transforms.fft_pricer`\n- Key imports:\n  - `from\
+    \ trellis.models.transforms.fft_pricer import fft_price`\n  - `from trellis.models.transforms.cos_method\
+    \ import cos_price`\n- Notes:\n  - Concrete transform helpers live in submodules;\
+    \ do not import `trellis.models.transforms` directly.\n  - fft_price expects CF\
+    \ of log(S_T) — include log(S0)\n#### copulas\n- Module: `trellis.models.copulas.factor`\n\
+    - Key imports:\n  - `from trellis.models.copulas.factor import FactorCopula`\n\
+    \  - `from trellis.models.copulas.gaussian import GaussianCopula`\n  - `from trellis.models.copulas.student_t\
+    \ import StudentTCopula`\n#### analytical\n- Module: `trellis.models.zcb_option`\n\
+    - Key imports:\n  - `from trellis.models.zcb_option import resolve_zcb_option_hw_inputs,\
+    \ price_zcb_option_jamshidian`\n  - `from trellis.models.analytical.jamshidian\
+    \ import ResolvedJamshidianInputs, zcb_option_hw_raw`\n  - `from trellis.models.analytical\
+    \ import zcb_option_hw`\n  - `from trellis.models.analytical import terminal_vanilla_from_basis`\n\
+    \  - `from trellis.models.rate_style_swaption import ResolvedSwaptionBlack76Inputs,\
+    \ resolve_swaption_black76_inputs, price_swaption_black76_raw, price_bermudan_swaption_black76_lower_bound`\n\
+    #### calibration\n- Module: `trellis.models.calibration`\n- Key imports:\n  -\
+    \ `from trellis.models.calibration import implied_vol, implied_vol_jaeckel`\n\
     \  - `from trellis.models.calibration import RatesCalibrationResult, calibrate_cap_floor_black_vol,\
     \ calibrate_swaption_black_vol, swaption_terms`\n  - `from trellis.models.calibration\
     \ import calibrate_sabr`\n  - `from trellis.models.calibration import dupire_local_vol`\n\
@@ -868,33 +887,31 @@ calls:
     \ MarketState capability unless the product explicitly sources it from a live\
     \ market snapshot.\n- Canonical model grammar:\n  - `credit_single_name_reduced_form`\
     \ -> `Reduced-form single-name credit`\n  - `rates_bootstrap_curve` -> `Rates\
-    \ bootstrap curve bundle`\n- Repeated fixes to reuse:\n  - `CDS spread / curve\
-    \ unit mismatch` -> Enforce and normalize input conventions (auto-convert spread\
-    \ in bps to decimal if > 1, require explicit units), require and validate presence\
+    \ bootstrap curve bundle`\n- Repeated fixes to reuse:\n  - `Date-vs-number mix-up`\
+    \ -> Convert all date inputs to consistent numeric year fractions before pricing,\
+    \ and validate input types at the API boundary.\n  - `CDS spread / curve unit\
+    \ mismatch` -> Enforce and normalize input conventions (auto-convert spread in\
+    \ bps to decimal if > 1, require explicit units), require and validate presence\
     \ of discount_curve and credit_curve before pricing, and add PV sanity checks\
-    \ (compare |PV| to notional) to fail fast with actionable errors.\n  - `Missing\
-    \ CDS contract specification` -> Provide a complete CDS product specification\
-    \ (effective/termination dates, payment frequency, day-count, business-day convention,\
-    \ notional, coupon/spread, recovery rate, accrual-on-default rule, settlement\
-    \ lag) and add or link an instrument-specific cookbook/evaluate() template plus\
-    \ the primitive payoff adapter; ensure discount and hazard inputs use pinned conventions\
-    \ and consistent units.\n\n## Generated Skills\n- [lesson] NthToDefaultPayoff\
-    \ analytical must use Gaussian copula integration, not independent binomial: Use\
-    \ the Gaussian copula conditional independence formula (integrate over common\
-    \ factor Z). This is the analytical counterpart of the GaussianCopula MC. from\
-    \ math import comb from scipy import integrate from scipy.stat...\n\n## Instrument\
-    \ Disambiguation\n- Treat this request as a single-name CDS / credit_default_swap\
-    \ contract.\n- Do not reinterpret CDS here as nth_to_default, basket CDS, first-to-default,\
-    \ or any multi-name credit product.\n- Do not import copula or Gaussian-copula\
-    \ machinery unless the request explicitly says nth-to-default, first-to-default,\
-    \ basket CDS, or multiple reference names.\n## Structured Lane Card\n- Method\
-    \ family: `analytical`\n- Instrument type: `cds`\n- Semantic contract: `credit_default_swap`,\
-    \ request=`credit_default_swap`, bridge=`canonical_semantic`, instrument=`cds`,\
-    \ payoff=`credit_default_swap`, structure=`single_reference_entity`\n- Valuation\
-    \ context: market_source=`unbound_market_snapshot`\n- Lane boundary: family=`analytical`,\
-    \ kind=`exact_target_binding`, timeline_roles=`settlement`, `payment`, `observation`,\
-    \ exact_bindings=`trellis.models.credit_default_swap.build_cds_schedule`, `trellis.models.credit_default_swap.price_cds_analytical`\n\
-    - Lowering boundary: family_ir=`CreditDefaultSwapIR`, expr=`ThenExpr`, helpers=`trellis.models.credit_default_swap.build_cds_schedule`,\
+    \ (compare |PV| to notional) to fail fast with actionable errors.\n- Stale adapters:\
+    \ `trellis.instruments._agent.fxvanillaanalytical`, `trellis.instruments._agent.fxvanillamontecarlo`\n\
+    \n## Generated Skills\n- [lesson] NthToDefaultPayoff analytical must use Gaussian\
+    \ copula integration, not independent binomial: Use the Gaussian copula conditional\
+    \ independence formula (integrate over common factor Z). This is the analytical\
+    \ counterpart of the GaussianCopula MC. from math import comb from scipy import\
+    \ integrate from scipy.stat...\n\n## Instrument Disambiguation\n- Treat this request\
+    \ as a single-name CDS / credit_default_swap contract.\n- Do not reinterpret CDS\
+    \ here as nth_to_default, basket CDS, first-to-default, or any multi-name credit\
+    \ product.\n- Do not import copula or Gaussian-copula machinery unless the request\
+    \ explicitly says nth-to-default, first-to-default, basket CDS, or multiple reference\
+    \ names.\n## Structured Lane Card\n- Method family: `analytical`\n- Instrument\
+    \ type: `cds`\n- Semantic contract: `credit_default_swap`, request=`credit_default_swap`,\
+    \ bridge=`canonical_semantic`, instrument=`cds`, payoff=`credit_default_swap`,\
+    \ structure=`single_reference_entity`\n- Valuation context: market_source=`unbound_market_snapshot`\n\
+    - Lane boundary: family=`analytical`, kind=`exact_target_binding`, timeline_roles=`settlement`,\
+    \ `payment`, `observation`, exact_bindings=`trellis.models.credit_default_swap.build_cds_schedule`,\
+    \ `trellis.models.credit_default_swap.price_cds_analytical`\n- Lowering boundary:\
+    \ family_ir=`CreditDefaultSwapIR`, expr=`ThenExpr`, helpers=`trellis.models.credit_default_swap.build_cds_schedule`,\
     \ `trellis.models.credit_default_swap.price_cds_analytical`, route_alias=`credit_default_swap_analytical`\n\
     - Validation contract: bundle=`analytical:credit_default_swap`, checks=`check_cds_spread_quote_normalization`,\
     \ `check_cds_credit_curve_sensitivity`, `premium_leg_accrues_on_schedule`, `protection_leg_triggers_on_default`,\
@@ -1098,8 +1115,19 @@ calls:
 - seq: 3
   function: llm_generate_json
   stage: critic
-  prompt_hash: 6e9f21b69d01fcfa8128e2a33f03dcb95f16931d0c7ed9c75a53444d49423a79
-  response_text: '{}'
+  prompt_hash: 1277909b3cf69539b0932ff0d3132ef8739422d1041e87742129a9c91308e5f3
+  response_text: '{"check_id": "price_non_negative", "description": "Protection-buyer
+    CDS PV can be negative because the implementation prices a signed MTM without
+    enforcing long-protection non-negativity.", "severity": "warning", "evidence":
+    "`evaluate()` directly returns `price_cds_analytical(...)` with no sanity clamp
+    or orientation check. For a protection buyer, PV is typically protection leg minus
+    premium leg; if the input spread is high relative to the curve, the returned MTM
+    can be negative, which would violate the selected non-negative pricing check in
+    the default review harness.", "remediation": "Verify the sign convention expected
+    by the backend helper for protection buyer CDS. If the route is intended to represent
+    a long protection position, ensure the helper returns the correct signed PV or
+    wrap the result only if the contract explicitly requires a non-negative payoff.",
+    "status": "suspect"}'
   prompt_text: "You are a quantitative model validator reviewing agent-generated pricing\
     \ code.\nYour job is to find deterministic review concerns, not to praise. Be\
     \ adversarial.\n\n## Code to review\n```python\n\"\"\"Agent-generated payoff:\
@@ -1160,30 +1188,31 @@ calls:
     \      return self._spec\n\n    @property\n    def requirements(self) -> set[str]:\n\
     \        return {\"credit_curve\", \"discount_curve\"}\n\n    def evaluate(self,\
     \ market_state: MarketState) -> float:\n        spec = self._spec\n        spec\
-    \ = self._spec\n        if market_state.credit_curve is None:\n            raise\
-    \ ValueError(\"CDS pricing requires market_state.credit_curve\")\n        if market_state.discount\
-    \ is None:\n            raise ValueError(\"CDS pricing requires market_state.discount\"\
-    )\n\n        from trellis.models.credit_default_swap import build_cds_schedule,\
-    \ price_cds_analytical\n\n        spread = spec.spread\n        if spread > 1.0:\n\
-    \            spread = spread / 10000.0\n\n        schedule = build_cds_schedule(\n\
-    \            spec.start_date,\n            spec.end_date,\n            spec.frequency,\n\
-    \            spec.day_count,\n            time_origin=spec.start_date,\n     \
-    \   )\n\n        return float(\n            price_cds_analytical(\n          \
-    \      notional=spec.notional,\n                spread_quote=spread,\n       \
-    \         recovery=spec.recovery,\n                schedule=schedule,\n      \
-    \          credit_curve=market_state.credit_curve,\n                discount_curve=market_state.discount,\n\
-    \            )\n        )\n\n```\n\n## Instrument description\nBuild a pricer\
-    \ for: CDS pricing: hazard rate MC vs survival prob analytical\n\nStandard single-name\
-    \ CDS, protection buyer side.\nNotional: $10,000,000.  Maturity: 5Y from settlement.\n\
-    Premium leg: quarterly payments, Act/360 day count.\nRunning CDS spread: 150 bp.\
-    \  Recovery rate: 40%.\nUse the investment-grade (IG) credit curve from the market\
-    \ snapshot\n(as_of 2024-11-15) — this provides term-dependent hazard rates\nbootstrapped\
-    \ from market CDS spreads at 1Y, 3Y, 5Y, and 10Y tenors.\nDo NOT use a flat hazard\
-    \ rate — the model must respect the full\nhazard rate term structure.\nUse the\
-    \ USD OIS curve for risk-free discounting.\nMethod 1: Monte Carlo simulation of\
-    \ default times from the hazard curve.\nMethod 2: Analytical (deterministic) survival-probability\
-    \ integration.\nCompute the mark-to-market PV (protection leg minus premium leg).\n\
-    \nConstruct methods: monte_carlo\nComparison targets: mc_cds (monte_carlo), analytical_cds\
+    \ = self._spec\n\n        credit_curve = getattr(market_state, \"credit_curve\"\
+    , None)\n        discount_curve = getattr(market_state, \"discount\", None)\n\
+    \        if credit_curve is None:\n            raise ValueError(\"CDSPayoff requires\
+    \ market_state.credit_curve\")\n        if discount_curve is None:\n         \
+    \   raise ValueError(\"CDSPayoff requires market_state.discount\")\n\n       \
+    \ spread = spec.spread\n        if spread > 1.0:\n            spread *= 1e-4\n\
+    \n        schedule = build_cds_schedule(\n            spec.start_date,\n     \
+    \       spec.end_date,\n            spec.frequency,\n            spec.day_count,\n\
+    \            time_origin=spec.start_date,\n        )\n\n        return float(\n\
+    \            price_cds_analytical(\n                notional=spec.notional,\n\
+    \                spread_quote=spread,\n                recovery=spec.recovery,\n\
+    \                schedule=schedule,\n                credit_curve=credit_curve,\n\
+    \                discount_curve=discount_curve,\n            )\n        )\n\n\
+    ```\n\n## Instrument description\nBuild a pricer for: CDS pricing: hazard rate\
+    \ MC vs survival prob analytical\n\nStandard single-name CDS, protection buyer\
+    \ side.\nNotional: $10,000,000.  Maturity: 5Y from settlement.\nPremium leg: quarterly\
+    \ payments, Act/360 day count.\nRunning CDS spread: 150 bp.  Recovery rate: 40%.\n\
+    Use the investment-grade (IG) credit curve from the market snapshot\n(as_of 2024-11-15)\
+    \ — this provides term-dependent hazard rates\nbootstrapped from market CDS spreads\
+    \ at 1Y, 3Y, 5Y, and 10Y tenors.\nDo NOT use a flat hazard rate — the model must\
+    \ respect the full\nhazard rate term structure.\nUse the USD OIS curve for risk-free\
+    \ discounting.\nMethod 1: Monte Carlo simulation of default times from the hazard\
+    \ curve.\nMethod 2: Analytical (deterministic) survival-probability integration.\n\
+    Compute the mark-to-market PV (protection leg minus premium leg).\n\nConstruct\
+    \ methods: monte_carlo\nComparison targets: mc_cds (monte_carlo), analytical_cds\
     \ (analytical)\nCross-validation harness:\n  internal targets: mc_cds, analytical_cds\n\
     \  external targets: quantlib, financepy\nNew component: cds_pricing\n\nImplementation\
     \ target: analytical_cds\nPreferred method family: analytical\n\nImplementation\
@@ -1203,28 +1232,29 @@ calls:
     \ explicitly sources it from a live market snapshot.\n- Canonical model grammar:\n\
     \  - `credit_single_name_reduced_form` -> `Reduced-form single-name credit`\n\
     \  - `rates_bootstrap_curve` -> `Rates bootstrap curve bundle`\n- Known failure\
-    \ traps:\n  - `CDS spread / curve unit mismatch` -> Input conventions and required\
-    \ market data were not validated: running spread was treated with wrong units\
-    \ (bps vs decimal) and required curves (credit/discount) were missing or not passed\
-    \ to the analytical routine, causing unit/convention and data-availability errors.\n\
-    \  - `Missing CDS contract specification` -> The analytical CDS pricer requires\
-    \ an explicit instrument product shape (schedule, accrual, coupon/spread, recovery,\
-    \ settlement conventions, payoff adapter) but the request/DSl omitted these fields\
-    \ and no instrument-specific cookbook or payoff adapter was available.\n\n## Generated\
-    \ Skills\n- [lesson] NthToDefaultPayoff analytical must use Gaussian copula integration,\
-    \ not independent binomial: Use the Gaussian copula conditional independence formula\
-    \ (integrate over common factor Z). This is the analytical counterpart of the\
-    \ GaussianCopula MC. from math import comb from scipy import integrate from scipy.stat...\n\
-    \n## Instrument Disambiguation\n- Treat this request as a single-name CDS / credit_default_swap\
-    \ contract.\n- Do not reinterpret CDS here as nth_to_default, basket CDS, first-to-default,\
-    \ or any multi-name credit product.\n- Do not import copula or Gaussian-copula\
-    \ machinery unless the request explicitly says nth-to-default, first-to-default,\
-    \ basket CDS, or multiple reference names.\n\n\n## Compiled Route Contract\n-\
-    \ Method family: `analytical`\n- Instrument type: `cds`\n- Semantic contract:\
-    \ `credit_default_swap`, request=`credit_default_swap`, bridge=`canonical_semantic`,\
-    \ instrument=`cds`, payoff=`credit_default_swap`, structure=`single_reference_entity`\n\
-    - Valuation context: market_source=`unbound_market_snapshot`\n- Lane boundary:\
-    \ family=`analytical`, kind=`exact_target_binding`, timeline_roles=`settlement`,\
+    \ traps:\n  - `Date-vs-number mix-up` -> This usually happens when time-to-maturity\
+    \ or a rate input is pulled from a dated market snapshot without converting dates\
+    \ into numeric year fractions first. The mental model failure is treating calendar\
+    \ fields and model parameters as interchangeable numeric values.\n  - `CDS spread\
+    \ / curve unit mismatch` -> Input conventions and required market data were not\
+    \ validated: running spread was treated with wrong units (bps vs decimal) and\
+    \ required curves (credit/discount) were missing or not passed to the analytical\
+    \ routine, causing unit/convention and data-availability errors.\n- Stale adapters:\
+    \ `trellis.instruments._agent.fxvanillaanalytical`, `trellis.instruments._agent.fxvanillamontecarlo`\n\
+    \n## Generated Skills\n- [lesson] NthToDefaultPayoff analytical must use Gaussian\
+    \ copula integration, not independent binomial: Use the Gaussian copula conditional\
+    \ independence formula (integrate over common factor Z). This is the analytical\
+    \ counterpart of the GaussianCopula MC. from math import comb from scipy import\
+    \ integrate from scipy.stat...\n\n## Instrument Disambiguation\n- Treat this request\
+    \ as a single-name CDS / credit_default_swap contract.\n- Do not reinterpret CDS\
+    \ here as nth_to_default, basket CDS, first-to-default, or any multi-name credit\
+    \ product.\n- Do not import copula or Gaussian-copula machinery unless the request\
+    \ explicitly says nth-to-default, first-to-default, basket CDS, or multiple reference\
+    \ names.\n\n\n## Compiled Route Contract\n- Method family: `analytical`\n- Instrument\
+    \ type: `cds`\n- Semantic contract: `credit_default_swap`, request=`credit_default_swap`,\
+    \ bridge=`canonical_semantic`, instrument=`cds`, payoff=`credit_default_swap`,\
+    \ structure=`single_reference_entity`\n- Valuation context: market_source=`unbound_market_snapshot`\n\
+    - Lane boundary: family=`analytical`, kind=`exact_target_binding`, timeline_roles=`settlement`,\
     \ `payment`, `observation`, exact_bindings=`trellis.models.credit_default_swap.build_cds_schedule`,\
     \ `trellis.models.credit_default_swap.price_cds_analytical`\n- Lowering boundary:\
     \ family_ir=`CreditDefaultSwapIR`, expr=`ThenExpr`, helpers=`trellis.models.credit_default_swap.build_cds_schedule`,\

--- a/cassettes/full_task/T38.yaml
+++ b/cassettes/full_task/T38.yaml
@@ -1,5 +1,5 @@
 meta:
-  recorded_at: '2026-04-12T08:06:00.723462+00:00'
+  recorded_at: '2026-04-12T08:13:51.594685+00:00'
   provider: openai
   model: gpt-5.4-mini
   total_calls: 4
@@ -8,19 +8,21 @@ calls:
 - seq: 0
   function: llm_generate
   stage: code_generation
-  prompt_hash: 60746e4aa23cd856cbe6da02db4a814b49d876620e4e540f803c2fac2235c8d2
-  response_text: "from trellis.core.differentiable import get_numpy\n        from\
-    \ trellis.models.credit_default_swap import build_cds_schedule, price_cds_monte_carlo\n\
-    \n        np = get_numpy()\n        spec = self._spec\n\n        spread = float(spec.spread)\n\
-    \        if spread > 1.0:\n            spread *= 1e-4\n\n        schedule = build_cds_schedule(\n\
+  prompt_hash: 61d9527e9e53bafef67a8eb3f23ed84d2ff81f1b281017bdf90af6f410c28218
+  response_text: "def evaluate(self, market_state: MarketState) -> float:\n      \
+    \  from trellis.core.differentiable import get_numpy\n        from trellis.models.credit_default_swap\
+    \ import build_cds_schedule, price_cds_monte_carlo\n\n        spec = self._spec\n\
+    \        np = get_numpy()\n\n        spread = float(spec.spread)\n        if spread\
+    \ > 1.0:\n            spread *= 1e-4\n\n        schedule = build_cds_schedule(\n\
     \            spec.start_date,\n            spec.end_date,\n            spec.frequency,\n\
     \            day_count=spec.day_count,\n            time_origin=spec.start_date,\n\
-    \        )\n\n        return float(\n            price_cds_monte_carlo(\n    \
-    \            notional=float(spec.notional),\n                spread_quote=spread,\n\
-    \                recovery=float(spec.recovery),\n                schedule=schedule,\n\
-    \                credit_curve=market_state.credit_curve,\n                discount_curve=market_state.discount,\n\
-    \                n_paths=int(spec.n_paths),\n                seed=42,\n      \
-    \      )\n        )"
+    \        )\n\n        n_paths = int(spec.n_paths) if getattr(spec, \"n_paths\"\
+    , None) is not None else 250000\n        n_paths = max(n_paths, 10000)\n\n   \
+    \     price = price_cds_monte_carlo(\n            notional=float(spec.notional),\n\
+    \            spread_quote=spread,\n            recovery=float(spec.recovery),\n\
+    \            schedule=schedule,\n            credit_curve=market_state.credit_curve,\n\
+    \            discount_curve=market_state.discount,\n            n_paths=n_paths,\n\
+    \            seed=42,\n        )\n        return float(price)"
   prompt_text: "You are implementing the evaluate() method for `CDSPayoff` in the\
     \ Trellis pricing library.\n\n## Complete module (skeleton — everything is fixed\
     \ except evaluate)\n```python\n\"\"\"Agent-generated payoff: Build a pricer for:\
@@ -218,8 +220,7 @@ calls:
     \ the payoff as a thin adapter that calls trellis.core.differentiable.get_numpy\
     \ to obtain numpy arrays, perform all pathwise computations in numpy, and ensure\
     \ the payoff returns a 1D array of shape (n_paths,). Follow other assembly constraints\
-    \ (no banned imports, correct output shape).\n- Stale adapters: `trellis.instruments._agent.fxvanillaanalytical`,\
-    \ `trellis.instruments._agent.fxvanillamontecarlo`\n\n## Generated Skills\n- [lesson]\
+    \ (no banned imports, correct output shape).\n\n## Generated Skills\n- [lesson]\
     \ NthToDefaultPayoff analytical must use Gaussian copula integration, not independent\
     \ binomial: Use the Gaussian copula conditional independence formula (integrate\
     \ over common factor Z). This is the analytical counterpart of the GaussianCopula\
@@ -480,19 +481,19 @@ calls:
 - seq: 1
   function: llm_generate_json
   stage: critic
-  prompt_hash: 2b4022f9661d8c0d7c5ea6c06961758bfdb330bc5720269aa3c611e2675017e8
-  response_text: '{"check_id": "price_non_negative", "description": "CDS PV sign is
-    likely inverted for a protection buyer, making negative MTM plausible under the
-    default market state.", "severity": "error", "evidence": "The instrument spec
-    explicitly says ''protection buyer side'' and ''Compute the mark-to-market PV
-    (protection leg minus premium leg).'' However the implementation just forwards
-    to `price_cds_monte_carlo(...)` with `spread_quote=spread` and returns its raw
-    output without any sign normalization or side handling. If the backend helper
-    interprets the quoted spread as a premium paid by the buyer, the returned value
-    can be negative by construction for an out-of-the-money CDS.", "remediation":
-    "Verify and enforce the protection-buyer payoff convention at the route boundary;
-    if the backend returns seller PV or premium-minus-protection, flip the sign before
-    returning.", "status": "suspect"}'
+  prompt_hash: 8a87b649b3555874b94aa12e0133e63029506e9c83fe0941ceb2bf1fb32c9f55
+  response_text: '{"check_id": "price_non_negative", "description": "CDS PV can be
+    negative because the implementation returns protection-leg minus premium-leg for
+    a protection buyer, but the spread normalization and sign conventions are not
+    validated against the contract definition.", "severity": "warning", "evidence":
+    "`evaluate()` calls `price_cds_monte_carlo(... spread_quote=spread, recovery=...,
+    ...)` and returns the raw result. The instrument text says \"protection buyer
+    side\" and \"Compute the mark-to-market PV (protection leg minus premium leg)\",
+    but no safeguard ensures the route helper interprets this as a positive buyer
+    PV under the provided spread. If the helper uses a different sign convention,
+    the returned MTM can be negative.", "remediation": "Confirm the route helper''s
+    CDS sign convention against the contract definition and, if needed, map the returned
+    value to buyer-side PV consistently before returning it.", "status": "suspect"}'
   prompt_text: "You are a quantitative model validator reviewing agent-generated pricing\
     \ code.\nYour job is to find deterministic review concerns, not to praise. Be\
     \ adversarial.\n\n## Code to review\n```python\n\"\"\"Agent-generated payoff:\
@@ -553,48 +554,50 @@ calls:
     \ = spec\n\n    @property\n    def spec(self) -> CDSSpec:\n        return self._spec\n\
     \n    @property\n    def requirements(self) -> set[str]:\n        return {\"credit_curve\"\
     , \"discount_curve\"}\n\n    def evaluate(self, market_state: MarketState) ->\
-    \ float:\n        spec = self._spec\n        from trellis.models.credit_default_swap\
-    \ import build_cds_schedule, price_cds_monte_carlo\n\n        np = get_numpy()\n\
-    \        spec = self._spec\n\n        spread = float(spec.spread)\n        if\
-    \ spread > 1.0:\n            spread *= 1e-4\n\n        schedule = build_cds_schedule(\n\
-    \        spec.start_date,\n        spec.end_date,\n        spec.frequency,\n \
-    \       day_count=spec.day_count,\n        time_origin=spec.start_date,\n    \
-    \    )\n\n        return float(\n        price_cds_monte_carlo(\n            notional=float(spec.notional),\n\
-    \            spread_quote=spread,\n            recovery=float(spec.recovery),\n\
-    \            schedule=schedule,\n            credit_curve=market_state.credit_curve,\n\
-    \            discount_curve=market_state.discount,\n            n_paths=int(spec.n_paths),\n\
-    \            seed=42,\n        )\n        )\n\n```\n\n## Instrument description\n\
-    Build a pricer for: CDS pricing: hazard rate MC vs survival prob analytical\n\n\
-    Standard single-name CDS, protection buyer side.\nNotional: $10,000,000.  Maturity:\
-    \ 5Y from settlement.\nPremium leg: quarterly payments, Act/360 day count.\nRunning\
-    \ CDS spread: 150 bp.  Recovery rate: 40%.\nUse the investment-grade (IG) credit\
-    \ curve from the market snapshot\n(as_of 2024-11-15) — this provides term-dependent\
-    \ hazard rates\nbootstrapped from market CDS spreads at 1Y, 3Y, 5Y, and 10Y tenors.\n\
-    Do NOT use a flat hazard rate — the model must respect the full\nhazard rate term\
-    \ structure.\nUse the USD OIS curve for risk-free discounting.\nMethod 1: Monte\
-    \ Carlo simulation of default times from the hazard curve.\nMethod 2: Analytical\
-    \ (deterministic) survival-probability integration.\nCompute the mark-to-market\
-    \ PV (protection leg minus premium leg).\n\nConstruct methods: monte_carlo\nComparison\
-    \ targets: mc_cds (monte_carlo), analytical_cds (analytical)\nCross-validation\
-    \ harness:\n  internal targets: mc_cds, analytical_cds\n  external targets: quantlib,\
-    \ financepy\nNew component: cds_pricing\n\nImplementation target: mc_cds\nPreferred\
-    \ method family: monte_carlo\n\nImplementation target: mc_cds\n\n## Shared Knowledge\n\
-    ## Distilled Review Memory\n\n- Review principles:\n  - `P1`: Always calibrate\
-    \ rate trees to the discount curve before pricing\n  - `P2`: Callable bonds need\
-    \ issuer_call lattice control, discrete coupons, and exercise=par+coupon\n  -\
-    \ `P3`: Convert vol units at the boundary between market data and model\n- Review\
-    \ checkpoints:\n  - CONVERGENCE: Use at least 10,000 paths. Verify that the standard\
-    \ error is <1% of the price. If path-dependent, use at least 100 time steps per\
-    \ year.\n  - DISCRETE OBSERVATIONS: For instruments with discrete fixing/observation\
-    \ dates (Asian options, barriers), simulate paths that pass through those exact\
-    \ dates. Do not interpolate between steps.\n  - EARLY EXERCISE: For American or\
-    \ Bermudan exercise in Monte Carlo, use an approved optimal-stopping control primitive\
-    \ instead of inventing method=\"lsm\" or treating engine.price(...) as a substitute\
-    \ for early-exercise control. Trellis currently implements longstaff_schwartz.\
-    \ Planned policy classes include tsitsiklis_van_roy, primal_dual_mc, and stochastic_mesh.\
-    \ If the control primitive uses continuation regression, the basis or estimator\
-    \ choice is explicit; LaguerreBasis is a common option, not a mandatory route\
-    \ primitive.\n- Canonical model grammar:\n  - `credit_single_name_reduced_form`\
+    \ float:\n        spec = self._spec\n        from trellis.core.differentiable\
+    \ import get_numpy\n        from trellis.models.credit_default_swap import build_cds_schedule,\
+    \ price_cds_monte_carlo\n\n        spec = self._spec\n        np = get_numpy()\n\
+    \n        spread = float(spec.spread)\n        if spread > 1.0:\n            spread\
+    \ *= 1e-4\n\n        schedule = build_cds_schedule(\n            spec.start_date,\n\
+    \            spec.end_date,\n            spec.frequency,\n            day_count=spec.day_count,\n\
+    \            time_origin=spec.start_date,\n        )\n\n        n_paths = int(spec.n_paths)\
+    \ if getattr(spec, \"n_paths\", None) is not None else 250000\n        n_paths\
+    \ = max(n_paths, 10000)\n\n        price = price_cds_monte_carlo(\n          \
+    \  notional=float(spec.notional),\n            spread_quote=spread,\n        \
+    \    recovery=float(spec.recovery),\n            schedule=schedule,\n        \
+    \    credit_curve=market_state.credit_curve,\n            discount_curve=market_state.discount,\n\
+    \            n_paths=n_paths,\n            seed=42,\n        )\n        return\
+    \ float(price)\n\n```\n\n## Instrument description\nBuild a pricer for: CDS pricing:\
+    \ hazard rate MC vs survival prob analytical\n\nStandard single-name CDS, protection\
+    \ buyer side.\nNotional: $10,000,000.  Maturity: 5Y from settlement.\nPremium\
+    \ leg: quarterly payments, Act/360 day count.\nRunning CDS spread: 150 bp.  Recovery\
+    \ rate: 40%.\nUse the investment-grade (IG) credit curve from the market snapshot\n\
+    (as_of 2024-11-15) — this provides term-dependent hazard rates\nbootstrapped from\
+    \ market CDS spreads at 1Y, 3Y, 5Y, and 10Y tenors.\nDo NOT use a flat hazard\
+    \ rate — the model must respect the full\nhazard rate term structure.\nUse the\
+    \ USD OIS curve for risk-free discounting.\nMethod 1: Monte Carlo simulation of\
+    \ default times from the hazard curve.\nMethod 2: Analytical (deterministic) survival-probability\
+    \ integration.\nCompute the mark-to-market PV (protection leg minus premium leg).\n\
+    \nConstruct methods: monte_carlo\nComparison targets: mc_cds (monte_carlo), analytical_cds\
+    \ (analytical)\nCross-validation harness:\n  internal targets: mc_cds, analytical_cds\n\
+    \  external targets: quantlib, financepy\nNew component: cds_pricing\n\nImplementation\
+    \ target: mc_cds\nPreferred method family: monte_carlo\n\nImplementation target:\
+    \ mc_cds\n\n## Shared Knowledge\n## Distilled Review Memory\n\n- Review principles:\n\
+    \  - `P1`: Always calibrate rate trees to the discount curve before pricing\n\
+    \  - `P2`: Callable bonds need issuer_call lattice control, discrete coupons,\
+    \ and exercise=par+coupon\n  - `P3`: Convert vol units at the boundary between\
+    \ market data and model\n- Review checkpoints:\n  - CONVERGENCE: Use at least\
+    \ 10,000 paths. Verify that the standard error is <1% of the price. If path-dependent,\
+    \ use at least 100 time steps per year.\n  - DISCRETE OBSERVATIONS: For instruments\
+    \ with discrete fixing/observation dates (Asian options, barriers), simulate paths\
+    \ that pass through those exact dates. Do not interpolate between steps.\n  -\
+    \ EARLY EXERCISE: For American or Bermudan exercise in Monte Carlo, use an approved\
+    \ optimal-stopping control primitive instead of inventing method=\"lsm\" or treating\
+    \ engine.price(...) as a substitute for early-exercise control. Trellis currently\
+    \ implements longstaff_schwartz. Planned policy classes include tsitsiklis_van_roy,\
+    \ primal_dual_mc, and stochastic_mesh. If the control primitive uses continuation\
+    \ regression, the basis or estimator choice is explicit; LaguerreBasis is a common\
+    \ option, not a mandatory route primitive.\n- Canonical model grammar:\n  - `credit_single_name_reduced_form`\
     \ -> `Reduced-form single-name credit`\n  - `heston_smile_workflow` -> `Heston`\n\
     - Known failure traps:\n  - `MC payoff must use market_state.discount` -> The\
     \ generated Monte Carlo payoff did not call the required market_state.discount\
@@ -605,7 +608,6 @@ calls:
     \ was implemented as ordinary numpy/opaque operations and did not adapt to the\
     \ selected assembly's required semantic primitive (trellis.core.differentiable.get_numpy).\
     \ The payoff also risked returning the wrong shape (e.g. (n_paths, n_steps+1)).\n\
-    - Stale adapters: `trellis.instruments._agent.fxvanillaanalytical`, `trellis.instruments._agent.fxvanillamontecarlo`\n\
     \n## Generated Skills\n- [lesson] NthToDefaultPayoff analytical must use Gaussian\
     \ copula integration, not independent binomial: Use the Gaussian copula conditional\
     \ independence formula (integrate over common factor Z). This is the analytical\
@@ -688,20 +690,19 @@ calls:
 - seq: 2
   function: llm_generate
   stage: code_generation
-  prompt_hash: 1a5a6cde692fe9d37f1d11b364768785aa34963d43028b9f7178c6b6caa912aa
-  response_text: "spec = self._spec\n\n        credit_curve = getattr(market_state,\
-    \ \"credit_curve\", None)\n        discount_curve = getattr(market_state, \"discount\"\
-    , None)\n        if credit_curve is None:\n            raise ValueError(\"CDSPayoff\
-    \ requires market_state.credit_curve\")\n        if discount_curve is None:\n\
-    \            raise ValueError(\"CDSPayoff requires market_state.discount\")\n\n\
-    \        spread = spec.spread\n        if spread > 1.0:\n            spread *=\
-    \ 1e-4\n\n        schedule = build_cds_schedule(\n            spec.start_date,\n\
-    \            spec.end_date,\n            spec.frequency,\n            spec.day_count,\n\
-    \            time_origin=spec.start_date,\n        )\n\n        return float(\n\
-    \            price_cds_analytical(\n                notional=spec.notional,\n\
-    \                spread_quote=spread,\n                recovery=spec.recovery,\n\
-    \                schedule=schedule,\n                credit_curve=credit_curve,\n\
-    \                discount_curve=discount_curve,\n            )\n        )"
+  prompt_hash: c069da6203a1cd88a7747ae13cd8065c2b7994bbdf2c763faf2fe3ad357c8a3b
+  response_text: "spec = self._spec\n\n        if market_state.credit_curve is None:\n\
+    \            raise ValueError(\"CDSPayoff requires market_state.credit_curve\"\
+    )\n        if market_state.discount is None:\n            raise ValueError(\"\
+    CDSPayoff requires market_state.discount\")\n\n        spread = spec.spread\n\
+    \        if spread > 1.0:\n            spread = spread / 10000.0\n\n        schedule\
+    \ = build_cds_schedule(\n            spec.start_date,\n            spec.end_date,\n\
+    \            spec.frequency,\n            spec.day_count,\n            time_origin=spec.start_date,\n\
+    \        )\n\n        return float(\n            price_cds_analytical(\n     \
+    \           notional=spec.notional,\n                spread_quote=spread,\n  \
+    \              recovery=spec.recovery,\n                schedule=schedule,\n \
+    \               credit_curve=market_state.credit_curve,\n                discount_curve=market_state.discount,\n\
+    \            )\n        )"
   prompt_text: "You are implementing the evaluate() method for `CDSPayoff` in the\
     \ Trellis pricing library.\n\n## Complete module (skeleton — everything is fixed\
     \ except evaluate)\n```python\n\"\"\"Agent-generated payoff: Build a pricer for:\
@@ -887,31 +888,33 @@ calls:
     \ MarketState capability unless the product explicitly sources it from a live\
     \ market snapshot.\n- Canonical model grammar:\n  - `credit_single_name_reduced_form`\
     \ -> `Reduced-form single-name credit`\n  - `rates_bootstrap_curve` -> `Rates\
-    \ bootstrap curve bundle`\n- Repeated fixes to reuse:\n  - `Date-vs-number mix-up`\
-    \ -> Convert all date inputs to consistent numeric year fractions before pricing,\
-    \ and validate input types at the API boundary.\n  - `CDS spread / curve unit\
-    \ mismatch` -> Enforce and normalize input conventions (auto-convert spread in\
-    \ bps to decimal if > 1, require explicit units), require and validate presence\
+    \ bootstrap curve bundle`\n- Repeated fixes to reuse:\n  - `CDS spread / curve\
+    \ unit mismatch` -> Enforce and normalize input conventions (auto-convert spread\
+    \ in bps to decimal if > 1, require explicit units), require and validate presence\
     \ of discount_curve and credit_curve before pricing, and add PV sanity checks\
-    \ (compare |PV| to notional) to fail fast with actionable errors.\n- Stale adapters:\
-    \ `trellis.instruments._agent.fxvanillaanalytical`, `trellis.instruments._agent.fxvanillamontecarlo`\n\
-    \n## Generated Skills\n- [lesson] NthToDefaultPayoff analytical must use Gaussian\
-    \ copula integration, not independent binomial: Use the Gaussian copula conditional\
-    \ independence formula (integrate over common factor Z). This is the analytical\
-    \ counterpart of the GaussianCopula MC. from math import comb from scipy import\
-    \ integrate from scipy.stat...\n\n## Instrument Disambiguation\n- Treat this request\
-    \ as a single-name CDS / credit_default_swap contract.\n- Do not reinterpret CDS\
-    \ here as nth_to_default, basket CDS, first-to-default, or any multi-name credit\
-    \ product.\n- Do not import copula or Gaussian-copula machinery unless the request\
-    \ explicitly says nth-to-default, first-to-default, basket CDS, or multiple reference\
-    \ names.\n## Structured Lane Card\n- Method family: `analytical`\n- Instrument\
-    \ type: `cds`\n- Semantic contract: `credit_default_swap`, request=`credit_default_swap`,\
-    \ bridge=`canonical_semantic`, instrument=`cds`, payoff=`credit_default_swap`,\
-    \ structure=`single_reference_entity`\n- Valuation context: market_source=`unbound_market_snapshot`\n\
-    - Lane boundary: family=`analytical`, kind=`exact_target_binding`, timeline_roles=`settlement`,\
-    \ `payment`, `observation`, exact_bindings=`trellis.models.credit_default_swap.build_cds_schedule`,\
-    \ `trellis.models.credit_default_swap.price_cds_analytical`\n- Lowering boundary:\
-    \ family_ir=`CreditDefaultSwapIR`, expr=`ThenExpr`, helpers=`trellis.models.credit_default_swap.build_cds_schedule`,\
+    \ (compare |PV| to notional) to fail fast with actionable errors.\n  - `Missing\
+    \ CDS contract specification` -> Provide a complete CDS product specification\
+    \ (effective/termination dates, payment frequency, day-count, business-day convention,\
+    \ notional, coupon/spread, recovery rate, accrual-on-default rule, settlement\
+    \ lag) and add or link an instrument-specific cookbook/evaluate() template plus\
+    \ the primitive payoff adapter; ensure discount and hazard inputs use pinned conventions\
+    \ and consistent units.\n\n## Generated Skills\n- [lesson] NthToDefaultPayoff\
+    \ analytical must use Gaussian copula integration, not independent binomial: Use\
+    \ the Gaussian copula conditional independence formula (integrate over common\
+    \ factor Z). This is the analytical counterpart of the GaussianCopula MC. from\
+    \ math import comb from scipy import integrate from scipy.stat...\n\n## Instrument\
+    \ Disambiguation\n- Treat this request as a single-name CDS / credit_default_swap\
+    \ contract.\n- Do not reinterpret CDS here as nth_to_default, basket CDS, first-to-default,\
+    \ or any multi-name credit product.\n- Do not import copula or Gaussian-copula\
+    \ machinery unless the request explicitly says nth-to-default, first-to-default,\
+    \ basket CDS, or multiple reference names.\n## Structured Lane Card\n- Method\
+    \ family: `analytical`\n- Instrument type: `cds`\n- Semantic contract: `credit_default_swap`,\
+    \ request=`credit_default_swap`, bridge=`canonical_semantic`, instrument=`cds`,\
+    \ payoff=`credit_default_swap`, structure=`single_reference_entity`\n- Valuation\
+    \ context: market_source=`unbound_market_snapshot`\n- Lane boundary: family=`analytical`,\
+    \ kind=`exact_target_binding`, timeline_roles=`settlement`, `payment`, `observation`,\
+    \ exact_bindings=`trellis.models.credit_default_swap.build_cds_schedule`, `trellis.models.credit_default_swap.price_cds_analytical`\n\
+    - Lowering boundary: family_ir=`CreditDefaultSwapIR`, expr=`ThenExpr`, helpers=`trellis.models.credit_default_swap.build_cds_schedule`,\
     \ `trellis.models.credit_default_swap.price_cds_analytical`, route_alias=`credit_default_swap_analytical`\n\
     - Validation contract: bundle=`analytical:credit_default_swap`, checks=`check_cds_spread_quote_normalization`,\
     \ `check_cds_credit_curve_sensitivity`, `premium_leg_accrues_on_schedule`, `protection_leg_triggers_on_default`,\
@@ -1115,18 +1118,19 @@ calls:
 - seq: 3
   function: llm_generate_json
   stage: critic
-  prompt_hash: 1277909b3cf69539b0932ff0d3132ef8739422d1041e87742129a9c91308e5f3
-  response_text: '{"check_id": "price_non_negative", "description": "Protection-buyer
-    CDS PV can be negative because the implementation prices a signed MTM without
-    enforcing long-protection non-negativity.", "severity": "warning", "evidence":
-    "`evaluate()` directly returns `price_cds_analytical(...)` with no sanity clamp
-    or orientation check. For a protection buyer, PV is typically protection leg minus
-    premium leg; if the input spread is high relative to the curve, the returned MTM
-    can be negative, which would violate the selected non-negative pricing check in
-    the default review harness.", "remediation": "Verify the sign convention expected
-    by the backend helper for protection buyer CDS. If the route is intended to represent
-    a long protection position, ensure the helper returns the correct signed PV or
-    wrap the result only if the contract explicitly requires a non-negative payoff.",
+  prompt_hash: 2a3b514a3bf7279e1bdcf028104e3505571bab8415c5edfc1b06be6eae55bd61
+  response_text: '{"check_id": "price_non_negative", "description": "Premium spread
+    unit normalization is only handled for values above 1.0, so an input of 150 bp
+    is converted to 0.015, but a valid decimal spread below 1.0 would bypass conversion.
+    This creates a unit-convention ambiguity in the only pricing input passed to the
+    analytical CDS routine and can produce a materially wrong PV, including negative
+    values when combined with the wrong spread scale.", "severity": "error", "evidence":
+    "In evaluate(), `spread = spec.spread; if spread > 1.0: spread = spread / 10000.0`
+    and then `spread_quote=spread` is passed to `price_cds_analytical(...)`. The code
+    never validates whether the spec spread is bps or decimal and silently assumes
+    bps only when >1.0.", "remediation": "Require an explicit spread unit contract
+    and normalize deterministically (or reject ambiguous inputs). Pass a clearly defined
+    decimal spread_quote to the analytical pricer after validating the convention.",
     "status": "suspect"}'
   prompt_text: "You are a quantitative model validator reviewing agent-generated pricing\
     \ code.\nYour job is to find deterministic review concerns, not to praise. Be\
@@ -1188,31 +1192,29 @@ calls:
     \      return self._spec\n\n    @property\n    def requirements(self) -> set[str]:\n\
     \        return {\"credit_curve\", \"discount_curve\"}\n\n    def evaluate(self,\
     \ market_state: MarketState) -> float:\n        spec = self._spec\n        spec\
-    \ = self._spec\n\n        credit_curve = getattr(market_state, \"credit_curve\"\
-    , None)\n        discount_curve = getattr(market_state, \"discount\", None)\n\
-    \        if credit_curve is None:\n            raise ValueError(\"CDSPayoff requires\
-    \ market_state.credit_curve\")\n        if discount_curve is None:\n         \
-    \   raise ValueError(\"CDSPayoff requires market_state.discount\")\n\n       \
-    \ spread = spec.spread\n        if spread > 1.0:\n            spread *= 1e-4\n\
-    \n        schedule = build_cds_schedule(\n            spec.start_date,\n     \
-    \       spec.end_date,\n            spec.frequency,\n            spec.day_count,\n\
+    \ = self._spec\n\n        if market_state.credit_curve is None:\n            raise\
+    \ ValueError(\"CDSPayoff requires market_state.credit_curve\")\n        if market_state.discount\
+    \ is None:\n            raise ValueError(\"CDSPayoff requires market_state.discount\"\
+    )\n\n        spread = spec.spread\n        if spread > 1.0:\n            spread\
+    \ = spread / 10000.0\n\n        schedule = build_cds_schedule(\n            spec.start_date,\n\
+    \            spec.end_date,\n            spec.frequency,\n            spec.day_count,\n\
     \            time_origin=spec.start_date,\n        )\n\n        return float(\n\
     \            price_cds_analytical(\n                notional=spec.notional,\n\
     \                spread_quote=spread,\n                recovery=spec.recovery,\n\
-    \                schedule=schedule,\n                credit_curve=credit_curve,\n\
-    \                discount_curve=discount_curve,\n            )\n        )\n\n\
-    ```\n\n## Instrument description\nBuild a pricer for: CDS pricing: hazard rate\
-    \ MC vs survival prob analytical\n\nStandard single-name CDS, protection buyer\
-    \ side.\nNotional: $10,000,000.  Maturity: 5Y from settlement.\nPremium leg: quarterly\
-    \ payments, Act/360 day count.\nRunning CDS spread: 150 bp.  Recovery rate: 40%.\n\
-    Use the investment-grade (IG) credit curve from the market snapshot\n(as_of 2024-11-15)\
-    \ — this provides term-dependent hazard rates\nbootstrapped from market CDS spreads\
-    \ at 1Y, 3Y, 5Y, and 10Y tenors.\nDo NOT use a flat hazard rate — the model must\
-    \ respect the full\nhazard rate term structure.\nUse the USD OIS curve for risk-free\
-    \ discounting.\nMethod 1: Monte Carlo simulation of default times from the hazard\
-    \ curve.\nMethod 2: Analytical (deterministic) survival-probability integration.\n\
-    Compute the mark-to-market PV (protection leg minus premium leg).\n\nConstruct\
-    \ methods: monte_carlo\nComparison targets: mc_cds (monte_carlo), analytical_cds\
+    \                schedule=schedule,\n                credit_curve=market_state.credit_curve,\n\
+    \                discount_curve=market_state.discount,\n            )\n      \
+    \  )\n\n```\n\n## Instrument description\nBuild a pricer for: CDS pricing: hazard\
+    \ rate MC vs survival prob analytical\n\nStandard single-name CDS, protection\
+    \ buyer side.\nNotional: $10,000,000.  Maturity: 5Y from settlement.\nPremium\
+    \ leg: quarterly payments, Act/360 day count.\nRunning CDS spread: 150 bp.  Recovery\
+    \ rate: 40%.\nUse the investment-grade (IG) credit curve from the market snapshot\n\
+    (as_of 2024-11-15) — this provides term-dependent hazard rates\nbootstrapped from\
+    \ market CDS spreads at 1Y, 3Y, 5Y, and 10Y tenors.\nDo NOT use a flat hazard\
+    \ rate — the model must respect the full\nhazard rate term structure.\nUse the\
+    \ USD OIS curve for risk-free discounting.\nMethod 1: Monte Carlo simulation of\
+    \ default times from the hazard curve.\nMethod 2: Analytical (deterministic) survival-probability\
+    \ integration.\nCompute the mark-to-market PV (protection leg minus premium leg).\n\
+    \nConstruct methods: monte_carlo\nComparison targets: mc_cds (monte_carlo), analytical_cds\
     \ (analytical)\nCross-validation harness:\n  internal targets: mc_cds, analytical_cds\n\
     \  external targets: quantlib, financepy\nNew component: cds_pricing\n\nImplementation\
     \ target: analytical_cds\nPreferred method family: analytical\n\nImplementation\
@@ -1232,29 +1234,28 @@ calls:
     \ explicitly sources it from a live market snapshot.\n- Canonical model grammar:\n\
     \  - `credit_single_name_reduced_form` -> `Reduced-form single-name credit`\n\
     \  - `rates_bootstrap_curve` -> `Rates bootstrap curve bundle`\n- Known failure\
-    \ traps:\n  - `Date-vs-number mix-up` -> This usually happens when time-to-maturity\
-    \ or a rate input is pulled from a dated market snapshot without converting dates\
-    \ into numeric year fractions first. The mental model failure is treating calendar\
-    \ fields and model parameters as interchangeable numeric values.\n  - `CDS spread\
-    \ / curve unit mismatch` -> Input conventions and required market data were not\
-    \ validated: running spread was treated with wrong units (bps vs decimal) and\
-    \ required curves (credit/discount) were missing or not passed to the analytical\
-    \ routine, causing unit/convention and data-availability errors.\n- Stale adapters:\
-    \ `trellis.instruments._agent.fxvanillaanalytical`, `trellis.instruments._agent.fxvanillamontecarlo`\n\
-    \n## Generated Skills\n- [lesson] NthToDefaultPayoff analytical must use Gaussian\
-    \ copula integration, not independent binomial: Use the Gaussian copula conditional\
-    \ independence formula (integrate over common factor Z). This is the analytical\
-    \ counterpart of the GaussianCopula MC. from math import comb from scipy import\
-    \ integrate from scipy.stat...\n\n## Instrument Disambiguation\n- Treat this request\
-    \ as a single-name CDS / credit_default_swap contract.\n- Do not reinterpret CDS\
-    \ here as nth_to_default, basket CDS, first-to-default, or any multi-name credit\
-    \ product.\n- Do not import copula or Gaussian-copula machinery unless the request\
-    \ explicitly says nth-to-default, first-to-default, basket CDS, or multiple reference\
-    \ names.\n\n\n## Compiled Route Contract\n- Method family: `analytical`\n- Instrument\
-    \ type: `cds`\n- Semantic contract: `credit_default_swap`, request=`credit_default_swap`,\
-    \ bridge=`canonical_semantic`, instrument=`cds`, payoff=`credit_default_swap`,\
-    \ structure=`single_reference_entity`\n- Valuation context: market_source=`unbound_market_snapshot`\n\
-    - Lane boundary: family=`analytical`, kind=`exact_target_binding`, timeline_roles=`settlement`,\
+    \ traps:\n  - `CDS spread / curve unit mismatch` -> Input conventions and required\
+    \ market data were not validated: running spread was treated with wrong units\
+    \ (bps vs decimal) and required curves (credit/discount) were missing or not passed\
+    \ to the analytical routine, causing unit/convention and data-availability errors.\n\
+    \  - `Missing CDS contract specification` -> The analytical CDS pricer requires\
+    \ an explicit instrument product shape (schedule, accrual, coupon/spread, recovery,\
+    \ settlement conventions, payoff adapter) but the request/DSl omitted these fields\
+    \ and no instrument-specific cookbook or payoff adapter was available.\n\n## Generated\
+    \ Skills\n- [lesson] NthToDefaultPayoff analytical must use Gaussian copula integration,\
+    \ not independent binomial: Use the Gaussian copula conditional independence formula\
+    \ (integrate over common factor Z). This is the analytical counterpart of the\
+    \ GaussianCopula MC. from math import comb from scipy import integrate from scipy.stat...\n\
+    \n## Instrument Disambiguation\n- Treat this request as a single-name CDS / credit_default_swap\
+    \ contract.\n- Do not reinterpret CDS here as nth_to_default, basket CDS, first-to-default,\
+    \ or any multi-name credit product.\n- Do not import copula or Gaussian-copula\
+    \ machinery unless the request explicitly says nth-to-default, first-to-default,\
+    \ basket CDS, or multiple reference names.\n\n\n## Compiled Route Contract\n-\
+    \ Method family: `analytical`\n- Instrument type: `cds`\n- Semantic contract:\
+    \ `credit_default_swap`, request=`credit_default_swap`, bridge=`canonical_semantic`,\
+    \ instrument=`cds`, payoff=`credit_default_swap`, structure=`single_reference_entity`\n\
+    - Valuation context: market_source=`unbound_market_snapshot`\n- Lane boundary:\
+    \ family=`analytical`, kind=`exact_target_binding`, timeline_roles=`settlement`,\
     \ `payment`, `observation`, exact_bindings=`trellis.models.credit_default_swap.build_cds_schedule`,\
     \ `trellis.models.credit_default_swap.price_cds_analytical`\n- Lowering boundary:\
     \ family_ir=`CreditDefaultSwapIR`, expr=`ThenExpr`, helpers=`trellis.models.credit_default_swap.build_cds_schedule`,\

--- a/docs/developer/dsl_system_design_review.md
+++ b/docs/developer/dsl_system_design_review.md
@@ -215,6 +215,14 @@ such as ``zcb_option`` now blocks fallback drafting into a generic
 ``vanilla_option`` contract when the prose only happens to contain generic
 ``option`` language.
 
+The analytical / PDE / FFT helper cohort now behaves the same way.
+Helper-backed Black76 swaption routes, vanilla-equity PDE / event-aware PDE
+helper branches, and the vanilla-equity transform helper keep only backend
+binding, admissibility, and signature-validation authority. When generated code
+tries to reconstruct spot/strike/time bundles or call those helpers on the
+wrong surface, semantic validation now fails directly instead of leaning on
+route-card repair prose.
+
 The Monte Carlo compiler now has the matching bounded family surface for the
 next migration tranche:
 

--- a/docs/plans/route-registry-minimization.md
+++ b/docs/plans/route-registry-minimization.md
@@ -276,6 +276,17 @@ The active route-card retirement queue is now tracked under umbrella
    `analytical_black76`, `vanilla_equity_theta_pde`, `pde_theta_1d`,
    `transform_fft`
    Validation cohort: `T13`, `T17`, `T39`, `T53`, `T73`, `T94`, `E21`, `E22`, `T103`
+   Closeout status: helper-backed route cards are thin, explicit empty
+   adapter/note overrides now survive conditional resolution, exact-helper
+   signature enforcement covers the vanilla-equity transform / Monte Carlo /
+   PDE helpers, and analytical cap/floor strips now admit on typed schedule
+   state instead of failing the generic automatic-event gate. `T13` and `T94`
+   still pass; `E22` now reaches a successful analytical comparator and carries
+   the remaining Monte Carlo comparator failure to `QUA-784`; `T17` carries
+   forward to `QUA-787`; `T39` and the helper-backed comparator side of `E21`
+   carry forward to `QUA-788`; `T73` carries forward to `QUA-789`; `T53` and
+   `T103` no longer fail on route-surface authority but remain broader
+   comparator/build-quality work outside this slice.
 5. `QUA-784` generic Monte Carlo and basket routes:
    `monte_carlo_paths`, `correlated_basket_monte_carlo`
    Validation cohort: `T37`, `T53`, `T102`, `T104`, `T126`, `E21`, `E22`, `E24`, `E26`
@@ -314,7 +325,7 @@ Status mirror last synced: `2026-04-12`
 | `QUA-778` | Route surfaces: FX and quanto exact-helper routes stop emitting procedural authority | Done |
 | `QUA-782` | Route surfaces: credit and copula routes retire procedural authority behind backend helpers | Done |
 | `QUA-781` | Route surfaces: rate-tree routes retire procedural authority and stay task-backed | Done |
-| `QUA-783` | Route surfaces: analytical Black76, PDE, and FFT routes retire procedural guidance | Backlog |
+| `QUA-783` | Route surfaces: analytical Black76, PDE, and FFT routes retire procedural guidance | Done |
 | `QUA-784` | Route surfaces: generic Monte Carlo and basket routes collapse to family-first metadata | Backlog |
 | `QUA-785` | Route inventory: audit metadata-first residual route cards against representative tasks | Backlog |
 | `QUA-777` | Route scoring: remove residual route-identity authority after route-card retirement | Backlog |

--- a/docs/quant/contract_algebra.rst
+++ b/docs/quant/contract_algebra.rst
@@ -409,6 +409,11 @@ For the migrated families above:
 - typed ``obligations`` and ``SemanticTimeline`` are authoritative for settlement
 - typed ``EventMachine`` is authoritative for automatic event semantics
 - legacy ``settlement_rule`` and ``event_transitions`` are mirrors only
+- helper-backed analytical / PDE / FFT routes admit on lowered family IR and
+  typed schedule/state semantics, not on route-card instructions
+- structural cap/floor strips lowered onto ``AnalyticalBlack76IR`` use typed
+  ``schedule_state`` authority and no longer fail the generic
+  ``unsupported_event_support:automatic_triggers`` gate
 
 Validation now distinguishes:
 

--- a/docs/quant/pricing_stack.rst
+++ b/docs/quant/pricing_stack.rst
@@ -254,6 +254,21 @@ helpers, but the route cards no longer carry lattice-construction or
 short-rate-input assembly instructions once the helper surface already owns
 that work.
 
+The analytical / PDE / FFT helper cohort now follows the same rule. The
+helper-backed Black76 swaption routes, the vanilla-equity PDE helper, the
+bounded event-aware PDE helper branches, and the vanilla-equity transform
+helper keep backend binding, admissibility, and validation ownership while
+dropping route-card adapter prose and backend notes once the checked helper
+surface already owns that assembly. Exact-helper validation now enforces the
+thin ``(market_state, spec, ...)`` call surface for those helpers instead of
+letting comparator or repair scaffolds rebuild raw market-input bundles inline.
+
+For schedule-driven cap/floor strips lowered onto ``analytical_black76``, the
+typed schedule state now carries admissibility directly. Structural
+caplet/floorlet strips no longer get rejected as generic ``automatic`` event
+routes when the lowered family IR is already the checked analytical strip
+surface.
+
 Below those public callable wrappers, the reusable coupon/event/control layer
 now lives in ``trellis.models.short_rate_fixed_income``. Coupon schedule
 compilation, embedded issuer/holder exercise semantics, straight-bond

--- a/tests/test_agent/test_build_loop.py
+++ b/tests/test_agent/test_build_loop.py
@@ -332,6 +332,39 @@ def test_reference_modules_include_generic_rate_tree_surfaces_for_callable_bond(
     assert ("trellis.models.trees.control", "Lattice exercise/control helpers") in modules
 
 
+def test_reference_modules_use_concrete_transform_surfaces_for_fft_pricing():
+    from types import SimpleNamespace
+
+    from trellis.agent.executor import _reference_modules
+
+    modules = _reference_modules(
+        pricing_plan=SimpleNamespace(method="fft_pricing"),
+        instrument_type="european_option",
+    )
+
+    assert ("trellis.models.transforms", "Transform package exports") not in modules
+    assert ("trellis.models.transforms.fft_pricer", "FFT transform pricer") in modules
+    assert ("trellis.models.transforms.cos_method", "COS transform pricer") in modules
+    assert ("trellis.models.equity_option_transforms", "Vanilla equity transform helper") in modules
+
+
+def test_reference_modules_use_concrete_copula_surfaces():
+    from types import SimpleNamespace
+
+    from trellis.agent.executor import _reference_modules
+
+    modules = _reference_modules(
+        pricing_plan=SimpleNamespace(method="copula"),
+        instrument_type="nth_to_default",
+    )
+
+    assert ("trellis.models.copulas", "Copula package exports") not in modules
+    assert ("trellis.models.copulas.factor", "Factor copula kernel") in modules
+    assert ("trellis.models.copulas.gaussian", "Gaussian copula kernel") in modules
+    assert ("trellis.models.copulas.student_t", "Student-t copula kernel") in modules
+    assert ("trellis.models.credit_basket_copula", "Credit basket copula helper") in modules
+
+
 def test_generate_quanto_monte_carlo_skeleton_uses_family_helper_surface():
     from types import SimpleNamespace
 

--- a/tests/test_agent/test_codegen_guardrails.py
+++ b/tests/test_agent/test_codegen_guardrails.py
@@ -7,6 +7,7 @@ from trellis.agent.codegen_guardrails import (
     render_generation_plan,
     render_review_contract_card,
     render_generation_route_card,
+    render_semantic_repair_card,
     sanitize_generated_source,
     validate_generated_imports,
 )
@@ -214,6 +215,21 @@ def test_generation_route_card_for_fx_exact_helper_stays_helper_only():
     assert "map_fx_spot_and_curves_to_garman_kohlhagen_inputs" not in text
 
 
+def test_generation_route_card_for_swaption_analytical_stays_helper_only():
+    compiled = compile_build_request(
+        "European swaption on fixed-for-float swap",
+        instrument_type="swaption",
+        preferred_method="analytical",
+    )
+
+    text = render_generation_route_card(compiled.generation_plan)
+
+    assert "price_swaption_black76" in text
+    assert "reuse_checked_in_rate_style_swaption_helper" not in text
+    assert "Hull-White-implied Black vol" not in text
+    assert "Backend notes:" not in text
+
+
 def test_generation_route_card_for_quanto_exact_helper_stays_helper_only():
     compiled = compile_build_request(
         "Quanto option on SAP in USD with EUR underlier currency expiring 2025-11-15",
@@ -283,6 +299,50 @@ def test_generation_route_card_for_zcb_option_tree_stays_helper_only():
     assert "price_zcb_option_tree" in text
     assert "build_generic_lattice" not in text
     assert "MODEL_REGISTRY" not in text
+
+
+def test_generation_route_card_for_vanilla_equity_pde_stays_helper_only():
+    compiled = compile_build_request(
+        "European equity call on AAPL",
+        instrument_type="european_option",
+        preferred_method="pde_solver",
+    )
+
+    text = render_generation_route_card(compiled.generation_plan)
+
+    assert "price_vanilla_equity_option_pde" in text
+    assert "reuse_checked_in_vanilla_equity_pde_helper" not in text
+    assert "Grid + BlackScholesOperator + theta_method_1d" not in text
+    assert "Backend notes:" not in text
+
+
+def test_generation_route_card_for_vanilla_equity_fft_stays_helper_only():
+    compiled = compile_build_request(
+        "European equity call on AAPL via FFT",
+        instrument_type="european_option",
+        preferred_method="fft_pricing",
+    )
+
+    text = render_generation_route_card(compiled.generation_plan)
+
+    assert "price_vanilla_equity_option_transform" in text
+    assert "build_vector_safe_characteristic_function" not in text
+    assert "GBM characteristic functions" not in text
+    assert "Backend notes:" not in text
+
+
+def test_semantic_repair_card_for_helper_backed_pde_route_omits_route_notes_and_adapters():
+    compiled = compile_build_request(
+        "European equity call on AAPL",
+        instrument_type="european_option",
+        preferred_method="pde_solver",
+    )
+
+    text = render_semantic_repair_card(compiled.generation_plan)
+
+    assert "price_vanilla_equity_option_pde" in text
+    assert "Required adapters:" not in text
+    assert "Route notes:" not in text
 
 
 def test_review_contract_card_renders_wrapper_route_and_validation_scope():

--- a/tests/test_agent/test_import_registry.py
+++ b/tests/test_agent/test_import_registry.py
@@ -1,5 +1,6 @@
 """Tests for the structured import registry."""
 
+import trellis.agent.knowledge.import_registry as import_registry
 from trellis.agent.knowledge.import_registry import (
     find_symbol_modules,
     get_import_registry,
@@ -51,3 +52,22 @@ def test_module_exists_rejects_unknown_modules():
 def test_formatted_registry_mentions_known_import():
     registry_text = get_import_registry()
     assert "from trellis.models.black import" in registry_text
+
+
+def test_static_registry_fallback_covers_route_minimization_modules(monkeypatch):
+    import_registry.reset_registry_cache()
+    monkeypatch.setattr(
+        import_registry,
+        "_build_registry_data_from_introspection",
+        lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    snapshot = import_registry.get_registry_snapshot()
+
+    assert "trellis.models.equity_option_transforms" in snapshot
+    assert "price_vanilla_equity_option_transform" in snapshot["trellis.models.equity_option_transforms"]
+    assert "trellis.models.credit_basket_copula" in snapshot
+    assert "price_credit_basket_tranche" in snapshot["trellis.models.credit_basket_copula"]
+    assert "trellis.models.transforms.single_state_diffusion" in snapshot
+    assert "resolve_single_state_diffusion_inputs" in snapshot["trellis.models.transforms.single_state_diffusion"]
+
+    import_registry.reset_registry_cache()

--- a/tests/test_agent/test_lite_review.py
+++ b/tests/test_agent/test_lite_review.py
@@ -233,7 +233,7 @@ def price(spec, market_state):
             primitives=(
                 PrimitiveRef("trellis.models.rate_style_swaption", "price_swaption_black76", "route_helper"),
             ),
-            adapters=("reuse_checked_in_rate_style_swaption_helper",),
+            adapters=(),
             blockers=(),
         ),
     )
@@ -287,7 +287,7 @@ def price(spec, market_state):
             primitives=(
                 PrimitiveRef("trellis.models.rate_style_swaption_tree", "price_swaption_tree", "route_helper"),
             ),
-            adapters=("reuse_checked_in_rate_style_swaption_helper",),
+            adapters=(),
             blockers=(),
         ),
     )
@@ -341,7 +341,7 @@ def price(spec, market_state):
             primitives=(
                 PrimitiveRef("trellis.models.rate_style_swaption", "price_swaption_monte_carlo", "route_helper"),
             ),
-            adapters=("reuse_checked_in_rate_style_swaption_helper",),
+            adapters=(),
             blockers=(),
         ),
     )
@@ -695,7 +695,7 @@ def price(spec, market_state):
                     "route_helper",
                 ),
             ),
-            adapters=("reuse_checked_in_vanilla_equity_pde_helper",),
+            adapters=(),
             blockers=(),
         ),
     )

--- a/tests/test_agent/test_primitive_planning.py
+++ b/tests/test_agent/test_primitive_planning.py
@@ -140,7 +140,8 @@ def test_builds_pde_plan_for_european_option_uses_helper_route():
     primitive_modules = {primitive.module for primitive in plan.primitive_plan.primitives}
     assert primitive_symbols == {"price_vanilla_equity_option_pde"}
     assert primitive_modules == {"trellis.models.equity_option_pde"}
-    assert any("theta_0.5" in note for note in plan.primitive_plan.notes)
+    assert plan.primitive_plan.adapters == ()
+    assert plan.primitive_plan.notes == ()
 
 
 def test_builds_primitive_plan_for_swaption():
@@ -167,6 +168,8 @@ def test_builds_primitive_plan_for_swaption():
     primitive_symbols = {primitive.symbol for primitive in plan.primitive_plan.primitives}
     assert {"price_swaption_black76"} <= primitive_symbols
     assert "black76_call" not in primitive_symbols
+    assert plan.primitive_plan.adapters == ()
+    assert plan.primitive_plan.notes == ()
     assert plan.primitive_plan.blockers == ()
 
 

--- a/tests/test_agent/test_prompts.py
+++ b/tests/test_agent/test_prompts.py
@@ -767,7 +767,7 @@ def test_evaluate_prompt_compact_surface_mentions_swaption_helper_route():
             primitives=(
                 PrimitiveRef("trellis.models.rate_style_swaption", "price_swaption_black76", "route_helper"),
             ),
-            adapters=("reuse_checked_in_rate_style_swaption_helper",),
+            adapters=(),
             blockers=(),
         ),
     )

--- a/tests/test_agent/test_route_registry.py
+++ b/tests/test_agent/test_route_registry.py
@@ -888,10 +888,12 @@ class TestAnalyticalRoutes:
         assert resolve_route_adapters(spec, self.BERMUDAN_SWAPTION_IR) == ()
 
     def test_rate_cap_floor_strip_analytical_admissibility_accepts_structural_schedule_contract(self, registry):
+        from dataclasses import replace
+
         from trellis.agent.semantic_contracts import make_rate_cap_floor_strip_contract
 
-        spec = find_route_by_id("analytical_black76", registry)
-        assert spec is not None
+        black76_spec = find_route_by_id("analytical_black76", registry)
+        assert black76_spec is not None
 
         contract = make_rate_cap_floor_strip_contract(
             description="5Y cap on SOFR with quarterly caplets under Black-76",
@@ -901,10 +903,27 @@ class TestAnalyticalRoutes:
         )
         bp = _semantic_blueprint_for(contract, preferred_method="analytical")
 
-        decision = evaluate_route_admissibility(spec, semantic_blueprint=bp)
+        decision = evaluate_route_admissibility(black76_spec, semantic_blueprint=bp)
 
         assert decision.ok
         assert "unsupported_event_support:automatic_triggers" not in decision.failures
+
+        raw_bp = replace(
+            bp,
+            dsl_lowering=replace(bp.dsl_lowering, family_ir=None),
+        )
+        raw_decision = evaluate_route_admissibility(black76_spec, semantic_blueprint=raw_bp)
+        assert not raw_decision.ok
+        assert "unsupported_event_support:automatic_triggers" in raw_decision.failures
+
+        zcb_spec = find_route_by_id("zcb_option_analytical", registry)
+        assert zcb_spec is not None
+        zcb_decision = evaluate_route_admissibility(zcb_spec, semantic_blueprint=bp)
+        assert not zcb_decision.ok
+        assert all(
+            failure != "unsupported_event_support:automatic_triggers"
+            for failure in zcb_decision.failures
+        )
 
     def test_engine_family(self, registry):
         spec = [r for r in registry.routes if r.id == "analytical_black76"][0]

--- a/tests/test_agent/test_route_registry.py
+++ b/tests/test_agent/test_route_registry.py
@@ -488,6 +488,12 @@ class TestMonteCarloPathsRoutes:
         payoff_family="vanilla_option",
         exercise_style="european",
     )
+    GENERIC_IR = ProductIR(
+        instrument="path_dependent_note",
+        payoff_family="path_dependent_generic",
+        exercise_style="none",
+        model_family="generic",
+    )
 
     def test_candidate(self, registry):
         new = _new_routes(registry, "monte_carlo", self.EUROPEAN_IR)
@@ -504,6 +510,13 @@ class TestMonteCarloPathsRoutes:
             ),
         }
         assert _prim_set(new_prims) == expected_prims
+
+    def test_default_branch_preserves_base_adapters_and_notes_for_generic_requests(self, registry):
+        spec = [r for r in registry.routes if r.id == "monte_carlo_paths"][0]
+
+        assert resolve_route_primitives(spec, self.GENERIC_IR) == spec.primitives
+        assert resolve_route_adapters(spec, self.GENERIC_IR) == spec.adapters
+        assert resolve_route_notes(spec, self.GENERIC_IR) == spec.notes
 
     def test_admissibility_hydrates_process_and_path_contracts(self, registry):
         generic = find_route_by_id("monte_carlo_paths", registry)

--- a/tests/test_agent/test_route_registry.py
+++ b/tests/test_agent/test_route_registry.py
@@ -853,11 +853,10 @@ class TestAnalyticalRoutes:
             ),
         }
 
-    def test_swaption_notes_pin_helper_backed_route(self, registry):
+    def test_swaption_helper_route_is_thin(self, registry):
         spec = [r for r in registry.routes if r.id == "analytical_black76"][0]
-        notes = resolve_route_notes(spec, self.SWAPTION_IR)
-        assert any("price_swaption_black76" in note for note in notes)
-        assert any("Hull-White-implied Black vol" in note for note in notes)
+        assert resolve_route_notes(spec, self.SWAPTION_IR) == ()
+        assert resolve_route_adapters(spec, self.SWAPTION_IR) == ()
 
     def test_bermudan_swaption_primitives_use_lower_bound_helper(self, registry):
         spec = [r for r in registry.routes if r.id == "analytical_black76"][0]
@@ -869,6 +868,30 @@ class TestAnalyticalRoutes:
                 "route_helper",
             ),
         }
+
+    def test_bermudan_swaption_analytical_route_is_thin(self, registry):
+        spec = [r for r in registry.routes if r.id == "analytical_black76"][0]
+        assert resolve_route_notes(spec, self.BERMUDAN_SWAPTION_IR) == ()
+        assert resolve_route_adapters(spec, self.BERMUDAN_SWAPTION_IR) == ()
+
+    def test_rate_cap_floor_strip_analytical_admissibility_accepts_structural_schedule_contract(self, registry):
+        from trellis.agent.semantic_contracts import make_rate_cap_floor_strip_contract
+
+        spec = find_route_by_id("analytical_black76", registry)
+        assert spec is not None
+
+        contract = make_rate_cap_floor_strip_contract(
+            description="5Y cap on SOFR with quarterly caplets under Black-76",
+            instrument_class="cap",
+            observation_schedule=("2026-03-20", "2026-06-20", "2026-09-20", "2026-12-20"),
+            preferred_method="analytical",
+        )
+        bp = _semantic_blueprint_for(contract, preferred_method="analytical")
+
+        decision = evaluate_route_admissibility(spec, semantic_blueprint=bp)
+
+        assert decision.ok
+        assert "unsupported_event_support:automatic_triggers" not in decision.failures
 
     def test_engine_family(self, registry):
         spec = [r for r in registry.routes if r.id == "analytical_black76"][0]
@@ -1069,6 +1092,17 @@ class TestFallbackRoutes:
         }
         assert _prim_set(new_prims) == expected_prims
 
+    def test_vanilla_equity_transform_helper_route_is_thin(self, registry):
+        spec = [r for r in registry.routes if r.id == "transform_fft"][0]
+        ir = ProductIR(
+            instrument="european_option",
+            payoff_family="vanilla_option",
+            exercise_style="european",
+            model_family="equity_diffusion",
+        )
+        assert resolve_route_notes(spec, ir) == ()
+        assert resolve_route_adapters(spec, ir) == ()
+
     def test_stochastic_vol_transform_primitives_fall_back_to_raw_kernels(self, registry):
         spec = [r for r in registry.routes if r.id == "transform_fft"][0]
         ir = ProductIR(
@@ -1107,6 +1141,16 @@ class TestFallbackRoutes:
         }
         assert _prim_set(new_prims) == expected_prims
 
+    def test_vanilla_equity_pde_helper_route_is_thin(self, registry):
+        spec = [r for r in registry.routes if r.id == "vanilla_equity_theta_pde"][0]
+        ir = ProductIR(
+            instrument="european_option",
+            payoff_family="vanilla_option",
+            exercise_style="european",
+        )
+        assert resolve_route_notes(spec, ir) == ()
+        assert resolve_route_adapters(spec, ir) == ()
+
     def test_holder_max_equity_pde_primitives(self, registry):
         spec = [r for r in registry.routes if r.id == "pde_theta_1d"][0]
         ir = ProductIR(
@@ -1121,6 +1165,17 @@ class TestFallbackRoutes:
         }
         assert _prim_set(new_prims) == expected_prims
 
+    def test_holder_max_equity_pde_helper_route_is_thin(self, registry):
+        spec = [r for r in registry.routes if r.id == "pde_theta_1d"][0]
+        ir = ProductIR(
+            instrument="american_option",
+            payoff_family="vanilla_option",
+            exercise_style="bermudan",
+            model_family="equity_diffusion",
+        )
+        assert resolve_route_notes(spec, ir) == ()
+        assert resolve_route_adapters(spec, ir) == ()
+
     def test_callable_bond_pde_primitives(self, registry):
         spec = [r for r in registry.routes if r.id == "pde_theta_1d"][0]
         ir = ProductIR(
@@ -1134,6 +1189,17 @@ class TestFallbackRoutes:
             ("trellis.models.callable_bond_pde", "price_callable_bond_pde", "route_helper"),
         }
         assert _prim_set(new_prims) == expected_prims
+
+    def test_callable_bond_pde_helper_route_is_thin(self, registry):
+        spec = [r for r in registry.routes if r.id == "pde_theta_1d"][0]
+        ir = ProductIR(
+            instrument="callable_bond",
+            payoff_family="callable_fixed_income",
+            exercise_style="issuer_call",
+            model_family="interest_rate",
+        )
+        assert resolve_route_notes(spec, ir) == ()
+        assert resolve_route_adapters(spec, ir) == ()
 
     def test_pde_admissibility_hydrates_operator_and_event_contracts(self, registry):
         vanilla = find_route_by_id("vanilla_equity_theta_pde", registry)

--- a/tests/test_agent/test_semantic_validators.py
+++ b/tests/test_agent/test_semantic_validators.py
@@ -257,6 +257,118 @@ def evaluate(self, market_state):
         findings = validator.validate(source, _make_plan("analytical_garman_kohlhagen"), spec)
         assert not any(f.category == "route_helper_signature_mismatch" for f in findings)
 
+    def test_flags_vanilla_equity_transform_helper_signature_mismatch(self, registry):
+        spec = [r for r in registry.routes if r.id == "transform_fft"][0]
+        vanilla_ir = ProductIR(
+            instrument="european_option",
+            payoff_family="vanilla_option",
+            exercise_style="european",
+            model_family="equity_diffusion",
+        )
+        spec = replace(spec, primitives=resolve_route_primitives(spec, vanilla_ir))
+        source = '''
+from trellis.models.equity_option_transforms import price_vanilla_equity_option_transform
+
+def evaluate(self, market_state):
+    return price_vanilla_equity_option_transform(
+        market_state=market_state,
+        spec=self._spec,
+        spot=self._spec.spot,
+    )
+'''
+        validator = AlgorithmContractValidator()
+        findings = validator.validate(source, _make_plan("transform_fft", "fft_pricing"), spec)
+        assert any(f.category == "route_helper_signature_mismatch" for f in findings)
+
+    def test_accepts_vanilla_equity_transform_helper_surface(self, registry):
+        spec = [r for r in registry.routes if r.id == "transform_fft"][0]
+        vanilla_ir = ProductIR(
+            instrument="european_option",
+            payoff_family="vanilla_option",
+            exercise_style="european",
+            model_family="equity_diffusion",
+        )
+        spec = replace(spec, primitives=resolve_route_primitives(spec, vanilla_ir))
+        source = '''
+from trellis.models.equity_option_transforms import price_vanilla_equity_option_transform
+
+def evaluate(self, market_state):
+    return price_vanilla_equity_option_transform(market_state, self._spec, method="fft")
+'''
+        validator = AlgorithmContractValidator()
+        findings = validator.validate(source, _make_plan("transform_fft", "fft_pricing"), spec)
+        assert not any(f.category == "route_helper_signature_mismatch" for f in findings)
+
+    def test_flags_vanilla_equity_monte_carlo_helper_signature_mismatch(self, registry):
+        spec = [r for r in registry.routes if r.id == "monte_carlo_paths"][0]
+        vanilla_ir = ProductIR(
+            instrument="european_option",
+            payoff_family="vanilla_option",
+            exercise_style="european",
+            model_family="equity_diffusion",
+        )
+        spec = replace(spec, primitives=resolve_route_primitives(spec, vanilla_ir))
+        source = '''
+from trellis.models.equity_option_monte_carlo import price_vanilla_equity_option_monte_carlo
+
+def evaluate(self, market_state):
+    return price_vanilla_equity_option_monte_carlo(
+        market_state=market_state,
+        spec=self._spec,
+        spot=self._spec.spot,
+    )
+'''
+        validator = AlgorithmContractValidator()
+        findings = validator.validate(source, _make_plan("monte_carlo_paths", "monte_carlo"), spec)
+        assert any(f.category == "route_helper_signature_mismatch" for f in findings)
+
+    def test_accepts_vanilla_equity_monte_carlo_helper_surface(self, registry):
+        spec = [r for r in registry.routes if r.id == "monte_carlo_paths"][0]
+        vanilla_ir = ProductIR(
+            instrument="european_option",
+            payoff_family="vanilla_option",
+            exercise_style="european",
+            model_family="equity_diffusion",
+        )
+        spec = replace(spec, primitives=resolve_route_primitives(spec, vanilla_ir))
+        source = '''
+from trellis.models.equity_option_monte_carlo import price_vanilla_equity_option_monte_carlo
+
+def evaluate(self, market_state):
+    return price_vanilla_equity_option_monte_carlo(market_state, self._spec, n_paths=50000)
+'''
+        validator = AlgorithmContractValidator()
+        findings = validator.validate(source, _make_plan("monte_carlo_paths", "monte_carlo"), spec)
+        assert not any(f.category == "route_helper_signature_mismatch" for f in findings)
+
+    def test_flags_vanilla_equity_pde_helper_signature_mismatch(self, registry):
+        spec = [r for r in registry.routes if r.id == "vanilla_equity_theta_pde"][0]
+        source = '''
+from trellis.models.equity_option_pde import price_vanilla_equity_option_pde
+
+def evaluate(self, market_state):
+    return price_vanilla_equity_option_pde(
+        market_state=market_state,
+        spec=self._spec,
+        strike=self._spec.strike,
+    )
+'''
+        validator = AlgorithmContractValidator()
+        findings = validator.validate(source, _make_plan("vanilla_equity_theta_pde", "pde_solver"), spec)
+        assert any(f.category == "route_helper_signature_mismatch" for f in findings)
+
+    def test_accepts_vanilla_equity_pde_helper_surface(self, registry):
+        spec = [r for r in registry.routes if r.id == "vanilla_equity_theta_pde"][0]
+        source = '''
+from trellis.models.equity_option_pde import price_vanilla_equity_option_pde
+
+def evaluate(self, market_state):
+    return price_vanilla_equity_option_pde(market_state, self._spec, theta=0.5)
+'''
+        validator = AlgorithmContractValidator()
+        findings = validator.validate(source, _make_plan("vanilla_equity_theta_pde", "pde_solver"), spec)
+        assert not any(f.category == "route_helper_signature_mismatch" for f in findings)
+
     def test_flags_quanto_exact_helper_signature_mismatch(self, registry):
         spec = [r for r in registry.routes if r.id == "quanto_adjustment_analytical"][0]
         source = '''

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -3467,7 +3467,10 @@ def _reference_modules(
             modules.append(("trellis.models.processes.gbm", "GBM process reference"))
         elif method == "copula":
             modules.append(("trellis.instruments.nth_to_default", "NthToDefaultPayoff (copula reference)"))
-            modules.append(("trellis.models.copulas", "Copula package exports"))
+            modules.append(("trellis.models.credit_basket_copula", "Credit basket copula helper"))
+            modules.append(("trellis.models.copulas.factor", "Factor copula kernel"))
+            modules.append(("trellis.models.copulas.gaussian", "Gaussian copula kernel"))
+            modules.append(("trellis.models.copulas.student_t", "Student-t copula kernel"))
         elif method == "pde_solver":
             modules.append(("trellis.models.pde", "PDE package exports"))
             modules.append(("trellis.models.pde.theta_method", "Theta-method solver reference"))
@@ -3476,7 +3479,11 @@ def _reference_modules(
             if normalized_instrument == "european_option":
                 modules.append(("trellis.models.equity_option_pde", "Vanilla equity PDE helper"))
         elif method == "fft_pricing":
-            modules.append(("trellis.models.transforms", "Transform package exports"))
+            modules.append(("trellis.models.transforms.fft_pricer", "FFT transform pricer"))
+            modules.append(("trellis.models.transforms.cos_method", "COS transform pricer"))
+            modules.append(("trellis.models.transforms.single_state_diffusion", "Transform diffusion contracts"))
+            if normalized_instrument == "european_option":
+                modules.append(("trellis.models.equity_option_transforms", "Vanilla equity transform helper"))
             modules.append(("trellis.models.processes.heston", "Heston process reference"))
         elif method == "waterfall":
             modules.append(("trellis.models.cashflow_engine.waterfall", "Cashflow waterfall reference"))

--- a/trellis/agent/knowledge/canonical/api_map.yaml
+++ b/trellis/agent/knowledge/canonical/api_map.yaml
@@ -125,10 +125,12 @@ pde:
 # Model imports — FFT / Fourier
 # ---------------------------------------------------------------------------
 fft:
-  module: trellis.models.transforms
+  module: trellis.models.transforms.fft_pricer
   key_imports:
-    - "from trellis.models.transforms import fft_price, cos_price"
+    - "from trellis.models.transforms.fft_pricer import fft_price"
+    - "from trellis.models.transforms.cos_method import cos_price"
   notes:
+    - "Concrete transform helpers live in submodules; do not import `trellis.models.transforms` directly."
     - "fft_price expects CF of log(S_T) — include log(S0)"
     - "cos_price expects CF of log(S_T/S0) — log-return only"
 
@@ -136,9 +138,11 @@ fft:
 # Model imports — copulas
 # ---------------------------------------------------------------------------
 copulas:
-  module: trellis.models.copulas
+  module: trellis.models.copulas.factor
   key_imports:
-    - "from trellis.models.copulas import GaussianCopula, StudentTCopula, FactorCopula"
+    - "from trellis.models.copulas.factor import FactorCopula"
+    - "from trellis.models.copulas.gaussian import GaussianCopula"
+    - "from trellis.models.copulas.student_t import StudentTCopula"
 
 # ---------------------------------------------------------------------------
 # Model imports — analytical

--- a/trellis/agent/knowledge/canonical/routes.yaml
+++ b/trellis/agent/knowledge/canonical/routes.yaml
@@ -775,10 +775,7 @@ routes:
             symbol: price_bermudan_swaption_black76_lower_bound
             role: route_helper
         adapters: []
-        notes:
-          - "For Bermudan swaption analytical comparators, prefer `trellis.models.rate_style_swaption.price_bermudan_swaption_black76_lower_bound(...)`."
-          - "Interpret the analytical comparator as the European swaption exercisable only on the final Bermudan date."
-          - "Keep the generated route as a thin adapter over the helper; do not sum multiple exercise-date European prices or rebuild co-terminal schedule loops inline."
+        notes: []
       - when:
           payoff_family: swaption
           exercise_style: [european]
@@ -786,13 +783,8 @@ routes:
           - module: trellis.models.rate_style_swaption
             symbol: price_swaption_black76
             role: route_helper
-        adapters:
-          - reuse_checked_in_rate_style_swaption_helper
-        notes:
-          - "For European rate-style swaptions, prefer `price_swaption_black76(market_state, spec, ...)` from `trellis.models.rate_style_swaption`."
-          - "This helper owns expiry, annuity, forward swap rate, quote-regime normalization, and Black76 execution."
-          - "When the request supplies explicit Hull-White comparison parameters, pass `mean_reversion=` and `sigma=` into `price_swaption_black76(...)` so the analytical comparator uses a Hull-White-implied Black vol instead of drifting to an unrelated market vol surface."
-          - "Keep the generated route as a thin adapter over the helper-backed family surface; do not rebuild annuity, forward-swap-rate, expiry binding, or swaption-vol normalization inline."
+        adapters: []
+        notes: []
       - when: default
         primitives:
           - module: trellis.models.black
@@ -936,9 +928,7 @@ routes:
             symbol: price_vanilla_equity_option_transform
             role: route_helper
         adapters: []
-        notes:
-          - "Use `trellis.models.equity_option_transforms.price_vanilla_equity_option_transform(...)` directly for vanilla European equity transform routes."
-          - "Treat transform generation as a thin adapter over the checked helper; do not rebuild GBM characteristic functions, put/call parity, or raw FFT/COS argument plumbing inline."
+        notes: []
       - when: default
         primitives:
           - module: trellis.models.transforms.fft_pricer
@@ -988,13 +978,8 @@ routes:
       - module: trellis.models.equity_option_pde
         symbol: price_vanilla_equity_option_pde
         role: route_helper
-    adapters:
-      - reuse_checked_in_vanilla_equity_pde_helper
-    notes:
-      - "For vanilla European equity PDE routes, prefer `price_vanilla_equity_option_pde(market_state, spec, theta=...)` so the adapter stays thin."
-      - "Map `implementation_target=theta_0.5` to `theta=0.5` and `implementation_target=theta_1.0` to `theta=1.0`."
-      - "The checked-in helper already owns grid sizing, terminal payoff assembly, boundary conditions, theta-method solve, and interpolation back to spot."
-      - "Use the lower-level `Grid + BlackScholesOperator + theta_method_1d` path only when the payoff or boundary contract genuinely differs from plain vanilla European call/put."
+    adapters: []
+    notes: []
     market_data_access:
       required:
         discount_curve: [market_state.discount]
@@ -1028,9 +1013,7 @@ routes:
             symbol: price_event_aware_equity_option_pde
             role: route_helper
         adapters: []
-        notes:
-          - "Use `trellis.models.equity_option_pde.price_event_aware_equity_option_pde(...)` for bounded holder-max equity PDE routes."
-          - "Keep the adapter thin: resolve market-state discount/vol inputs and let the checked helper assemble `EventAwarePDEProblem` buckets for Bermudan or American exercise."
+        notes: []
       - when:
           payoff_family: callable_fixed_income
           exercise_style: [issuer_call]
@@ -1040,9 +1023,7 @@ routes:
             symbol: price_callable_bond_pde
             role: route_helper
         adapters: []
-        notes:
-          - "Use `trellis.models.callable_bond_pde.price_callable_bond_pde(...)` for bounded issuer-min callable-bond PDE routes."
-          - "Keep the adapter thin: resolve discount and Black-vol inputs, then let the checked helper assemble short-rate `add_cashflow` and `project_min` event buckets on the shared `EventAwarePDEProblem` substrate."
+        notes: []
       - when: default
         primitives:
           - module: trellis.models.pde.grid

--- a/trellis/agent/knowledge/import_registry.py
+++ b/trellis/agent/knowledge/import_registry.py
@@ -524,6 +524,7 @@ from trellis.models.monte_carlo.variance_reduction import antithetic, control_va
 from trellis.models.monte_carlo.schemes import Euler, Milstein, Exact, LogEuler, LaguerreBasis, PolynomialBasis
 from trellis.models.monte_carlo.ranked_observation_payoffs import build_ranked_observation_basket_initial_state, build_ranked_observation_basket_process, build_ranked_observation_basket_state_payoff, price_ranked_observation_basket_monte_carlo, recommended_ranked_observation_basket_mc_engine_kwargs, terminal_ranked_observation_basket_payoff
 from trellis.models.monte_carlo.semantic_basket import RankedObservationBasketMonteCarloPayoff, RankedObservationBasketSpec
+from trellis.models.equity_option_monte_carlo import build_vanilla_equity_monte_carlo_problem, price_single_state_terminal_claim_monte_carlo_result, price_vanilla_equity_option_monte_carlo, price_vanilla_equity_option_monte_carlo_result, resolve_single_state_terminal_claim_monte_carlo_inputs, resolve_vanilla_equity_monte_carlo_inputs
 
 ### Models — QMC
 from trellis.models.qmc import brownian_bridge, sobol_normals
@@ -535,10 +536,13 @@ from trellis.models.pde.rate_operator import HullWhitePDEOperator
 from trellis.models.pde.psor import psor_1d
 from trellis.models.pde.grid import Grid
 from trellis.models.pde.thomas import thomas_solve
+from trellis.models.equity_option_pde import build_event_aware_equity_pde_problem, build_event_aware_pde_problem, build_vanilla_equity_pde_problem, interpolate_pde_values, price_event_aware_equity_option_pde, price_vanilla_equity_option_pde, resolve_vanilla_equity_pde_inputs, solve_event_aware_equity_option_pde_surface, solve_event_aware_pde, solve_vanilla_equity_option_pde_surface
 
 ### Models — Transforms (FFT/COS)
 from trellis.models.transforms.cos_method import cos_price
 from trellis.models.transforms.fft_pricer import fft_price
+from trellis.models.transforms.single_state_diffusion import price_single_state_terminal_claim_transform_result, resolve_single_state_diffusion_inputs, resolve_single_state_terminal_claim_transform_inputs
+from trellis.models.equity_option_transforms import gbm_log_ratio_char_fn, gbm_log_spot_char_fn, price_vanilla_equity_option_transform, price_vanilla_equity_option_transform_result, put_from_call_parity, resolve_single_state_terminal_claim_transform_inputs, resolve_vanilla_equity_transform_inputs, terminal_intrinsic_from_resolved
 
 ### Models — Processes
 from trellis.models.processes.gbm import GBM
@@ -554,6 +558,7 @@ from trellis.models.processes.local_vol import LocalVol
 from trellis.models.copulas.gaussian import GaussianCopula
 from trellis.models.copulas.factor import FactorCopula
 from trellis.models.copulas.student_t import StudentTCopula
+from trellis.models.credit_basket_copula import price_credit_basket_nth_to_default, price_credit_basket_tranche, price_credit_basket_tranche_result, price_nth_to_default_basket, resolve_credit_basket_inputs
 
 ### Models — Calibration
 from trellis.models.calibration.implied_vol import implied_vol, implied_vol_jaeckel

--- a/trellis/agent/route_registry.py
+++ b/trellis/agent/route_registry.py
@@ -24,6 +24,7 @@ import yaml
 
 from trellis.agent.codegen_guardrails import PrimitiveRef
 from trellis.agent.family_lowering_ir import (
+    AnalyticalBlack76IR,
     EventAwareMonteCarloIR,
     EventAwarePDEIR,
     TransformPricingIR,
@@ -73,8 +74,8 @@ class ConditionalPrimitive:
 
     when: dict[str, Any] | str  # dict of trait conditions, or "default"
     primitives: tuple[PrimitiveRef, ...] = ()
-    adapters: tuple[str, ...] = ()
-    notes: tuple[str, ...] = ()
+    adapters: tuple[str, ...] | None = None
+    notes: tuple[str, ...] | None = None
 
 
 @dataclass(frozen=True)
@@ -282,8 +283,8 @@ def _parse_conditional_primitives(raw: list | None) -> tuple[ConditionalPrimitiv
     for entry in raw:
         when = entry.get("when", "default")
         primitives = tuple(_parse_primitive(p) for p in entry.get("primitives", ()))
-        adapters = tuple(entry.get("adapters", ()))
-        notes = tuple(entry.get("notes", ()))
+        adapters = None if "adapters" not in entry else tuple(entry.get("adapters", ()))
+        notes = None if "notes" not in entry else tuple(entry.get("notes", ()))
         result.append(ConditionalPrimitive(
             when=when,
             primitives=primitives,
@@ -869,10 +870,10 @@ def resolve_route_adapters(
 
     for cond in spec.conditional_primitives:
         if isinstance(cond.when, str) and cond.when == "default":
-            return cond.adapters if cond.adapters else spec.adapters
+            return spec.adapters if cond.adapters is None else cond.adapters
         if isinstance(cond.when, dict):
             if _matches_condition(cond.when, payoff_family, exercise, model_family, product_ir):
-                return cond.adapters if cond.adapters else spec.adapters
+                return spec.adapters if cond.adapters is None else cond.adapters
 
     return spec.adapters
 
@@ -895,8 +896,8 @@ def resolve_route_notes(
                 matched = True
             elif isinstance(cond.when, dict):
                 matched = _matches_condition(cond.when, payoff_family, exercise, model_family, product_ir)
-            if matched and cond.notes:
-                base_notes = list(cond.notes)
+            if matched:
+                base_notes = list(spec.notes if cond.notes is None else cond.notes)
                 break
 
     # Resolve dynamic notes
@@ -1327,7 +1328,14 @@ def evaluate_route_admissibility(
     ):
         failures.append("unsupported_phase_order:custom_same_day_order")
 
-    if _has_automatic_events(product) and admissibility.event_support == "none":
+    if (
+        _has_automatic_events(product)
+        and admissibility.event_support == "none"
+        and not _allows_structural_schedule_strip_on_non_event_route(
+            family_ir=family_ir,
+            supported_state_tags=set(admissibility.supported_state_tags or ()),
+        )
+    ):
         failures.append("unsupported_event_support:automatic_triggers")
 
     if spec.engine_family == "lattice":
@@ -1467,6 +1475,25 @@ def _has_automatic_events(product) -> bool:
         if typed_surface_present:
             return True
     return bool(getattr(product, "schedule_dependence", False) and getattr(product, "event_transitions", ()))
+
+
+def _allows_structural_schedule_strip_on_non_event_route(
+    *,
+    family_ir,
+    supported_state_tags: set[str],
+) -> bool:
+    """Allow structural schedule strips lowered onto thin analytical helper surfaces.
+
+    Schedule-driven cap/floor strips lower to an analytical Black-76 family IR
+    with explicit schedule-state support but no event-machine runtime. Those
+    should not be rejected by the generic automatic-event guard.
+    """
+    if "schedule_state" not in supported_state_tags:
+        return False
+    return (
+        isinstance(family_ir, AnalyticalBlack76IR)
+        and str(getattr(family_ir, "payoff_family", "") or "") == "rate_cap_floor_strip"
+    )
 
 
 def _requires_cross_currency_support(product, market_binding_spec, valuation_context) -> bool:

--- a/trellis/agent/route_registry.py
+++ b/trellis/agent/route_registry.py
@@ -870,10 +870,18 @@ def resolve_route_adapters(
 
     for cond in spec.conditional_primitives:
         if isinstance(cond.when, str) and cond.when == "default":
-            return spec.adapters if cond.adapters is None else cond.adapters
+            if cond.adapters is None:
+                return spec.adapters
+            if not cond.primitives and not cond.adapters:
+                return spec.adapters
+            return cond.adapters
         if isinstance(cond.when, dict):
             if _matches_condition(cond.when, payoff_family, exercise, model_family, product_ir):
-                return spec.adapters if cond.adapters is None else cond.adapters
+                if cond.adapters is None:
+                    return spec.adapters
+                if not cond.primitives and not cond.adapters:
+                    return spec.adapters
+                return cond.adapters
 
     return spec.adapters
 
@@ -897,7 +905,12 @@ def resolve_route_notes(
             elif isinstance(cond.when, dict):
                 matched = _matches_condition(cond.when, payoff_family, exercise, model_family, product_ir)
             if matched:
-                base_notes = list(spec.notes if cond.notes is None else cond.notes)
+                if cond.notes is None:
+                    base_notes = list(spec.notes)
+                elif not cond.primitives and not cond.notes:
+                    base_notes = list(spec.notes)
+                else:
+                    base_notes = list(cond.notes)
                 break
 
     # Resolve dynamic notes

--- a/trellis/agent/semantic_validators/algorithm_contract.py
+++ b/trellis/agent/semantic_validators/algorithm_contract.py
@@ -129,6 +129,81 @@ _EXACT_HELPER_SIGNATURES = {
             "`expiry_date`, and optional exercise fields instead of inventing helper keywords."
         ),
     },
+    "price_vanilla_equity_option_monte_carlo": {
+        "min_positional_args": 2,
+        "max_positional_args": 2,
+        "required_parameters": ("market_state", "spec"),
+        "required_keyword_groups": (frozenset({"market_state", "spec"}),),
+        "allowed_keywords": frozenset({
+            "market_state",
+            "spec",
+            "scheme",
+            "variance_reduction",
+            "n_paths",
+            "n_steps",
+            "seed",
+        }),
+        "required_positional_markers": (
+            frozenset({"market_state"}),
+            frozenset({"spec", "_spec"}),
+        ),
+        "message": (
+            "`price_vanilla_equity_option_monte_carlo(...)` expects `(market_state, "
+            "spec, *, scheme=..., variance_reduction=..., n_paths=..., n_steps=..., "
+            "seed=...)`. Pass the live market state and original spec-like object "
+            "instead of spot/strike scalars or hand-built Monte Carlo plumbing."
+        ),
+    },
+    "price_vanilla_equity_option_transform": {
+        "min_positional_args": 2,
+        "max_positional_args": 2,
+        "required_parameters": ("market_state", "spec"),
+        "required_keyword_groups": (frozenset({"market_state", "spec"}),),
+        "allowed_keywords": frozenset({
+            "market_state",
+            "spec",
+            "method",
+            "fft_alpha",
+            "fft_points",
+            "fft_eta",
+            "cos_points",
+            "cos_truncation",
+        }),
+        "required_positional_markers": (
+            frozenset({"market_state"}),
+            frozenset({"spec", "_spec"}),
+        ),
+        "message": (
+            "`price_vanilla_equity_option_transform(...)` expects `(market_state, spec, "
+            "*, method=..., fft_alpha=..., fft_points=..., fft_eta=..., cos_points=..., "
+            "cos_truncation=...)`. Pass the live market state and original spec-like "
+            "object instead of raw transform arguments or reconstructed spot/strike inputs."
+        ),
+    },
+    "price_vanilla_equity_option_pde": {
+        "min_positional_args": 2,
+        "max_positional_args": 2,
+        "required_parameters": ("market_state", "spec"),
+        "required_keyword_groups": (frozenset({"market_state", "spec"}),),
+        "allowed_keywords": frozenset({
+            "market_state",
+            "spec",
+            "theta",
+            "n_x",
+            "n_t",
+            "s_max_multiplier",
+        }),
+        "required_positional_markers": (
+            frozenset({"market_state"}),
+            frozenset({"spec", "_spec"}),
+        ),
+        "message": (
+            "`price_vanilla_equity_option_pde(...)` expects `(market_state, spec, *, "
+            "theta=..., n_x=..., n_t=..., s_max_multiplier=...)`. Pass the live market "
+            "state and original spec-like object instead of explicit spot/strike/time "
+            "keywords or manual PDE setup."
+        ),
+    },
     "price_callable_bond_tree": {
         "min_positional_args": 2,
         "max_positional_args": 2,


### PR DESCRIPTION
## Summary\n- thin helper-backed analytical / PDE / FFT route cards so they stop emitting procedural route guidance\n- preserve explicit empty conditional adapter / note overrides and add exact-helper signature enforcement for vanilla-equity transform / MC / PDE helpers\n- replace package-level FFT / copula prompt references with concrete submodule references and admit analytical cap/floor strips on typed schedule state\n\n## Validation\n- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_semantic_validators.py tests/test_agent/test_build_loop.py -q\n- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_route_registry.py tests/test_agent/test_semantic_validators.py tests/test_agent/test_build_loop.py -q\n- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_prompts.py tests/test_agent/test_build_loop.py tests/test_agent/test_lite_review.py tests/test_agent/test_primitive_planning.py tests/test_agent/test_route_registry.py tests/test_agent/test_codegen_guardrails.py tests/test_agent/test_semantic_validators.py -q\n- /Users/steveyang/miniforge3/bin/python3 -m py_compile trellis/agent/route_registry.py trellis/agent/executor.py trellis/agent/semantic_validators/algorithm_contract.py\n- live reruns for T13/T17/T39/T53/T73/T94/T103 plus isolated E21 and E22 reruns