### PR TITLE
QUA-804: define binding-first exotic proof cohort

### DIFF
--- a/docs/plans/binding-first-exotic-assembly.md
+++ b/docs/plans/binding-first-exotic-assembly.md
@@ -179,8 +179,8 @@ Status mirror last synced: `2026-04-12`
 
 ### Ordered Exotic Composition Proof Queue
 
-| Ticket | Status |
-| --- | --- |
+| Ticket | Description | Status |
+| --- | --- | --- |
 | `QUA-804` | Exotic benchmark: define constructable proof cohort for binding-first assembly | Done |
 | `QUA-808` | Exotic assembly: prove event-control-schedule structures without new route identities | Backlog |
 | `QUA-809` | Exotic assembly: prove basket-credit and loss-distribution structures on binding roles | Backlog |

--- a/docs/plans/binding-first-exotic-assembly.md
+++ b/docs/plans/binding-first-exotic-assembly.md
@@ -181,10 +181,13 @@ Status mirror last synced: `2026-04-12`
 
 | Ticket | Status |
 | --- | --- |
-| `QUA-804` | Exotic benchmark: define constructable proof cohort for binding-first assembly | Backlog |
+| `QUA-804` | Exotic benchmark: define constructable proof cohort for binding-first assembly | Done |
 | `QUA-808` | Exotic assembly: prove event-control-schedule structures without new route identities | Backlog |
 | `QUA-809` | Exotic assembly: prove basket-credit and loss-distribution structures on binding roles | Backlog |
 | `QUA-815` | Exotic program closeout: measure proof-cohort outcomes on the binding-first runtime | Backlog |
+
+The benchmark contract for those proof tickets lives in
+`docs/plans/binding-first-exotic-proof-cohort.md`.
 
 ## Cross-Epic Sequencing Constraints
 

--- a/docs/plans/binding-first-exotic-proof-cohort.md
+++ b/docs/plans/binding-first-exotic-proof-cohort.md
@@ -100,7 +100,7 @@ These tasks define the `QUA-809` proof surface.
 | `T53` Multi-name portfolio loss distribution: recursive vs FFT vs MC | `proved` | loss-distribution composition across recursive, transform, and MC bindings | Core proof that loss aggregation is binding-role-driven rather than route-driven |
 | `E26` Nth-to-default basket: Gaussian copula vs default-time MC | `proved` | basket-credit hybrid under the stress tranche | Stress follow-on for `T50` |
 | `T102` Rainbow option (best-of-two): Stulz formula vs MC | `proved` | multi-underlier basket state and dependence-aware exact binding | Keeps non-credit basket composition in scope |
-| `T126` Spread option: Kirk approximation vs 2D MC vs 2D FFT | `proved` | multi-factor transform and MC parity on a non-credit hybrid payoff | Checks binding-first assembly across analytical, transform, and MC lanes |
+| `T126` Spread option (Kirk approximation) vs 2D MC vs 2D FFT | `proved` | multi-factor transform and MC parity on a non-credit hybrid payoff | Checks binding-first assembly across analytical, transform, and MC lanes |
 
 ## Acceptance Rules For Later Tickets
 

