### PR TITLE
QUA-791: align offline route-learning features

### DIFF
--- a/docs/developer/dsl_system_design_review.md
+++ b/docs/developer/dsl_system_design_review.md
@@ -325,6 +325,10 @@ and schedule constraints can still surface as hard constraints, but route-card
 notes are no longer projected as live ``route_hint`` records and the prompt
 rankers no longer sort exact ``route:<id>`` matches ahead of broader
 instrument / method / family fit.
+The offline ``trellis.agent.route_learning`` scaffold is now explicitly
+experimental-only and reuses the live scorer feature contract instead of
+encoding separate route-id or route-family authority, so later retraining work
+starts from the minimized surface rather than an older route-first one.
 
 Callable-bond wrappers now follow the same “thin public shell over reusable
 family helpers” rule as the newer event-aware routes. The public PDE/tree

--- a/docs/plans/route-registry-minimization.md
+++ b/docs/plans/route-registry-minimization.md
@@ -242,10 +242,11 @@ planned tranches.
   `route_hint` records and both the prompt ranker and executor-side retry
   retrieval still sorted exact `route:<id>` matches ahead of broader
   instrument / method / family fit.
-- `QUA-791` tracks the offline learned-ranker tail. The experimental
-  `trellis/agent/route_learning.py` scaffold still emitted
-  `route:<id>` / `route_family:<family>` feature authority even though the live
-  scorer no longer does.
+- `QUA-791` closed the offline learned-ranker tail. The experimental
+  `trellis/agent/route_learning.py` scaffold now reuses the live minimized
+  scorer features through the same backend-binding / family-capability surface
+  and no longer emits `route:<id>` / `route_family:<family>` one-hot
+  authority.
 
 ## 2026-04-12 Route-Card Retirement Program
 
@@ -375,4 +376,4 @@ Status mirror last synced: `2026-04-12`
 | `QUA-785` | Route inventory: audit metadata-first residual route cards against representative tasks | Done |
 | `QUA-777` | Route scoring: remove residual route-identity authority after route-card retirement | Done |
 | `QUA-790` | Route prompts: demote residual route-note authority in skill selection | Done |
-| `QUA-791` | Route learning: align offline learned-ranker features with minimized scorer contract | Backlog |
+| `QUA-791` | Route learning: align offline learned-ranker features with minimized scorer contract | Done |

--- a/docs/quant/pricing_stack.rst
+++ b/docs/quant/pricing_stack.rst
@@ -192,6 +192,10 @@ and schedule constraints still surface when needed, but route-card notes are
 kept as historical metadata rather than live ``route_hint`` authority, and
 prompt ranking no longer gives first-class priority to exact ``route:<id>``
 tag matches over broader family / method / instrument fit.
+The experimental offline route-learning scaffold now reuses that same
+minimized feature surface instead of emitting its own route-id or
+route-family one-hots, so future retraining work cannot silently regress the
+live scorer contract.
 
 For rate-style swaption comparison builds, the semantic compiler now also keeps
 the contract-level convention surface attached to each method-specific plan.

--- a/tests/test_agent/test_route_learning.py
+++ b/tests/test_agent/test_route_learning.py
@@ -33,7 +33,8 @@ def test_build_route_training_rows_emits_proceed_and_block_decisions():
     assert any(
         row.instrument == "callable_bond"
         and row.route == "exercise_lattice"
-        and row.feature_map["route_family_matches_ir"] == 1.0
+        and row.feature_map["family_capability_ok"] == 1.0
+        and row.feature_map["binding_has_exact_surface"] == 1.0
         for row in rows
     )
     assert any(
@@ -41,6 +42,51 @@ def test_build_route_training_rows_emits_proceed_and_block_decisions():
         and row.decision == "block"
         for row in rows
     )
+    assert all("route_family_matches_ir" not in row.feature_map for row in rows)
+    assert all(
+        not any(
+            feature_name.startswith("route:") or feature_name.startswith("route_family:")
+            for feature_name in row.feature_map
+        )
+        for row in rows
+    )
+
+
+def test_extract_route_feature_map_matches_minimized_live_scorer_contract():
+    from trellis.agent.codegen_guardrails import rank_primitive_routes
+    from trellis.agent.knowledge.decompose import decompose_to_ir
+    from trellis.agent.quant import PricingPlan
+    from trellis.agent.route_learning import extract_route_feature_map
+
+    product_ir = decompose_to_ir(
+        "European payer swaption",
+        instrument_type="swaption",
+    )
+    pricing_plan = PricingPlan(
+        method="analytical",
+        method_modules=["trellis.models.black"],
+        required_market_data=set(product_ir.required_market_data),
+        model_to_build="swaption",
+        reasoning="test",
+    )
+    ranked = rank_primitive_routes(
+        pricing_plan=pricing_plan,
+        product_ir=product_ir,
+    )
+    candidate = next(candidate for candidate in ranked if candidate.route == "analytical_black76")
+
+    feature_map = extract_route_feature_map(
+        candidate,
+        product_ir,
+        pricing_plan=pricing_plan,
+    )
+
+    assert feature_map["family_capability_ok"] == 1.0
+    assert feature_map["binding_role:route_helper"] == 1.0
+    assert feature_map["binding_has_exact_surface"] == 1.0
+    assert "route_family_matches_ir" not in feature_map
+    assert "route:analytical_black76" not in feature_map
+    assert "route_family:analytical" not in feature_map
 
 
 def test_fit_linear_route_ranker_prefers_exercise_routes_for_known_products():

