### PR TITLE
QUA-801: make family lowering dispatch binding-first

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -89,6 +89,10 @@ maintenance around the deterministic engines.
   `trellis/agent/semantic_validators/algorithm_contract.py` now consume the
   resolved binding surface first, so exact helper/kernel/schedule lookup is
   binding-first even while route ids still exist as transitional aliases.
+- `trellis/agent/family_lowering_ir.py` now resolves the same binding surface
+  before it emits family IRs, so family selection no longer depends primarily
+  on direct route-id branches for analytical, lattice, Monte Carlo, credit,
+  or copula lowering.
 - `trellis/agent/route_registry.py`, `trellis/agent/build_gate.py`,
   `trellis/agent/family_lowering_ir.py`, and `trellis/agent/dsl_lowering.py`
   govern admissibility and lowering onto checked route families. The route

--- a/docs/plans/binding-first-exotic-assembly.md
+++ b/docs/plans/binding-first-exotic-assembly.md
@@ -156,7 +156,7 @@ Status mirror last synced: `2026-04-12`
 
 | Ticket | Status |
 | --- | --- |
-| `QUA-801` | Family lowering: replace route-id special cases with binding-role dispatch | Backlog |
+| `QUA-801` | Family lowering: replace route-id special cases with binding-role dispatch | Done |
 | `QUA-805` | DSL lowering: resolve helpers, kernels, schedules, and controls from binding roles | Backlog |
 | `QUA-811` | Semantic blockers: rename route-shaped helper gaps to binding and primitive taxonomy | Backlog |
 

--- a/docs/quant/pricing_stack.rst
+++ b/docs/quant/pricing_stack.rst
@@ -114,6 +114,11 @@ families. The shared compiler program consists of:
 - ``EventProgramIR``
 - ``ControlProgramIR``
 
+Family lowering is now binding-first as well: the compiler resolves the exact
+binding surface before it emits these family IRs, and the family dispatch
+logic keys off binding roles and exact helper/kernel symbols rather than
+direct route-id branches.
+
 Those objects are the canonical semantic authority for scheduled events,
 exercise/call control, and same-day phase ordering. Family IRs then project
 that shared program into their bounded numerical forms:

--- a/tests/test_agent/test_family_lowering_ir.py
+++ b/tests/test_agent/test_family_lowering_ir.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import replace
 
+from trellis.agent.backend_bindings import ResolvedBackendBindingSpec
+from trellis.agent.codegen_guardrails import PrimitiveRef
 from trellis.agent.family_lowering_ir import (
     AnalyticalBlack76IR,
     CorrelatedBasketMonteCarloIR,
@@ -35,6 +37,53 @@ def _make_bermudan_equity_pde_contract():
         observation_schedule=("2026-03-20", "2026-06-20", "2026-09-20", "2026-12-20"),
         preferred_method="pde_solver",
         exercise_style="bermudan",
+    )
+
+
+def _resolved_binding_spec(
+    *primitives: PrimitiveRef,
+    route_id: str,
+    route_family: str,
+    engine_family: str,
+) -> ResolvedBackendBindingSpec:
+    primitive_refs = tuple(
+        dict.fromkeys(f"{primitive.module}.{primitive.symbol}" for primitive in primitives)
+    )
+
+    def refs_for_role(role: str) -> tuple[str, ...]:
+        return tuple(
+            dict.fromkeys(
+                f"{primitive.module}.{primitive.symbol}"
+                for primitive in primitives
+                if primitive.role == role
+            )
+        )
+
+    return ResolvedBackendBindingSpec(
+        route_id=route_id,
+        engine_family=engine_family,
+        route_family=route_family,
+        binding_id=f"{engine_family}.{route_id}",
+        primitives=tuple(primitives),
+        primitive_refs=primitive_refs,
+        helper_refs=refs_for_role("route_helper"),
+        pricing_kernel_refs=refs_for_role("pricing_kernel"),
+        schedule_builder_refs=refs_for_role("schedule_builder"),
+        cashflow_engine_refs=refs_for_role("cashflow_engine"),
+        market_binding_refs=refs_for_role("market_binding"),
+        exact_target_refs=primitive_refs,
+    )
+
+
+def _patch_binding(monkeypatch, binding_spec: ResolvedBackendBindingSpec) -> None:
+    import trellis.agent.family_lowering_ir as family_lowering_ir
+
+    monkeypatch.setattr(
+        family_lowering_ir,
+        "_resolve_family_lowering_binding",
+        lambda route_id, *, product_ir=None: (
+            binding_spec if route_id == binding_spec.route_id else None
+        ),
     )
 
 
