### PR TITLE
QUA-799: carry binding identity through runtime plans

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -81,6 +81,10 @@ maintenance around the deterministic engines.
 - `trellis/agent/backend_bindings.py` is the canonical catalog of exact helper,
   kernel, schedule-builder, cashflow-engine, and market-binding facts used by
   the runtime.
+- `trellis/agent/codegen_guardrails.py` now carries those backend-binding facts
+  on `PrimitivePlan` and `GenerationPlan`, so runtime plans no longer need to
+  rediscover exact helper identity from route ids later in validation or trace
+  code.
 - `trellis/agent/route_registry.py`, `trellis/agent/build_gate.py`,
   `trellis/agent/family_lowering_ir.py`, and `trellis/agent/dsl_lowering.py`
   govern admissibility and lowering onto checked route families. The route

--- a/cassettes/full_task/T38.yaml
+++ b/cassettes/full_task/T38.yaml
@@ -1,5 +1,5 @@
 meta:
-  recorded_at: '2026-04-12T13:06:52.245001+00:00'
+  recorded_at: '2026-04-12T21:18:05.748182+00:00'
   provider: openai
   model: gpt-5.4-mini
   total_calls: 4
@@ -8,20 +8,22 @@ calls:
 - seq: 0
   function: llm_generate
   stage: code_generation
