### PR TITLE
QUA-798: introduce canonical backend binding catalog

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -78,9 +78,14 @@ maintenance around the deterministic engines.
   `trellis/agent/valuation_context.py`, and
   `trellis/agent/market_binding.py` hold the typed semantic and valuation
   boundary.
+- `trellis/agent/backend_bindings.py` is the canonical catalog of exact helper,
+  kernel, schedule-builder, cashflow-engine, and market-binding facts used by
+  the runtime.
 - `trellis/agent/route_registry.py`, `trellis/agent/build_gate.py`,
   `trellis/agent/family_lowering_ir.py`, and `trellis/agent/dsl_lowering.py`
-  govern admissibility and lowering onto checked route families.
+  govern admissibility and lowering onto checked route families. The route
+  registry is now a compatibility and admissibility surface over the binding
+  catalog, not the only source of exact backend identity.
 - `trellis/agent/quant.py`, `trellis/agent/planner.py`,
   `trellis/agent/builder.py`, `trellis/agent/critic.py`,
   `trellis/agent/arbiter.py`, and `trellis/agent/executor.py` implement the
@@ -137,11 +142,12 @@ The agent-assisted path is:
 
 1. Enter through `trellis.ask(...)` or `Session.ask(...)`.
 2. Normalize the request in `trellis.agent.platform_requests`.
-3. Compile semantic contracts, valuation context, required data, and route
-   candidates.
-4. Reuse an existing checked route when possible; otherwise plan/build/review a
-   payoff adapter that lands under `trellis/instruments/_agent/`.
-5. Execute pricing through the same deterministic runtime after the route is
+3. Compile semantic contracts, valuation context, required data, and candidate
+   backend bindings.
+4. Reuse an existing checked helper/kernel binding when possible; otherwise
+   plan/build/review a payoff adapter that lands under
+   `trellis/instruments/_agent/`.
+5. Execute pricing through the same deterministic runtime after the binding is
    admitted.
 
 ### Batch and scenario execution

--- a/cassettes/full_task/T13.yaml
+++ b/cassettes/full_task/T13.yaml
@@ -1,5 +1,5 @@
 meta:
-  recorded_at: '2026-04-12T12:44:24.400878+00:00'
+  recorded_at: '2026-04-12T20:32:42.799199+00:00'
   provider: openai
   model: gpt-5.4-mini
   total_calls: 4
@@ -8,13 +8,13 @@ calls:
 - seq: 0
   function: llm_generate
   stage: code_generation
-  prompt_hash: d5c83af4493fd91969606ace2708b4ce85e15cee9c05ba34eda4d6dc02475bb0
+  prompt_hash: aa89066d6f6013f0ce431ff610d2d4b6d973aa4c4874a9651e441760ff2ede39
   response_text: "spec = self._spec\n        from trellis.models.equity_option_pde\
     \ import price_vanilla_equity_option_pde\n\n        if spec.option_type.lower()\
     \ not in {\"call\", \"put\"}:\n            raise ValueError(f\"Unsupported option_type:\
-    \ {spec.option_type!r}\")\n\n        price = price_vanilla_equity_option_pde(\n\
-    \            market_state,\n            spec,\n            theta=0.5,\n      \
-    \  )\n        return float(price)"
+    \ {spec.option_type!r}\")\n\n        return float(\n            price_vanilla_equity_option_pde(\n\
+    \                market_state,\n                spec,\n                theta=0.5,\n\
+    \            )\n        )"
   prompt_text: "You are implementing the evaluate() method for `EuropeanOptionAnalyticalPayoff`\
     \ in the Trellis pricing library.\n\n## Complete module (skeleton — everything\
     \ is fixed except evaluate)\n```python\n\"\"\"Agent-generated payoff: Build a\
@@ -213,7 +213,8 @@ calls:
     \ engine=`pde_solver`, authority=`exact_backend_fit`\n  - Route alias: `vanilla_equity_theta_pde`\n\
     \  - Validation bundle: `pde_solver:european_option`\n  - Validation checks: `check_non_negativity`,\
     \ `check_price_sanity`, `check_vol_sensitivity`, `check_vol_monotonicity`\n  -\
