### PR TITLE
QUA-802: key exact validation bundles by binding identity

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -85,6 +85,11 @@ maintenance around the deterministic engines.
   on `PrimitivePlan` and `GenerationPlan`, so runtime plans no longer need to
   rediscover exact helper identity from route ids later in validation or trace
   code.
+- `trellis/agent/validation_contract.py` now keeps the generic validation pack
+  id separate from the exact binding-scoped validation identity, so exact-fit
+  validation, route authority summaries, and downstream traces can key off
+  backend binding ids without turning route aliases back into the primary join
+  key.
 - `trellis/agent/dsl_lowering.py` and
   `trellis/agent/semantic_validators/algorithm_contract.py` now consume the
   resolved binding surface first, so exact helper/kernel/schedule lookup is

--- a/docs/plans/binding-first-exotic-assembly.md
+++ b/docs/plans/binding-first-exotic-assembly.md
@@ -130,7 +130,7 @@ ultimately targets.
 
 ## Linear Ticket Mirror
 
-Status mirror last synced: `2026-04-12`
+Status mirror last synced: `2026-04-13`
 
 ### Ordered Epic Queue
 
@@ -164,7 +164,7 @@ Status mirror last synced: `2026-04-12`
 
 | Ticket | Status |
 | --- | --- |
-| `QUA-802` | Validation contract: key exact-fit validation bundles by binding identity | Backlog |
+| `QUA-802` | Validation contract: key exact-fit validation bundles by binding identity | Done |
 | `QUA-806` | Platform traces and diagnostics: primary construction provenance is binding-first | Backlog |
 | `QUA-812` | Replay and checkpoints: regenerate binding-first canary and learning artifacts | Backlog |
 | `QUA-813` | Task stores and benchmark reports: retire route-primary health summaries | Backlog |

--- a/docs/quant/pricing_stack.rst
+++ b/docs/quant/pricing_stack.rst
@@ -204,6 +204,11 @@ The runtime plans now also carry that identity directly: ``PrimitivePlan`` and
 ``GenerationPlan`` persist ``backend_binding_id`` plus exact helper/kernel and
 schedule-builder refs, so later validation, traces, and replay do not need to
 reconstruct the binding contract from a route alias.
+The validation surface now follows the same split: ``CompiledValidationContract``
+keeps the generic validation pack id in ``bundle_id`` but also emits an
+exact binding-scoped validation identity for exact-fit requests, so route ids
+are no longer required as the primary exact-fit key in validation summaries,
+route-binding authority packets, or downstream trace consumers.
 That exact-surface contract now also drives live plan construction, DSL
 lowering, and semantic helper review: those paths resolve helpers, kernels,
 and schedule builders from ``trellis.agent.backend_bindings`` first and only

--- a/tests/test_agent/test_platform_requests.py
+++ b/tests/test_agent/test_platform_requests.py
@@ -150,6 +150,10 @@ def test_compile_build_request_attaches_route_binding_authority_packet():
     ]
     assert "trellis.models.quanto_option.price_quanto_option_analytical_from_market_state" in backend_binding["helper_refs"]
     assert authority["validation_bundle_id"] == "analytical:quanto_option"
+    assert (
+        authority["exact_validation_bundle_id"]
+        == "analytical:quanto_option@trellis.models.quanto_option.price_quanto_option_analytical_from_market_state"
+    )
     assert "check_non_negativity" in authority["validation_check_ids"]
     assert backend_binding["admissibility"]["multicurrency_support"] == "native_payout_with_fx"
     assert backend_binding["admissibility_failures"] == []

--- a/tests/test_agent/test_platform_traces.py
+++ b/tests/test_agent/test_platform_traces.py
@@ -636,6 +636,10 @@ def test_platform_trace_persists_semantic_checkpoint_and_generation_boundary(
         trace.generation_boundary["route_binding_authority"]["validation_bundle_id"]
         == trace.validation_contract["bundle_id"]
     )
+    assert (
+        trace.generation_boundary["route_binding_authority"]["exact_validation_bundle_id"]
+        == trace.validation_contract["exact_bundle_id"]
+    )
     assert expected_module in trace.generation_boundary["approved_modules"]
     assert expected_module in boundary["generation_boundary"]["approved_modules"]
     if expected_helper is not None:

