### PR TITLE
Route surfaces: minimize generic Monte Carlo route cards

### DIFF
--- a/docs/developer/dsl_system_design_review.md
+++ b/docs/developer/dsl_system_design_review.md
@@ -307,6 +307,14 @@ accurate because the generic vanilla MC routes have not yet all switched over
 to that family, even though the compiler now emits it for the bounded
 schedule-driven swaption slice.
 
+The generic Monte Carlo route cards are now also explicitly metadata-first.
+`monte_carlo_paths` and `correlated_basket_monte_carlo` still exist as backend
+binding records, but they no longer carry procedural synthesis guidance. The
+semantic and decomposition layers now decide when a generic `basket_option`
+wrapper stays on the generic Monte Carlo path, when ranked-observation traits
+refine it onto the basket helper route, and when explicit credit-basket cues
+upgrade it to the nth-to-default family before route binding.
+
 Callable-bond wrappers now follow the same “thin public shell over reusable
 family helpers” rule as the newer event-aware routes. The public PDE/tree
 helpers still exist, but coupon timeline compilation, embedded exercise

--- a/docs/plans/route-registry-minimization.md
+++ b/docs/plans/route-registry-minimization.md
@@ -290,6 +290,18 @@ The active route-card retirement queue is now tracked under umbrella
 5. `QUA-784` generic Monte Carlo and basket routes:
    `monte_carlo_paths`, `correlated_basket_monte_carlo`
    Validation cohort: `T37`, `T53`, `T102`, `T104`, `T126`, `E21`, `E22`, `E24`, `E26`
+   Closeout status: both route cards are now metadata-first, with explicit
+   empty adapter / note overrides through conditional resolution. Ranked-
+   observation baskets stay on `correlated_basket_monte_carlo`, generic
+   `basket_option` wrappers now stay on `monte_carlo_paths`, and explicit
+   credit-basket cues on generic basket wrappers upgrade through the semantic /
+   decomposition layer to `nth_to_default_monte_carlo` instead of widening into
+   the basket helper route. `E21` and `E22` still pass; `E26` now reaches the
+   correct nth-to-default helper pair and carries only a downstream comparison
+   failure outside this slice; `T102` now stays on the generic Monte Carlo path
+   and carries only downstream build-quality gaps outside this slice; `T37`,
+   `T53`, and `E24` no longer fail because of route-card authority but remain
+   broader out-of-scope comparison / semantic gaps.
 6. `QUA-785` metadata-first residual audit:
    `exercise_monte_carlo`, `local_vol_monte_carlo`, `qmc_sobol_paths`,
    `waterfall_cashflows`
@@ -326,6 +338,6 @@ Status mirror last synced: `2026-04-12`
 | `QUA-782` | Route surfaces: credit and copula routes retire procedural authority behind backend helpers | Done |
 | `QUA-781` | Route surfaces: rate-tree routes retire procedural authority and stay task-backed | Done |
 | `QUA-783` | Route surfaces: analytical Black76, PDE, and FFT routes retire procedural guidance | Done |
-| `QUA-784` | Route surfaces: generic Monte Carlo and basket routes collapse to family-first metadata | Backlog |
+| `QUA-784` | Route surfaces: generic Monte Carlo and basket routes collapse to family-first metadata | Done |
 | `QUA-785` | Route inventory: audit metadata-first residual route cards against representative tasks | Backlog |
 | `QUA-777` | Route scoring: remove residual route-identity authority after route-card retirement | Backlog |

--- a/tests/test_agent/test_codegen_guardrails.py
+++ b/tests/test_agent/test_codegen_guardrails.py
@@ -119,7 +119,7 @@ def test_qmc_generation_plan_approves_qmc_family_modules():
     assert "brownian_bridge" in plan.symbols_to_reuse
 
 