--- a/trellis/agent/route_learning.py
+++ b/trellis/agent/route_learning.py
@@ -10,6 +10,10 @@ candidate routes after:
 This module builds a small offline dataset from synthetic and known products,
 fits a simple linear scorer, and evaluates route choices under the same hard
 blocker semantics as the live build path.
+
+The scaffold is still experimental-only. Its feature extraction is intentionally
+kept aligned with the minimized live scorer contract so future retraining work
+cannot silently reintroduce route-id or route-family authority.
 """
 
 from __future__ import annotations
@@ -19,6 +23,8 @@ from dataclasses import dataclass
 from trellis.agent.codegen_guardrails import PrimitivePlan, rank_primitive_routes
 from trellis.agent.knowledge.decompose import decompose_to_ir
 from trellis.agent.quant import PricingPlan
+from trellis.agent.route_registry import find_route_by_id, resolve_route_family
+from trellis.agent.route_scorer import ScoringContext, extract_scoring_features
 from trellis.core.differentiable import get_numpy
 
 
@@ -157,7 +163,11 @@ def build_route_training_rows(
                 target=target,
                 decision=decision,
                 blockers=candidate.blockers,
-                feature_map=extract_route_feature_map(candidate, product_ir),
+                feature_map=extract_route_feature_map(
+                    candidate,
+                    product_ir,
+                    pricing_plan=pricing_plan,
+                ),
             ))
     return tuple(rows)
 
@@ -206,7 +216,11 @@ def rank_routes_with_learned_model(
         LearnedRouteCandidate(
             route=candidate.route,
             learned_score=ranker.score_feature_map(
-                extract_route_feature_map(candidate, product_ir)
+                extract_route_feature_map(
+                    candidate,
+                    product_ir,
+                    pricing_plan=pricing_plan,
+                )
             ),
             heuristic_score=candidate.score,
             blockers=candidate.blockers,
@@ -260,10 +274,26 @@ def learned_route_decision(
     )
 
 
-def extract_route_feature_map(candidate: PrimitivePlan, product_ir) -> dict[str, float]:
-    """Extract a stable numeric feature map for route learning."""
-    route_family = getattr(candidate, "route_family", "") or candidate.engine_family
-    route_families = set(getattr(product_ir, "route_families", ()) or ())
+def extract_route_feature_map(
+    candidate: PrimitivePlan,
+    product_ir,
+    *,
+    pricing_plan: PricingPlan | None = None,
+) -> dict[str, float]:
+    """Extract a stable numeric feature map aligned with the live scorer."""
+    route_spec = find_route_by_id(candidate.route)
+    if route_spec is not None:
+        route_family = resolve_route_family(route_spec, product_ir)
+        return extract_scoring_features(
+            ScoringContext(
+                product_ir=product_ir,
+                route_spec=route_spec,
+                pricing_plan=pricing_plan,
+                blockers=list(candidate.blockers),
+                route_family=route_family,
+            )
+        )
+
     feature_map: dict[str, float] = {
         "bias": 1.0,
         "blocker_count": float(len(candidate.blockers)),
@@ -271,14 +301,20 @@ def extract_route_feature_map(candidate: PrimitivePlan, product_ir) -> dict[str,
         "schedule_dependence": 1.0 if product_ir.schedule_dependence else 0.0,
         "has_unresolved_primitives": 1.0 if product_ir.unresolved_primitives else 0.0,
         "engine_family_matches_ir": 1.0 if candidate.engine_family in product_ir.candidate_engine_families else 0.0,
-        "route_family_matches_ir": 1.0 if route_family in route_families else 0.0,
     }
-    feature_map[f"route:{candidate.route}"] = 1.0
+    roles = {primitive.role for primitive in getattr(candidate, "primitives", ())}
+    exact_surface_roles = {"route_helper", "pricing_kernel", "cashflow_engine"}
+
+    feature_map["binding_role_count"] = float(len(roles))
+    feature_map["binding_has_exact_surface"] = 1.0 if roles.intersection(exact_surface_roles) else 0.0
+    feature_map["family_capability_ok"] = 1.0
     feature_map[f"engine_family:{candidate.engine_family}"] = 1.0
-    feature_map[f"route_family:{route_family}"] = 1.0
     feature_map[f"exercise:{product_ir.exercise_style}"] = 1.0
     feature_map[f"state:{product_ir.state_dependence}"] = 1.0
     feature_map[f"model:{product_ir.model_family}"] = 1.0
+    feature_map[f"payoff:{product_ir.payoff_family}"] = 1.0
+    for role in roles:
+        feature_map[f"binding_role:{role}"] = 1.0
     for blocker in candidate.blockers:
         feature_map[f"blocker:{blocker}"] = 1.0
     return feature_map


### PR DESCRIPTION
## Summary
- route the offline learned-ranker feature map through the minimized live scorer contract when a canonical route exists
- remove route-id / route-family one-hot authority from the offline scaffold and tests
- document the route-learning module as experimental-only and sync the route-minimization mirror

## Validation
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_route_learning.py -q
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_route_learning.py tests/test_agent/test_route_scorer.py -q
- /Users/steveyang/miniforge3/bin/python3 scripts/remediate.py --analyze-only