### PR TITLE
Route scoring: remove residual route identity authority

### DIFF
--- a/docs/developer/dsl_system_design_review.md
+++ b/docs/developer/dsl_system_design_review.md
@@ -315,6 +315,12 @@ wrapper stays on the generic Monte Carlo path, when ranked-observation traits
 refine it onto the basket helper route, and when explicit credit-basket cues
 upgrade it to the nth-to-default family before route binding.
 
+Route scoring now follows the same rule. The learned and heuristic scorers no
+longer treat route ids as first-class authority; they rank candidates from
+family capability, blocker state, and backend-binding role facts. This keeps
+selection aligned with the retired route-card surface instead of letting
+route-id or route-family signals quietly reintroduce route-first behavior.
+
 Callable-bond wrappers now follow the same “thin public shell over reusable
 family helpers” rule as the newer event-aware routes. The public PDE/tree
 helpers still exist, but coupon timeline compilation, embedded exercise

--- a/docs/plans/route-registry-minimization.md
+++ b/docs/plans/route-registry-minimization.md
@@ -322,6 +322,15 @@ The active route-card retirement queue is now tracked under umbrella
    this audit slice.
 7. `QUA-777` route scoring tail after the route-card surfaces themselves are
    retired
+   Closeout status: the learned and heuristic scorers no longer treat
+   `route:<id>` or `route_family:<family>` as first-class authority. Feature
+   extraction and fallback scoring now rank candidates from family capability,
+   blocker state, and backend-binding roles such as `route_helper`,
+   `pricing_kernel`, and `cashflow_engine`. Representative route-retirement
+   cohort reruns still pass on the modern surface (`T01`, `T13`, `T38`,
+   `T105`), and `E26` continues to land on the correct nth-to-default helper
+   pair while carrying only its downstream comparison failure outside this
+   workstream.
 
 This queue is intentionally task-backed. The goal is not to delete route files
 in the abstract. The goal is to remove route-card synthesis authority while
@@ -330,14 +339,14 @@ semantic/family/lane surface.
 
 ## Linear Mirror
 
-Status mirror last synced: `2026-04-12`
+Status mirror last synced: `2026-04-11`
 
 ### Workstream Ticket
 
 | Ticket | Status |
 | --- | --- |
 | `QUA-727` | Route registry minimization: family-first backend binding cleanup | Done |
-| `QUA-780` | Route surfaces: task-backed retirement of residual route-card synthesis authority | Backlog |
+| `QUA-780` | Route surfaces: task-backed retirement of residual route-card synthesis authority | Done |
 
 ### Ordered Queue
 
@@ -354,4 +363,4 @@ Status mirror last synced: `2026-04-12`
 | `QUA-783` | Route surfaces: analytical Black76, PDE, and FFT routes retire procedural guidance | Done |
 | `QUA-784` | Route surfaces: generic Monte Carlo and basket routes collapse to family-first metadata | Done |
 | `QUA-785` | Route inventory: audit metadata-first residual route cards against representative tasks | Done |
-| `QUA-777` | Route scoring: remove residual route-identity authority after route-card retirement | Backlog |
+| `QUA-777` | Route scoring: remove residual route-identity authority after route-card retirement | Done |

--- a/docs/quant/pricing_stack.rst
+++ b/docs/quant/pricing_stack.rst
@@ -183,6 +183,11 @@ The first migrated vanilla cases now use that boundary directly:
   dependence-family controls without exposing the raw scalar copula kernels as
   the public route helper
 
+Route selection now follows that same minimization rule. The deterministic
+scorer no longer emits route-id or route-family one-hot authority; it ranks
+routes from family capability, blocker state, and backend-binding facts such as
+``route_helper`` / ``pricing_kernel`` / ``cashflow_engine`` surfaces instead.
+
 For rate-style swaption comparison builds, the semantic compiler now also keeps
 the contract-level convention surface attached to each method-specific plan.
 Fixed-leg and floating-leg day-count terms, rate-index bindings, and the

--- a/tests/test_agent/test_rate_tree_generation.py
+++ b/tests/test_agent/test_rate_tree_generation.py
@@ -286,3 +286,61 @@ def test_zcb_artifact_normalizes_quoted_option_type():
     )
 
     assert price_payoff(mod.ZCBOptionPayoff(spec), market_state) > 0.0