-def test_basket_route_card_calls_helper_directly():
+def test_basket_route_card_stays_backend_binding_only():
     description = (
         "Price a Himalaya-style basket on AAPL, MSFT, NVDA, and AMZN. "
         "Observe monthly on 2026-04-01, 2026-05-01, and 2026-06-01. "
@@ -136,20 +136,35 @@ def test_basket_route_card_calls_helper_directly():
     card = render_generation_route_card(compiled.generation_plan)
 
     assert "correlated_basket_monte_carlo" in card
-    assert "Parse `spec.underlyings` into a Python list of ticker strings" in card
     assert "resolve_basket_semantics" in card
     assert "price_ranked_observation_basket_monte_carlo" in card
-    assert "RankedObservationBasketSpec" in card
-    assert "Bind the market state with `resolve_basket_semantics(...)`" in card
-    assert "delegate straight to `price_ranked_observation_basket_monte_carlo(...)` through a thin adapter" in card
-    assert "import only `trellis.models.resolution.basket_semantics` and `trellis.models.monte_carlo.semantic_basket`" in card
-    assert "do not import process primitives directly" in card
-    assert "Do not introduce a bespoke basket spec name such as `HimalayaBasketSpec` or reimplement rank/remove/aggregate logic inline." in card
+    assert "Required adapters:" not in card
+    assert "Backend notes:" not in card
+    assert "Parse `spec.underlyings` into a Python list of ticker strings" not in card
+    assert "delegate straight to `price_ranked_observation_basket_monte_carlo(...)` through a thin adapter" not in card
+    assert "HimalayaBasketSpec" not in card
     assert "CorrelatedGBM" not in card
     assert "trellis.models.processes.correlated_gbm" not in card
     assert "trellis.models.basket" not in card
     assert "trellis.models.ranked_observation" not in card
     assert "trellis.models.payoff" not in card
+
+
+def test_generation_route_card_for_generic_monte_carlo_stays_backend_binding_only():
+    compiled = compile_build_request(
+        "Path-dependent note with monthly averaging under Monte Carlo",
+        instrument_type="structured_note",
+        preferred_method="monte_carlo",
+    )
+
+    card = render_generation_route_card(compiled.generation_plan)
+
+    assert "monte_carlo_paths" in card
+    assert "price_event_aware_monte_carlo" in card
+    assert "Required adapters:" not in card
+    assert "Backend notes:" not in card
+    assert "build_payoff_vector_from_paths" not in card
+    assert "Prefer existing MC simulation helpers over bespoke path loops." not in card
 
 
 def test_generation_plan_renders_compiled_semantic_and_validation_boundary():

--- a/tests/test_agent/test_platform_requests.py
+++ b/tests/test_agent/test_platform_requests.py
@@ -756,6 +756,46 @@ def test_compile_build_request_does_not_block_title_only_credit_builder_requests
     assert compiled.product_ir.instrument == expected_instrument
 
 
+def test_compile_build_request_treats_generic_basket_wrapper_as_nth_to_default_when_credit_cues_dominate():
+    from trellis.agent.platform_requests import compile_build_request
+
+    compiled = compile_build_request(
+        "Nth-to-default basket: Gaussian copula vs default-time MC",
+        instrument_type="basket_option",
+        preferred_method="monte_carlo",
+    )
+
+    assert compiled.semantic_contract is None
+    assert compiled.execution_plan.reason == "free_form_build_request"
+    assert compiled.product_ir is not None
+    assert compiled.product_ir.instrument == "nth_to_default"
+    assert compiled.product_ir.route_families == ("nth_to_default",)
+    assert compiled.pricing_plan is not None
+    assert compiled.pricing_plan.method == "monte_carlo"
+    assert compiled.generation_plan is not None
+    assert compiled.generation_plan.primitive_plan is not None
+    assert compiled.generation_plan.primitive_plan.route == "nth_to_default_monte_carlo"
+
+
+def test_compile_build_request_keeps_generic_basket_option_off_ranked_observation_route():
+    from trellis.agent.platform_requests import compile_build_request
+
+    compiled = compile_build_request(
+        "Rainbow option (best-of-two): Stulz formula vs MC",
+        instrument_type="basket_option",
+        preferred_method="monte_carlo",
+    )
+
+    assert compiled.semantic_contract is None
+    assert compiled.execution_plan.reason == "free_form_build_request"
+    assert compiled.product_ir is not None
+    assert compiled.product_ir.instrument == "basket_option"
+    assert compiled.product_ir.payoff_family == "basket_option"
+    assert compiled.generation_plan is not None
+    assert compiled.generation_plan.primitive_plan is not None
+    assert compiled.generation_plan.primitive_plan.route == "monte_carlo_paths"
+
+
 def test_novel_request_persists_semantic_extension_trace(monkeypatch, tmp_path):
     from trellis.agent.platform_requests import compile_build_request
     import trellis.agent.knowledge.promotion as promotion_mod

--- a/tests/test_agent/test_route_registry.py
+++ b/tests/test_agent/test_route_registry.py
@@ -386,7 +386,8 @@ class TestBasketRoutes:
 
     def test_monte_carlo_candidate(self, registry):
         new = _new_routes(registry, "monte_carlo", self.BASKET_IR)
-        assert new == ("correlated_basket_monte_carlo",)
+        assert new[0] == "correlated_basket_monte_carlo"
+        assert "monte_carlo_paths" in new
 
     def test_primitives(self, registry):
         spec = [r for r in registry.routes if r.id == "correlated_basket_monte_carlo"][0]
@@ -396,6 +397,8 @@ class TestBasketRoutes:
             ("trellis.models.monte_carlo.semantic_basket", "price_ranked_observation_basket_monte_carlo", "route_helper"),
         }
         assert _prim_set(new_prims) == expected_prims