--- a/docs/plans/binding-first-exotic-proof-cohort.md
+++ b/docs/plans/binding-first-exotic-proof-cohort.md
@@ -1,0 +1,142 @@
+# Binding-First Exotic Proof Cohort
+
+## Purpose
+
+This document defines the benchmark cohort for the binding-first exotic
+assembly program.
+
+The cohort exists so later tickets can prove concrete capability rather than
+making architectural claims in the abstract. Every proof slice under
+`QUA-808`, `QUA-809`, and `QUA-815` should use this cohort unless a later
+ticket explicitly amends it.
+
+## Design Rules
+
+- Use existing tasks from `TASKS.yaml`; do not invent synthetic benchmark ids
+  for the proof program.
+- Prefer tasks that exercise composition pressure:
+  - event structure
+  - control style
+  - schedule dependence
+  - basket / dependence structure
+  - credit / loss-distribution structure
+  - cross-currency or multi-factor market binding
+- Include at least one honest-block sentinel so the program proves that the
+  runtime can refuse unsupported structures cleanly instead of forcing them
+  into a legacy route bucket.
+
+## Outcome Taxonomy
+
+Each cohort item must be evaluated against one of these expected outcomes.
+
+### Proved
+
+Use `proved` when the task reaches a valid compare-ready or price-ready result
+on the binding-first runtime and the run artifact shows:
+
+- a stable binding identity for each exact helper-backed lane
+- no new route ids created to make the task succeed
+- no route-card-only notes or prose acting as the critical source of helper or
+  kernel selection
+
+### Honest block
+
+Use `honest_block` when the runtime rejects the task through typed
+family/binding/primitive blockers that explain why the structure is outside the
+current constructable surface.
+
+This is an acceptable result only for tasks explicitly marked as honest-block
+sentinels in this cohort.
+
+### Out of scope
+
+Use `out_of_scope` only when the task goes beyond the current program target
+even if the runtime blocks honestly. This category should be rare. The default
+for unsupported-but-intentional sentinels in this cohort is `honest_block`,
+not `out_of_scope`.
+
+## Measurement Protocol
+
+All proof slices must use the same measurement protocol.
+
+1. Fix the repo revision for the whole cohort pass.
+2. Run fresh builds for proof tasks; do not rely on stale generated adapters as
+   hidden support.
+3. Record, for each task and each method lane:
+   - selected binding ids
+   - comparison or pricing outcome
+   - `first_pass`
+   - `attempts_to_success`
+   - retry taxonomy
+   - elapsed time
+   - token usage
+4. When a task is expected to block honestly, record the blocker taxonomy and
+   show that it is family/binding/primitive-first rather than route-first.
+5. No ticket may claim proof success if it needed a new route id or route-card
+   prose update to make the benchmark pass.
+
+## Cohort
+
+### Event / Control / Schedule Cohort
+
+These tasks define the `QUA-808` proof surface.
+
+| Task | Expected outcome | Binding-first capability under test | Notes |
+| --- | --- | --- | --- |
+| `T17` Callable bond: HW rate PDE (PSOR) vs HW tree | `proved` | same-day event schedule plus issuer control across PDE and lattice bindings | Tests event transforms, fixed-income schedule semantics, and explicit issuer control |
+| `T73` European swaption: Black76 vs HW tree vs HW MC | `proved` | rate-style schedule semantics and method-spanning helper bindings | Good check that schedule-aware analytical, lattice, and MC bindings share one semantic contract |
+| `E22` Cap/floor: Black caplet stack vs MC rate simulation | `proved` | rate cap/floor strip decomposition without route-local rescue logic | Confirms typed family lowering plus rate MC/analytical bindings |
+| `T105` Quanto option: quanto-adjusted BS vs MC cross-currency | `proved` | cross-currency market binding plus analytical/MC parity | Keeps the proof program honest about multi-currency exact bindings |
+| `E27` American Asian barrier under Heston: PDE vs MC vs FFT should block honestly | `honest_block` | honest refusal for unsupported multi-control, path-dependent hybrid structure | Sentinel that the runtime should not force a fake route fit |
+
+### Basket / Credit / Loss Cohort
+
+These tasks define the `QUA-809` proof surface.
+
+| Task | Expected outcome | Binding-first capability under test | Notes |
+| --- | --- | --- | --- |
+| `T49` CDO tranche: Gaussian vs Student-t copula | `proved` | tranche attachment/detachment and copula-backed loss bindings | Baseline tranche/loss distribution proof |
+| `T50` Nth-to-default: MC correlated defaults vs semi-analytical | `proved` | default-time basket-credit structure across MC and analytical lanes | Tests basket-credit composition directly |
+| `T53` Multi-name portfolio loss distribution: recursive vs FFT vs MC | `proved` | loss-distribution composition across recursive, transform, and MC bindings | Core proof that loss aggregation is binding-role-driven rather than route-driven |
+| `E26` Nth-to-default basket: Gaussian copula vs default-time MC | `proved` | basket-credit hybrid under the stress tranche | Stress follow-on for `T50` |
+| `T102` Rainbow option (best-of-two): Stulz formula vs MC | `proved` | multi-underlier basket state and dependence-aware exact binding | Keeps non-credit basket composition in scope |
+| `T126` Spread option: Kirk approximation vs 2D MC vs 2D FFT | `proved` | multi-factor transform and MC parity on a non-credit hybrid payoff | Checks binding-first assembly across analytical, transform, and MC lanes |
+
+## Acceptance Rules For Later Tickets
+
+### `QUA-808`
+
+`QUA-808` is done only when:
+
+- every `QUA-808` cohort item above is either `proved` or reaches its expected
+  `honest_block`
+- the run artifacts show binding ids for the successful exact-helper lanes
+- no new route ids were introduced to make the cohort pass
+
+### `QUA-809`
+
+`QUA-809` is done only when:
+
+- every `QUA-809` cohort item above is `proved`
+- the run artifacts show binding ids for each exact helper-backed lane and the
+  basket-credit/loss-distribution surfaces no longer depend on route-local
+  exact-lookup authority
+
+### `QUA-815`
+
+`QUA-815` is the closeout ticket for the whole cohort. It should summarize:
+
+- per-task outcome
+- pass vs honest-block rate
+- first-pass and retry metrics
+- time and token cost
+- any remaining blocker families that still prevent the claimed end state
+
+## Review Notes
+
+- `T01`, `T13`, `T38`, `T94`, `T108`, and `E25` remain valuable regression
+  gates for the binding runtime, but they are not the exotic proof cohort.
+  They are support controls, not the program’s primary exotic evidence.
+- The cohort intentionally mixes baseline production tasks (`T*`) and stress
+  tasks (`E*`). The proof program should show both real throughput and clean
+  failure boundaries.


### PR DESCRIPTION
## Summary
- define the checked-in proof cohort for the binding-first exotic assembly program
- map event/control/schedule and basket/credit/loss tasks to later proof tickets
- document success, honest-block, and measurement rules for the proof program

## Validation
- planning/doc-only slice; task inventory and acceptance rules reviewed against TASKS.yaml
