### PR TITLE
QUA-800: move exact binding lookup onto binding specs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -85,6 +85,10 @@ maintenance around the deterministic engines.
   on `PrimitivePlan` and `GenerationPlan`, so runtime plans no longer need to
   rediscover exact helper identity from route ids later in validation or trace
   code.
+- `trellis/agent/dsl_lowering.py` and
+  `trellis/agent/semantic_validators/algorithm_contract.py` now consume the
+  resolved binding surface first, so exact helper/kernel/schedule lookup is
+  binding-first even while route ids still exist as transitional aliases.
 - `trellis/agent/route_registry.py`, `trellis/agent/build_gate.py`,
   `trellis/agent/family_lowering_ir.py`, and `trellis/agent/dsl_lowering.py`
   govern admissibility and lowering onto checked route families. The route

--- a/docs/plans/binding-first-exotic-assembly.md
+++ b/docs/plans/binding-first-exotic-assembly.md
@@ -149,7 +149,7 @@ Status mirror last synced: `2026-04-12`
 | --- | --- |
 | `QUA-798` | Backend binding: introduce canonical binding catalog beside route registry | Done |
 | `QUA-799` | Backend binding: carry binding identity through primitive and generation plans | Done |
-| `QUA-800` | Backend binding: move exact helper and kernel lookup onto binding specs | Backlog |
+| `QUA-800` | Backend binding: move exact helper and kernel lookup onto binding specs | Done |
 | `QUA-810` | Route aliases: collapse route registry to transitional alias and admissibility shell | Backlog |
 
 ### Ordered Lowering And Assembly Queue

--- a/docs/quant/pricing_stack.rst
+++ b/docs/quant/pricing_stack.rst
@@ -199,6 +199,10 @@ The runtime plans now also carry that identity directly: ``PrimitivePlan`` and
 ``GenerationPlan`` persist ``backend_binding_id`` plus exact helper/kernel and
 schedule-builder refs, so later validation, traces, and replay do not need to
 reconstruct the binding contract from a route alias.
+That exact-surface contract now also drives live plan construction, DSL
+lowering, and semantic helper review: those paths resolve helpers, kernels,
+and schedule builders from ``trellis.agent.backend_bindings`` first and only
+fall back to route-card primitives when no binding surface exists.
 The generated prompt-skill layer now follows the same contract: exact helper
 and schedule constraints still surface when needed, but route-card notes are
 kept as historical metadata rather than live ``route_hint`` authority, and

--- a/tests/test_agent/test_backend_bindings.py
+++ b/tests/test_agent/test_backend_bindings.py
@@ -53,6 +53,7 @@ def test_resolve_backend_binding_spec_captures_helper_schedule_and_cashflow_role
     )
 
     assert cds_resolved.binding_id == "trellis.models.credit_default_swap.price_cds_monte_carlo"
+    assert cds_resolved.primitives[0].symbol == "build_cds_schedule"
     assert cds_resolved.helper_refs == (
         "trellis.models.credit_default_swap.price_cds_monte_carlo",
     )

--- a/tests/test_agent/test_codegen_guardrails.py
+++ b/tests/test_agent/test_codegen_guardrails.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 from trellis.agent.codegen_guardrails import (
+    PrimitiveRef,
     build_generation_plan,
+    rank_primitive_routes,
     render_generation_plan,
     render_review_contract_card,
     render_generation_route_card,
@@ -84,6 +88,87 @@ def test_generation_plan_carries_backend_binding_identity_for_exact_helper_route
         "trellis.models.quanto_option.price_quanto_option_analytical_from_market_state",
     )
     assert compiled.generation_plan.backend_compatibility_alias_policy == "internal_only"