--- a/tests/test_agent/test_validation_contract.py
+++ b/tests/test_agent/test_validation_contract.py
@@ -28,6 +28,14 @@ def test_compile_build_request_attaches_validation_contract_summary():
 
     assert contract is not None
     assert contract.bundle_id == "analytical:quanto_option"
+    assert (
+        contract.backend_binding_id
+        == "trellis.models.quanto_option.price_quanto_option_analytical_from_market_state"
+    )
+    assert (
+        contract.exact_bundle_id
+        == "analytical:quanto_option@trellis.models.quanto_option.price_quanto_option_analytical_from_market_state"
+    )
     assert contract.route_id == "quanto_adjustment_analytical"
     assert contract.route_family == "analytical"
     assert {check.check_id for check in contract.deterministic_checks} >= {
@@ -38,6 +46,14 @@ def test_compile_build_request_attaches_validation_contract_summary():
     }
     assert "black_vol_surface" in contract.required_market_data
     assert compiled.request.metadata["validation_contract"]["bundle_id"] == contract.bundle_id
+    assert (
+        compiled.request.metadata["validation_contract"]["backend_binding_id"]
+        == contract.backend_binding_id
+    )
+    assert (
+        compiled.request.metadata["validation_contract"]["exact_bundle_id"]
+        == contract.exact_bundle_id
+    )
     assert compiled.request.metadata["validation_contract"]["route_id"] == contract.route_id
     assert (
         compiled.request.metadata["validation_contract"]["deterministic_checks"][0]["check_id"]
@@ -136,6 +152,8 @@ def test_compile_validation_contract_prefers_more_specific_product_family_over_g
 
     assert contract is not None
     assert contract.bundle_id == "analytical:zcb_option"
+    assert contract.backend_binding_id is None
+    assert contract.exact_bundle_id is None
     assert contract.instrument_type == "zcb_option"
 
 
@@ -153,6 +171,8 @@ def test_route_less_semantic_request_keeps_validation_contract_truthful():
     contract = compiled.validation_contract
 
     assert contract is not None
+    assert contract.backend_binding_id is None
+    assert contract.exact_bundle_id is None
     assert contract.route_id is None
     assert contract.route_family is None
     check_ids = {check.check_id for check in contract.deterministic_checks}
@@ -276,14 +296,21 @@ def test_representative_semantic_requests_compile_stable_validation_contracts(
     assert compiled.request.metadata["semantic_blueprint"]["dsl_route"] == expected_route
     assert contract.route_id == expected_route
     assert contract.bundle_id == expected_bundle
+    assert contract.backend_binding_id
+    assert contract.exact_bundle_id == f"{expected_bundle}@{contract.backend_binding_id}"
     assert set(contract.required_market_data) == required_inputs
     assert contract.lowering_errors == ()
     assert contract.admissibility_failures == expected_admissibility
     assert contract.review_hints["has_lowering_errors"] is False
     assert contract.review_hints["has_admissibility_failures"] == bool(expected_admissibility)
+    assert contract.review_hints["has_exact_validation_identity"] is True
 
     assert contract == contract_again
     assert compiled.request.metadata["validation_contract"]["bundle_id"] == expected_bundle
+    assert (
+        compiled.request.metadata["validation_contract"]["exact_bundle_id"]
+        == contract.exact_bundle_id
+    )
     assert compiled.request.metadata["validation_contract"]["route_id"] == expected_route
 
 
@@ -313,6 +340,14 @@ def test_platform_trace_persists_validation_contract_summary(tmp_path):
     assert len(traces) == 1
     assert traces[0].validation_contract["route_id"] == "credit_default_swap_analytical"
     assert traces[0].validation_contract["bundle_id"] == "analytical:credit_default_swap"
+    assert (
+        traces[0].validation_contract["backend_binding_id"]
+        == "trellis.models.credit_default_swap.price_cds_analytical"
+    )
+    assert (
+        traces[0].validation_contract["exact_bundle_id"]
+        == "analytical:credit_default_swap@trellis.models.credit_default_swap.price_cds_analytical"
+    )
 
 
 def test_validate_build_emits_validation_contract_summary_in_bundle_events(monkeypatch):
@@ -382,10 +417,18 @@ def test_validate_build_emits_validation_contract_summary_in_bundle_events(monke
     executed = next(details for event, details in events if event == "validation_bundle_executed")
     assert selected["validation_contract"]["route_id"] == "quanto_adjustment_analytical"
     assert selected["validation_contract"]["bundle_id"] == "analytical:quanto_option"
+    assert (
+        selected["validation_contract"]["exact_bundle_id"]
+        == "analytical:quanto_option@trellis.models.quanto_option.price_quanto_option_analytical_from_market_state"
+    )
     assert selected["route_binding_authority"]["route_id"] == "quanto_adjustment_analytical"
     assert selected["route_binding_authority"]["canary_task_ids"] == ["T105"]
     assert executed["validation_contract"]["bundle_id"] == "analytical:quanto_option"
     assert executed["route_binding_authority"]["validation_bundle_id"] == "analytical:quanto_option"
+    assert (
+        executed["route_binding_authority"]["exact_validation_bundle_id"]
+        == "analytical:quanto_option@trellis.models.quanto_option.price_quanto_option_analytical_from_market_state"
+    )
 
 
 def test_validate_build_passes_validation_contract_to_review_policy(monkeypatch):

--- a/trellis/agent/route_registry.py
+++ b/trellis/agent/route_registry.py
@@ -195,6 +195,7 @@ class RouteBindingAuthority:
     backend_binding: BackendBindingAuthority
     compatibility_alias_policy: str = "operator_visible"
     validation_bundle_id: str = ""
+    exact_validation_bundle_id: str = ""
     validation_check_ids: tuple[str, ...] = ()
     canary_task_ids: tuple[str, ...] = ()
     provenance: dict[str, object] = field(default_factory=dict)
@@ -1150,6 +1151,10 @@ def compile_route_binding_authority(
         if str(item).strip()
     )
     validation_bundle_id = str(getattr(validation_contract, "bundle_id", "") or "")
+    exact_validation_bundle_id = (
+        str(getattr(validation_contract, "exact_bundle_id", "") or "").strip()
+        or validation_bundle_id
+    )
     validation_check_ids = tuple(
         str(getattr(check, "check_id", "") or "").strip()
         for check in (getattr(validation_contract, "deterministic_checks", ()) or ())
@@ -1213,6 +1218,7 @@ def compile_route_binding_authority(
         backend_binding=backend_binding,
         compatibility_alias_policy=compatibility_alias_policy,
         validation_bundle_id=validation_bundle_id,
+        exact_validation_bundle_id=exact_validation_bundle_id,
         validation_check_ids=validation_check_ids,
         canary_task_ids=canary_task_ids,
         provenance=provenance,
@@ -1261,6 +1267,7 @@ def route_binding_authority_summary(
             "admissibility_failures": list(backend_binding.admissibility_failures),
         },
         "validation_bundle_id": authority.validation_bundle_id,
+        "exact_validation_bundle_id": authority.exact_validation_bundle_id,
         "validation_check_ids": list(authority.validation_check_ids),
         "canary_task_ids": list(authority.canary_task_ids),
         "provenance": dict(authority.provenance),

--- a/trellis/agent/route_registry.py
+++ b/trellis/agent/route_registry.py
@@ -1151,10 +1151,7 @@ def compile_route_binding_authority(
         if str(item).strip()
     )
     validation_bundle_id = str(getattr(validation_contract, "bundle_id", "") or "")
-    exact_validation_bundle_id = (
-        str(getattr(validation_contract, "exact_bundle_id", "") or "").strip()
-        or validation_bundle_id
-    )
+    exact_validation_bundle_id = str(getattr(validation_contract, "exact_bundle_id", "") or "").strip()
     validation_check_ids = tuple(
         str(getattr(check, "check_id", "") or "").strip()
         for check in (getattr(validation_contract, "deterministic_checks", ()) or ())

--- a/trellis/agent/validation_contract.py
+++ b/trellis/agent/validation_contract.py
@@ -64,6 +64,8 @@ class CompiledValidationContract:
     instrument_type: str
     method: str
     bundle_id: str
+    backend_binding_id: str | None = None
+    exact_bundle_id: str | None = None
     route_id: str | None = None
     route_family: str | None = None
     required_market_data: tuple[str, ...] = ()
@@ -114,6 +116,16 @@ def compile_validation_contract(
         generation_plan=generation_plan,
         semantic_blueprint=semantic_blueprint,
     )
+    backend_binding_id = _resolve_backend_binding_identity(
+        generation_plan=generation_plan,
+        route_id=route_id,
+        product_ir=product_ir,
+        semantic_blueprint=semantic_blueprint,
+    )
+    exact_bundle_id = _exact_bundle_id_for(
+        bundle_id=bundle.bundle_id,
+        backend_binding_id=backend_binding_id,
+    )
     lowering_errors = _lowering_errors_for(semantic_blueprint)
     admissibility_failures = _admissibility_failures_for(
         route_id=route_id,
@@ -159,12 +171,15 @@ def compile_validation_contract(
         "requires_relation_semantics": any(
             relation.relation == "unspecified" for relation in comparison_relations
         ),
+        "has_exact_validation_identity": bool(exact_bundle_id),
     }
     return CompiledValidationContract(
         contract_id=f"{method}:{resolved_instrument}",
         instrument_type=resolved_instrument,
         method=method,
         bundle_id=bundle.bundle_id,
+        backend_binding_id=backend_binding_id,
+        exact_bundle_id=exact_bundle_id,
         route_id=route_id,
         route_family=route_family,
         required_market_data=required_market_data,
@@ -189,6 +204,8 @@ def validation_contract_summary(
         "instrument_type": contract.instrument_type,
         "method": contract.method,
         "bundle_id": contract.bundle_id,
+        "backend_binding_id": contract.backend_binding_id,
+        "exact_bundle_id": contract.exact_bundle_id,
         "route_id": contract.route_id,
         "route_family": contract.route_family,
         "required_market_data": list(contract.required_market_data),
@@ -238,11 +255,31 @@ def _resolve_route_identity(
     semantic_blueprint=None,
 ) -> tuple[str | None, str | None]:
     """Return the selected route id and route family when available."""
+    has_exact_backend_fit = _generation_plan_has_exact_backend_fit(generation_plan) and not _lowering_errors_for(
+        semantic_blueprint
+    )
     primitive_plan = getattr(generation_plan, "primitive_plan", None)
     if primitive_plan is not None and getattr(primitive_plan, "route", None):
         return (
             str(getattr(primitive_plan, "route", None) or "").strip() or None,
-            str(getattr(primitive_plan, "route_family", None) or "").strip() or None,
+            (
+                str(getattr(primitive_plan, "route_family", None) or "").strip()
+                or (
+                    str(getattr(generation_plan, "backend_route_family", None) or "").strip()
+                    if has_exact_backend_fit
+                    else ""
+                )
+                or None
+            ),
+        )
+    if (
+        has_exact_backend_fit
+        and generation_plan is not None
+        and getattr(generation_plan, "backend_route_family", None)
+    ):
+        return (
+            None,
+            str(getattr(generation_plan, "backend_route_family", None) or "").strip() or None,
         )
     lowering = getattr(semantic_blueprint, "dsl_lowering", None)
     if lowering is not None:
@@ -251,6 +288,74 @@ def _resolve_route_identity(
             str(getattr(lowering, "route_family", None) or "").strip() or None,
         )
     return None, None
+
+
+def _resolve_backend_binding_identity(
+    *,
+    generation_plan=None,
+    route_id: str | None = None,
+    product_ir=None,
+    semantic_blueprint=None,
+) -> str | None:
+    """Return the exact backend-binding identity when available."""
+    if _lowering_errors_for(semantic_blueprint):
+        return None
+    if (
+        _generation_plan_has_exact_backend_fit(generation_plan)
+        and generation_plan is not None
+        and getattr(generation_plan, "backend_binding_id", None)
+    ):
+        return str(getattr(generation_plan, "backend_binding_id", None) or "").strip() or None
+    primitive_plan = getattr(generation_plan, "primitive_plan", None)
+    if (
+        _generation_plan_has_exact_backend_fit(generation_plan)
+        and primitive_plan is not None
+        and getattr(primitive_plan, "backend_binding_id", None)
+    ):
+        return str(getattr(primitive_plan, "backend_binding_id", None) or "").strip() or None
+    if not route_id or _lowering_errors_for(semantic_blueprint):
+        return None
+    from trellis.agent.backend_bindings import resolve_backend_binding_by_route_id
+
+    resolved = resolve_backend_binding_by_route_id(
+        route_id,
+        product_ir=product_ir,
+        primitive_plan=primitive_plan,
+    )
+    if resolved is None:
+        return None
+    return str(getattr(resolved, "binding_id", "") or "").strip() or None
+
+
+def _exact_bundle_id_for(
+    *,
+    bundle_id: str,
+    backend_binding_id: str | None,
+) -> str | None:
+    """Return the binding-scoped exact validation identity when available."""
+    normalized_bundle = str(bundle_id or "").strip()
+    normalized_binding = str(backend_binding_id or "").strip()
+    if not normalized_bundle or not normalized_binding:
+        return None
+    return f"{normalized_bundle}@{normalized_binding}"
+
+
+def _generation_plan_has_exact_backend_fit(generation_plan) -> bool:
+    """Return whether the generation plan represents an exact backend fit."""
+    if generation_plan is None:
+        return False
+    if str(getattr(generation_plan, "lane_plan_kind", "") or "").strip() == "exact_target_binding":
+        return True
+    for attr in ("backend_exact_target_refs", "backend_helper_refs"):
+        if tuple(getattr(generation_plan, attr, ()) or ()):
+            return True
+    primitive_plan = getattr(generation_plan, "primitive_plan", None)
+    if primitive_plan is None:
+        return False
+    for attr in ("backend_exact_target_refs", "backend_helper_refs"):
+        if tuple(getattr(primitive_plan, attr, ()) or ()):
+            return True
+    return False
 
 
 def _requested_outputs_for(*, request=None, semantic_blueprint=None) -> tuple[str, ...]:

--- a/trellis/agent/validation_contract.py
+++ b/trellis/agent/validation_contract.py
@@ -300,20 +300,21 @@ def _resolve_backend_binding_identity(
     """Return the exact backend-binding identity when available."""
     if _lowering_errors_for(semantic_blueprint):
         return None
+    has_exact_backend_fit = _generation_plan_has_exact_backend_fit(generation_plan)
     if (
-        _generation_plan_has_exact_backend_fit(generation_plan)
+        has_exact_backend_fit
         and generation_plan is not None
         and getattr(generation_plan, "backend_binding_id", None)
     ):
         return str(getattr(generation_plan, "backend_binding_id", None) or "").strip() or None
     primitive_plan = getattr(generation_plan, "primitive_plan", None)
     if (
-        _generation_plan_has_exact_backend_fit(generation_plan)
+        has_exact_backend_fit
         and primitive_plan is not None
         and getattr(primitive_plan, "backend_binding_id", None)
     ):
         return str(getattr(primitive_plan, "backend_binding_id", None) or "").strip() or None
-    if not route_id or _lowering_errors_for(semantic_blueprint):
+    if not route_id:
         return None
     from trellis.agent.backend_bindings import resolve_backend_binding_by_route_id
 


### PR DESCRIPTION
## Summary
- add binding-scoped exact validation identity to compiled validation contracts while keeping generic bundle packs stable
- surface the exact validation identity through route binding authority, request metadata, and traces
- document the binding-first validation split and mark QUA-802 done in the program mirror

## Validation
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_validation_contract.py tests/test_agent/test_platform_requests.py tests/test_agent/test_platform_traces.py -q`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_semantic_validators.py tests/test_agent/test_route_registry.py tests/test_agent/test_checkpoints.py -q`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_tasks/test_t01_zcb_option.py -q`
- `PYTHONHASHSEED=0 /Users/steveyang/miniforge3/bin/python3 scripts/run_canary.py --task T13 --replay`
- `PYTHONHASHSEED=0 /Users/steveyang/miniforge3/bin/python3 scripts/run_canary.py --task T38 --replay`
- `/Users/steveyang/miniforge3/bin/python3 scripts/run_knowledge_light_proving.py --cases KL01 --output /tmp/qua802_kl01.json`
- `/Users/steveyang/miniforge3/bin/python3 scripts/run_knowledge_light_proving.py --cases KL03 --output /tmp/qua802_kl03.json`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/ -x -q -m "not integration"`