+        assert resolve_route_adapters(spec, self.BASKET_IR) == ()
+        assert resolve_route_notes(spec, self.BASKET_IR) == ()
 
     def test_admissibility_rejects_strategic_control_for_basket_event_route(self, registry):
         from dataclasses import replace
@@ -494,10 +497,22 @@ class TestMonteCarloPathsRoutes:
         exercise_style="none",
         model_family="generic",
     )
+    GENERIC_BASKET_IR = ProductIR(
+        instrument="basket_option",
+        payoff_family="basket_option",
+        payoff_traits=("vanilla_option",),
+        exercise_style="european",
+        model_family="generic",
+    )
 
     def test_candidate(self, registry):
         new = _new_routes(registry, "monte_carlo", self.EUROPEAN_IR)
         assert "monte_carlo_paths" in new
+
+    def test_generic_basket_candidate_stays_on_generic_monte_carlo_surface(self, registry):
+        new = _new_routes(registry, "monte_carlo", self.GENERIC_BASKET_IR)
+        assert "monte_carlo_paths" in new
+        assert "correlated_basket_monte_carlo" not in new
 
     def test_primitives(self, registry):
         spec = [r for r in registry.routes if r.id == "monte_carlo_paths"][0]
@@ -517,6 +532,14 @@ class TestMonteCarloPathsRoutes:
         assert resolve_route_primitives(spec, self.GENERIC_IR) == spec.primitives
         assert resolve_route_adapters(spec, self.GENERIC_IR) == spec.adapters
         assert resolve_route_notes(spec, self.GENERIC_IR) == spec.notes
+
+    def test_helper_backed_branches_do_not_reintroduce_route_notes_or_adapters(self, registry):
+        spec = [r for r in registry.routes if r.id == "monte_carlo_paths"][0]
+
+        assert resolve_route_adapters(spec, self.EUROPEAN_IR) == ()
+        assert resolve_route_notes(spec, self.EUROPEAN_IR) == ()
+        assert resolve_route_adapters(spec, self.GENERIC_IR) == ()
+        assert resolve_route_notes(spec, self.GENERIC_IR) == ()
 
     def test_admissibility_hydrates_process_and_path_contracts(self, registry):
         generic = find_route_by_id("monte_carlo_paths", registry)

--- a/tests/test_agent/test_semantic_contracts.py
+++ b/tests/test_agent/test_semantic_contracts.py
@@ -1202,6 +1202,19 @@ class TestCreditConceptResolution:
         resolution = resolve_semantic_concept("first to default basket on IG credits")
         assert resolution.concept_id == "nth_to_default"
 