+
+
+def test_rank_primitive_routes_prefers_binding_spec_primitives_when_route_card_is_stale(monkeypatch):
+    from trellis.agent import backend_bindings as backend_bindings_module
+    from trellis.agent import route_registry as route_registry_module
+    from trellis.agent import route_scorer as route_scorer_module
+
+    stale_helper = PrimitiveRef("trellis.models.stale", "stale_helper", "route_helper")
+    fresh_helper = PrimitiveRef("trellis.models.synthetic", "fresh_helper", "route_helper")
+    spec = SimpleNamespace(
+        id="synthetic_route",
+        engine_family="analytical",
+        route_family="analytical",
+        score_hints={},
+        aliases=(),
+    )
+
+    monkeypatch.setattr(
+        route_registry_module,
+        "load_route_registry",
+        lambda: SimpleNamespace(routes=(spec,)),
+    )
+    monkeypatch.setattr(
+        route_registry_module,
+        "match_candidate_routes",
+        lambda registry, method, product_ir, pricing_plan=None: (spec,),
+    )
+    monkeypatch.setattr(
+        route_registry_module,
+        "resolve_route_primitives",
+        lambda spec, product_ir: (stale_helper,),
+    )
+    monkeypatch.setattr(route_registry_module, "resolve_route_adapters", lambda spec, product_ir: ())
+    monkeypatch.setattr(route_registry_module, "resolve_route_notes", lambda spec, product_ir: ())
+    monkeypatch.setattr(route_registry_module, "resolve_route_family", lambda spec, product_ir: "analytical")
+    monkeypatch.setattr(
+        backend_bindings_module,
+        "load_backend_binding_catalog",
+        lambda registry=None: object(),
+    )
+    monkeypatch.setattr(
+        backend_bindings_module,
+        "resolve_backend_binding_by_route_id",
+        lambda route_id, product_ir=None, primitive_plan=None, catalog=None: SimpleNamespace(
+            primitives=(fresh_helper,),
+            binding_id="trellis.models.synthetic.fresh_helper",
+            aliases=(),
+            exact_target_refs=("trellis.models.synthetic.fresh_helper",),
+            helper_refs=("trellis.models.synthetic.fresh_helper",),
+            pricing_kernel_refs=(),
+            schedule_builder_refs=(),
+            cashflow_engine_refs=(),
+            market_binding_refs=(),
+            compatibility_alias_policy="operator_visible",
+            engine_family="analytical",
+            route_family="analytical",
+        ),
+    )
+
+    class _FakeScorer:
+        def __init__(self, registry):
+            self.registry = registry
+
+        def score_route(self, ctx):
+            return SimpleNamespace(final_score=1.0)
+
+    monkeypatch.setattr(route_scorer_module, "RouteScorer", _FakeScorer)
+
+    ranked = rank_primitive_routes(
+        pricing_plan=PricingPlan(
+            method="analytical",
+            method_modules=["trellis.models.synthetic"],
+            required_market_data=set(),
+            model_to_build="synthetic",
+            reasoning="test",
+        ),
+        product_ir=None,
+    )
+
+    assert ranked[0].primitives == (fresh_helper,)
+    assert ranked[0].backend_binding_id == "trellis.models.synthetic.fresh_helper"
 
 
 def test_validate_generated_imports_accepts_valid_code():

--- a/tests/test_agent/test_dsl_lowering.py
+++ b/tests/test_agent/test_dsl_lowering.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
+from trellis.agent.codegen_guardrails import PrimitiveRef
 from trellis.agent.dsl_algebra import ChoiceExpr, ContractAtom, ThenExpr, ControlStyle
 from trellis.agent.family_lowering_ir import (
     AnalyticalBlack76IR,
@@ -104,6 +107,48 @@ def test_callable_bond_lowers_to_explicit_issuer_choice_plus_helper_targets():
         in lowering.helper_refs
     )
     assert "trellis.models.callable_bond_tree" in blueprint.route_modules
+
+
+def test_quanto_lowering_prefers_binding_spec_targets_when_route_primitives_are_stale(monkeypatch):
+    from trellis.agent import backend_bindings as backend_bindings_module
+    from trellis.agent import dsl_lowering as dsl_lowering_module
+    from trellis.agent.semantic_contract_compiler import compile_semantic_contract
+    from trellis.agent.semantic_contracts import make_quanto_option_contract
+
+    monkeypatch.setattr(
+        dsl_lowering_module,
+        "resolve_route_primitives",
+        lambda route, product_ir: (),
+    )
+    monkeypatch.setattr(
+        backend_bindings_module,
+        "resolve_backend_binding_by_route_id",
+        lambda route_id, product_ir=None, primitive_plan=None, catalog=None: SimpleNamespace(
+            primitives=(
+                PrimitiveRef(
+                    "trellis.models.quanto_option",
+                    "price_quanto_option_analytical_from_market_state",
+                    "route_helper",
+                ),
+            ),
+            route_family="analytical",
+        ),
+    )
+
+    contract = make_quanto_option_contract(
+        description="Quanto option on SAP in USD with EUR underlier currency expiring 2025-11-15",
+        underliers=("SAP",),
+        observation_schedule=("2025-11-15",),
+        preferred_method="analytical",
+    )
+    blueprint = compile_semantic_contract(contract, preferred_method="analytical")
+
+    lowering = blueprint.dsl_lowering
+    assert lowering is not None
+    assert lowering.errors == ()
+    assert lowering.helper_refs == (
+        "trellis.models.quanto_option.price_quanto_option_analytical_from_market_state",
+    )
 
 
 def test_callable_bond_pde_lowers_to_event_aware_helper():