-  prompt_hash: b6e7c7998645f2509476762d576facad203263e35ed8f3bb597feb597b4dfb22
+  prompt_hash: 37281ae71e7e4e748f38f37a4d0f6b79a9a5942c6ba2f0b97e9411cd64a7abc0
   response_text: "def evaluate(self, market_state: MarketState) -> float:\n      \
-    \  from trellis.core.differentiable import get_numpy\n        from trellis.models.credit_default_swap\
-    \ import build_cds_schedule, price_cds_monte_carlo\n\n        spec = self._spec\n\
-    \        np = get_numpy()\n\n        spread = float(spec.spread)\n        if spread\
-    \ > 1.0:\n            spread *= 1e-4\n\n        schedule = build_cds_schedule(\n\
+    \  from trellis.core.differentiable import get_numpy\n        from trellis.core.date_utils\
+    \ import year_fraction\n        from trellis.models.credit_default_swap import\
+    \ build_cds_schedule, price_cds_monte_carlo, interval_default_probability\n\n\
+    \        spec = self._spec\n        np = get_numpy()\n\n        spread = float(spec.spread)\n\
+    \        if spread > 1.0:\n            spread *= 1e-4\n\n        schedule = build_cds_schedule(\n\
     \            spec.start_date,\n            spec.end_date,\n            spec.frequency,\n\
     \            day_count=spec.day_count,\n            time_origin=spec.start_date,\n\
-    \        )\n\n        return float(\n            price_cds_monte_carlo(\n    \
-    \            notional=float(spec.notional),\n                spread_quote=spread,\n\
-    \                recovery=float(spec.recovery),\n                schedule=schedule,\n\
-    \                credit_curve=market_state.credit_curve,\n                discount_curve=market_state.discount,\n\
-    \                n_paths=int(spec.n_paths),\n                seed=42,\n      \
-    \      )\n        )"
+    \        )\n\n        _ = interval_default_probability  # exact backend binding\
+    \ kept explicit per route contract\n\n        pv = price_cds_monte_carlo(\n  \
+    \          notional=float(spec.notional),\n            spread_quote=spread,\n\
+    \            recovery=float(spec.recovery),\n            schedule=schedule,\n\
+    \            credit_curve=market_state.credit_curve,\n            discount_curve=market_state.discount,\n\
+    \            n_paths=int(spec.n_paths) if getattr(spec, \"n_paths\", None) is\
+    \ not None else 250000,\n            seed=42,\n        )\n        return float(pv)"
   prompt_text: "You are implementing the evaluate() method for `CDSPayoff` in the\
     \ Trellis pricing library.\n\n## Complete module (skeleton — everything is fixed\
     \ except evaluate)\n```python\n\"\"\"Agent-generated payoff: Build a pricer for:\
@@ -263,9 +265,8 @@ calls:
     \  - Validation bundle: `monte_carlo:credit_default_swap`\n  - Validation checks:\
     \ `check_cds_spread_quote_normalization`, `check_cds_credit_curve_sensitivity`,\
     \ `check_non_negativity`, `check_price_sanity`\n  - Canary coverage: canaries=`T38`\n\
-    \  - Helper authority: `trellis.models.credit_default_swap.build_cds_schedule`,\
-    \ `trellis.models.credit_default_swap.interval_default_probability`\n  - Exact\
-    \ target bindings: `trellis.models.credit_default_swap.build_cds_schedule`, `trellis.models.credit_default_swap.price_cds_monte_carlo`\n\
+    \  - Helper authority: `trellis.models.credit_default_swap.price_cds_monte_carlo`\n\
+    \  - Exact target bindings: `trellis.models.credit_default_swap.price_cds_monte_carlo`\n\
     - Backend binding:\n  - Route: `credit_default_swap_monte_carlo`\n  - Engine family:\
     \ `monte_carlo`\n  - Route family: `credit_default_swap`\n  - Selected primitives:\n\
     \    - `trellis.models.credit_default_swap.build_cds_schedule` (schedule_builder)\n\
@@ -481,20 +482,17 @@ calls:
 - seq: 1
   function: llm_generate_json
   stage: critic
-  prompt_hash: a59fc1c2dd9ec224fdafb8742786df470873ebfde67ba46a96083e16f3613bcd
-  response_text: '{"check_id": "price_non_negative", "description": "The implementation
-    is mis-specified for a buyer-protection CDS PV and can plausibly return a negative
-    value under the given market state because it hardcodes a quote normalization
-    branch but does not ensure the protection leg is valued as positive buyer value
-    minus premium outflow in the final sign convention.", "severity": "warning", "evidence":
-    "evaluate() forwards spread_quote directly into price_cds_monte_carlo(...). The
-    code does not show any explicit PV sign handling, and the prompt itself says \"Compute
-    the mark-to-market PV (protection leg minus premium leg)\" while the class is
-    named CDSPayoff for a protection buyer. If the backend interprets buyer/seller
-    sign differently, the returned PV can flip negative.", "remediation": "Make the
-    buyer-side sign convention explicit at the payoff boundary and verify the returned
-    PV is protection-leg minus premium-leg for the protection buyer under the backend
-    contract.", "status": "suspect"}'
+  prompt_hash: 433b17eeb9e051ba06ee0900bf5418bca7eae845ea3c764ac7d4261f4efa653d
+  response_text: '{"check_id": "price_non_negative", "description": "Monte Carlo CDS
+    pricer may return a negative PV because the contract side/sign is not explicitly
+    enforced as protection-buyer positive value.", "severity": "error", "evidence":
+    "`evaluate()` directly returns `price_cds_monte_carlo(...)` with no sign normalization
+    or post-check. The request says to compute MTM as protection leg minus premium
+    leg, which should be positive for an underpriced spread, but the code never verifies
+    the helper uses buyer-side sign conventions.", "remediation": "Explicitly confirm
+    the helper’s convention is protection-buyer PV = protection leg minus premium
+    leg, or negate/adjust the returned value if the backend prices the opposite side.",
+    "status": "suspect"}'
   prompt_text: "You are a quantitative model validator reviewing agent-generated pricing\
     \ code.\nYour job is to find deterministic review concerns, not to praise. Be\
     \ adversarial.\n\n## Code to review\n```python\n\"\"\"Agent-generated payoff:\
@@ -556,48 +554,50 @@ calls:
     \n    @property\n    def requirements(self) -> set[str]:\n        return {\"credit_curve\"\
     , \"discount_curve\"}\n\n    def evaluate(self, market_state: MarketState) ->\
     \ float:\n        spec = self._spec\n        from trellis.core.differentiable\
-    \ import get_numpy\n        from trellis.models.credit_default_swap import build_cds_schedule,\
-    \ price_cds_monte_carlo\n\n        spec = self._spec\n        np = get_numpy()\n\
+    \ import get_numpy\n        from trellis.core.date_utils import year_fraction\n\
+    \        from trellis.models.credit_default_swap import build_cds_schedule, price_cds_monte_carlo,\
+    \ interval_default_probability\n\n        spec = self._spec\n        np = get_numpy()\n\
     \n        spread = float(spec.spread)\n        if spread > 1.0:\n            spread\
     \ *= 1e-4\n\n        schedule = build_cds_schedule(\n            spec.start_date,\n\
     \            spec.end_date,\n            spec.frequency,\n            day_count=spec.day_count,\n\
-    \            time_origin=spec.start_date,\n        )\n\n        return float(\n\
-    \            price_cds_monte_carlo(\n                notional=float(spec.notional),\n\
-    \                spread_quote=spread,\n                recovery=float(spec.recovery),\n\
-    \                schedule=schedule,\n                credit_curve=market_state.credit_curve,\n\
-    \                discount_curve=market_state.discount,\n                n_paths=int(spec.n_paths),\n\
-    \                seed=42,\n            )\n        )\n\n```\n\n## Instrument description\n\
-    Build a pricer for: CDS pricing: hazard rate MC vs survival prob analytical\n\n\
-    Standard single-name CDS, protection buyer side.\nNotional: $10,000,000.  Maturity:\
-    \ 5Y from settlement.\nPremium leg: quarterly payments, Act/360 day count.\nRunning\
-    \ CDS spread: 150 bp.  Recovery rate: 40%.\nUse the investment-grade (IG) credit\
-    \ curve from the market snapshot\n(as_of 2024-11-15) — this provides term-dependent\
-    \ hazard rates\nbootstrapped from market CDS spreads at 1Y, 3Y, 5Y, and 10Y tenors.\n\
-    Do NOT use a flat hazard rate — the model must respect the full\nhazard rate term\
-    \ structure.\nUse the USD OIS curve for risk-free discounting.\nMethod 1: Monte\
-    \ Carlo simulation of default times from the hazard curve.\nMethod 2: Analytical\
-    \ (deterministic) survival-probability integration.\nCompute the mark-to-market\
-    \ PV (protection leg minus premium leg).\n\nConstruct methods: monte_carlo\nComparison\
-    \ targets: mc_cds (monte_carlo), analytical_cds (analytical)\nCross-validation\
-    \ harness:\n  internal targets: mc_cds, analytical_cds\n  external targets: quantlib,\
-    \ financepy\nNew component: cds_pricing\n\nImplementation target: mc_cds\nPreferred\
-    \ method family: monte_carlo\n\nImplementation target: mc_cds\n\n## Shared Knowledge\n\
-    ## Distilled Review Memory\n\n- Review principles:\n  - `P1`: Always calibrate\
-    \ rate trees to the discount curve before pricing\n  - `P2`: Callable bonds need\
-    \ issuer_call lattice control, discrete coupons, and exercise=par+coupon\n  -\
-    \ `P3`: Convert vol units at the boundary between market data and model\n- Review\
-    \ checkpoints:\n  - CONVERGENCE: Use at least 10,000 paths. Verify that the standard\
-    \ error is <1% of the price. If path-dependent, use at least 100 time steps per\
-    \ year.\n  - DISCRETE OBSERVATIONS: For instruments with discrete fixing/observation\
-    \ dates (Asian options, barriers), simulate paths that pass through those exact\
-    \ dates. Do not interpolate between steps.\n  - EARLY EXERCISE: For American or\
-    \ Bermudan exercise in Monte Carlo, use an approved optimal-stopping control primitive\
-    \ instead of inventing method=\"lsm\" or treating engine.price(...) as a substitute\
-    \ for early-exercise control. Trellis currently implements longstaff_schwartz.\
-    \ Planned policy classes include tsitsiklis_van_roy, primal_dual_mc, and stochastic_mesh.\
-    \ If the control primitive uses continuation regression, the basis or estimator\
-    \ choice is explicit; LaguerreBasis is a common option, not a mandatory route\
-    \ primitive.\n- Canonical model grammar:\n  - `credit_single_name_reduced_form`\
+    \            time_origin=spec.start_date,\n        )\n\n        _ = interval_default_probability\
+    \  # exact backend binding kept explicit per route contract\n\n        pv = price_cds_monte_carlo(\n\
+    \            notional=float(spec.notional),\n            spread_quote=spread,\n\
+    \            recovery=float(spec.recovery),\n            schedule=schedule,\n\
+    \            credit_curve=market_state.credit_curve,\n            discount_curve=market_state.discount,\n\
+    \            n_paths=int(spec.n_paths) if getattr(spec, \"n_paths\", None) is\
+    \ not None else 250000,\n            seed=42,\n        )\n        return float(pv)\n\
+    \n```\n\n## Instrument description\nBuild a pricer for: CDS pricing: hazard rate\
+    \ MC vs survival prob analytical\n\nStandard single-name CDS, protection buyer\
+    \ side.\nNotional: $10,000,000.  Maturity: 5Y from settlement.\nPremium leg: quarterly\
+    \ payments, Act/360 day count.\nRunning CDS spread: 150 bp.  Recovery rate: 40%.\n\
+    Use the investment-grade (IG) credit curve from the market snapshot\n(as_of 2024-11-15)\
+    \ — this provides term-dependent hazard rates\nbootstrapped from market CDS spreads\
+    \ at 1Y, 3Y, 5Y, and 10Y tenors.\nDo NOT use a flat hazard rate — the model must\
+    \ respect the full\nhazard rate term structure.\nUse the USD OIS curve for risk-free\
+    \ discounting.\nMethod 1: Monte Carlo simulation of default times from the hazard\
+    \ curve.\nMethod 2: Analytical (deterministic) survival-probability integration.\n\
+    Compute the mark-to-market PV (protection leg minus premium leg).\n\nConstruct\
+    \ methods: monte_carlo\nComparison targets: mc_cds (monte_carlo), analytical_cds\
+    \ (analytical)\nCross-validation harness:\n  internal targets: mc_cds, analytical_cds\n\
+    \  external targets: quantlib, financepy\nNew component: cds_pricing\n\nImplementation\
+    \ target: mc_cds\nPreferred method family: monte_carlo\n\nImplementation target:\
+    \ mc_cds\n\n## Shared Knowledge\n## Distilled Review Memory\n\n- Review principles:\n\
+    \  - `P1`: Always calibrate rate trees to the discount curve before pricing\n\
+    \  - `P2`: Callable bonds need issuer_call lattice control, discrete coupons,\
+    \ and exercise=par+coupon\n  - `P3`: Convert vol units at the boundary between\
+    \ market data and model\n- Review checkpoints:\n  - CONVERGENCE: Use at least\
+    \ 10,000 paths. Verify that the standard error is <1% of the price. If path-dependent,\
+    \ use at least 100 time steps per year.\n  - DISCRETE OBSERVATIONS: For instruments\
+    \ with discrete fixing/observation dates (Asian options, barriers), simulate paths\
+    \ that pass through those exact dates. Do not interpolate between steps.\n  -\
+    \ EARLY EXERCISE: For American or Bermudan exercise in Monte Carlo, use an approved\
+    \ optimal-stopping control primitive instead of inventing method=\"lsm\" or treating\
+    \ engine.price(...) as a substitute for early-exercise control. Trellis currently\
+    \ implements longstaff_schwartz. Planned policy classes include tsitsiklis_van_roy,\
+    \ primal_dual_mc, and stochastic_mesh. If the control primitive uses continuation\
+    \ regression, the basis or estimator choice is explicit; LaguerreBasis is a common\
+    \ option, not a mandatory route primitive.\n- Canonical model grammar:\n  - `credit_single_name_reduced_form`\
     \ -> `Reduced-form single-name credit`\n  - `heston_smile_workflow` -> `Heston`\n\
     - Known failure traps:\n  - `MC payoff must use market_state.discount` -> The\
     \ generated Monte Carlo payoff did not call the required market_state.discount\
@@ -652,9 +652,8 @@ calls:
     \  - Validation bundle: `monte_carlo:credit_default_swap`\n  - Validation checks:\
     \ `check_cds_spread_quote_normalization`, `check_cds_credit_curve_sensitivity`,\
     \ `check_non_negativity`, `check_price_sanity`\n  - Canary coverage: canaries=`T38`\n\
-    \  - Helper authority: `trellis.models.credit_default_swap.build_cds_schedule`,\
-    \ `trellis.models.credit_default_swap.interval_default_probability`\n  - Exact\
-    \ target bindings: `trellis.models.credit_default_swap.build_cds_schedule`, `trellis.models.credit_default_swap.price_cds_monte_carlo`\n\
+    \  - Helper authority: `trellis.models.credit_default_swap.price_cds_monte_carlo`\n\
+    \  - Exact target bindings: `trellis.models.credit_default_swap.price_cds_monte_carlo`\n\
     - Backend binding:\n  - Route: `credit_default_swap_monte_carlo`\n  - Engine family:\
     \ `monte_carlo`\n  - Route family: `credit_default_swap`\n  - Selected primitives:\n\
     \    - `trellis.models.credit_default_swap.build_cds_schedule` (schedule_builder)\n\
@@ -691,15 +690,15 @@ calls:
 - seq: 2
   function: llm_generate
   stage: code_generation
-  prompt_hash: 672502d9ff304aeef7a90b100afe86bc29cc3bb5e24b16d6c7b5dcc497cdeadb
-  response_text: "spec = self._spec\n        if market_state.credit_curve is None:\n\
-    \            raise ValueError(\"MarketState is missing required credit_curve\"\
-    )\n        if market_state.discount is None:\n            raise ValueError(\"\
-    MarketState is missing required discount curve\")\n\n        spread = spec.spread\n\
-    \        if spread > 1.0:\n            spread = spread / 10000.0\n\n        schedule\
-    \ = build_cds_schedule(\n            spec.start_date,\n            spec.end_date,\n\
-    \            spec.frequency,\n            spec.day_count,\n            time_origin=spec.start_date,\n\
-    \        )\n\n        pv = price_cds_analytical(\n            notional=spec.notional,\n\
+  prompt_hash: 03dfd709fa98ef61627ca73548a15a80f6730541ad2be75da6eb4741379b49e6
+  response_text: "spec = self._spec\n        if market_state.discount is None:\n \
+    \           raise ValueError(\"CDSPayoff.evaluate requires market_state.discount\"\
+    )\n        if market_state.credit_curve is None:\n            raise ValueError(\"\
+    CDSPayoff.evaluate requires market_state.credit_curve\")\n\n        spread = spec.spread\n\
+    \        if spread > 1.0:\n            spread *= 1e-4\n\n        schedule = build_cds_schedule(\n\
+    \            spec.start_date,\n            spec.end_date,\n            spec.frequency,\n\
+    \            spec.day_count,\n            time_origin=spec.start_date,\n     \
+    \   )\n\n        pv = price_cds_analytical(\n            notional=spec.notional,\n\
     \            spread_quote=spread,\n            recovery=spec.recovery,\n     \
     \       schedule=schedule,\n            credit_curve=market_state.credit_curve,\n\
     \            discount_curve=market_state.discount,\n        )\n\n        return\
@@ -942,9 +941,8 @@ calls:
     \  - Validation bundle: `analytical:credit_default_swap`\n  - Validation checks:\
     \ `check_cds_spread_quote_normalization`, `check_cds_credit_curve_sensitivity`,\
     \ `check_non_negativity`, `check_price_sanity`\n  - Canary coverage: canaries=`T38`\n\
-    \  - Helper authority: `trellis.models.credit_default_swap.build_cds_schedule`,\
-    \ `trellis.models.credit_default_swap.price_cds_analytical`\n  - Exact target\
-    \ bindings: `trellis.models.credit_default_swap.build_cds_schedule`, `trellis.models.credit_default_swap.price_cds_analytical`\n\
+    \  - Helper authority: `trellis.models.credit_default_swap.price_cds_analytical`\n\
+    \  - Exact target bindings: `trellis.models.credit_default_swap.price_cds_analytical`\n\
     - Backend binding:\n  - Route: `credit_default_swap_analytical`\n  - Engine family:\
     \ `analytical`\n  - Route family: `credit_default_swap`\n  - Selected primitives:\n\
     \    - `trellis.models.credit_default_swap.build_cds_schedule` (schedule_builder)\n\
@@ -1120,17 +1118,18 @@ calls:
 - seq: 3
   function: llm_generate_json
   stage: critic
-  prompt_hash: e1f2b41af079fba390425158896d34f85f495ad93c205cc29dfae93b26c1491b
-  response_text: '{"check_id": "price_non_negative", "description": "Likely negative
-    PV due to protection-buyer sign convention being hardwired as premium-leg PV only
-    or misapplied to the wrong cashflow direction.", "severity": "error", "evidence":
-    "The implementation claims ''protection leg minus premium leg'' but delegates
-    to `price_cds_analytical(...)` without any explicit protection-leg construction
-    or sign handling in the wrapper. For a protection buyer CDS, a sign or leg-order
-    mismatch can easily flip the PV negative, especially if the backend expects seller-side
-    quoting.", "remediation": "Verify the backend route returns protection-leg PV
-    minus premium-leg PV for a protection buyer, and explicitly align the sign convention
-    with the contract specification before returning the float.", "status": "suspect"}'
+  prompt_hash: 030ebee0f01985cad1998c17db25543976ef3c4d897559028807e89f13c58a6f
+  response_text: '{"check_id": "price_non_negative", "description": "The CDS spread
+    is passed through a brittle unit conversion that can mis-scale the coupon input
+    and produce an invalid PV sign/magnitude.", "severity": "error", "evidence": "In
+    evaluate(), `spread = spec.spread` followed by `if spread > 1.0: spread *= 1e-4`
+    assumes only bps inputs are > 1.0. The instrument spec says 150 bp, but the code
+    does not normalize unambiguously to a decimal running spread. A wrong spread unit
+    directly feeds `price_cds_analytical(...)`, which can invert or distort the premium
+    leg and lead to an invalid PV.", "remediation": "Explicitly normalize the running
+    spread from bps to decimal using the documented convention before pricing, and
+    validate the accepted input units rather than relying on a threshold heuristic.",
+    "status": "suspect"}'
   prompt_text: "You are a quantitative model validator reviewing agent-generated pricing\
     \ code.\nYour job is to find deterministic review concerns, not to praise. Be\
     \ adversarial.\n\n## Code to review\n```python\n\"\"\"Agent-generated payoff:\
@@ -1191,16 +1190,15 @@ calls:
     \      return self._spec\n\n    @property\n    def requirements(self) -> set[str]:\n\
     \        return {\"credit_curve\", \"discount_curve\"}\n\n    def evaluate(self,\
     \ market_state: MarketState) -> float:\n        spec = self._spec\n        spec\
-    \ = self._spec\n        if market_state.credit_curve is None:\n            raise\
-    \ ValueError(\"MarketState is missing required credit_curve\")\n        if market_state.discount\
-    \ is None:\n            raise ValueError(\"MarketState is missing required discount\
-    \ curve\")\n\n        spread = spec.spread\n        if spread > 1.0:\n       \
-    \     spread = spread / 10000.0\n\n        schedule = build_cds_schedule(\n  \
-    \          spec.start_date,\n            spec.end_date,\n            spec.frequency,\n\
-    \            spec.day_count,\n            time_origin=spec.start_date,\n     \
-    \   )\n\n        pv = price_cds_analytical(\n            notional=spec.notional,\n\
-    \            spread_quote=spread,\n            recovery=spec.recovery,\n     \
-    \       schedule=schedule,\n            credit_curve=market_state.credit_curve,\n\
+    \ = self._spec\n        if market_state.discount is None:\n            raise ValueError(\"\
+    CDSPayoff.evaluate requires market_state.discount\")\n        if market_state.credit_curve\
+    \ is None:\n            raise ValueError(\"CDSPayoff.evaluate requires market_state.credit_curve\"\
+    )\n\n        spread = spec.spread\n        if spread > 1.0:\n            spread\
+    \ *= 1e-4\n\n        schedule = build_cds_schedule(\n            spec.start_date,\n\
+    \            spec.end_date,\n            spec.frequency,\n            spec.day_count,\n\
+    \            time_origin=spec.start_date,\n        )\n\n        pv = price_cds_analytical(\n\
+    \            notional=spec.notional,\n            spread_quote=spread,\n     \
+    \       recovery=spec.recovery,\n            schedule=schedule,\n            credit_curve=market_state.credit_curve,\n\
     \            discount_curve=market_state.discount,\n        )\n\n        return\
     \ float(pv)\n\n```\n\n## Instrument description\nBuild a pricer for: CDS pricing:\
     \ hazard rate MC vs survival prob analytical\n\nStandard single-name CDS, protection\
@@ -1284,9 +1282,8 @@ calls:
     \  - Validation bundle: `analytical:credit_default_swap`\n  - Validation checks:\
     \ `check_cds_spread_quote_normalization`, `check_cds_credit_curve_sensitivity`,\
     \ `check_non_negativity`, `check_price_sanity`\n  - Canary coverage: canaries=`T38`\n\
-    \  - Helper authority: `trellis.models.credit_default_swap.build_cds_schedule`,\
-    \ `trellis.models.credit_default_swap.price_cds_analytical`\n  - Exact target\
-    \ bindings: `trellis.models.credit_default_swap.build_cds_schedule`, `trellis.models.credit_default_swap.price_cds_analytical`\n\
+    \  - Helper authority: `trellis.models.credit_default_swap.price_cds_analytical`\n\
+    \  - Exact target bindings: `trellis.models.credit_default_swap.price_cds_analytical`\n\
     - Backend binding:\n  - Route: `credit_default_swap_analytical`\n  - Engine family:\
     \ `analytical`\n  - Route family: `credit_default_swap`\n  - Selected primitives:\n\
     \    - `trellis.models.credit_default_swap.build_cds_schedule` (schedule_builder)\n\

--- a/docs/plans/binding-first-exotic-assembly.md
+++ b/docs/plans/binding-first-exotic-assembly.md
@@ -73,7 +73,9 @@ identity and assembly authority.
 
 ### What still needs to move
 
-- `PrimitivePlan` / `GenerationPlan` still center `route` and `route_family`
+- `PrimitivePlan` / `GenerationPlan` now carry explicit backend-binding
+  identity, but downstream lowering/validation surfaces still treat route ids
+  as the dominant join key
 - family lowering still branches directly on `route_id`
 - DSL lowering still resolves helpers/kernels/schedules by route id
 - validation and trace contracts still store route identity as primary runtime
@@ -145,8 +147,8 @@ Status mirror last synced: `2026-04-12`
 
 | Ticket | Status |
 | --- | --- |
-| `QUA-798` | Backend binding: introduce canonical binding catalog beside route registry | Backlog |
-| `QUA-799` | Backend binding: carry binding identity through primitive and generation plans | Backlog |
+| `QUA-798` | Backend binding: introduce canonical binding catalog beside route registry | Done |
+| `QUA-799` | Backend binding: carry binding identity through primitive and generation plans | Done |
 | `QUA-800` | Backend binding: move exact helper and kernel lookup onto binding specs | Backlog |
 | `QUA-810` | Route aliases: collapse route registry to transitional alias and admissibility shell | Backlog |
 

--- a/docs/quant/pricing_stack.rst
+++ b/docs/quant/pricing_stack.rst
@@ -195,6 +195,10 @@ Those exact helper/kernel facts are now materialized through
 ``trellis.agent.backend_bindings`` as a separate canonical binding catalog, and
 the route registry derives its backend-binding authority summary from that
 catalog rather than acting as the only source of exact backend identity.
+The runtime plans now also carry that identity directly: ``PrimitivePlan`` and
+``GenerationPlan`` persist ``backend_binding_id`` plus exact helper/kernel and
+schedule-builder refs, so later validation, traces, and replay do not need to
+reconstruct the binding contract from a route alias.
 The generated prompt-skill layer now follows the same contract: exact helper
 and schedule constraints still surface when needed, but route-card notes are
 kept as historical metadata rather than live ``route_hint`` authority, and

--- a/tests/test_agent/test_codegen_guardrails.py
+++ b/tests/test_agent/test_codegen_guardrails.py
@@ -64,6 +64,28 @@ def test_generation_plan_includes_common_modules_and_targets():
     assert plan.test_map is not None
 
 
+def test_generation_plan_carries_backend_binding_identity_for_exact_helper_routes():
+    compiled = compile_build_request(
+        "Quanto option on SAP in USD with EUR underlier currency expiring 2025-11-15",
+        instrument_type="quanto_option",
+        model="claude-sonnet-4-6",
+    )
+
+    assert compiled.generation_plan.primitive_plan is not None
+    assert compiled.generation_plan.backend_binding_id == (
+        "trellis.models.quanto_option.price_quanto_option_analytical_from_market_state"
+    )
+    assert compiled.generation_plan.backend_engine_family == "analytical"
+    assert compiled.generation_plan.backend_route_family == "analytical"
+    assert compiled.generation_plan.backend_exact_target_refs == (
+        "trellis.models.quanto_option.price_quanto_option_analytical_from_market_state",
+    )
+    assert compiled.generation_plan.backend_helper_refs == (
+        "trellis.models.quanto_option.price_quanto_option_analytical_from_market_state",
+    )
+    assert compiled.generation_plan.backend_compatibility_alias_policy == "internal_only"
+
+
 def test_validate_generated_imports_accepts_valid_code():
     report = validate_generated_imports(VALID_SOURCE, _analytical_plan())
     assert report.ok

--- a/tests/test_agent/test_platform_requests.py
+++ b/tests/test_agent/test_platform_requests.py
@@ -1016,16 +1016,27 @@ def test_request_missing_schedule_returns_semantic_error():
 
 
 @pytest.mark.parametrize(
-    "preferred_method,expected_route,expected_expr_kind",
+    "preferred_method,expected_route,expected_expr_kind,expected_helper",
     [
-        ("analytical", "credit_default_swap_analytical", "ThenExpr"),
-        ("monte_carlo", "credit_default_swap_monte_carlo", "ThenExpr"),
+        (
+            "analytical",
+            "credit_default_swap_analytical",
+            "ThenExpr",
+            "trellis.models.credit_default_swap.price_cds_analytical",
+        ),
+        (
+            "monte_carlo",
+            "credit_default_swap_monte_carlo",
+            "ThenExpr",
+            "trellis.models.credit_default_swap.price_cds_monte_carlo",
+        ),
     ],
 )
 def test_compile_build_request_uses_credit_default_swap_semantic_contract_blueprint(
     preferred_method,
     expected_route,
     expected_expr_kind,
+    expected_helper,
 ):
     from trellis.agent.platform_requests import compile_build_request
 
@@ -1055,6 +1066,10 @@ def test_compile_build_request_uses_credit_default_swap_semantic_contract_bluepr
         compiled.request.metadata["semantic_blueprint"]["dsl_family_ir"]["schedule_builder_symbol"]
         == "build_cds_schedule"
     )
+    authority = compiled.request.metadata["route_binding_authority"]
+    primitive_refs = authority["backend_binding"]["primitive_refs"]
+    assert expected_helper in primitive_refs
+    assert any(ref.endswith(".build_cds_schedule") for ref in primitive_refs)
     assert "trellis.models.credit_default_swap" in compiled.semantic_blueprint.target_modules
 
 

--- a/tests/test_agent/test_platform_requests.py
+++ b/tests/test_agent/test_platform_requests.py
@@ -132,6 +132,12 @@ def test_compile_build_request_attaches_route_binding_authority_packet():
     authority = compiled.request.metadata["route_binding_authority"]
     backend_binding = authority["backend_binding"]
 
+    assert compiled.generation_plan.backend_binding_id == backend_binding["binding_id"]
+    assert compiled.generation_plan.backend_exact_target_refs == tuple(backend_binding["exact_target_refs"])
+    assert compiled.generation_plan.backend_helper_refs == tuple(backend_binding["helper_refs"])
+    assert compiled.generation_plan.backend_engine_family == backend_binding["engine_family"]
+    assert compiled.generation_plan.backend_route_family == authority["route_family"]
+    assert compiled.generation_plan.backend_compatibility_alias_policy == authority["compatibility_alias_policy"]
     assert authority["route_id"] == "quanto_adjustment_analytical"
     assert authority["route_family"] == "analytical"
     assert authority["authority_kind"] == "exact_backend_fit"

--- a/tests/test_agent/test_platform_traces.py
+++ b/tests/test_agent/test_platform_traces.py
@@ -621,6 +621,14 @@ def test_platform_trace_persists_semantic_checkpoint_and_generation_boundary(
     assert boundary["generation_boundary"]["route_binding_authority"]["route_id"] == expected_route_id
     assert trace.generation_boundary["route_binding_authority"]["authority_kind"] == "exact_backend_fit"
     assert (
+        trace.generation_boundary["primitive_plan"]["backend_binding_id"]
+        == trace.generation_boundary["route_binding_authority"]["backend_binding"]["binding_id"]
+    )
+    assert (
+        boundary["generation_boundary"]["primitive_plan"]["backend_binding_id"]
+        == boundary["generation_boundary"]["route_binding_authority"]["backend_binding"]["binding_id"]
+    )
+    assert (
         trace.generation_boundary["route_binding_authority"]["backend_binding"]["engine_family"]
         in {"analytical", "monte_carlo"}
     )

--- a/tests/test_agent/test_route_registry.py
+++ b/tests/test_agent/test_route_registry.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import pytest
 
 from dataclasses import replace
+from types import SimpleNamespace
 
 from trellis.agent.codegen_guardrails import PrimitiveRef
 from trellis.agent.family_lowering_ir import (
@@ -35,6 +36,7 @@ from trellis.agent.route_registry import (
     resolve_route_notes,
     resolve_route_primitives,
     validate_registry,
+    compile_route_binding_authority,
 )
 
 
@@ -270,6 +272,40 @@ class TestRegistryValidation:
         assert analytical_quanto.reuse_module_paths == ("instruments/_agent/quantooptionanalytical.py",)
         assert monte_carlo_quanto is not None
         assert monte_carlo_quanto.reuse_module_paths == ("instruments/_agent/quantooptionmontecarlo.py",)
+
+    def test_compile_route_binding_authority_accepts_plan_carried_binding_identity_without_route(self):
+        authority = compile_route_binding_authority(
+            generation_plan=SimpleNamespace(
+                primitive_plan=None,
+                backend_binding_id="trellis.models.synthetic.price_bound_helper",
+                backend_exact_target_refs=("trellis.models.synthetic.price_bound_helper",),
+                backend_helper_refs=("trellis.models.synthetic.price_bound_helper",),
+                backend_pricing_kernel_refs=(),
+                backend_schedule_builder_refs=(),
+                backend_cashflow_engine_refs=(),
+                backend_market_binding_refs=(),
+                backend_engine_family="analytical",
+                backend_route_family="analytical",
+                backend_compatibility_alias_policy="internal_only",
+                approved_modules=("trellis.models.synthetic",),
+                lane_plan_kind="exact_target_binding",
+                method="analytical",
+                lane_family="analytical",
+                repo_revision="test-rev",
+            ),
+        )
+
+        assert authority is not None
+        assert authority.route_id == ""
+        assert authority.route_family == "analytical"
+        assert authority.authority_kind == "exact_backend_fit"
+        assert authority.compatibility_alias_policy == "internal_only"
+        assert authority.backend_binding.binding_id == "trellis.models.synthetic.price_bound_helper"
+        assert authority.backend_binding.engine_family == "analytical"
+        assert authority.backend_binding.exact_backend_fit is True
+        assert authority.backend_binding.exact_target_refs == (
+            "trellis.models.synthetic.price_bound_helper",
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/trellis/agent/codegen_guardrails.py
+++ b/trellis/agent/codegen_guardrails.py
@@ -161,6 +161,15 @@ class PrimitivePlan:
     adapters: tuple[str, ...]
     blockers: tuple[str, ...]
     route_family: str = ""
+    backend_binding_id: str = ""
+    backend_binding_aliases: tuple[str, ...] = ()
+    backend_exact_target_refs: tuple[str, ...] = ()
+    backend_helper_refs: tuple[str, ...] = ()
+    backend_pricing_kernel_refs: tuple[str, ...] = ()
+    backend_schedule_builder_refs: tuple[str, ...] = ()
+    backend_cashflow_engine_refs: tuple[str, ...] = ()
+    backend_market_binding_refs: tuple[str, ...] = ()
+    backend_compatibility_alias_policy: str = "operator_visible"
     notes: tuple[str, ...] = ()
     score: float = 0.0
 
@@ -204,6 +213,17 @@ class GenerationPlan:
     lane_reusable_primitives: tuple[str, ...] = ()
     lane_exact_binding_refs: tuple[str, ...] = ()
     lane_unresolved_primitives: tuple[str, ...] = ()
+    backend_binding_id: str = ""
+    backend_binding_aliases: tuple[str, ...] = ()
+    backend_exact_target_refs: tuple[str, ...] = ()
+    backend_helper_refs: tuple[str, ...] = ()
+    backend_pricing_kernel_refs: tuple[str, ...] = ()
+    backend_schedule_builder_refs: tuple[str, ...] = ()
+    backend_cashflow_engine_refs: tuple[str, ...] = ()
+    backend_market_binding_refs: tuple[str, ...] = ()
+    backend_engine_family: str = ""
+    backend_route_family: str = ""
+    backend_compatibility_alias_policy: str = "operator_visible"
     lowering_route_id: str = ""
     lowering_expr_kind: str = ""
     lowering_family_ir_type: str = ""
@@ -350,6 +370,14 @@ def build_generation_plan(
         product_ir=product_ir,
         instrument_type=instrument_type,
     )
+    lane_plan_kind = str(getattr(lane_plan, "plan_kind", "") or "")
+    backend_exact_target_refs = tuple(getattr(primitive_plan, "backend_exact_target_refs", ()) or ())
+    if not backend_exact_target_refs and lane_plan_kind == "exact_target_binding":
+        backend_exact_target_refs = tuple(getattr(lane_plan, "exact_target_refs", ()) or ())
+    backend_binding_id = (
+        str(getattr(primitive_plan, "backend_binding_id", "") or "").strip()
+        or (str(backend_exact_target_refs[0]).strip() if backend_exact_target_refs else "")
+    )
 
     plan = GenerationPlan(
         method=method,
@@ -367,7 +395,7 @@ def build_generation_plan(
         package_map=package_map,
         test_map=test_map,
         lane_family=str(getattr(lane_plan, "lane_family", "") or ""),
-        lane_plan_kind=str(getattr(lane_plan, "plan_kind", "") or ""),
+        lane_plan_kind=lane_plan_kind,
         lane_timeline_roles=tuple(getattr(lane_plan, "timeline_roles", ()) or ()),
         lane_market_requirements=tuple(getattr(lane_plan, "market_requirements", ()) or ()),
         lane_state_obligations=tuple(getattr(lane_plan, "state_obligations", ()) or ()),
@@ -380,6 +408,28 @@ def build_generation_plan(
         ),
         lane_exact_binding_refs=tuple(getattr(lane_plan, "exact_target_refs", ()) or ()),
         lane_unresolved_primitives=tuple(getattr(lane_plan, "unresolved_primitives", ()) or ()),
+        backend_binding_id=backend_binding_id,
+        backend_binding_aliases=tuple(getattr(primitive_plan, "backend_binding_aliases", ()) or ()),
+        backend_exact_target_refs=backend_exact_target_refs,
+        backend_helper_refs=tuple(getattr(primitive_plan, "backend_helper_refs", ()) or ()),
+        backend_pricing_kernel_refs=tuple(
+            getattr(primitive_plan, "backend_pricing_kernel_refs", ()) or ()
+        ),
+        backend_schedule_builder_refs=tuple(
+            getattr(primitive_plan, "backend_schedule_builder_refs", ()) or ()
+        ),
+        backend_cashflow_engine_refs=tuple(
+            getattr(primitive_plan, "backend_cashflow_engine_refs", ()) or ()
+        ),
+        backend_market_binding_refs=tuple(
+            getattr(primitive_plan, "backend_market_binding_refs", ()) or ()
+        ),
+        backend_engine_family=str(getattr(primitive_plan, "engine_family", "") or ""),
+        backend_route_family=str(getattr(primitive_plan, "route_family", "") or ""),
+        backend_compatibility_alias_policy=str(
+            getattr(primitive_plan, "backend_compatibility_alias_policy", None)
+            or "operator_visible"
+        ),
     )
     plan = replace(
         plan,
@@ -939,6 +989,24 @@ def enrich_generation_plan(
         semantic_id=semantic_id,
         requested_instrument_type=requested_instrument_type,
     )
+    lane_plan_kind = str(getattr(lane_plan, "plan_kind", "") or "")
+    preserve_backend_binding = bool(
+        plan.primitive_plan is not None or lane_plan_kind == "exact_target_binding"
+    )
+    backend_exact_target_refs = tuple(getattr(plan, "backend_exact_target_refs", ()) or ())
+    if not plan.primitive_plan and lane_plan_kind == "exact_target_binding":
+        backend_exact_target_refs = tuple(getattr(lane_plan, "exact_target_refs", ()) or ())
+    elif not preserve_backend_binding:
+        backend_exact_target_refs = ()
+    backend_binding_id = (
+        str(getattr(plan.primitive_plan, "backend_binding_id", "") or "").strip()
+        or (str(backend_exact_target_refs[0]).strip() if backend_exact_target_refs else "")
+        or (
+            str(getattr(plan, "backend_binding_id", "") or "").strip()
+            if preserve_backend_binding
+            else ""
+        )
+    )
 
     enriched_plan = replace(
         plan,
@@ -955,7 +1023,7 @@ def enrich_generation_plan(
         ),
         valuation_requested_outputs=tuple(getattr(semantic_blueprint, "requested_outputs", ()) or ()),
         lane_family=str(getattr(lane_plan, "lane_family", "") or ""),
-        lane_plan_kind=str(getattr(lane_plan, "plan_kind", "") or ""),
+        lane_plan_kind=lane_plan_kind,
         lane_timeline_roles=tuple(getattr(lane_plan, "timeline_roles", ()) or ()),
         lane_market_requirements=tuple(getattr(lane_plan, "market_requirements", ()) or ()),
         lane_state_obligations=tuple(getattr(lane_plan, "state_obligations", ()) or ()),
@@ -968,6 +1036,53 @@ def enrich_generation_plan(
         ),
         lane_exact_binding_refs=tuple(getattr(lane_plan, "exact_target_refs", ()) or ()),
         lane_unresolved_primitives=tuple(getattr(lane_plan, "unresolved_primitives", ()) or ()),
+        backend_binding_id=backend_binding_id,
+        backend_binding_aliases=(
+            tuple(getattr(plan, "backend_binding_aliases", ()) or ())
+            if preserve_backend_binding
+            else ()
+        ),
+        backend_exact_target_refs=backend_exact_target_refs,
+        backend_helper_refs=(
+            tuple(getattr(plan, "backend_helper_refs", ()) or ())
+            if preserve_backend_binding
+            else ()
+        ),
+        backend_pricing_kernel_refs=(
+            tuple(getattr(plan, "backend_pricing_kernel_refs", ()) or ())
+            if preserve_backend_binding
+            else ()
+        ),
+        backend_schedule_builder_refs=(
+            tuple(getattr(plan, "backend_schedule_builder_refs", ()) or ())
+            if preserve_backend_binding
+            else ()
+        ),
+        backend_cashflow_engine_refs=(
+            tuple(getattr(plan, "backend_cashflow_engine_refs", ()) or ())
+            if preserve_backend_binding
+            else ()
+        ),
+        backend_market_binding_refs=(
+            tuple(getattr(plan, "backend_market_binding_refs", ()) or ())
+            if preserve_backend_binding
+            else ()
+        ),
+        backend_engine_family=(
+            str(getattr(plan, "backend_engine_family", "") or "")
+            if preserve_backend_binding
+            else ""
+        ),
+        backend_route_family=(
+            str(getattr(plan, "backend_route_family", "") or "")
+            if preserve_backend_binding
+            else ""
+        ),
+        backend_compatibility_alias_policy=(
+            str(getattr(plan, "backend_compatibility_alias_policy", "") or "operator_visible")
+            if preserve_backend_binding
+            else "operator_visible"
+        ),
         lowering_route_id=str(getattr(lowering, "route_id", "") or ""),
         lowering_expr_kind=(
             "" if lowering is None or getattr(lowering, "normalized_expr", None) is None
@@ -1387,10 +1502,16 @@ def rank_primitive_routes(
         resolve_route_notes,
         resolve_route_primitives,
     )
+    from trellis.agent.backend_bindings import (
+        find_backend_binding_by_route_id,
+        load_backend_binding_catalog,
+        resolve_backend_binding_spec,
+    )
     from trellis.agent.route_scorer import RouteScorer, ScoringContext
 
     method = normalize_method(pricing_plan.method)
     registry = load_route_registry()
+    binding_catalog = load_backend_binding_catalog(registry=registry)
     candidates = match_candidate_routes(
         registry, method, product_ir, pricing_plan=pricing_plan,
     )
@@ -1409,6 +1530,13 @@ def rank_primitive_routes(
         route_family = resolve_route_family(spec, product_ir)
         if route == "exercise_lattice" and route_family == "equity_tree":
             engine_family = "tree"
+        binding_spec = None
+        binding_entry = find_backend_binding_by_route_id(route, binding_catalog)
+        if binding_entry is not None:
+            binding_spec = resolve_backend_binding_spec(
+                binding_entry,
+                product_ir=product_ir,
+            )
 
         ctx = ScoringContext(
             product_ir=product_ir,
@@ -1427,6 +1555,17 @@ def rank_primitive_routes(
             adapters=tuple(adapters),
             blockers=tuple(dict.fromkeys(blockers)),
             notes=tuple(notes),
+            backend_binding_id=str(getattr(binding_spec, "binding_id", "") or ""),
+            backend_binding_aliases=tuple(getattr(binding_spec, "aliases", ()) or ()),
+            backend_exact_target_refs=tuple(getattr(binding_spec, "exact_target_refs", ()) or ()),
+            backend_helper_refs=tuple(getattr(binding_spec, "helper_refs", ()) or ()),
+            backend_pricing_kernel_refs=tuple(getattr(binding_spec, "pricing_kernel_refs", ()) or ()),
+            backend_schedule_builder_refs=tuple(getattr(binding_spec, "schedule_builder_refs", ()) or ()),
+            backend_cashflow_engine_refs=tuple(getattr(binding_spec, "cashflow_engine_refs", ()) or ()),
+            backend_market_binding_refs=tuple(getattr(binding_spec, "market_binding_refs", ()) or ()),
+            backend_compatibility_alias_policy=str(
+                getattr(binding_spec, "compatibility_alias_policy", None) or "operator_visible"
+            ),
             score=route_score.final_score,
         )
         ranked.append(plan)

--- a/trellis/agent/platform_traces.py
+++ b/trellis/agent/platform_traces.py
@@ -560,6 +560,13 @@ def _generation_boundary_summary(
                 "route": getattr(primitive_plan, "route", ""),
                 "engine_family": getattr(primitive_plan, "engine_family", ""),
                 "route_family": getattr(primitive_plan, "route_family", ""),
+                "backend_binding_id": getattr(primitive_plan, "backend_binding_id", ""),
+                "backend_exact_target_refs": list(
+                    getattr(primitive_plan, "backend_exact_target_refs", ()) or ()
+                ),
+                "backend_helper_refs": list(
+                    getattr(primitive_plan, "backend_helper_refs", ()) or ()
+                ),
                 "adapters": list(getattr(primitive_plan, "adapters", ()) or ()),
                 "blockers": list(getattr(primitive_plan, "blockers", ()) or ()),
             }

--- a/trellis/agent/route_registry.py
+++ b/trellis/agent/route_registry.py
@@ -994,7 +994,20 @@ def compile_route_binding_authority(
     route_id = _route_id_for_authority(generation_plan=generation_plan, semantic_blueprint=semantic_blueprint)
     primitive_plan = getattr(generation_plan, "primitive_plan", None)
     route_spec = find_route_by_id(route_id, registry) if route_id else None
-    if not route_id and primitive_plan is None and route_spec is None:
+    lane_plan_kind = str(getattr(generation_plan, "lane_plan_kind", "") or "").strip()
+    has_plan_binding_identity = bool(
+        lane_plan_kind == "exact_target_binding"
+        and (
+            str(getattr(generation_plan, "backend_binding_id", "") or "").strip()
+            or tuple(getattr(generation_plan, "backend_exact_target_refs", ()) or ())
+            or tuple(getattr(generation_plan, "backend_helper_refs", ()) or ())
+            or tuple(getattr(generation_plan, "backend_pricing_kernel_refs", ()) or ())
+            or tuple(getattr(generation_plan, "backend_schedule_builder_refs", ()) or ())
+            or tuple(getattr(generation_plan, "backend_cashflow_engine_refs", ()) or ())
+            or tuple(getattr(generation_plan, "backend_market_binding_refs", ()) or ())
+        )
+    )
+    if not route_id and primitive_plan is None and route_spec is None and not has_plan_binding_identity:
         return None
 
     binding_catalog = load_backend_binding_catalog(registry=registry)
@@ -1009,26 +1022,39 @@ def compile_route_binding_authority(
             )
 
     route_family = (
-        str(getattr(binding_spec, "route_family", "") or "").strip()
+        str(getattr(generation_plan, "backend_route_family", "") or "").strip()
+        or str(getattr(binding_spec, "route_family", "") or "").strip()
         or str(getattr(route_spec, "route_family", "") or "").strip()
         or str(getattr(primitive_plan, "route_family", "") or "").strip()
         or str(getattr(validation_contract, "route_family", "") or "").strip()
     )
     engine_family = (
-        str(getattr(binding_spec, "engine_family", "") or "").strip()
+        str(getattr(generation_plan, "backend_engine_family", "") or "").strip()
+        or str(getattr(binding_spec, "engine_family", "") or "").strip()
         or str(getattr(route_spec, "engine_family", "") or "").strip()
         or str(getattr(primitive_plan, "engine_family", "") or "").strip()
         or route_family
     )
-    exact_target_refs = (
-        tuple(getattr(generation_plan, "lane_exact_binding_refs", ()) or ())
-        or tuple(getattr(binding_spec, "exact_target_refs", ()) or ())
+    exact_target_refs = tuple(
+        dict.fromkeys(
+            str(ref).strip()
+            for ref in (
+                getattr(generation_plan, "backend_exact_target_refs", ())
+                or getattr(primitive_plan, "backend_exact_target_refs", ())
+                or getattr(generation_plan, "lane_exact_binding_refs", ())
+                or getattr(binding_spec, "exact_target_refs", ())
+                or ()
+            )
+            if str(ref).strip()
+        )
     )
     helper_refs = tuple(
         dict.fromkeys(
             str(ref).strip()
             for ref in (
-                getattr(generation_plan, "lowering_helper_refs", ())
+                getattr(generation_plan, "backend_helper_refs", ())
+                or getattr(primitive_plan, "backend_helper_refs", ())
+                or getattr(generation_plan, "lowering_helper_refs", ())
                 or getattr(getattr(semantic_blueprint, "dsl_lowering", None), "helper_refs", ())
                 or getattr(binding_spec, "helper_refs", ())
                 or ()
@@ -1036,15 +1062,70 @@ def compile_route_binding_authority(
             if str(ref).strip()
         )
     )
-    primitive_refs = tuple(getattr(binding_spec, "primitive_refs", ()) or ()) or _primitive_refs_for(
+    primitive_refs = tuple(
+        dict.fromkeys(
+            str(ref).strip()
+            for ref in (
+                getattr(generation_plan, "backend_exact_target_refs", ())
+                or getattr(primitive_plan, "backend_exact_target_refs", ())
+                or getattr(binding_spec, "primitive_refs", ())
+                or ()
+            )
+            if str(ref).strip()
+        )
+    ) or _primitive_refs_for(
         primitive_plan=primitive_plan,
         route_spec=route_spec,
         product_ir=product_ir,
     )
-    pricing_kernel_refs = tuple(getattr(binding_spec, "pricing_kernel_refs", ()) or ())
-    schedule_builder_refs = tuple(getattr(binding_spec, "schedule_builder_refs", ()) or ())
-    cashflow_engine_refs = tuple(getattr(binding_spec, "cashflow_engine_refs", ()) or ())
-    market_binding_refs = tuple(getattr(binding_spec, "market_binding_refs", ()) or ())
+    pricing_kernel_refs = tuple(
+        dict.fromkeys(
+            str(ref).strip()
+            for ref in (
+                getattr(generation_plan, "backend_pricing_kernel_refs", ())
+                or getattr(primitive_plan, "backend_pricing_kernel_refs", ())
+                or getattr(binding_spec, "pricing_kernel_refs", ())
+                or ()
+            )
+            if str(ref).strip()
+        )
+    )
+    schedule_builder_refs = tuple(
+        dict.fromkeys(
+            str(ref).strip()
+            for ref in (
+                getattr(generation_plan, "backend_schedule_builder_refs", ())
+                or getattr(primitive_plan, "backend_schedule_builder_refs", ())
+                or getattr(binding_spec, "schedule_builder_refs", ())
+                or ()
+            )
+            if str(ref).strip()
+        )
+    )
+    cashflow_engine_refs = tuple(
+        dict.fromkeys(
+            str(ref).strip()
+            for ref in (
+                getattr(generation_plan, "backend_cashflow_engine_refs", ())
+                or getattr(primitive_plan, "backend_cashflow_engine_refs", ())
+                or getattr(binding_spec, "cashflow_engine_refs", ())
+                or ()
+            )
+            if str(ref).strip()
+        )
+    )
+    market_binding_refs = tuple(
+        dict.fromkeys(
+            str(ref).strip()
+            for ref in (
+                getattr(generation_plan, "backend_market_binding_refs", ())
+                or getattr(primitive_plan, "backend_market_binding_refs", ())
+                or getattr(binding_spec, "market_binding_refs", ())
+                or ()
+            )
+            if str(ref).strip()
+        )
+    )
     approved_modules = tuple(
         dict.fromkeys(
             str(module).strip()
@@ -1092,8 +1173,18 @@ def compile_route_binding_authority(
         "lane_plan_kind": str(getattr(generation_plan, "lane_plan_kind", "") or ""),
         "repo_revision": str(getattr(generation_plan, "repo_revision", "") or ""),
     }
+    compatibility_alias_policy = (
+        str(getattr(generation_plan, "backend_compatibility_alias_policy", "") or "").strip()
+        or str(getattr(primitive_plan, "backend_compatibility_alias_policy", "") or "").strip()
+        or str(getattr(binding_spec, "compatibility_alias_policy", "") or "").strip()
+        or str(getattr(route_spec, "compatibility_alias_policy", "") or "").strip()
+        or "operator_visible"
+    )
     backend_binding = BackendBindingAuthority(
-        binding_id=str(getattr(binding_spec, "binding_id", "") or "").strip() or _backend_binding_id_for(
+        binding_id=str(getattr(generation_plan, "backend_binding_id", "") or "").strip()
+        or str(getattr(primitive_plan, "backend_binding_id", "") or "").strip()
+        or str(getattr(binding_spec, "binding_id", "") or "").strip()
+        or _backend_binding_id_for(
             engine_family=engine_family,
             route_family=route_family,
             exact_target_refs=exact_target_refs,
@@ -1119,7 +1210,7 @@ def compile_route_binding_authority(
         route_family=route_family,
         authority_kind=authority_kind,
         backend_binding=backend_binding,
-        compatibility_alias_policy=str(getattr(route_spec, "compatibility_alias_policy", "") or "operator_visible"),
+        compatibility_alias_policy=compatibility_alias_policy,
         validation_bundle_id=validation_bundle_id,
         validation_check_ids=validation_check_ids,
         canary_task_ids=canary_task_ids,

--- a/trellis/agent/route_registry.py
+++ b/trellis/agent/route_registry.py
@@ -1065,18 +1065,19 @@ def compile_route_binding_authority(
     primitive_refs = tuple(
         dict.fromkeys(
             str(ref).strip()
-            for ref in (
-                getattr(generation_plan, "backend_exact_target_refs", ())
-                or getattr(primitive_plan, "backend_exact_target_refs", ())
-                or getattr(binding_spec, "primitive_refs", ())
-                or ()
+            for refs in (
+                getattr(binding_spec, "primitive_refs", ()) or (),
+                _primitive_refs_for(
+                    primitive_plan=primitive_plan,
+                    route_spec=route_spec,
+                    product_ir=product_ir,
+                ),
+                getattr(generation_plan, "backend_exact_target_refs", ()) or (),
+                getattr(primitive_plan, "backend_exact_target_refs", ()) or (),
             )
+            for ref in refs
             if str(ref).strip()
         )
-    ) or _primitive_refs_for(
-        primitive_plan=primitive_plan,
-        route_spec=route_spec,
-        product_ir=product_ir,
     )
     pricing_kernel_refs = tuple(
         dict.fromkeys(


### PR DESCRIPTION
## Summary
- carry backend binding identity through `PrimitivePlan` and `GenerationPlan`
- make route binding authority and trace summaries prefer plan-carried binding facts
- add regression coverage and refresh the `T38` replay cassette for the current branch surface

## Validation
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_route_registry.py tests/test_agent/test_codegen_guardrails.py tests/test_agent/test_platform_requests.py tests/test_agent/test_platform_traces.py -q`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_tasks/test_t01_zcb_option.py tests/test_contracts/test_canary_replay_contracts.py -q`
- `/Users/steveyang/miniforge3/bin/python3 scripts/run_knowledge_light_proving.py --cases KL01 --output /tmp/qua799_kl01.json`
- `/Users/steveyang/miniforge3/bin/python3 -m py_compile trellis/agent/codegen_guardrails.py trellis/agent/route_registry.py trellis/agent/platform_traces.py`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/ -x -q -m "not integration"`