+
+
+def test_zcb_artifact_accepts_case_variants_and_bond_market_aliases():
+    sys.path.insert(0, str(ROOT))
+    mod = import_module("trellis.instruments._agent.zcboption")
+    settle = date(2024, 11, 15)
+    market_state = MarketState(
+        as_of=settle,
+        settlement=settle,
+        discount=YieldCurve.flat(0.05, max_tenor=12.0),
+        vol_surface=FlatVol(0.20),
+        model_parameters={
+            "model_family": "hull_white",
+            "mean_reversion": 0.1,
+            "sigma": 0.01,
+        },
+    )
+
+    for option_type in ("Call", "PUT", "payer", "receiver"):
+        spec = mod.ZCBOptionSpec(
+            notional=100.0,
+            strike=63.0,
+            expiry_date=date(2027, 11, 15),
+            bond_maturity_date=date(2033, 11, 15),
+            option_type=option_type,
+        )
+        assert price_payoff(mod.ZCBOptionPayoff(spec), market_state) > 0.0
+
+
+def test_zcb_artifact_does_not_probe_vol_surface_when_sigma_is_calibrated():
+    sys.path.insert(0, str(ROOT))
+    mod = import_module("trellis.instruments._agent.zcboption")
+    settle = date(2024, 11, 15)
+
+    class ExplodingVolSurface:
+        def black_vol(self, t: float, strike: float) -> float:
+            raise AssertionError("zcb artifact should not probe vol_surface when sigma is present")
+
+    market_state = MarketState(
+        as_of=settle,
+        settlement=settle,
+        discount=YieldCurve.flat(0.05, max_tenor=12.0),
+        vol_surface=ExplodingVolSurface(),
+        model_parameters={
+            "model_family": "hull_white",
+            "mean_reversion": 0.1,
+            "sigma": 0.01,
+        },
+    )
+    spec = mod.ZCBOptionSpec(
+        notional=100.0,
+        strike=63.0,
+        expiry_date=date(2027, 11, 15),
+        bond_maturity_date=date(2033, 11, 15),
+        option_type="call",
+    )
+
+    assert price_payoff(mod.ZCBOptionPayoff(spec), market_state) > 0.0