@@ -765,3 +814,312 @@ def test_nth_to_default_compiles_to_family_ir():
     assert family_ir.reference_entities == ("ACME", "BRAVO", "CHARLIE", "DELTA", "ECHO")
     assert family_ir.required_input_ids == blueprint.required_market_data
     assert family_ir.requested_outputs == ("price", "scenario_pnl")
+
+
+def test_black76_family_ir_dispatches_from_binding_surface_not_route_id(monkeypatch):
+    from trellis.agent.family_lowering_ir import build_family_lowering_ir
+    from trellis.agent.semantic_contract_compiler import compile_semantic_contract
+    from trellis.agent.semantic_contracts import make_vanilla_option_contract
+
+    contract = make_vanilla_option_contract(
+        description="EUR call on AAPL, K=150, T=1y",
+        underliers=("AAPL",),
+        observation_schedule=("2026-06-20",),
+    )
+    blueprint = compile_semantic_contract(contract)
+    synthetic_route_id = "binding_black76_terminal"
+    _patch_binding(
+        monkeypatch,
+        _resolved_binding_spec(
+            PrimitiveRef("trellis.models.black", "black76_call", "pricing_kernel"),
+            PrimitiveRef("trellis.models.black", "black76_put", "pricing_kernel"),
+            PrimitiveRef(
+                "trellis.models.analytical",
+                "terminal_vanilla_from_basis",
+                "assembly_helper",
+                required=False,
+            ),
+            PrimitiveRef("trellis.models.time", "year_fraction", "time_measure", required=False),
+            route_id=synthetic_route_id,
+            route_family="analytical",
+            engine_family="analytical",
+        ),
+    )
+
+    family_ir = build_family_lowering_ir(
+        contract,
+        route_id=synthetic_route_id,
+        route_family="legacy_route_family_should_not_matter",
+        product_ir=blueprint.product_ir,
+    )
+
+    assert isinstance(family_ir, AnalyticalBlack76IR)
+    assert family_ir.route_id == synthetic_route_id
+    assert family_ir.route_family == "analytical"
+    assert family_ir.kernel_symbol == "black76_call"
+
+
+def test_exercise_lattice_dispatches_from_binding_surface_not_route_id(monkeypatch):
+    from trellis.agent.family_lowering_ir import build_family_lowering_ir
+    from trellis.agent.semantic_contract_compiler import compile_semantic_contract
+    from trellis.agent.semantic_contracts import make_callable_bond_contract
+
+    contract = make_callable_bond_contract(
+        description="Callable bond with annual coupons and issuer call dates 2026-01-15, 2027-01-15",
+        observation_schedule=("2026-01-15", "2027-01-15"),
+    )
+    blueprint = compile_semantic_contract(contract)
+    synthetic_route_id = "binding_tree_callable"
+    _patch_binding(
+        monkeypatch,
+        _resolved_binding_spec(
+            PrimitiveRef(
+                "trellis.models.trees.callable_bond",
+                "price_callable_bond_tree",
+                "route_helper",
+            ),
+            PrimitiveRef(
+                "trellis.models.trees.lattice",
+                "build_rate_lattice",
+                "lattice_builder",
+            ),
+            PrimitiveRef(
+                "trellis.models.trees.lattice",
+                "lattice_backward_induction",
+                "backward_induction",
+            ),
+            PrimitiveRef(
+                "trellis.models.trees.control",
+                "resolve_lattice_exercise_policy",
+                "control_policy",
+            ),
+            route_id=synthetic_route_id,
+            route_family="lattice",
+            engine_family="lattice",
+        ),
+    )
+
+    family_ir = build_family_lowering_ir(
+        contract,
+        route_id=synthetic_route_id,
+        route_family="legacy_route_family_should_not_matter",
+        product_ir=blueprint.product_ir,
+    )
+
+    assert isinstance(family_ir, ExerciseLatticeIR)
+    assert family_ir.route_id == synthetic_route_id
+    assert family_ir.route_family == "lattice"
+    assert family_ir.helper_symbol == "price_callable_bond_tree"
+
+
+def test_event_aware_pde_dispatches_from_binding_surface_not_route_id(monkeypatch):
+    from trellis.agent.family_lowering_ir import build_family_lowering_ir
+    from trellis.agent.semantic_contract_compiler import compile_semantic_contract
+    from trellis.agent.semantic_contracts import make_callable_bond_contract
+
+    contract = make_callable_bond_contract(
+        description="Callable bond with annual coupons and issuer call dates 2026-01-15, 2027-01-15",
+        observation_schedule=("2026-01-15", "2027-01-15"),
+        preferred_method="pde_solver",
+    )
+    blueprint = compile_semantic_contract(contract, preferred_method="pde_solver")
+    synthetic_route_id = "binding_callable_pde"
+    _patch_binding(
+        monkeypatch,
+        _resolved_binding_spec(
+            PrimitiveRef("trellis.models.pde.grid", "Grid", "grid"),
+            PrimitiveRef(
+                "trellis.models.pde.operator",
+                "BlackScholesOperator",
+                "spatial_operator",
+            ),
+            PrimitiveRef(
+                "trellis.models.pde.theta_method",
+                "theta_method_1d",
+                "time_stepping",
+            ),
+            PrimitiveRef(
+                "trellis.models.callable_bond_pde",
+                "price_callable_bond_pde",
+                "route_helper",
+            ),
+            route_id=synthetic_route_id,
+            route_family="pde_solver",
+            engine_family="pde_solver",
+        ),
+    )
+
+    family_ir = build_family_lowering_ir(
+        contract,
+        route_id=synthetic_route_id,
+        route_family="legacy_route_family_should_not_matter",
+        product_ir=blueprint.product_ir,
+    )
+
+    assert isinstance(family_ir, EventAwarePDEIR)
+    assert family_ir.route_id == synthetic_route_id
+    assert family_ir.route_family == "pde_solver"
+    assert family_ir.helper_symbol == "price_callable_bond_pde"
+
+
+def test_local_vol_monte_carlo_dispatches_from_binding_surface_not_route_id(monkeypatch):
+    from trellis.agent.family_lowering_ir import build_family_lowering_ir
+    from trellis.agent.semantic_contract_compiler import compile_semantic_contract
+    from trellis.agent.semantic_contracts import make_vanilla_option_contract
+
+    contract = make_vanilla_option_contract(
+        description="EUR call on AAPL under local-vol Monte Carlo",
+        underliers=("AAPL",),
+        observation_schedule=("2026-06-20",),
+        preferred_method="monte_carlo",
+    )
+    blueprint = compile_semantic_contract(contract, preferred_method="monte_carlo")
+    synthetic_route_id = "binding_local_vol_mc"
+    _patch_binding(
+        monkeypatch,
+        _resolved_binding_spec(
+            PrimitiveRef(
+                "trellis.models.processes.local_vol",
+                "LocalVol",
+                "state_process",
+            ),
+            PrimitiveRef(
+                "trellis.models.monte_carlo.engine",
+                "MonteCarloEngine",
+                "path_simulation",
+            ),
+            PrimitiveRef(
+                "trellis.models.local_vol",
+                "local_vol_european_vanilla_price",
+                "pricing_kernel",
+            ),
+            route_id=synthetic_route_id,
+            route_family="monte_carlo",
+            engine_family="monte_carlo",
+        ),
+    )
+
+    family_ir = build_family_lowering_ir(
+        contract,
+        route_id=synthetic_route_id,
+        route_family="legacy_route_family_should_not_matter",
+        product_ir=blueprint.product_ir,
+    )
+
+    assert isinstance(family_ir, EventAwareMonteCarloIR)
+    assert family_ir.route_id == synthetic_route_id
+    assert family_ir.route_family == "monte_carlo"
+    assert family_ir.process_spec.process_family == "local_vol_1d"
+    assert family_ir.process_spec.simulation_scheme == "euler_local_vol"
+
+
+def test_credit_default_swap_dispatches_from_binding_surface_not_route_id(monkeypatch):
+    from trellis.agent.family_lowering_ir import build_family_lowering_ir
+    from trellis.agent.semantic_contract_compiler import compile_semantic_contract
+    from trellis.agent.semantic_contracts import make_credit_default_swap_contract
+
+    contract = make_credit_default_swap_contract(
+        description="Single-name CDS on ACME Monte Carlo",
+        observation_schedule=("2026-06-20", "2026-09-20", "2026-12-20", "2027-03-20", "2027-06-20"),
+        preferred_method="monte_carlo",
+    )
+    blueprint = compile_semantic_contract(contract, preferred_method="monte_carlo")
+    synthetic_route_id = "binding_cds_mc"
+    _patch_binding(
+        monkeypatch,
+        _resolved_binding_spec(
+            PrimitiveRef(
+                "trellis.models.credit_schedule",
+                "build_cds_schedule",
+                "schedule_builder",
+            ),
+            PrimitiveRef(
+                "trellis.models.credit_survival",
+                "interval_default_probability",
+                "event_probability",
+            ),
+            PrimitiveRef("trellis.models.cds", "price_cds_monte_carlo", "route_helper"),
+            PrimitiveRef(
+                "trellis.core.differentiable",
+                "get_numpy",
+                "array_backend",
+            ),
+            route_id=synthetic_route_id,
+            route_family="credit_default_swap",
+            engine_family="monte_carlo",
+        ),
+    )
+
+    family_ir = build_family_lowering_ir(
+        contract,
+        route_id=synthetic_route_id,
+        route_family="legacy_route_family_should_not_matter",
+        product_ir=blueprint.product_ir,
+    )
+
+    assert isinstance(family_ir, CreditDefaultSwapIR)
+    assert family_ir.route_id == synthetic_route_id
+    assert family_ir.route_family == "credit_default_swap"
+    assert family_ir.pricing_mode == "monte_carlo"
+    assert family_ir.helper_symbol == "price_cds_monte_carlo"
+
+
+def test_nth_to_default_dispatches_from_binding_surface_not_route_id(monkeypatch):
+    from trellis.agent.family_lowering_ir import build_family_lowering_ir
+    from trellis.agent.semantic_contract_compiler import compile_semantic_contract
+    from trellis.agent.semantic_contracts import make_nth_to_default_contract
+
+    contract = make_nth_to_default_contract(
+        description="First-to-default basket on ACME, BRAVO, CHARLIE, DELTA, ECHO through 2029-11-15",
+        observation_schedule=("2029-11-15",),
+        reference_entities=("ACME", "BRAVO", "CHARLIE", "DELTA", "ECHO"),
+        trigger_rank=1,
+    )
+    blueprint = compile_semantic_contract(contract)
+    synthetic_route_id = "binding_nth_to_default"
+    _patch_binding(
+        monkeypatch,
+        _resolved_binding_spec(
+            PrimitiveRef(
+                "trellis.models.schedule",
+                "generate_schedule",
+                "schedule_builder",
+            ),
+            PrimitiveRef(
+                "trellis.models.time",
+                "year_fraction",
+                "time_measure",
+            ),
+            PrimitiveRef(
+                "trellis.models.copula",
+                "GaussianCopula",
+                "default_time_sampler",
+            ),
+            PrimitiveRef(
+                "trellis.models.nth_to_default",
+                "price_nth_to_default_basket",
+                "route_helper",
+            ),
+            PrimitiveRef(
+                "trellis.models.monte_carlo.engine",
+                "MonteCarloEngine",
+                "path_simulation",
+            ),
+            route_id=synthetic_route_id,
+            route_family="nth_to_default",
+            engine_family="monte_carlo",
+        ),
+    )
+
+    family_ir = build_family_lowering_ir(
+        contract,
+        route_id=synthetic_route_id,
+        route_family="legacy_route_family_should_not_matter",
+        product_ir=blueprint.product_ir,
+    )
+
+    assert isinstance(family_ir, NthToDefaultIR)
+    assert family_ir.route_id == synthetic_route_id
+    assert family_ir.route_family == "nth_to_default"
+    assert family_ir.helper_symbol == "price_nth_to_default_basket"
+    assert family_ir.copula_symbol == "GaussianCopula"