+    def test_nth_to_default_draft_accepts_generic_basket_wrapper_when_credit_cues_are_explicit(self):
+        from trellis.agent.semantic_contracts import draft_semantic_contract
+
+        contract = draft_semantic_contract(
+            "First-to-default basket on IBM, GE with maturity 2027-06-20 and Gaussian copula default correlation",
+            instrument_type="basket_option",
+        )
+
+        assert contract is not None
+        assert contract.semantic_id == "nth_to_default"
+        assert contract.product.instrument_class == "nth_to_default"
+        assert contract.product.constituents == ("IBM", "GE")
+
     def test_ambiguous_credit_with_overlapping_cues(self):
         """Request matching cues from both CDS and NTD should be ambiguous or contested."""
         from trellis.agent.semantic_concepts import resolve_semantic_concept

--- a/trellis/agent/knowledge/canonical/routes.yaml
+++ b/trellis/agent/knowledge/canonical/routes.yaml
@@ -208,7 +208,6 @@ routes:
       non_european_penalty: -1.5
     match:
       methods: [monte_carlo, qmc]
-      instruments: [basket_option]
       payoff_family: [basket_path_payoff]
       payoff_traits: [ranked_observation]
     admissibility:
@@ -227,18 +226,8 @@ routes:
       - module: trellis.models.monte_carlo.semantic_basket
         symbol: price_ranked_observation_basket_monte_carlo
         role: route_helper
-    adapters:
-      - reuse_shared_basket_market_binding
-      - reuse_shared_basket_mc_route_helper
-    notes:
-      - "Basket Monte Carlo routing should use generic basket semantics and snapshot-based state instead of a product-specific mountain-range branch."
-      - "The generated basket adapter must require a real `black_vol_surface` plus discounting and spot inputs; do not treat basket pricing as discount-curve only."
-      - "Parse `spec.underlyings` into a Python list of ticker strings and `spec.observation_dates` into `date` objects before basket resolution; do not pass raw comma-separated strings into the resolver."
-      - "Bind the market state with `resolve_basket_semantics(...)`, then delegate straight to `price_ranked_observation_basket_monte_carlo(...)` through a thin adapter; do not import process primitives directly in the generated adapter."
-      - "Use `resolved.constituent_spots` as the multi-asset initial state for the Monte Carlo helper; do not reshape or index the raw `MarketState` as if it were a path tensor."
-      - "Build `RankedObservationBasketSpec` with `constituents` and `option_type`; do not pass `basket_assets`, `asset_names`, `underlyings`, `is_call`, or `start_date` into the shared spec."
-      - "Reuse `RankedObservationBasketSpec` and `RankedObservationBasketMonteCarloPayoff` from `trellis.models.monte_carlo.semantic_basket`, import only `trellis.models.resolution.basket_semantics` and `trellis.models.monte_carlo.semantic_basket` for the basket adapter, and do not invent extra `trellis.models.*` basket or payoff subpackages."
-      - "Do not introduce a bespoke basket spec name such as `HimalayaBasketSpec` or reimplement rank/remove/aggregate logic inline."
+    adapters: []
+    notes: []
     market_data_access:
       required:
         discount_curve: [market_state.discount]
@@ -326,7 +315,7 @@ routes:
       penalize_when_market_data: {local_vol_surface: -3.0}
     match:
       methods: [monte_carlo]
-      exclude_instruments: [quanto_option, cds, nth_to_default, basket_option]
+      exclude_instruments: [quanto_option, cds, nth_to_default]
     admissibility:
       control_styles: [identity]
       event_support: automatic
@@ -351,10 +340,8 @@ routes:
       - module: trellis.models.monte_carlo.event_aware
         symbol: price_event_aware_monte_carlo
         role: route_helper
-    adapters:
-      - build_payoff_vector_from_paths
-    notes:
-      - "Prefer existing MC simulation helpers over bespoke path loops."
+    adapters: []
+    notes: []
     market_data_access:
       required:
         discount_curve: [market_state.discount]
@@ -368,9 +355,7 @@ routes:
             symbol: price_vanilla_equity_option_monte_carlo
             role: route_helper
         adapters: []
-        notes:
-          - "For vanilla European equity options, prefer `trellis.models.equity_option_monte_carlo.price_vanilla_equity_option_monte_carlo(...)`."
-          - "Treat the generated route as a thin adapter over the checked family helper; do not rebuild GBM process construction, scheme wiring, or variance-reduction glue inline."
+        notes: []
       - when:
           payoff_family: swaption
           exercise_style: [european]