--- a/tests/test_agent/test_semantic_validators.py
+++ b/tests/test_agent/test_semantic_validators.py
@@ -196,6 +196,27 @@ def evaluate(self, market_state):
         findings = validator.validate(source, _make_plan("quanto_adjustment_analytical"), spec)
         assert any(f.category == "route_helper_not_called" for f in findings)
 
+    def test_prefers_plan_primitives_over_route_card_for_route_helper_checks(self, registry):
+        spec = [r for r in registry.routes if r.id == "analytical_garman_kohlhagen"][0]
+        spec = replace(spec, primitives=())
+        plan = _make_plan(
+            "analytical_garman_kohlhagen",
+            primitives=(
+                PrimitiveRef(
+                    "trellis.models.fx_vanilla",
+                    "price_fx_vanilla_analytical",
+                    "route_helper",
+                ),
+            ),
+        )
+        source = '''
+def evaluate(self, market_state):
+    return 42.0
+'''
+        validator = AlgorithmContractValidator()
+        findings = validator.validate(source, plan, spec)
+        assert any(f.category == "route_helper_not_called" for f in findings)
+
     def test_flags_missing_discount(self, registry):
         spec = [r for r in registry.routes if r.id == "analytical_black76"][0]
         source = '''

--- a/trellis/agent/backend_bindings.py
+++ b/trellis/agent/backend_bindings.py
@@ -55,6 +55,7 @@ class ResolvedBackendBindingSpec:
     aliases: tuple[str, ...] = ()
     compatibility_alias_policy: str = "operator_visible"
     binding_id: str = ""
+    primitives: tuple[PrimitiveRef, ...] = ()
     primitive_refs: tuple[str, ...] = ()
     helper_refs: tuple[str, ...] = ()
     pricing_kernel_refs: tuple[str, ...] = ()
@@ -170,6 +171,7 @@ def resolve_backend_binding_spec(
         aliases=binding.aliases,
         compatibility_alias_policy=binding.compatibility_alias_policy,
         binding_id=binding_id,
+        primitives=primitives,
         primitive_refs=primitive_refs,
         helper_refs=helper_refs,
         pricing_kernel_refs=pricing_kernel_refs,
@@ -177,6 +179,24 @@ def resolve_backend_binding_spec(
         cashflow_engine_refs=cashflow_engine_refs,
         market_binding_refs=market_binding_refs,
         exact_target_refs=exact_target_refs,
+    )
+
+
+def resolve_backend_binding_by_route_id(
+    route_id: str,
+    *,
+    product_ir: ProductIR | None = None,
+    primitive_plan=None,
+    catalog: BackendBindingCatalog | None = None,
+) -> ResolvedBackendBindingSpec | None:
+    """Resolve one binding surface by route id or alias."""
+    binding = find_backend_binding_by_route_id(route_id, catalog)
+    if binding is None:
+        return None
+    return resolve_backend_binding_spec(
+        binding,
+        product_ir=product_ir,
+        primitive_plan=primitive_plan,
     )
 
 

--- a/trellis/agent/codegen_guardrails.py
+++ b/trellis/agent/codegen_guardrails.py
@@ -1503,9 +1503,8 @@ def rank_primitive_routes(
         resolve_route_primitives,
     )
     from trellis.agent.backend_bindings import (
-        find_backend_binding_by_route_id,
         load_backend_binding_catalog,
-        resolve_backend_binding_spec,
+        resolve_backend_binding_by_route_id,
     )
     from trellis.agent.route_scorer import RouteScorer, ScoringContext
 
@@ -1520,23 +1519,22 @@ def rank_primitive_routes(
 
     ranked: list[PrimitivePlan] = []
     for spec in candidates:
-        primitives = list(resolve_route_primitives(spec, product_ir))
+        route_primitives = list(resolve_route_primitives(spec, product_ir))
         adapters = resolve_route_adapters(spec, product_ir)
         notes = resolve_route_notes(spec, product_ir)
         route = spec.id
+        binding_spec = resolve_backend_binding_by_route_id(
+            route,
+            product_ir=product_ir,
+            catalog=binding_catalog,
+        )
+        primitives = list(getattr(binding_spec, "primitives", ()) or route_primitives)
         blockers = list(product_ir.unresolved_primitives if product_ir is not None else ())
         blockers.extend(_verify_primitives(primitives))
-        engine_family = spec.engine_family
-        route_family = resolve_route_family(spec, product_ir)
+        engine_family = str(getattr(binding_spec, "engine_family", "") or spec.engine_family)
+        route_family = str(getattr(binding_spec, "route_family", "") or resolve_route_family(spec, product_ir))
         if route == "exercise_lattice" and route_family == "equity_tree":
             engine_family = "tree"
-        binding_spec = None
-        binding_entry = find_backend_binding_by_route_id(route, binding_catalog)
-        if binding_entry is not None:
-            binding_spec = resolve_backend_binding_spec(
-                binding_entry,
-                product_ir=product_ir,
-            )
 
         ctx = ScoringContext(
             product_ir=product_ir,

--- a/trellis/agent/dsl_lowering.py
+++ b/trellis/agent/dsl_lowering.py
@@ -163,17 +163,17 @@ def lower_semantic_blueprint(
             )
             continue
 
-        bindings = tuple(
-            DslTargetBinding(
-                module=primitive.module,
-                symbol=primitive.symbol,
-                role=primitive.role,
-                required=primitive.required,
-            )
-            for primitive in resolve_route_primitives(route, product_ir)
+        binding_spec = _resolve_backend_binding_for_route(
+            route_id,
+            product_ir=product_ir,
+        )
+        bindings = _target_bindings_for_route(
+            route,
+            product_ir=product_ir,
+            binding_spec=binding_spec,
         )
 
-        route_family = resolve_route_family(route, product_ir)
+        route_family = str(getattr(binding_spec, "route_family", "") or resolve_route_family(route, product_ir))
         adapters = resolve_route_adapters(route, product_ir)
         notes = resolve_route_notes(route, product_ir)
         try:
@@ -281,6 +281,39 @@ def lower_semantic_blueprint(
         expr=None,
         normalized_expr=None,
         errors=tuple(errors),
+    )
+
+
+def _resolve_backend_binding_for_route(
+    route_id: str,
+    *,
+    product_ir,
+):
+    """Resolve the canonical backend binding for one route when available."""
+    try:
+        from trellis.agent.backend_bindings import resolve_backend_binding_by_route_id
+
+        return resolve_backend_binding_by_route_id(route_id, product_ir=product_ir)
+    except Exception:
+        return None
+
+
+def _target_bindings_for_route(
+    route,
+    *,
+    product_ir,
+    binding_spec,
+) -> tuple[DslTargetBinding, ...]:
+    """Resolve DSL bindings from the binding catalog before falling back to route cards."""
+    primitives = tuple(getattr(binding_spec, "primitives", ()) or resolve_route_primitives(route, product_ir))
+    return tuple(
+        DslTargetBinding(
+            module=primitive.module,
+            symbol=primitive.symbol,
+            role=primitive.role,
+            required=primitive.required,
+        )
+        for primitive in primitives
     )
 
 

--- a/trellis/agent/semantic_validators/algorithm_contract.py
+++ b/trellis/agent/semantic_validators/algorithm_contract.py
@@ -456,12 +456,14 @@ class AlgorithmContractValidator:
         if route_spec is None:
             return ()
 
+        exact_surface_primitives = _exact_surface_primitives(plan, route_spec)
+
         # 1. Engine family consistency
-        findings.extend(self._check_engine_family(source, route_spec))
+        findings.extend(self._check_engine_family(source, route_spec, exact_surface_primitives))
 
         # 2. Route helper usage
-        findings.extend(self._check_route_helper(source, route_spec))
-        findings.extend(self._check_exact_helper_surface(source, route_spec))
+        findings.extend(self._check_route_helper(source, route_spec, exact_surface_primitives))
+        findings.extend(self._check_exact_helper_surface(source, route_spec, exact_surface_primitives))
 
         # 3. Discount application
         findings.extend(self._check_discount_application(source, route_spec))
@@ -472,7 +474,10 @@ class AlgorithmContractValidator:
         return tuple(findings)
 
     def _check_engine_family(
-        self, source: str, route_spec: RouteSpec,
+        self,
+        source: str,
+        route_spec: RouteSpec,
+        exact_surface_primitives,
     ) -> list[SemanticFinding]:
         """Verify code uses the expected engine family signatures."""
         engine = route_spec.engine_family
@@ -482,7 +487,7 @@ class AlgorithmContractValidator:
 
         helper_symbols = tuple(
             prim.symbol
-            for prim in route_spec.primitives
+            for prim in exact_surface_primitives
             if prim.role == "route_helper" and prim.required
         )
         if helper_symbols and any(_calls_symbol(source, symbol) for symbol in helper_symbols):
@@ -503,11 +508,14 @@ class AlgorithmContractValidator:
         return []
 
     def _check_route_helper(
-        self, source: str, route_spec: RouteSpec,
+        self,
+        source: str,
+        route_spec: RouteSpec,
+        exact_surface_primitives,
     ) -> list[SemanticFinding]:
         """Verify route_helper primitives are actually called."""
         findings = []
-        for prim in route_spec.primitives:
+        for prim in exact_surface_primitives:
             if prim.role == "route_helper" and prim.required:
                 if not _calls_symbol(source, prim.symbol):
                     findings.append(SemanticFinding(
@@ -523,7 +531,10 @@ class AlgorithmContractValidator:
         return findings
 
     def _check_exact_helper_surface(
-        self, source: str, route_spec: RouteSpec,
+        self,
+        source: str,
+        route_spec: RouteSpec,
+        exact_surface_primitives,
     ) -> list[SemanticFinding]:
         """Verify exact backend helpers are called with an admissible surface."""
         try:
@@ -532,7 +543,7 @@ class AlgorithmContractValidator:
             return []
 
         findings: list[SemanticFinding] = []
-        for prim in route_spec.primitives:
+        for prim in exact_surface_primitives:
             if prim.role != "route_helper" or not prim.required:
                 continue
             signature = _EXACT_HELPER_SIGNATURES.get(prim.symbol)
@@ -644,6 +655,18 @@ class AlgorithmContractValidator:
                 ),
             )]
         return []
+
+
+def _exact_surface_primitives(
+    plan: GenerationPlan,
+    route_spec: RouteSpec,
+):
+    """Prefer the compiled plan's resolved primitives over route-card primitives."""
+    primitive_plan = getattr(plan, "primitive_plan", None)
+    plan_primitives = tuple(getattr(primitive_plan, "primitives", ()) or ())
+    if plan_primitives:
+        return plan_primitives
+    return tuple(getattr(route_spec, "primitives", ()) or ())
 
 
 def _call_satisfies_required_surface(


### PR DESCRIPTION
## Summary
- move exact helper/kernel/schedule lookup onto resolved backend binding specs
- make primitive planning, DSL lowering, and semantic helper review consume binding surfaces first
- add binding-first regression coverage and update architecture/plan docs

## Validation
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_backend_bindings.py tests/test_agent/test_codegen_guardrails.py tests/test_agent/test_dsl_lowering.py tests/test_agent/test_semantic_validators.py -q
- /Users/steveyang/miniforge3/bin/python3 -m py_compile trellis/agent/backend_bindings.py trellis/agent/codegen_guardrails.py trellis/agent/dsl_lowering.py trellis/agent/semantic_validators/algorithm_contract.py
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_route_registry.py tests/test_agent/test_platform_requests.py tests/test_agent/test_platform_traces.py tests/test_agent/test_dsl_lowering.py tests/test_agent/test_codegen_guardrails.py tests/test_agent/test_backend_bindings.py tests/test_agent/test_semantic_validators.py -q
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_tasks/test_t01_zcb_option.py -q
- PYTHONHASHSEED=0 /Users/steveyang/miniforge3/bin/python3 scripts/run_canary.py --task T13 --replay
- PYTHONHASHSEED=0 /Users/steveyang/miniforge3/bin/python3 scripts/run_canary.py --task T38 --replay
- /Users/steveyang/miniforge3/bin/python3 scripts/run_canary.py --task T105
- /Users/steveyang/miniforge3/bin/python3 scripts/run_knowledge_light_proving.py --cases KL03 --output /tmp/qua800_kl03.json
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/ -x -q -m "not integration"