-    \ Exact target bindings: `trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
+    \ Helper authority: `trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
+    \  - Exact target bindings: `trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
     - Backend binding:\n  - Route: `vanilla_equity_theta_pde`\n  - Engine family:\
     \ `pde_solver`\n  - Route family: `pde_solver`\n  - Selected primitives:\n   \
     \ - `trellis.models.equity_option_pde.price_vanilla_equity_option_pde` (route_helper)\n\
@@ -366,19 +367,8 @@ calls:
 - seq: 1
   function: llm_generate_json
   stage: critic
-  prompt_hash: f044b6b44be8242bbc1b37f3a13874fb5fca8c8be3258e5da5d6d3e539173fc2
-  response_text: '{"check_id": "volatility_input_usage", "description": "Volatility
-    is not explicitly wired into the PDE pricer input path, so the implementation
-    may be insensitive to vol shifts.", "severity": "error", "evidence": "`evaluate()`
-    only forwards `market_state` and `spec` to `price_vanilla_equity_option_pde(...)`
-    and this wrapper does not construct or validate the required `expiry_black_vol`
-    state; the spec/requirements contract says the backend needs `black_vol_surface`
-    and `expiry_black_vol`, but the code never references or enforces them. If the
-    helper cannot extract vol from `market_state`, pricing will not respond to volatility
-    changes.", "remediation": "Ensure the market state passed into `price_vanilla_equity_option_pde`
-    contains the option expiry Black vol input and that the wrapper validates/threads
-    the correct volatility surface or expiry vol through the exact backend binding.",
-    "status": "suspect"}'
+  prompt_hash: 512cd7779e921f692765cb1586523a12ae6bbeabe8d4110f471377aa6f6e5f34
+  response_text: '{}'
   prompt_text: "You are a quantitative model validator reviewing agent-generated pricing\
     \ code.\nYour job is to find deterministic review concerns, not to praise. Be\
     \ adversarial.\n\n## Code to review\n```python\n\"\"\"Agent-generated payoff:\
@@ -433,17 +423,17 @@ calls:
     \ float:\n        spec = self._spec\n        spec = self._spec\n        from trellis.models.equity_option_pde\
     \ import price_vanilla_equity_option_pde\n\n        if spec.option_type.lower()\
     \ not in {\"call\", \"put\"}:\n            raise ValueError(f\"Unsupported option_type:\
-    \ {spec.option_type!r}\")\n\n        price = price_vanilla_equity_option_pde(\n\
-    \            market_state,\n            spec,\n            theta=0.5,\n      \
-    \  )\n        return float(price)\n\n```\n\n## Instrument description\nBuild a\
-    \ pricer for: European call: theta-method convergence order measurement\n\nEuropean\
-    \ call option on a non-dividend-paying stock.\nS0=100, K=105, T=1Y, risk-free\
-    \ rate r=5%, volatility sigma=20%.\nSolve with the Black-Scholes PDE operator\
-    \ using Crank-Nicolson\n(theta=0.5) and fully implicit (theta=1.0) on a 200-point\
-    \ spot grid\n× 100 time steps.\nMeasure convergence order by doubling the grid:\
-    \ the CN scheme should\nshow O(dt^2 + dS^2) convergence and the implicit scheme\
-    \ O(dt + dS^2).\nCompare both to the Black-Scholes analytical price.\n\nConstruct\
-    \ methods: pde_solver\nComparison targets: theta_0.5 (pde_solver), theta_1.0 (pde_solver),\
+    \ {spec.option_type!r}\")\n\n        return float(\n            price_vanilla_equity_option_pde(\n\
+    \                market_state,\n                spec,\n                theta=0.5,\n\
+    \            )\n        )\n\n```\n\n## Instrument description\nBuild a pricer\
+    \ for: European call: theta-method convergence order measurement\n\nEuropean call\
+    \ option on a non-dividend-paying stock.\nS0=100, K=105, T=1Y, risk-free rate\
+    \ r=5%, volatility sigma=20%.\nSolve with the Black-Scholes PDE operator using\
+    \ Crank-Nicolson\n(theta=0.5) and fully implicit (theta=1.0) on a 200-point spot\
+    \ grid\n× 100 time steps.\nMeasure convergence order by doubling the grid: the\
+    \ CN scheme should\nshow O(dt^2 + dS^2) convergence and the implicit scheme O(dt\
+    \ + dS^2).\nCompare both to the Black-Scholes analytical price.\n\nConstruct methods:\
+    \ pde_solver\nComparison targets: theta_0.5 (pde_solver), theta_1.0 (pde_solver),\
     \ black_scholes (analytical)\nCross-validation harness:\n  internal targets: theta_0.5,\
     \ theta_1.0\n  analytical benchmark: black_scholes\n  external targets: quantlib\n\
     New component: convergence_order_diagnostic\n\nImplementation target: theta_0.5\n\
@@ -485,7 +475,8 @@ calls:
     \ engine=`pde_solver`, authority=`exact_backend_fit`\n  - Route alias: `vanilla_equity_theta_pde`\n\
     \  - Validation bundle: `pde_solver:european_option`\n  - Validation checks: `check_non_negativity`,\
     \ `check_price_sanity`, `check_vol_sensitivity`, `check_vol_monotonicity`\n  -\
-    \ Exact target bindings: `trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
+    \ Helper authority: `trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
+    \  - Exact target bindings: `trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
     - Backend binding:\n  - Route: `vanilla_equity_theta_pde`\n  - Engine family:\
     \ `pde_solver`\n  - Route family: `pde_solver`\n  - Selected primitives:\n   \
     \ - `trellis.models.equity_option_pde.price_vanilla_equity_option_pde` (route_helper)\n\
@@ -517,11 +508,24 @@ calls:
 - seq: 2
   function: llm_generate
   stage: code_generation
-  prompt_hash: 8e108fde98618ef2e02e0ea63081d7a891510ae7db1b2921dfc872ab62915680
-  response_text: "spec = self._spec\n        from trellis.models.equity_option_pde\
-    \ import price_vanilla_equity_option_pde\n\n        return float(\n          \
-    \  price_vanilla_equity_option_pde(\n                market_state,\n         \
-    \       spec,\n                theta=1.0,\n            )\n        )"
+  prompt_hash: adc037065d43818190092f4023d09fba77c271513fe8aa0320b5635435c17fee
+  response_text: "spec = self._spec\n        from trellis.core.date_utils import year_fraction\n\
+    \        from trellis.models.equity_option_pde import price_vanilla_equity_option_pde\n\
+    \n        if market_state.discount is None:\n            raise ValueError(\"MarketState\
+    \ is missing a discount curve\")\n        if market_state.vol_surface is None:\n\
+    \            raise ValueError(\"MarketState is missing a black vol surface\")\n\
+    \n        t = year_fraction(market_state.as_of, spec.expiry_date, spec.day_count)\n\
+    \        if t < 0.0:\n            raise ValueError(\"Expiry date is before valuation\
+    \ date\")\n\n        class _ResolvedSpec:\n            def __init__(self, notional,\
+    \ spot, strike, expiry_date, option_type, day_count):\n                self.notional\
+    \ = notional\n                self.spot = spot\n                self.strike =\
+    \ strike\n                self.expiry_date = expiry_date\n                self.option_type\
+    \ = option_type\n                self.day_count = day_count\n\n        resolved_spec\
+    \ = _ResolvedSpec(\n            spec.notional,\n            spec.spot,\n     \
+    \       spec.strike,\n            spec.expiry_date,\n            spec.option_type,\n\
+    \            spec.day_count,\n        )\n\n        pv = price_vanilla_equity_option_pde(\n\
+    \            market_state,\n            resolved_spec,\n            theta=1.0,\n\
+    \        )\n        return float(pv)"
   prompt_text: "You are implementing the evaluate() method for `EuropeanOptionAnalyticalPayoff`\
     \ in the Trellis pricing library.\n\n## Complete module (skeleton — everything\
     \ is fixed except evaluate)\n```python\n\"\"\"Agent-generated payoff: Build a\
@@ -720,7 +724,8 @@ calls:
     \ engine=`pde_solver`, authority=`exact_backend_fit`\n  - Route alias: `vanilla_equity_theta_pde`\n\
     \  - Validation bundle: `pde_solver:european_option`\n  - Validation checks: `check_non_negativity`,\
     \ `check_price_sanity`, `check_vol_sensitivity`, `check_vol_monotonicity`\n  -\
-    \ Exact target bindings: `trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
+    \ Helper authority: `trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
+    \  - Exact target bindings: `trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
     - Backend binding:\n  - Route: `vanilla_equity_theta_pde`\n  - Engine family:\
     \ `pde_solver`\n  - Route family: `pde_solver`\n  - Selected primitives:\n   \
     \ - `trellis.models.equity_option_pde.price_vanilla_equity_option_pde` (route_helper)\n\
@@ -873,19 +878,16 @@ calls:
 - seq: 3
   function: llm_generate_json
   stage: critic
-  prompt_hash: 02f7a7ca3391193cbd871fe83e5f7381edd7f0c86a2864333407d1f38b7ea838
-  response_text: '{"check_id": "volatility_input_usage", "description": "Volatility
-    is not surfaced in the spec or explicitly bound in the pricer, so the PDE price
-    may be insensitive to market vol inputs.", "severity": "error", "evidence": "`EuropeanOptionSpec`
-    only stores notional, spot, strike, expiry_date, option_type, and day_count. `evaluate()`
-    forwards `market_state` and `spec` directly to `price_vanilla_equity_option_pde(...)`
-    with no explicit sigma/vol extraction or validation. Given the compiled route
-    obligations require `expiry_black_vol`, this code can easily end up pricing without
-    actually using volatility in the boundary state or solver setup.", "remediation":
-    "Ensure the market state passed into the route helper includes the required flat/term
-    vol surface or expiry_black_vol, and verify the helper consumes it; if necessary,
-    add explicit vol propagation/checks before calling the PDE pricer.", "status":
-    "suspect"}'
+  prompt_hash: 7cbf6f137ebbacc126eaf9a134cd67885a6fde516f2f40b8948bd223c36dd0da
+  response_text: '{"check_id": "price_non_negative", "description": "PDE price is
+    delegated to a backend with no explicit guard against negative outputs, despite
+    route/market mismatches being possible.", "severity": "warning", "evidence": "evaluate()
+    returns float(pv) directly from price_vanilla_equity_option_pde(...) without any
+    sanity check or clipping. The compiled route contract expects validation checks
+    like check_non_negativity, but none are invoked in this code path.", "remediation":
+    "Add explicit non-negativity validation on the returned PV and ensure the backend
+    is called with the exact route-helper contract and expected state bindings.",
+    "status": "suspect"}'
   prompt_text: "You are a quantitative model validator reviewing agent-generated pricing\
     \ code.\nYour job is to find deterministic review concerns, not to praise. Be\
     \ adversarial.\n\n## Code to review\n```python\n\"\"\"Agent-generated payoff:\
@@ -937,40 +939,52 @@ calls:
     \    @property\n    def spec(self) -> EuropeanOptionSpec:\n        return self._spec\n\
     \n    @property\n    def requirements(self) -> set[str]:\n        return {\"black_vol_surface\"\
     , \"discount_curve\"}\n\n    def evaluate(self, market_state: MarketState) ->\
-    \ float:\n        spec = self._spec\n        spec = self._spec\n        from trellis.models.equity_option_pde\
-    \ import price_vanilla_equity_option_pde\n\n        return float(\n          \
-    \  price_vanilla_equity_option_pde(\n                market_state,\n         \
-    \       spec,\n                theta=1.0,\n            )\n        )\n\n```\n\n\
-    ## Instrument description\nBuild a pricer for: European call: theta-method convergence\
-    \ order measurement\n\nEuropean call option on a non-dividend-paying stock.\n\
-    S0=100, K=105, T=1Y, risk-free rate r=5%, volatility sigma=20%.\nSolve with the\
-    \ Black-Scholes PDE operator using Crank-Nicolson\n(theta=0.5) and fully implicit\
-    \ (theta=1.0) on a 200-point spot grid\n× 100 time steps.\nMeasure convergence\
-    \ order by doubling the grid: the CN scheme should\nshow O(dt^2 + dS^2) convergence\
-    \ and the implicit scheme O(dt + dS^2).\nCompare both to the Black-Scholes analytical\
-    \ price.\n\nConstruct methods: pde_solver\nComparison targets: theta_0.5 (pde_solver),\
-    \ theta_1.0 (pde_solver), black_scholes (analytical)\nCross-validation harness:\n\
-    \  internal targets: theta_0.5, theta_1.0\n  analytical benchmark: black_scholes\n\
-    \  external targets: quantlib\nNew component: convergence_order_diagnostic\n\n\
-    Implementation target: theta_1.0\nPreferred method family: pde_solver\n\nImplementation\
-    \ target: theta_1.0\n\n## Shared Knowledge\n## Distilled Review Memory\n\n- Review\
-    \ principles:\n  - `P1`: Always calibrate rate trees to the discount curve before\
-    \ pricing\n  - `P2`: Callable bonds need issuer_call lattice control, discrete\
-    \ coupons, and exercise=par+coupon\n  - `P3`: Convert vol units at the boundary\
-    \ between market data and model\n- Review checkpoints:\n  - GRID: Use at least\
-    \ 200 spatial points and 200+ time steps. For barrier options, use non-uniform\
-    \ grid concentrated near the barrier.\n  - BOUNDARY CONDITIONS: Set V(0,t)=0 for\
-    \ calls, V(S_max,t)=S_max-K*exp(-r*(T-t)) for calls. For puts: V(0,t)=K*exp(-r*(T-t)),\
-    \ V(S_max,t)=0.\n  - STABILITY: Crank-Nicolson (theta=0.5) is second-order but\
-    \ may oscillate near discontinuities. Use Rannacher smoothing (2-4 implicit steps\
-    \ at start) for digital/barrier payoffs.\n- Canonical model grammar:\n  - `local_vol_surface_workflow`\
-    \ -> `Dupire local vol`\n  - `sabr_smile_workflow` -> `SABR smile`\n- Known failure\
-    \ traps:\n  - `BlackScholesOperator constructor mismatch` -> The generated code\
-    \ treated the PDE operator as if it accepted scalar 'r' and 'sigma' keywords,\
-    \ but trellis.models.pde.operator.BlackScholesOperator actually expects callables\
-    \ '(sigma_fn, r_fn)'. The mismatch caused constructor failure during module build.\n\
-    \  - `PDE price blow-up from unit/scale mismatch` -> The generated PDE branch\
-    \ called theta_method_1d with the obsolete operator/s_grid/t_grid/boundary_conditions\
+    \ float:\n        spec = self._spec\n        spec = self._spec\n        from trellis.core.date_utils\
+    \ import year_fraction\n        from trellis.models.equity_option_pde import price_vanilla_equity_option_pde\n\
+    \n        if market_state.discount is None:\n            raise ValueError(\"MarketState\
+    \ is missing a discount curve\")\n        if market_state.vol_surface is None:\n\
+    \            raise ValueError(\"MarketState is missing a black vol surface\")\n\
+    \n        t = year_fraction(market_state.as_of, spec.expiry_date, spec.day_count)\n\
+    \        if t < 0.0:\n            raise ValueError(\"Expiry date is before valuation\
+    \ date\")\n\n        class _ResolvedSpec:\n            def __init__(self, notional,\
+    \ spot, strike, expiry_date, option_type, day_count):\n                self.notional\
+    \ = notional\n                self.spot = spot\n                self.strike =\
+    \ strike\n                self.expiry_date = expiry_date\n                self.option_type\
+    \ = option_type\n                self.day_count = day_count\n\n        resolved_spec\
+    \ = _ResolvedSpec(\n            spec.notional,\n            spec.spot,\n     \
+    \       spec.strike,\n            spec.expiry_date,\n            spec.option_type,\n\
+    \            spec.day_count,\n        )\n\n        pv = price_vanilla_equity_option_pde(\n\
+    \            market_state,\n            resolved_spec,\n            theta=1.0,\n\
+    \        )\n        return float(pv)\n\n```\n\n## Instrument description\nBuild\
+    \ a pricer for: European call: theta-method convergence order measurement\n\n\
+    European call option on a non-dividend-paying stock.\nS0=100, K=105, T=1Y, risk-free\
+    \ rate r=5%, volatility sigma=20%.\nSolve with the Black-Scholes PDE operator\
+    \ using Crank-Nicolson\n(theta=0.5) and fully implicit (theta=1.0) on a 200-point\
+    \ spot grid\n× 100 time steps.\nMeasure convergence order by doubling the grid:\
+    \ the CN scheme should\nshow O(dt^2 + dS^2) convergence and the implicit scheme\
+    \ O(dt + dS^2).\nCompare both to the Black-Scholes analytical price.\n\nConstruct\
+    \ methods: pde_solver\nComparison targets: theta_0.5 (pde_solver), theta_1.0 (pde_solver),\
+    \ black_scholes (analytical)\nCross-validation harness:\n  internal targets: theta_0.5,\
+    \ theta_1.0\n  analytical benchmark: black_scholes\n  external targets: quantlib\n\
+    New component: convergence_order_diagnostic\n\nImplementation target: theta_1.0\n\
+    Preferred method family: pde_solver\n\nImplementation target: theta_1.0\n\n##\
+    \ Shared Knowledge\n## Distilled Review Memory\n\n- Review principles:\n  - `P1`:\
+    \ Always calibrate rate trees to the discount curve before pricing\n  - `P2`:\
+    \ Callable bonds need issuer_call lattice control, discrete coupons, and exercise=par+coupon\n\
+    \  - `P3`: Convert vol units at the boundary between market data and model\n-\
+    \ Review checkpoints:\n  - GRID: Use at least 200 spatial points and 200+ time\
+    \ steps. For barrier options, use non-uniform grid concentrated near the barrier.\n\
+    \  - BOUNDARY CONDITIONS: Set V(0,t)=0 for calls, V(S_max,t)=S_max-K*exp(-r*(T-t))\
+    \ for calls. For puts: V(0,t)=K*exp(-r*(T-t)), V(S_max,t)=0.\n  - STABILITY: Crank-Nicolson\
+    \ (theta=0.5) is second-order but may oscillate near discontinuities. Use Rannacher\
+    \ smoothing (2-4 implicit steps at start) for digital/barrier payoffs.\n- Canonical\
+    \ model grammar:\n  - `local_vol_surface_workflow` -> `Dupire local vol`\n  -\
+    \ `sabr_smile_workflow` -> `SABR smile`\n- Known failure traps:\n  - `BlackScholesOperator\
+    \ constructor mismatch` -> The generated code treated the PDE operator as if it\
+    \ accepted scalar 'r' and 'sigma' keywords, but trellis.models.pde.operator.BlackScholesOperator\
+    \ actually expects callables '(sigma_fn, r_fn)'. The mismatch caused constructor\
+    \ failure during module build.\n  - `PDE price blow-up from unit/scale mismatch`\
+    \ -> The generated PDE branch called theta_method_1d with the obsolete operator/s_grid/t_grid/boundary_conditions\
     \ signature and then read the wrong element of the result instead of interpolating\
     \ the returned solution over grid.x. The actual API is theta_method_1d(grid, operator,\
     \ terminal_condition, theta=..., lower_bc_fn=..., upper_bc_fn=...), and it returns\
@@ -991,7 +1005,8 @@ calls:
     \ engine=`pde_solver`, authority=`exact_backend_fit`\n  - Route alias: `vanilla_equity_theta_pde`\n\
     \  - Validation bundle: `pde_solver:european_option`\n  - Validation checks: `check_non_negativity`,\
     \ `check_price_sanity`, `check_vol_sensitivity`, `check_vol_monotonicity`\n  -\
-    \ Exact target bindings: `trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
+    \ Helper authority: `trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
+    \  - Exact target bindings: `trellis.models.equity_option_pde.price_vanilla_equity_option_pde`\n\
     - Backend binding:\n  - Route: `vanilla_equity_theta_pde`\n  - Engine family:\
     \ `pde_solver`\n  - Route family: `pde_solver`\n  - Selected primitives:\n   \
     \ - `trellis.models.equity_option_pde.price_vanilla_equity_option_pde` (route_helper)\n\

--- a/docs/quant/pricing_stack.rst
+++ b/docs/quant/pricing_stack.rst
@@ -31,6 +31,10 @@ Layering
      - ``ProductIR``, ``PricingPlan``, ``RouteSpec``, ``BuildGateDecision``
      - Checked summary, method choice, typed admissibility, and gatekeeping
      - ``trellis/agent/semantic_contract_compiler.py``, ``trellis/agent/route_registry.py``, ``trellis/agent/build_gate.py``
+   * - Backend binding catalog
+     - ``BackendBindingSpec``, ``ResolvedBackendBindingSpec``, binding catalogs
+     - Canonical exact helper/kernel/schedule/cashflow binding facts used by routing and validation
+     - ``trellis/agent/backend_bindings.py``
    * - Family lowering
      - family-specific lowering IRs + DSL lowering
      - Narrow typed lowering onto checked-in helper-backed routes
@@ -52,8 +56,8 @@ The current semantic pricing path is:
 1. Normalize a request into a ``SemanticContract``.
 2. Validate typed semantics, including phase order, obligations, and controller semantics.
 3. Build a ``ValuationContext`` and compile ``RequiredDataSpec`` plus ``MarketBindingSpec``.
-4. Build ``ProductIR`` and select a pricing method and candidate route.
-5. Apply typed route admissibility through ``BuildGateDecision``.
+4. Build ``ProductIR`` and select a pricing method plus candidate backend bindings.
+5. Apply typed admissibility through ``BuildGateDecision`` and resolve the exact binding surface.
 6. Lower onto a family-specific IR and then onto a checked helper or kernel.
 7. Execute the existing deterministic numerical code.
 
@@ -187,6 +191,10 @@ Route selection now follows that same minimization rule. The deterministic
 scorer no longer emits route-id or route-family one-hot authority; it ranks
 routes from family capability, blocker state, and backend-binding facts such as
 ``route_helper`` / ``pricing_kernel`` / ``cashflow_engine`` surfaces instead.
+Those exact helper/kernel facts are now materialized through
+``trellis.agent.backend_bindings`` as a separate canonical binding catalog, and
+the route registry derives its backend-binding authority summary from that
+catalog rather than acting as the only source of exact backend identity.
 The generated prompt-skill layer now follows the same contract: exact helper
 and schedule constraints still surface when needed, but route-card notes are
 kept as historical metadata rather than live ``route_hint`` authority, and

--- a/tests/test_agent/test_backend_bindings.py
+++ b/tests/test_agent/test_backend_bindings.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from trellis.agent.backend_bindings import (
+    find_backend_binding_by_route_id,
+    load_backend_binding_catalog,
+    resolve_backend_binding_spec,
+)
+from trellis.agent.knowledge.schema import ProductIR
+
+
+def test_binding_catalog_loads_core_route_backed_bindings():
+    catalog = load_backend_binding_catalog()
+
+    route_ids = {binding.route_id for binding in catalog.bindings}
+    assert {
+        "zcb_option_rate_tree",
+        "analytical_black76",
+        "credit_default_swap_analytical",
+        "analytical_garman_kohlhagen",
+        "waterfall_cashflows",
+    } <= route_ids
+
+
+def test_resolve_backend_binding_spec_captures_helper_schedule_and_cashflow_roles():
+    catalog = load_backend_binding_catalog()
+
+    cds = find_backend_binding_by_route_id("credit_default_swap_monte_carlo", catalog)
+    waterfall = find_backend_binding_by_route_id("waterfall_cashflows", catalog)
+
+    assert cds is not None
+    assert waterfall is not None
+
+    cds_resolved = resolve_backend_binding_spec(
+        cds,
+        product_ir=ProductIR(
+            instrument="cds",
+            payoff_family="credit_default_swap",
+            schedule_dependence=True,
+            state_dependence="pathwise_only",
+        ),
+    )
+    waterfall_resolved = resolve_backend_binding_spec(
+        waterfall,
+        product_ir=ProductIR(
+            instrument="waterfall",
+            payoff_family="waterfall",
+            schedule_dependence=True,
+            state_dependence="schedule_state",
+        ),
+    )
+
+    assert cds_resolved.binding_id == "trellis.models.credit_default_swap.price_cds_monte_carlo"
+    assert cds_resolved.helper_refs == (
+        "trellis.models.credit_default_swap.price_cds_monte_carlo",
+    )
+    assert cds_resolved.schedule_builder_refs == (
+        "trellis.models.credit_default_swap.build_cds_schedule",
+    )
+    assert waterfall_resolved.cashflow_engine_refs == (
+        "trellis.models.cashflow_engine.waterfall.Waterfall",
+        "trellis.models.cashflow_engine.waterfall.Tranche",
+    )
+    assert waterfall_resolved.binding_id == "trellis.models.cashflow_engine.waterfall.Waterfall"
+
+
+def test_resolve_backend_binding_spec_uses_route_conditionals_for_exact_targets():
+    catalog = load_backend_binding_catalog()
+    binding = find_backend_binding_by_route_id("analytical_black76", catalog)
+
+    assert binding is not None
+
+    swaption_resolved = resolve_backend_binding_spec(
+        binding,
+        product_ir=ProductIR(
+            instrument="swaption",
+            payoff_family="swaption",
+            exercise_style="european",
+            schedule_dependence=True,
+            state_dependence="schedule_state",
+        ),
+    )
+
+    assert (
+        swaption_resolved.helper_refs
+        == ("trellis.models.rate_style_swaption.price_swaption_black76",)
+    )
+    assert (
+        swaption_resolved.binding_id
+        == "trellis.models.rate_style_swaption.price_swaption_black76"
+    )

--- a/tests/test_agent/test_backend_bindings.py
+++ b/tests/test_agent/test_backend_bindings.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 from trellis.agent.backend_bindings import (
+    clear_backend_binding_catalog_cache,
     find_backend_binding_by_route_id,
     load_backend_binding_catalog,
     resolve_backend_binding_spec,
@@ -88,3 +91,37 @@ def test_resolve_backend_binding_spec_uses_route_conditionals_for_exact_targets(
         swaption_resolved.binding_id
         == "trellis.models.rate_style_swaption.price_swaption_black76"
     )
+
+
+def test_binding_catalog_cache_tracks_route_registry_freshness(monkeypatch):
+    clear_backend_binding_catalog_cache()
+
+    registry_one = SimpleNamespace(routes=())
+    registry_two = SimpleNamespace(routes=())
+    calls = iter((registry_one, registry_two))
+
+    from trellis.agent import route_registry as route_registry_module
+
+    monkeypatch.setattr(
+        route_registry_module,
+        "_cache_key",
+        lambda *, include_discovered: (include_discovered, 1.0, 0.0, "rev-a"),
+    )
+    monkeypatch.setattr(
+        route_registry_module,
+        "load_route_registry",
+        lambda *, include_discovered=False: next(calls),
+    )
+
+    first = load_backend_binding_catalog()
+    second = load_backend_binding_catalog()
+    assert first is second
+
+    monkeypatch.setattr(
+        route_registry_module,
+        "_cache_key",
+        lambda *, include_discovered: (include_discovered, 2.0, 0.0, "rev-a"),
+    )
+
+    third = load_backend_binding_catalog()
+    assert third is not first

--- a/trellis/agent/backend_bindings.py
+++ b/trellis/agent/backend_bindings.py
@@ -13,7 +13,6 @@ from typing import Any
 
 from trellis.agent.codegen_guardrails import PrimitiveRef
 from trellis.agent.knowledge.schema import ProductIR
-from trellis.agent.knowledge.import_registry import get_repo_revision
 
 
 @dataclass(frozen=True)
@@ -73,11 +72,13 @@ class BackendBindingCatalog:
     _route_index: dict[str, tuple[int, ...]] = field(default_factory=dict, repr=False)
 
 
-_CATALOG_CACHE: dict[tuple[bool, str], BackendBindingCatalog] = {}
+_CATALOG_CACHE: dict[tuple, BackendBindingCatalog] = {}
 
 
-def _cache_key(*, include_discovered: bool) -> tuple[bool, str]:
-    return (include_discovered, get_repo_revision())
+def _cache_key(*, include_discovered: bool) -> tuple:
+    from trellis.agent import route_registry as route_registry_module
+
+    return tuple(route_registry_module._cache_key(include_discovered=include_discovered))
 
 
 def load_backend_binding_catalog(

--- a/trellis/agent/backend_bindings.py
+++ b/trellis/agent/backend_bindings.py
@@ -217,9 +217,11 @@ def _resolve_binding_primitives(
     payoff_family = getattr(product_ir, "payoff_family", "") if product_ir is not None else ""
     model_family = getattr(product_ir, "model_family", "generic") if product_ir is not None else "generic"
 
+    explicit_default: tuple[PrimitiveRef, ...] | None = None
     for cond in binding.conditional_primitives:
         if isinstance(cond.when, str) and cond.when == "default":
-            return cond.primitives if cond.primitives else binding.primitives
+            explicit_default = cond.primitives if cond.primitives else binding.primitives
+            continue
         if isinstance(cond.when, dict) and _matches_condition(
             cond.when,
             payoff_family,
@@ -228,7 +230,7 @@ def _resolve_binding_primitives(
             product_ir,
         ):
             return cond.primitives if cond.primitives else binding.primitives
-    return binding.primitives
+    return explicit_default if explicit_default is not None else binding.primitives
 
 
 def _resolve_binding_route_family(

--- a/trellis/agent/backend_bindings.py
+++ b/trellis/agent/backend_bindings.py
@@ -1,0 +1,383 @@
+"""Canonical backend-binding catalog derived from the current route registry.
+
+This module is the first structural step in replacing route cards as the
+primary exact-backend identity surface. The catalog is intentionally loaded
+beside the route registry for now and resolves the exact helper/kernel/schedule
+facts without changing the downstream lowering or validation contracts yet.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from trellis.agent.codegen_guardrails import PrimitiveRef
+from trellis.agent.knowledge.schema import ProductIR
+from trellis.agent.knowledge.import_registry import get_repo_revision
+
+
+@dataclass(frozen=True)
+class ConditionalBindingPrimitives:
+    """Conditional primitive override carried by a backend-binding spec."""
+
+    when: dict[str, Any] | str
+    primitives: tuple[PrimitiveRef, ...] = ()
+
+
+@dataclass(frozen=True)
+class ConditionalBindingFamily:
+    """Conditional family override carried by a backend-binding spec."""
+
+    when: dict[str, Any] | str
+    route_family: str
+
+
+@dataclass(frozen=True)
+class BackendBindingSpec:
+    """Catalog entry for one route-backed exact binding surface."""
+
+    route_id: str
+    engine_family: str
+    route_family: str
+    aliases: tuple[str, ...] = ()
+    compatibility_alias_policy: str = "operator_visible"
+    primitives: tuple[PrimitiveRef, ...] = ()
+    conditional_primitives: tuple[ConditionalBindingPrimitives, ...] = ()
+    conditional_route_family: tuple[ConditionalBindingFamily, ...] = ()
+
+
+@dataclass(frozen=True)
+class ResolvedBackendBindingSpec:
+    """Resolved exact-backend facts for one product/binding combination."""
+
+    route_id: str
+    engine_family: str
+    route_family: str
+    aliases: tuple[str, ...] = ()
+    compatibility_alias_policy: str = "operator_visible"
+    binding_id: str = ""
+    primitive_refs: tuple[str, ...] = ()
+    helper_refs: tuple[str, ...] = ()
+    pricing_kernel_refs: tuple[str, ...] = ()
+    schedule_builder_refs: tuple[str, ...] = ()
+    cashflow_engine_refs: tuple[str, ...] = ()
+    market_binding_refs: tuple[str, ...] = ()
+    exact_target_refs: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class BackendBindingCatalog:
+    """Loaded binding catalog for canonical or analysis route authority."""
+
+    bindings: tuple[BackendBindingSpec, ...]
+    _route_index: dict[str, tuple[int, ...]] = field(default_factory=dict, repr=False)
+
+
+_CATALOG_CACHE: dict[tuple[bool, str], BackendBindingCatalog] = {}
+
+
+def _cache_key(*, include_discovered: bool) -> tuple[bool, str]:
+    return (include_discovered, get_repo_revision())
+
+
+def load_backend_binding_catalog(
+    *,
+    include_discovered: bool = False,
+    registry=None,
+) -> BackendBindingCatalog:
+    """Load the canonical backend-binding catalog beside the route registry."""
+    if registry is None:
+        key = _cache_key(include_discovered=include_discovered)
+        cached = _CATALOG_CACHE.get(key)
+        if cached is not None:
+            return cached
+        from trellis.agent.route_registry import load_route_registry
+
+        registry = load_route_registry(include_discovered=include_discovered)
+    else:
+        key = None
+
+    bindings = tuple(_binding_from_route(route) for route in registry.routes)
+    route_index: dict[str, list[int]] = {}
+    for idx, binding in enumerate(bindings):
+        route_index.setdefault(binding.route_id, []).append(idx)
+        for alias in binding.aliases:
+            route_index.setdefault(alias, []).append(idx)
+    catalog = BackendBindingCatalog(
+        bindings=bindings,
+        _route_index={key_: tuple(value) for key_, value in route_index.items()},
+    )
+    if key is not None:
+        _CATALOG_CACHE[key] = catalog
+    return catalog
+
+
+def clear_backend_binding_catalog_cache() -> None:
+    """Clear the backend-binding catalog cache."""
+    _CATALOG_CACHE.clear()
+
+
+def find_backend_binding_by_route_id(
+    route_id: str,
+    catalog: BackendBindingCatalog | None = None,
+) -> BackendBindingSpec | None:
+    """Look up a binding catalog entry by route id or alias."""
+    if not str(route_id or "").strip():
+        return None
+    if catalog is None:
+        catalog = load_backend_binding_catalog()
+    matches = catalog._route_index.get(str(route_id).strip(), ())
+    if not matches:
+        return None
+    return catalog.bindings[matches[0]]
+
+
+def resolve_backend_binding_spec(
+    binding: BackendBindingSpec,
+    *,
+    product_ir: ProductIR | None = None,
+    primitive_plan=None,
+) -> ResolvedBackendBindingSpec:
+    """Resolve one binding spec for the current product traits."""
+    route_family = _resolve_binding_route_family(binding, product_ir)
+    primitives = _resolve_binding_primitives(binding, product_ir)
+    primitive_refs = tuple(
+        dict.fromkeys(
+            f"{primitive.module}.{primitive.symbol}"
+            for primitive in primitives
+            if str(getattr(primitive, "module", "") or "").strip()
+            and str(getattr(primitive, "symbol", "") or "").strip()
+        )
+    )
+    helper_refs = _primitive_refs_for_role(primitives, "route_helper")
+    pricing_kernel_refs = _primitive_refs_for_role(primitives, "pricing_kernel")
+    schedule_builder_refs = _primitive_refs_for_role(primitives, "schedule_builder")
+    cashflow_engine_refs = _primitive_refs_for_role(primitives, "cashflow_engine")
+    market_binding_refs = _primitive_refs_for_role(primitives, "market_binding")
+    exact_target_refs = _exact_target_refs_for(primitives)
+    binding_id = _binding_id_for(
+        primitives=primitives,
+        exact_target_refs=exact_target_refs,
+        engine_family=binding.engine_family,
+        route_family=route_family,
+        primitive_plan=primitive_plan,
+    )
+    return ResolvedBackendBindingSpec(
+        route_id=binding.route_id,
+        engine_family=binding.engine_family,
+        route_family=route_family,
+        aliases=binding.aliases,
+        compatibility_alias_policy=binding.compatibility_alias_policy,
+        binding_id=binding_id,
+        primitive_refs=primitive_refs,
+        helper_refs=helper_refs,
+        pricing_kernel_refs=pricing_kernel_refs,
+        schedule_builder_refs=schedule_builder_refs,
+        cashflow_engine_refs=cashflow_engine_refs,
+        market_binding_refs=market_binding_refs,
+        exact_target_refs=exact_target_refs,
+    )
+
+
+def _binding_from_route(route) -> BackendBindingSpec:
+    return BackendBindingSpec(
+        route_id=str(route.id),
+        engine_family=str(route.engine_family),
+        route_family=str(route.route_family),
+        aliases=tuple(getattr(route, "aliases", ()) or ()),
+        compatibility_alias_policy=str(
+            getattr(route, "compatibility_alias_policy", None) or "operator_visible"
+        ),
+        primitives=tuple(getattr(route, "primitives", ()) or ()),
+        conditional_primitives=tuple(
+            ConditionalBindingPrimitives(
+                when=getattr(block, "when", "default"),
+                primitives=tuple(getattr(block, "primitives", ()) or ()),
+            )
+            for block in (getattr(route, "conditional_primitives", ()) or ())
+        ),
+        conditional_route_family=tuple(
+            ConditionalBindingFamily(
+                when=getattr(block, "when", "default"),
+                route_family=str(getattr(block, "route_family", "") or ""),
+            )
+            for block in (getattr(route, "conditional_route_family", ()) or ())
+        ),
+    )
+
+
+def _resolve_binding_primitives(
+    binding: BackendBindingSpec,
+    product_ir: ProductIR | None,
+) -> tuple[PrimitiveRef, ...]:
+    if not binding.conditional_primitives:
+        return binding.primitives
+
+    exercise = getattr(product_ir, "exercise_style", "none") if product_ir is not None else "none"
+    payoff_family = getattr(product_ir, "payoff_family", "") if product_ir is not None else ""
+    model_family = getattr(product_ir, "model_family", "generic") if product_ir is not None else "generic"
+
+    for cond in binding.conditional_primitives:
+        if isinstance(cond.when, str) and cond.when == "default":
+            return cond.primitives if cond.primitives else binding.primitives
+        if isinstance(cond.when, dict) and _matches_condition(
+            cond.when,
+            payoff_family,
+            exercise,
+            model_family,
+            product_ir,
+        ):
+            return cond.primitives if cond.primitives else binding.primitives
+    return binding.primitives
+
+
+def _resolve_binding_route_family(
+    binding: BackendBindingSpec,
+    product_ir: ProductIR | None,
+) -> str:
+    if not binding.conditional_route_family:
+        return binding.route_family
+
+    exercise = getattr(product_ir, "exercise_style", "none") if product_ir is not None else "none"
+    payoff_family = getattr(product_ir, "payoff_family", "") if product_ir is not None else ""
+    model_family = getattr(product_ir, "model_family", "generic") if product_ir is not None else "generic"
+
+    explicit_default = None
+    for cond in binding.conditional_route_family:
+        if isinstance(cond.when, str) and cond.when == "default":
+            explicit_default = cond.route_family
+            continue
+        if isinstance(cond.when, dict) and _matches_condition(
+            cond.when,
+            payoff_family,
+            exercise,
+            model_family,
+            product_ir,
+        ):
+            return cond.route_family
+    return explicit_default if explicit_default is not None else binding.route_family
+
+
+def _primitive_refs_for_role(
+    primitives: tuple[PrimitiveRef, ...],
+    role: str,
+) -> tuple[str, ...]:
+    return tuple(
+        dict.fromkeys(
+            f"{primitive.module}.{primitive.symbol}"
+            for primitive in primitives
+            if str(getattr(primitive, "role", "") or "").strip() == role
+            and str(getattr(primitive, "module", "") or "").strip()
+            and str(getattr(primitive, "symbol", "") or "").strip()
+        )
+    )
+
+
+def _exact_target_refs_for(
+    primitives: tuple[PrimitiveRef, ...],
+) -> tuple[str, ...]:
+    prioritized_roles = (
+        "route_helper",
+        "pricing_kernel",
+        "solver",
+        "payoff_kernel",
+        "engine",
+        "market_binding",
+        "cashflow_engine",
+    )
+    refs_by_role = {
+        role: _primitive_refs_for_role(primitives, role)
+        for role in prioritized_roles
+    }
+    for role in prioritized_roles:
+        refs = refs_by_role[role]
+        if refs:
+            return refs
+    return ()
+
+
+def _binding_id_for(
+    *,
+    primitives: tuple[PrimitiveRef, ...],
+    exact_target_refs: tuple[str, ...],
+    engine_family: str,
+    route_family: str,
+    primitive_plan=None,
+) -> str:
+    prioritized_roles = (
+        "route_helper",
+        "pricing_kernel",
+        "solver",
+        "payoff_kernel",
+        "engine",
+        "market_binding",
+        "cashflow_engine",
+    )
+    source_primitives = tuple(getattr(primitive_plan, "primitives", ()) or ()) or primitives
+    if source_primitives:
+        for role in prioritized_roles:
+            for primitive in source_primitives:
+                if str(getattr(primitive, "role", "") or "").strip() != role:
+                    continue
+                module = str(getattr(primitive, "module", "") or "").strip()
+                symbol = str(getattr(primitive, "symbol", "") or "").strip()
+                if module and symbol:
+                    return f"{module}.{symbol}"
+    if exact_target_refs:
+        return str(exact_target_refs[0]).strip()
+    engine = str(engine_family or "").strip()
+    family = str(route_family or "").strip()
+    if engine and family:
+        return f"{engine}:{family}:fallback"
+    if engine:
+        return f"{engine}:fallback"
+    return "unbound:fallback"
+
+
+def _matches_condition(
+    when: dict[str, Any],
+    payoff_family: str,
+    exercise_style: str,
+    model_family: str,
+    product_ir: ProductIR | None,
+) -> bool:
+    payoff_families = _expanded_payoff_families(payoff_family, product_ir)
+    for key, expected in when.items():
+        if key == "payoff_family":
+            if isinstance(expected, list):
+                if not any(candidate in payoff_families for candidate in expected):
+                    return False
+            elif expected not in payoff_families:
+                return False
+        elif key == "exercise_style":
+            if isinstance(expected, list):
+                if exercise_style not in expected:
+                    return False
+            elif exercise_style != expected:
+                return False
+        elif key == "model_family":
+            if isinstance(expected, list):
+                if model_family not in expected:
+                    return False
+            elif model_family != expected:
+                return False
+        elif key == "schedule_dependence":
+            if product_ir is not None and product_ir.schedule_dependence != expected:
+                return False
+        else:
+            return False
+    return True
+
+
+def _expanded_payoff_families(
+    payoff_family: str,
+    product_ir: ProductIR | None,
+) -> frozenset[str]:
+    families = {str(payoff_family or "")}
+    instrument = str(getattr(product_ir, "instrument", "") or "").strip().lower()
+    if instrument == "puttable_bond" or payoff_family == "puttable_fixed_income":
+        families.update({"puttable_fixed_income", "callable_fixed_income", "callable_bond", "bond"})
+    elif instrument == "callable_bond" or payoff_family == "callable_fixed_income":
+        families.update({"callable_fixed_income", "callable_bond", "bond"})
+    families.discard("")
+    return frozenset(families)

--- a/trellis/agent/route_registry.py
+++ b/trellis/agent/route_registry.py
@@ -177,6 +177,10 @@ class BackendBindingAuthority:
     approved_modules: tuple[str, ...] = ()
     primitive_refs: tuple[str, ...] = ()
     helper_refs: tuple[str, ...] = ()
+    pricing_kernel_refs: tuple[str, ...] = ()
+    schedule_builder_refs: tuple[str, ...] = ()
+    cashflow_engine_refs: tuple[str, ...] = ()
+    market_binding_refs: tuple[str, ...] = ()
     admissibility: RouteAdmissibilitySpec = RouteAdmissibilitySpec()
     admissibility_failures: tuple[str, ...] = ()
 
@@ -981,39 +985,66 @@ def compile_route_binding_authority(
     registry: RouteRegistry | None = None,
 ) -> RouteBindingAuthority | None:
     """Compile the structured route-binding authority packet for one request."""
+    from trellis.agent.backend_bindings import (
+        find_backend_binding_by_route_id,
+        load_backend_binding_catalog,
+        resolve_backend_binding_spec,
+    )
+
     route_id = _route_id_for_authority(generation_plan=generation_plan, semantic_blueprint=semantic_blueprint)
     primitive_plan = getattr(generation_plan, "primitive_plan", None)
     route_spec = find_route_by_id(route_id, registry) if route_id else None
     if not route_id and primitive_plan is None and route_spec is None:
         return None
 
+    binding_catalog = load_backend_binding_catalog(registry=registry or load_route_registry())
+    binding_spec = None
+    if route_id:
+        binding = find_backend_binding_by_route_id(route_id, binding_catalog)
+        if binding is not None:
+            binding_spec = resolve_backend_binding_spec(
+                binding,
+                product_ir=product_ir,
+                primitive_plan=primitive_plan,
+            )
+
     route_family = (
-        str(getattr(route_spec, "route_family", "") or "").strip()
+        str(getattr(binding_spec, "route_family", "") or "").strip()
+        or str(getattr(route_spec, "route_family", "") or "").strip()
         or str(getattr(primitive_plan, "route_family", "") or "").strip()
         or str(getattr(validation_contract, "route_family", "") or "").strip()
     )
     engine_family = (
-        str(getattr(route_spec, "engine_family", "") or "").strip()
+        str(getattr(binding_spec, "engine_family", "") or "").strip()
+        or str(getattr(route_spec, "engine_family", "") or "").strip()
         or str(getattr(primitive_plan, "engine_family", "") or "").strip()
         or route_family
     )
-    exact_target_refs = tuple(getattr(generation_plan, "lane_exact_binding_refs", ()) or ())
+    exact_target_refs = (
+        tuple(getattr(generation_plan, "lane_exact_binding_refs", ()) or ())
+        or tuple(getattr(binding_spec, "exact_target_refs", ()) or ())
+    )
     helper_refs = tuple(
         dict.fromkeys(
             str(ref).strip()
             for ref in (
                 getattr(generation_plan, "lowering_helper_refs", ())
                 or getattr(getattr(semantic_blueprint, "dsl_lowering", None), "helper_refs", ())
+                or getattr(binding_spec, "helper_refs", ())
                 or ()
             )
             if str(ref).strip()
         )
     )
-    primitive_refs = _primitive_refs_for(
+    primitive_refs = tuple(getattr(binding_spec, "primitive_refs", ()) or ()) or _primitive_refs_for(
         primitive_plan=primitive_plan,
         route_spec=route_spec,
         product_ir=product_ir,
     )
+    pricing_kernel_refs = tuple(getattr(binding_spec, "pricing_kernel_refs", ()) or ())
+    schedule_builder_refs = tuple(getattr(binding_spec, "schedule_builder_refs", ()) or ())
+    cashflow_engine_refs = tuple(getattr(binding_spec, "cashflow_engine_refs", ()) or ())
+    market_binding_refs = tuple(getattr(binding_spec, "market_binding_refs", ()) or ())
     approved_modules = tuple(
         dict.fromkeys(
             str(module).strip()
@@ -1062,7 +1093,7 @@ def compile_route_binding_authority(
         "repo_revision": str(getattr(generation_plan, "repo_revision", "") or ""),
     }
     backend_binding = BackendBindingAuthority(
-        binding_id=_backend_binding_id_for(
+        binding_id=str(getattr(binding_spec, "binding_id", "") or "").strip() or _backend_binding_id_for(
             engine_family=engine_family,
             route_family=route_family,
             exact_target_refs=exact_target_refs,
@@ -1076,6 +1107,10 @@ def compile_route_binding_authority(
         approved_modules=approved_modules,
         primitive_refs=primitive_refs,
         helper_refs=helper_refs,
+        pricing_kernel_refs=pricing_kernel_refs,
+        schedule_builder_refs=schedule_builder_refs,
+        cashflow_engine_refs=cashflow_engine_refs,
+        market_binding_refs=market_binding_refs,
         admissibility=admissibility,
         admissibility_failures=admissibility_failures,
     )
@@ -1112,6 +1147,10 @@ def route_binding_authority_summary(
             "approved_modules": list(backend_binding.approved_modules),
             "primitive_refs": list(backend_binding.primitive_refs),
             "helper_refs": list(backend_binding.helper_refs),
+            "pricing_kernel_refs": list(backend_binding.pricing_kernel_refs),
+            "schedule_builder_refs": list(backend_binding.schedule_builder_refs),
+            "cashflow_engine_refs": list(backend_binding.cashflow_engine_refs),
+            "market_binding_refs": list(backend_binding.market_binding_refs),
             "admissibility": {
                 "supported_control_styles": list(backend_binding.admissibility.supported_control_styles),
                 "event_support": backend_binding.admissibility.event_support,

--- a/trellis/agent/route_registry.py
+++ b/trellis/agent/route_registry.py
@@ -997,7 +997,7 @@ def compile_route_binding_authority(
     if not route_id and primitive_plan is None and route_spec is None:
         return None
 
-    binding_catalog = load_backend_binding_catalog(registry=registry or load_route_registry())
+    binding_catalog = load_backend_binding_catalog(registry=registry)
     binding_spec = None
     if route_id:
         binding = find_backend_binding_by_route_id(route_id, binding_catalog)


### PR DESCRIPTION
## Summary
- add a canonical backend binding catalog beside the route registry
- derive route binding authority summaries from resolved binding specs
- document the new binding-first exact backend identity surface and refresh the T13 replay cassette

## Validation
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_backend_bindings.py tests/test_agent/test_route_registry.py tests/test_contracts/test_canary_replay_contracts.py -q
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_platform_requests.py tests/test_agent/test_validation_contract.py tests/test_agent/test_platform_traces.py tests/test_agent/test_codegen_guardrails.py -q
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_tasks/test_t01_zcb_option.py -q
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_platform_requests.py -q -k 'compile_build_request_uses_quanto_semantic_contract_blueprint or compile_build_request_uses_credit_default_swap_semantic_contract_blueprint or route_binding_authority'
- /Users/steveyang/miniforge3/bin/python3 -m py_compile trellis/agent/backend_bindings.py trellis/agent/route_registry.py