--- a/trellis/agent/family_lowering_ir.py
+++ b/trellis/agent/family_lowering_ir.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 import re
+from typing import TYPE_CHECKING
 
 from trellis.core.types import TimelineRole
+
+if TYPE_CHECKING:
+    from trellis.agent.backend_bindings import ResolvedBackendBindingSpec
 
 
 def _tuple_unique(values) -> tuple[str, ...]:
@@ -775,6 +779,208 @@ def _lookup_by_composite_key(bindings, *keys: str) -> str:
     return ""
 
 
+def _resolve_family_lowering_binding(
+    route_id: str,
+    *,
+    product_ir,
+) -> ResolvedBackendBindingSpec | None:
+    """Resolve the typed binding surface used for family-lowering dispatch."""
+    if not str(route_id or "").strip():
+        return None
+    from trellis.agent.backend_bindings import resolve_backend_binding_by_route_id
+
+    return resolve_backend_binding_by_route_id(route_id, product_ir=product_ir)
+
+
+def _binding_symbols_for_role(
+    binding_spec: ResolvedBackendBindingSpec | None,
+    role: str,
+) -> frozenset[str]:
+    """Return normalized binding symbols for one primitive role."""
+    if binding_spec is None:
+        return frozenset()
+    normalized_role = str(role or "").strip().lower()
+    return frozenset(
+        str(primitive.symbol or "").strip()
+        for primitive in getattr(binding_spec, "primitives", ()) or ()
+        if str(getattr(primitive, "role", "") or "").strip().lower() == normalized_role
+        and str(getattr(primitive, "symbol", "") or "").strip()
+    )
+
+
+def _binding_has_role(
+    binding_spec: ResolvedBackendBindingSpec | None,
+    role: str,
+) -> bool:
+    """Return whether the binding surface exposes one primitive role."""
+    return bool(_binding_symbols_for_role(binding_spec, role))
+
+
+def _binding_has_symbol(
+    binding_spec: ResolvedBackendBindingSpec | None,
+    role: str,
+    symbol: str,
+) -> bool:
+    """Return whether the binding surface exposes one exact primitive symbol."""
+    return str(symbol or "").strip() in _binding_symbols_for_role(binding_spec, role)
+
+
+def _binding_has_any_symbol(
+    binding_spec: ResolvedBackendBindingSpec | None,
+    role: str,
+    *symbols: str,
+) -> bool:
+    """Return whether the binding surface exposes any symbol from the given role."""
+    available = _binding_symbols_for_role(binding_spec, role)
+    return any(str(symbol or "").strip() in available for symbol in symbols)
+
+
+def _binding_supports_black76_analytical(
+    binding_spec: ResolvedBackendBindingSpec | None,
+    *,
+    route_id: str,
+) -> bool:
+    """Return whether the binding surface fits the Black76 analytical lane."""
+    if _binding_has_all_symbols(binding_spec, "pricing_kernel", "black76_call", "black76_put"):
+        return True
+    return route_id == "analytical_black76" and binding_spec is None
+
+
+def _binding_has_all_symbols(
+    binding_spec: ResolvedBackendBindingSpec | None,
+    role: str,
+    *symbols: str,
+) -> bool:
+    """Return whether the binding surface exposes all given role symbols."""
+    available = _binding_symbols_for_role(binding_spec, role)
+    return all(str(symbol or "").strip() in available for symbol in symbols)
+
+
+def _binding_supports_transform_pricing(
+    binding_spec: ResolvedBackendBindingSpec | None,
+    *,
+    route_id: str,
+) -> bool:
+    """Return whether the binding surface fits the transform-pricing lane."""
+    if _binding_has_role(binding_spec, "transform_pricer"):
+        return True
+    if _binding_has_symbol(binding_spec, "route_helper", "price_vanilla_equity_option_transform"):
+        return True
+    return route_id == "transform_fft" and binding_spec is None
+
+
+def _binding_supports_vanilla_equity_pde(
+    binding_spec: ResolvedBackendBindingSpec | None,
+    *,
+    route_id: str,
+) -> bool:
+    """Return whether the binding surface fits the vanilla-equity PDE lane."""
+    if _binding_has_symbol(binding_spec, "route_helper", "price_vanilla_equity_option_pde"):
+        return True
+    return route_id == "vanilla_equity_theta_pde" and binding_spec is None
+
+
+def _binding_supports_event_aware_pde(
+    binding_spec: ResolvedBackendBindingSpec | None,
+    *,
+    route_id: str,
+) -> bool:
+    """Return whether the binding surface fits the event-aware PDE lane."""
+    if _binding_has_all_symbols(binding_spec, "grid", "Grid") and _binding_has_role(
+        binding_spec,
+        "spatial_operator",
+    ) and _binding_has_role(binding_spec, "time_stepping"):
+        return True
+    if _binding_has_any_symbol(
+        binding_spec,
+        "route_helper",
+        "price_event_aware_equity_option_pde",
+        "price_callable_bond_pde",
+    ):
+        return True
+    return route_id == "pde_theta_1d" and binding_spec is None
+
+
+def _binding_supports_event_aware_monte_carlo(
+    binding_spec: ResolvedBackendBindingSpec | None,
+    *,
+    route_id: str,
+) -> bool:
+    """Return whether the binding surface fits the bounded event-aware MC lane."""
+    if _binding_has_role(binding_spec, "path_simulation") and _binding_has_role(binding_spec, "state_process"):
+        return True
+    if _binding_has_any_symbol(
+        binding_spec,
+        "route_helper",
+        "price_event_aware_monte_carlo",
+        "price_vanilla_equity_option_monte_carlo",
+        "price_swaption_monte_carlo",
+    ):
+        return True
+    return route_id in {"monte_carlo_paths", "local_vol_monte_carlo"} and binding_spec is None
+
+
+def _binding_supports_exercise_lattice(
+    binding_spec: ResolvedBackendBindingSpec | None,
+    *,
+    route_id: str,
+) -> bool:
+    """Return whether the binding surface fits the exercise-lattice lane."""
+    if _binding_has_role(binding_spec, "lattice_builder") and _binding_has_role(
+        binding_spec,
+        "backward_induction",
+    ):
+        return True
+    if _binding_has_any_symbol(
+        binding_spec,
+        "route_helper",
+        "price_vanilla_equity_option_tree",
+        "price_callable_bond_tree",
+        "price_bermudan_swaption_tree",
+    ):
+        return True
+    return route_id == "exercise_lattice" and binding_spec is None
+
+
+def _binding_supports_correlated_basket_monte_carlo(
+    binding_spec: ResolvedBackendBindingSpec | None,
+    *,
+    route_id: str,
+) -> bool:
+    """Return whether the binding surface fits the ranked-basket MC lane."""
+    if _binding_has_symbol(binding_spec, "market_binding", "resolve_basket_semantics"):
+        return True
+    if _binding_has_symbol(binding_spec, "route_helper", "price_ranked_observation_basket_monte_carlo"):
+        return True
+    return route_id == "correlated_basket_monte_carlo" and binding_spec is None
+
+
+def _binding_supports_credit_default_swap(
+    binding_spec: ResolvedBackendBindingSpec | None,
+    *,
+    route_id: str,
+) -> bool:
+    """Return whether the binding surface fits the CDS lowering lane."""
+    if _binding_has_symbol(binding_spec, "schedule_builder", "build_cds_schedule"):
+        return True
+    if _binding_has_any_symbol(binding_spec, "route_helper", "price_cds_analytical", "price_cds_monte_carlo"):
+        return True
+    return route_id in {"credit_default_swap_analytical", "credit_default_swap_monte_carlo"} and binding_spec is None
+
+
+def _binding_supports_nth_to_default(
+    binding_spec: ResolvedBackendBindingSpec | None,
+    *,
+    route_id: str,
+) -> bool:
+    """Return whether the binding surface fits the nth-to-default copula lane."""
+    if _binding_has_symbol(binding_spec, "default_time_sampler", "GaussianCopula"):
+        return True
+    if _binding_has_symbol(binding_spec, "route_helper", "price_nth_to_default_basket"):
+        return True
+    return route_id == "nth_to_default_monte_carlo" and binding_spec is None
+
+
 def _resolve_exercise_lattice_profile(contract, product_ir) -> ExerciseLatticeProfile | None:
     """Return the declared exercise-lattice lowering profile for one semantic contract."""
     for profile in _EXERCISE_LATTICE_PROFILES:
@@ -793,17 +999,19 @@ def build_family_lowering_ir(
     market_binding_spec=None,
 ) -> FamilyLoweringIR | None:
     """Build a typed family IR for migrated routes, else return ``None``."""
+    binding_spec = _resolve_family_lowering_binding(route_id, product_ir=product_ir)
+    resolved_route_family = str(getattr(binding_spec, "route_family", "") or route_family)
     common_kwargs = _common_kwargs(
         contract,
         product_ir=product_ir,
         valuation_context=valuation_context,
         market_binding_spec=market_binding_spec,
         route_id=route_id,
-        route_family=route_family,
+        route_family=resolved_route_family,
     )
 
     if _is_vanilla_european_contract(contract, product_ir):
-        if route_id == "analytical_black76":
+        if _binding_supports_black76_analytical(binding_spec, route_id=route_id):
             option_type = _option_type_for_contract(contract)
             return AnalyticalBlack76IR(
                 option_type=option_type,
@@ -811,14 +1019,14 @@ def build_family_lowering_ir(
                 **common_kwargs,
             )
 
-        if route_id == "transform_fft":
+        if _binding_supports_transform_pricing(binding_spec, route_id=route_id):
             return _build_transform_pricing_ir(
                 contract,
                 product_ir=product_ir,
                 **common_kwargs,
             )
 
-        if route_id == "vanilla_equity_theta_pde":
+        if _binding_supports_vanilla_equity_pde(binding_spec, route_id=route_id):
             control_program = _build_control_program(contract.product)
             return VanillaEquityPDEIR(
                 option_type=_option_type_for_contract(contract),
@@ -831,7 +1039,10 @@ def build_family_lowering_ir(
                 ),
                 **common_kwargs,
             )
-    if _is_rate_cap_floor_strip_contract(contract, product_ir) and route_id == "analytical_black76":
+    if _is_rate_cap_floor_strip_contract(contract, product_ir) and _binding_supports_black76_analytical(
+        binding_spec,
+        route_id=route_id,
+    ):
         option_type = _option_type_for_contract(contract)
         return AnalyticalBlack76IR(
             option_type=option_type,
@@ -839,35 +1050,37 @@ def build_family_lowering_ir(
             market_mapping="discount_curve_forward_curve_black_vol_to_caplet_strip",
             **common_kwargs,
         )
-    if route_id == "pde_theta_1d":
+    if _binding_supports_event_aware_pde(binding_spec, route_id=route_id):
         return _build_event_aware_pde_ir(
             contract,
             product_ir=product_ir,
             **common_kwargs,
         )
-    if route_id in {"monte_carlo_paths", "local_vol_monte_carlo"}:
+    if _binding_supports_event_aware_monte_carlo(binding_spec, route_id=route_id):
         return _build_event_aware_monte_carlo_ir(
             contract,
             product_ir=product_ir,
+            binding_spec=binding_spec,
             **common_kwargs,
         )
 
-    if route_id == "exercise_lattice":
+    if _binding_supports_exercise_lattice(binding_spec, route_id=route_id):
         return _build_exercise_lattice_ir(contract, product_ir=product_ir, **common_kwargs)
-    if route_id == "correlated_basket_monte_carlo":
+    if _binding_supports_correlated_basket_monte_carlo(binding_spec, route_id=route_id):
         return _build_correlated_basket_monte_carlo_ir(
             contract,
             product_ir=product_ir,
             market_binding_spec=market_binding_spec,
             **common_kwargs,
         )
-    if route_id in {"credit_default_swap_analytical", "credit_default_swap_monte_carlo"}:
+    if _binding_supports_credit_default_swap(binding_spec, route_id=route_id):
         return _build_credit_default_swap_ir(
             contract,
             product_ir=product_ir,
+            binding_spec=binding_spec,
             **common_kwargs,
         )
-    if route_id == "nth_to_default_monte_carlo":
+    if _binding_supports_nth_to_default(binding_spec, route_id=route_id):
         return _build_nth_to_default_ir(
             contract,
             product_ir=product_ir,
@@ -1230,6 +1443,7 @@ def _build_event_aware_monte_carlo_ir(
     contract,
     *,
     product_ir,
+    binding_spec: ResolvedBackendBindingSpec | None = None,
     route_id: str,
     route_family: str,
     product_instrument: str,
@@ -1251,7 +1465,11 @@ def _build_event_aware_monte_carlo_ir(
         return None
 
     state_spec = _mc_state_spec_for_product(product)
-    process_spec = _mc_process_spec_for_product(product, route_id=route_id)
+    process_spec = _mc_process_spec_for_product(
+        product,
+        binding_spec=binding_spec,
+        route_id=route_id,
+    )
     if not state_spec.state_variable or not process_spec.process_family:
         return None
 
@@ -1353,9 +1571,23 @@ def _mc_state_spec_for_product(product) -> MCStateSpec:
     return MCStateSpec()
 
 
-def _mc_process_spec_for_product(product, *, route_id: str) -> MCProcessSpec:
+def _mc_process_spec_for_product(
+    product,
+    *,
+    binding_spec: ResolvedBackendBindingSpec | None = None,
+    route_id: str,
+) -> MCProcessSpec:
     """Infer the bounded Monte Carlo process contract from semantic metadata."""
-    if route_id == "local_vol_monte_carlo":
+    if _binding_has_symbol(binding_spec, "state_process", "LocalVol") or _binding_has_symbol(
+        binding_spec,
+        "pricing_kernel",
+        "local_vol_european_vanilla_price",
+    ):
+        return MCProcessSpec(
+            process_family="local_vol_1d",
+            simulation_scheme="euler_local_vol",
+        )
+    if route_id == "local_vol_monte_carlo" and binding_spec is None:
         return MCProcessSpec(
             process_family="local_vol_1d",
             simulation_scheme="euler_local_vol",
@@ -1970,10 +2202,39 @@ def _build_correlated_basket_monte_carlo_ir(
     )
 
 
+def _credit_default_swap_pricing_mode(
+    binding_spec: ResolvedBackendBindingSpec | None,
+    *,
+    route_id: str,
+) -> str:
+    """Return the CDS pricing mode implied by the binding surface."""
+    if _binding_has_symbol(binding_spec, "event_probability", "interval_default_probability"):
+        return "monte_carlo"
+    if _binding_has_symbol(binding_spec, "route_helper", "price_cds_monte_carlo"):
+        return "monte_carlo"
+    if _binding_has_symbol(binding_spec, "route_helper", "price_cds_analytical"):
+        return "analytical"
+    return "monte_carlo" if route_id == "credit_default_swap_monte_carlo" else "analytical"
+
+
+def _credit_default_swap_helper_symbol(
+    binding_spec: ResolvedBackendBindingSpec | None,
+    *,
+    route_id: str,
+) -> str:
+    """Return the CDS helper symbol implied by the binding surface."""
+    if _binding_has_symbol(binding_spec, "route_helper", "price_cds_monte_carlo"):
+        return "price_cds_monte_carlo"
+    if _binding_has_symbol(binding_spec, "route_helper", "price_cds_analytical"):
+        return "price_cds_analytical"
+    return "price_cds_monte_carlo" if route_id == "credit_default_swap_monte_carlo" else "price_cds_analytical"
+
+
 def _build_credit_default_swap_ir(
     contract,
     *,
     product_ir,
+    binding_spec: ResolvedBackendBindingSpec | None = None,
     route_id: str,
     route_family: str,
     product_instrument: str,
@@ -2005,12 +2266,8 @@ def _build_credit_default_swap_ir(
         route_name="Credit-default-swap",
     )
 
-    helper_symbol = (
-        "price_cds_monte_carlo"
-        if route_id == "credit_default_swap_monte_carlo"
-        else "price_cds_analytical"
-    )
-    pricing_mode = "monte_carlo" if route_id == "credit_default_swap_monte_carlo" else "analytical"
+    helper_symbol = _credit_default_swap_helper_symbol(binding_spec, route_id=route_id)
+    pricing_mode = _credit_default_swap_pricing_mode(binding_spec, route_id=route_id)
     state_tags = (
         ("pathwise_only", "schedule_state")
         if pricing_mode == "monte_carlo"


### PR DESCRIPTION
## Summary
- replace direct `route_id` family-lowering branches with binding-surface dispatch in `family_lowering_ir`
- derive local-vol MC and CDS analytical/MC mode from binding roles and helper symbols instead of route names
- add synthetic regression tests that prove analytical, lattice, PDE, MC, credit, and copula lowering still work when the binding uses a non-legacy route id

## Validation
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_family_lowering_ir.py -q`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_dsl_lowering.py tests/test_agent/test_codegen_guardrails.py tests/test_agent/test_backend_bindings.py tests/test_agent/test_semantic_validators.py -q`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_tasks/test_t01_zcb_option.py -q`
- `PYTHONHASHSEED=0 /Users/steveyang/miniforge3/bin/python3 scripts/run_canary.py --task T13 --replay`
- `PYTHONHASHSEED=0 /Users/steveyang/miniforge3/bin/python3 scripts/run_canary.py --task T38 --replay`
- `/Users/steveyang/miniforge3/bin/python3 scripts/run_stress_tranche.py --task-id E22 --reuse --output /tmp/qua801_e22.json --report-json /tmp/qua801_e22_report.json --report-md /tmp/qua801_e22_report.md`
- `/Users/steveyang/miniforge3/bin/python3 scripts/run_stress_tranche.py --task-id E26 --reuse --output /tmp/qua801_e26.json --report-json /tmp/qua801_e26_report.json --report-md /tmp/qua801_e26_report.md`
- `/Users/steveyang/miniforge3/bin/python3 scripts/run_knowledge_light_proving.py --cases KL03 --output /tmp/qua801_kl03.json`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/ -x -q -m "not integration"`

## Notes
- `E26` remains the same pre-existing honest-block on clean `origin/main`: both methods build, but the comparison harness still returns `comparison_insufficient_results` with `'float' object has no attribute 'split'`. I re-ran the same stress task on a detached `origin/main` worktree and observed the same outcome, so this PR does not introduce that failure.