@@ -380,9 +365,7 @@ routes:
             symbol: price_swaption_monte_carlo
             role: route_helper
         adapters: []
-        notes:
-          - "For European rate-style swaptions, prefer `trellis.models.rate_style_swaption.price_swaption_monte_carlo(...)`."
-          - "Treat the generated route as a thin adapter over the checked family helper; do not rebuild Hull-White process resolution, event payload assembly, or Monte Carlo plumbing inline."
+        notes: []
       - when: default
         primitives: []
         adapters: []

--- a/trellis/agent/knowledge/decompose.py
+++ b/trellis/agent/knowledge/decompose.py
@@ -326,13 +326,37 @@ def _match_static_decomposition(
 
 def _infer_instrument(description: str, instrument_type: str | None) -> str | None:
     """Infer the most specific supported instrument key from text."""
+    desc = _normalise(description)
     if instrument_type:
         normalized = _normalise(instrument_type)
         if normalized in {"credit_default_swap"}:
             normalized = "cds"
+        if normalized in {"basket_option", "basket_path_payoff"}:
+            if any(
+                cue in desc
+                for cue in (
+                    "nth_to_default",
+                    "nth to default",
+                    "nth-default",
+                    "first_to_default",
+                    "first to default",
+                    "default correlation",
+                    "basket cds",
+                )
+            ):
+                return "nth_to_default"
+            if any(
+                cue in desc
+                for cue in (
+                    "cdo tranche",
+                    "collateralized debt obligation",
+                    "attachment",
+                    "detachment",
+                )
+            ):
+                return "cdo"
         return normalized
 
-    desc = _normalise(description)
     patterns = [
         ("bermudan_swaption", ("bermudan_swaption", "bermudan swaption")),
         ("callable_bond", ("callable_bond", "callable bond")),
@@ -602,8 +626,12 @@ def _payoff_family_for(
 ) -> str:
     """Map an instrument/trait set onto a stable payoff-family label."""
     product_traits = {"asian", "barrier", "lookback", "callable", "puttable"}
-    if instrument in {"basket_option", "ranked_observation_basket"}:
+    if instrument == "ranked_observation_basket":
         return "basket_path_payoff"
+    if instrument == "basket_option":
+        if "ranked_observation" in payoff_traits:
+            return "basket_path_payoff"
+        return "basket_option"
     if len(product_traits.intersection(payoff_traits)) >= 2:
         return "composite_option"
     if instrument in {"swaption", "bermudan_swaption"}:

--- a/trellis/agent/semantic_contracts.py
+++ b/trellis/agent/semantic_contracts.py
@@ -4684,6 +4684,8 @@ _GENERIC_SEMANTIC_DRAFT_ALIASES = frozenset({
     "instrument",
     "derivative",
     "security",
+    "basket_option",
+    "basket_path_payoff",
 })
 
 


### PR DESCRIPTION
## Summary
- collapse `monte_carlo_paths` and `correlated_basket_monte_carlo` to metadata-first route cards
- keep generic `basket_option` wrappers on `monte_carlo_paths` unless ranked-observation traits are explicit
- upgrade generic basket wrappers with explicit credit-basket cues to `nth_to_default` before route binding

## Validation
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_codegen_guardrails.py tests/test_agent/test_platform_requests.py tests/test_agent/test_semantic_contracts.py tests/test_agent/test_route_registry.py -q`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_platform_requests.py tests/test_agent/test_route_registry.py -q`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_codegen_guardrails.py tests/test_agent/test_platform_requests.py tests/test_agent/test_route_registry.py tests/test_agent/test_semantic_contracts.py tests/test_agent/test_semantic_validators.py tests/test_agent/test_platform_traces.py tests/test_agent/test_dsl_lowering.py tests/test_agent/test_validation_contract.py tests/test_agent/test_build_loop.py tests/test_agent/test_primitive_planning.py -q`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/ -x -q -m "not integration"`
- `/Users/steveyang/miniforge3/bin/python3 scripts/remediate.py --analyze-only`