--- a/tests/test_agent/test_route_scorer.py
+++ b/tests/test_agent/test_route_scorer.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from trellis.agent.knowledge.schema import ProductIR
+from trellis.agent.codegen_guardrails import PrimitiveRef
 from trellis.agent.route_registry import RouteAdmissibilitySpec, RouteSpec, load_route_registry
 from trellis.agent.route_scorer import (
     LearnedModel,
@@ -49,11 +50,15 @@ class TestFeatureExtraction:
         features = extract_scoring_features(ctx)
         assert features["bias"] == 1.0
         assert features["blocker_count"] == 0.0
-        assert features["route:analytical_black76"] == 1.0
         assert features["engine_family:analytical"] == 1.0
         assert features["exercise:european"] == 1.0
         assert features["payoff:swaption"] == 1.0
         assert features["family_capability_ok"] == 1.0
+        assert features["binding_role:route_helper"] == 1.0
+        assert features["binding_has_exact_surface"] == 1.0
+        assert "route:analytical_black76" not in features
+        assert "route_family:analytical" not in features
+        assert "route_family_matches_ir" not in features
 
     def test_blocker_features(self, registry):
         spec = [r for r in registry.routes if r.id == "monte_carlo_paths"][0]
@@ -249,6 +254,88 @@ class TestScoring:
 
         assert matching_score.final_score > mismatched_score.final_score
 
+    def test_helper_backed_route_scores_above_generic_route_without_identity_features(self, scorer):
+        helper_backed = RouteSpec(
+            id="helper_backed_mc",
+            engine_family="monte_carlo",
+            route_family="monte_carlo",
+            status="promoted",
+            confidence=1.0,
+            match_methods=("monte_carlo",),
+            match_instruments=None,
+            exclude_instruments=(),
+            match_payoff_family=None,
+            match_payoff_traits=None,
+            match_exercise=None,
+            exclude_exercise=(),
+            match_required_market_data=None,
+            exclude_required_market_data=None,
+            primitives=(
+                PrimitiveRef(
+                    module="trellis.models.monte_carlo.event_aware",
+                    symbol="price_event_aware_monte_carlo",
+                    role="route_helper",
+                ),
+            ),
+            conditional_primitives=(),
+            conditional_route_family=None,
+            adapters=(),
+            notes=(),
+            admissibility=RouteAdmissibilitySpec(
+                supported_state_tags=("terminal_markov",),
+            ),
+        )
+        generic = RouteSpec(
+            id="generic_mc",
+            engine_family="monte_carlo",
+            route_family="monte_carlo",
+            status="promoted",
+            confidence=1.0,
+            match_methods=("monte_carlo",),
+            match_instruments=None,
+            exclude_instruments=(),
+            match_payoff_family=None,
+            match_payoff_traits=None,
+            match_exercise=None,
+            exclude_exercise=(),
+            match_required_market_data=None,
+            exclude_required_market_data=None,
+            primitives=(
+                PrimitiveRef(
+                    module="trellis.models.processes.gbm",
+                    symbol="GBM",
+                    role="state_process",
+                ),
+                PrimitiveRef(
+                    module="trellis.models.monte_carlo.engine",
+                    symbol="MonteCarloEngine",
+                    role="path_simulation",
+                ),
+            ),
+            conditional_primitives=(),
+            conditional_route_family=None,
+            adapters=(),
+            notes=(),
+            admissibility=RouteAdmissibilitySpec(
+                supported_state_tags=("terminal_markov",),
+            ),
+        )
+        ir = ProductIR(
+            instrument="european_option",
+            payoff_family="vanilla_option",
+            candidate_engine_families=("monte_carlo",),
+            route_families=("monte_carlo",),
+        )
+
+        helper_score = scorer.score_route(
+            ScoringContext(product_ir=ir, route_spec=helper_backed, pricing_plan=None, blockers=[]),
+        )
+        generic_score = scorer.score_route(
+            ScoringContext(product_ir=ir, route_spec=generic, pricing_plan=None, blockers=[]),
+        )
+
+        assert helper_score.final_score > generic_score.final_score
+
 
 # ---------------------------------------------------------------------------
 # Model persistence
@@ -288,7 +375,7 @@ class TestModelPersistence:
 class TestTrainedModelScoring:
     def test_trained_model_overrides_heuristic(self, registry):
         model = LearnedModel(
-            feature_names=("bias", "route:analytical_black76"),
+            feature_names=("bias", "binding_role:pricing_kernel"),
             weights=(10.0, 5.0),
             training_size=50,
         )

--- a/tests/test_agent/test_route_scorer.py
+++ b/tests/test_agent/test_route_scorer.py
@@ -165,6 +165,17 @@ class TestScoring:
         assert scorer_result.final_score == heuristic_result
         assert scorer_result.heuristic_score == heuristic_result
 
+    def test_heuristic_score_handles_missing_route_spec(self):
+        from trellis.agent.codegen_guardrails import _route_score
+
+        ir = ProductIR(
+            instrument="european_option",
+            payoff_family="vanilla_option",
+            candidate_engine_families=("analytical",),
+        )
+
+        assert _route_score(None, ir, []) == 0.0
+
     def test_rank_routes_returns_sorted(self, scorer, registry):
         from trellis.agent.route_registry import resolve_route_family
         specs = [r for r in registry.routes if r.id in ("exercise_lattice", "rate_tree_backward_induction")]

--- a/trellis/agent/codegen_guardrails.py
+++ b/trellis/agent/codegen_guardrails.py
@@ -1481,7 +1481,7 @@ def _route_score(
         route_family = spec.route_family if spec is not None else ""
 
     score = 0.0
-    if product_ir is not None:
+    if product_ir is not None and spec is not None:
         resolved_primitives = tuple(resolve_route_primitives(spec, product_ir))
         resolved_roles = {primitive.role for primitive in resolved_primitives}
         exact_surface_roles = {"route_helper", "pricing_kernel", "cashflow_engine"}

--- a/trellis/agent/codegen_guardrails.py
+++ b/trellis/agent/codegen_guardrails.py
@@ -1467,27 +1467,32 @@ def _route_score(
 
     ``spec`` is a :class:`RouteSpec` from the route registry.  Route-specific
     bonuses and penalties are declared in ``score_hints`` within routes.yaml
-    rather than hard-coded per route name.
+    rather than hard-coded per route name. Fallback scoring should prefer
+    family capability and backend-binding facts over route identity.
     """
-    from trellis.agent.route_registry import evaluate_route_capability_match
+    from trellis.agent.route_registry import (
+        evaluate_route_capability_match,
+        resolve_route_primitives,
+    )
 
     hints = spec.score_hints if spec is not None else {}
-    route = spec.id if spec is not None else ""
     engine_family = spec.engine_family if spec is not None else ""
     if not route_family:
         route_family = spec.route_family if spec is not None else ""
 
     score = 0.0
-    if route:
-        score += 2.0
-
     if product_ir is not None:
-        # Semantic fit: route_family or engine_family matches ProductIR
-        ir_route_families = set(getattr(product_ir, "route_families", ()) or ())
-        if route_family in ir_route_families:
-            score += 2.5
-        elif engine_family in product_ir.candidate_engine_families:
-            score += 2.5
+        resolved_primitives = tuple(resolve_route_primitives(spec, product_ir))
+        resolved_roles = {primitive.role for primitive in resolved_primitives}
+        exact_surface_roles = {"route_helper", "pricing_kernel", "cashflow_engine"}
+        if engine_family in product_ir.candidate_engine_families:
+            score += 1.5
+        if resolved_roles.intersection(exact_surface_roles):
+            score += 1.5
+        elif "exercise_control" in resolved_roles:
+            score += 0.75
+        elif "low_discrepancy_sampler" in resolved_roles:
+            score += 0.5
 
         capability = evaluate_route_capability_match(spec, product_ir)
         if capability.ok:

--- a/trellis/agent/route_scorer.py
+++ b/trellis/agent/route_scorer.py
@@ -24,6 +24,7 @@ from trellis.agent.route_registry import (
     RouteRegistry,
     RouteSpec,
     evaluate_route_capability_match,
+    resolve_route_primitives,
 )
 from trellis.core.differentiable import get_numpy
 
@@ -137,9 +138,16 @@ def extract_scoring_features(ctx: ScoringContext) -> dict[str, float]:
         "route_confidence": spec.confidence,
         "successful_builds": float(min(spec.successful_builds, 20)),
     }
+    resolved_primitives = tuple(resolve_route_primitives(spec, ir))
+    resolved_roles = {primitive.role for primitive in resolved_primitives}
+    exact_surface_roles = {"route_helper", "pricing_kernel", "cashflow_engine"}
+
+    features["binding_role_count"] = float(len(resolved_roles))
+    features["binding_has_exact_surface"] = 1.0 if resolved_roles.intersection(exact_surface_roles) else 0.0
+    for role in resolved_roles:
+        features[f"binding_role:{role}"] = 1.0
 
     if ir is not None:
-        ir_route_families = set(getattr(ir, "route_families", ()) or ())
         capability = evaluate_route_capability_match(spec, ir)
         features["product_supported"] = 1.0 if ir.supported else 0.0
         features["schedule_dependence"] = 1.0 if ir.schedule_dependence else 0.0
@@ -147,7 +155,6 @@ def extract_scoring_features(ctx: ScoringContext) -> dict[str, float]:
         features["engine_family_matches_ir"] = (
             1.0 if spec.engine_family in ir.candidate_engine_families else 0.0
         )
-        features["route_family_matches_ir"] = 1.0 if route_family in ir_route_families else 0.0
         features["family_capability_ok"] = 1.0 if capability.ok else 0.0
         features["family_capability_match_count"] = float(len(capability.matched_predicates))
         features[f"exercise:{ir.exercise_style}"] = 1.0
@@ -159,9 +166,7 @@ def extract_scoring_features(ctx: ScoringContext) -> dict[str, float]:
         for failure in capability.failures:
             features[f"capability_failure:{failure}"] = 1.0
 
-    features[f"route:{spec.id}"] = 1.0
     features[f"engine_family:{spec.engine_family}"] = 1.0
-    features[f"route_family:{route_family}"] = 1.0
     features[f"status:{spec.status}"] = 1.0
 
     for blocker in ctx.blockers:

--- a/trellis/instruments/_agent/zcboption.py
+++ b/trellis/instruments/_agent/zcboption.py
@@ -27,12 +27,11 @@ Implementation target: jamshidian."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import date
 
 from trellis.core.market_state import MarketState
 from trellis.core.types import DayCountConvention
-from trellis.models.resolution.short_rate_claims import resolve_discount_bond_option_type
 from trellis.models.zcb_option import price_zcb_option_jamshidian
 
 
@@ -114,22 +113,25 @@ Implementation target: jamshidian."""
 
     def evaluate(self, market_state: MarketState) -> float:
         spec = self._spec
-        option_type = resolve_discount_bond_option_type(spec)
+        option_type = str(spec.option_type).strip().strip("\"'")
+        if option_type not in {"call", "put"}:
+            raise ValueError(f"Unsupported option_type: {spec.option_type!r}")
+        if option_type != spec.option_type:
+            spec = replace(spec, option_type=option_type)
 
         if spec.bond_maturity_date <= spec.expiry_date:
             raise ValueError("bond_maturity_date must be strictly after expiry_date")
 
-        if option_type not in {"call", "put"}:
-            raise ValueError(f"Unsupported option_type: {spec.option_type!r}")
+        if market_state.discount is None:
+            raise ValueError("market_state.discount is required for ZCB option pricing")
+        if market_state.vol_surface is None:
+            raise ValueError("market_state.vol_surface is required for ZCB option pricing")
 
-        try:
-            return float(
-                price_zcb_option_jamshidian(
-                    market_state,
-                    spec,
-                    mean_reversion=0.1,
-                )
-            )
-        except TypeError:
-            # Fallback for implementations that infer mean reversion from market/model state.
-            return float(price_zcb_option_jamshidian(market_state, spec))
+        # Ensure the market snapshot can provide the required expiry volatility.
+        T = (spec.expiry_date - market_state.as_of).days / 365.0
+        if T < 0:
+            raise ValueError("Option expiry must not be before market_state.as_of")
+
+        _ = market_state.vol_surface.black_vol(T, spec.strike / spec.notional if spec.notional else spec.strike)
+
+        return float(price_zcb_option_jamshidian(market_state, spec, mean_reversion=0.1))

--- a/trellis/instruments/_agent/zcboption.py
+++ b/trellis/instruments/_agent/zcboption.py
@@ -32,6 +32,7 @@ from datetime import date
 
 from trellis.core.market_state import MarketState
 from trellis.core.types import DayCountConvention
+from trellis.models.resolution.short_rate_claims import resolve_discount_bond_option_type
 from trellis.models.zcb_option import price_zcb_option_jamshidian
 
 
@@ -113,9 +114,7 @@ Implementation target: jamshidian."""
 
     def evaluate(self, market_state: MarketState) -> float:
         spec = self._spec
-        option_type = str(spec.option_type).strip().strip("\"'")
-        if option_type not in {"call", "put"}:
-            raise ValueError(f"Unsupported option_type: {spec.option_type!r}")
+        option_type = resolve_discount_bond_option_type(spec)
         if option_type != spec.option_type:
             spec = replace(spec, option_type=option_type)
 
@@ -124,14 +123,5 @@ Implementation target: jamshidian."""
 
         if market_state.discount is None:
             raise ValueError("market_state.discount is required for ZCB option pricing")
-        if market_state.vol_surface is None:
-            raise ValueError("market_state.vol_surface is required for ZCB option pricing")
-
-        # Ensure the market snapshot can provide the required expiry volatility.
-        T = (spec.expiry_date - market_state.as_of).days / 365.0
-        if T < 0:
-            raise ValueError("Option expiry must not be before market_state.as_of")
-
-        _ = market_state.vol_surface.black_vol(T, spec.strike / spec.notional if spec.notional else spec.strike)
 
         return float(price_zcb_option_jamshidian(market_state, spec, mean_reversion=0.1))


### PR DESCRIPTION
## Summary
- remove route-id and route-family one-hot authority from route scorer features
- make heuristic fallback prefer family capability and backend-binding roles over route identity
- sync the route-registry minimization plan and document the scorer contract change
- normalize quoted option types in the checked-in ZCB analytical adapter uncovered by full-suite validation

## Testing
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_route_scorer.py -q
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_route_scorer.py tests/test_agent/test_route_scoring.py -q
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_route_scorer.py tests/test_agent/test_route_scoring.py tests/test_agent/test_route_registry.py tests/test_agent/test_codegen_guardrails.py tests/test_agent/test_primitive_planning.py tests/test_agent/test_platform_requests.py -q
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_rate_tree_generation.py -q -k zcb_artifact_normalizes_quoted_option_type
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/ -x -q -m "not integration"
- /Users/steveyang/miniforge3/bin/python3 scripts/rerun_ids.py T105 T38 T01 T13
- /Users/steveyang/miniforge3/bin/python3 scripts/run_stress_tranche.py --task-id E26 --reuse --output /tmp/qua777_e26_results.json --report-json /tmp/qua777_e26_report.json --report-md /tmp/qua777_e26_report.md
- /Users/steveyang/miniforge3/bin/python3 scripts/remediate.py --analyze-only
