### PR TITLE
QUA-803: introduce binding-first operator metadata

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -81,6 +81,9 @@ maintenance around the deterministic engines.
 - `trellis/agent/backend_bindings.py` is the canonical catalog of exact helper,
   kernel, schedule-builder, cashflow-engine, and market-binding facts used by
   the runtime.
+- `trellis/agent/binding_operator_metadata.py` is the first-class catalog of
+  operator-facing binding display names, short descriptions, and diagnostic
+  labels, so operator wording no longer has to piggyback on route YAML prose.
 - `trellis/agent/codegen_guardrails.py` now carries those backend-binding facts
   on `PrimitivePlan` and `GenerationPlan`, so runtime plans no longer need to
   rediscover exact helper identity from route ids later in validation or trace

--- a/docs/plans/binding-first-exotic-assembly.md
+++ b/docs/plans/binding-first-exotic-assembly.md
@@ -173,7 +173,7 @@ Status mirror last synced: `2026-04-13`
 
 | Ticket | Status |
 | --- | --- |
-| `QUA-803` | Operator metadata: introduce first-class binding display and diagnostic catalog | Backlog |
+| `QUA-803` | Operator metadata: introduce first-class binding display and diagnostic catalog | Done |
 | `QUA-807` | Operator views: use binding metadata in MCP, session, and task diagnostics surfaces | Backlog |
 | `QUA-814` | Route YAML cleanup: strip operator-facing wording after binding metadata adoption | Backlog |
 

--- a/docs/quant/pricing_stack.rst
+++ b/docs/quant/pricing_stack.rst
@@ -209,6 +209,11 @@ keeps the generic validation pack id in ``bundle_id`` but also emits an
 exact binding-scoped validation identity for exact-fit requests, so route ids
 are no longer required as the primary exact-fit key in validation summaries,
 route-binding authority packets, or downstream trace consumers.
+Operator-facing binding wording now follows the same rule: display names,
+short descriptions, and diagnostic labels are resolved from a dedicated
+binding metadata catalog rather than route-card prose, and the compiled
+route-binding authority packet carries that metadata for downstream
+diagnostic surfaces.
 That exact-surface contract now also drives live plan construction, DSL
 lowering, and semantic helper review: those paths resolve helpers, kernels,
 and schedule builders from ``trellis.agent.backend_bindings`` first and only

--- a/tests/test_agent/test_binding_operator_metadata.py
+++ b/tests/test_agent/test_binding_operator_metadata.py
@@ -33,3 +33,33 @@ def test_resolve_binding_operator_metadata_derives_fallback_without_route_prose(
     assert metadata.display_name == "Pathwise Exotic (monte_carlo / basket_credit)"
     assert metadata.diagnostic_label == "synthetic_exotic_binding"
     assert "trellis.models.synthetic.price_pathwise_exotic_helper" in metadata.short_description
+
+
+def test_resolve_binding_operator_metadata_uses_symbol_slug_when_route_id_is_empty():
+    from trellis.agent.binding_operator_metadata import resolve_binding_operator_metadata
+
+    metadata = resolve_binding_operator_metadata(
+        binding_id="trellis.models.synthetic.price_bound_helper",
+        engine_family="analytical",
+        route_family="analytical",
+        route_id="",
+    )
+
+    assert metadata is not None
+    assert metadata.display_name == "Bound (analytical)"
+    assert metadata.diagnostic_label == "price_bound_helper"
+
+
+def test_resolve_binding_operator_metadata_returns_canonical_entry_for_black76_put():
+    from trellis.agent.binding_operator_metadata import resolve_binding_operator_metadata
+
+    metadata = resolve_binding_operator_metadata(
+        binding_id="trellis.models.black.black76_put",
+        engine_family="analytical",
+        route_family="analytical",
+        route_id="analytical_black76",
+    )
+
+    assert metadata is not None
+    assert metadata.display_name == "Black-76 analytical put binding"
+    assert metadata.diagnostic_label == "black76_put_analytical_binding"

--- a/tests/test_agent/test_binding_operator_metadata.py
+++ b/tests/test_agent/test_binding_operator_metadata.py
@@ -1,0 +1,35 @@
+"""Tests for binding-first operator metadata resolution."""
+
+from __future__ import annotations
+
+
+def test_resolve_binding_operator_metadata_returns_canonical_entry_for_known_binding():
+    from trellis.agent.binding_operator_metadata import resolve_binding_operator_metadata
+
+    metadata = resolve_binding_operator_metadata(
+        binding_id="trellis.models.quanto_option.price_quanto_option_analytical_from_market_state",
+        engine_family="analytical",
+        route_family="analytical",
+        route_id="quanto_adjustment_analytical",
+    )
+
+    assert metadata is not None
+    assert metadata.display_name == "Quanto option analytical binding"
+    assert metadata.diagnostic_label == "quanto_analytical_binding"
+    assert "semantic quanto option pricing" in metadata.short_description
+
+
+def test_resolve_binding_operator_metadata_derives_fallback_without_route_prose():
+    from trellis.agent.binding_operator_metadata import resolve_binding_operator_metadata
+
+    metadata = resolve_binding_operator_metadata(
+        binding_id="trellis.models.synthetic.price_pathwise_exotic_helper",
+        engine_family="monte_carlo",
+        route_family="basket_credit",
+        route_id="synthetic_exotic_binding",
+    )
+
+    assert metadata is not None
+    assert metadata.display_name == "Pathwise Exotic (monte_carlo / basket_credit)"
+    assert metadata.diagnostic_label == "synthetic_exotic_binding"
+    assert "trellis.models.synthetic.price_pathwise_exotic_helper" in metadata.short_description

--- a/tests/test_agent/test_platform_requests.py
+++ b/tests/test_agent/test_platform_requests.py
@@ -149,6 +149,11 @@ def test_compile_build_request_attaches_route_binding_authority_packet():
         "trellis.models.quanto_option.price_quanto_option_analytical_from_market_state"
     ]
     assert "trellis.models.quanto_option.price_quanto_option_analytical_from_market_state" in backend_binding["helper_refs"]
+    assert authority["operator_metadata"] == {
+        "display_name": "Quanto option analytical binding",
+        "short_description": "Exact analytical backend binding for semantic quanto option pricing.",
+        "diagnostic_label": "quanto_analytical_binding",
+    }
     assert authority["validation_bundle_id"] == "analytical:quanto_option"
     assert (
         authority["exact_validation_bundle_id"]

--- a/tests/test_agent/test_platform_traces.py
+++ b/tests/test_agent/test_platform_traces.py
@@ -620,6 +620,10 @@ def test_platform_trace_persists_semantic_checkpoint_and_generation_boundary(
     assert trace.generation_boundary["route_binding_authority"]["route_id"] == expected_route_id
     assert boundary["generation_boundary"]["route_binding_authority"]["route_id"] == expected_route_id
     assert trace.generation_boundary["route_binding_authority"]["authority_kind"] == "exact_backend_fit"
+    operator_metadata = trace.generation_boundary["route_binding_authority"]["operator_metadata"]
+    assert operator_metadata is not None
+    if expected_route_id == "quanto_adjustment_analytical":
+        assert operator_metadata["display_name"] == "Quanto option analytical binding"
     assert (
         trace.generation_boundary["primitive_plan"]["backend_binding_id"]
         == trace.generation_boundary["route_binding_authority"]["backend_binding"]["binding_id"]

--- a/tests/test_agent/test_route_registry.py
+++ b/tests/test_agent/test_route_registry.py
@@ -306,6 +306,9 @@ class TestRegistryValidation:
         assert authority.backend_binding.exact_target_refs == (
             "trellis.models.synthetic.price_bound_helper",
         )
+        assert authority.operator_metadata is not None
+        assert authority.operator_metadata.display_name == "Bound (analytical)"
+        assert authority.operator_metadata.diagnostic_label == "binding_fallback"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_agent/test_route_registry.py
+++ b/tests/test_agent/test_route_registry.py
@@ -308,7 +308,7 @@ class TestRegistryValidation:
         )
         assert authority.operator_metadata is not None
         assert authority.operator_metadata.display_name == "Bound (analytical)"
-        assert authority.operator_metadata.diagnostic_label == "binding_fallback"
+        assert authority.operator_metadata.diagnostic_label == "price_bound_helper"
 
 
 # ---------------------------------------------------------------------------

--- a/trellis/agent/binding_operator_metadata.py
+++ b/trellis/agent/binding_operator_metadata.py
@@ -1,0 +1,152 @@
+"""Operator-facing metadata for backend bindings.
+
+This catalog separates display/diagnostic wording from route YAML so operator
+surfaces can resolve stable binding-first labels without reading route-card
+prose. Explicit entries cover the current checked bindings that appear in
+operator traces and diagnostics; unknown bindings fall back to a generic,
+binding-id-derived label until a dedicated entry is added.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class BindingOperatorMetadata:
+    """Operator-facing metadata for one backend binding."""
+
+    display_name: str
+    short_description: str
+    diagnostic_label: str
+
+
+_CANONICAL_BINDING_OPERATOR_METADATA: dict[str, BindingOperatorMetadata] = {
+    "trellis.models.quanto_option.price_quanto_option_analytical_from_market_state": BindingOperatorMetadata(
+        display_name="Quanto option analytical binding",
+        short_description="Exact analytical backend binding for semantic quanto option pricing.",
+        diagnostic_label="quanto_analytical_binding",
+    ),
+    "trellis.models.fx_vanilla.price_fx_vanilla_analytical": BindingOperatorMetadata(
+        display_name="FX vanilla analytical binding",
+        short_description="Exact Garman-Kohlhagen analytical helper binding for FX vanilla pricing.",
+        diagnostic_label="fx_vanilla_analytical_binding",
+    ),
+    "trellis.models.credit_default_swap.price_cds_analytical": BindingOperatorMetadata(
+        display_name="CDS analytical binding",
+        short_description="Exact analytical backend binding for single-name CDS pricing.",
+        diagnostic_label="credit_default_swap_analytical_binding",
+    ),
+    "trellis.models.zcb_option.price_zcb_option_jamshidian": BindingOperatorMetadata(
+        display_name="ZCB option analytical binding",
+        short_description="Exact Jamshidian analytical binding for zero-coupon bond option pricing.",
+        diagnostic_label="zcb_option_analytical_binding",
+    ),
+    "trellis.models.zcb_option_tree.price_zcb_option_tree": BindingOperatorMetadata(
+        display_name="ZCB option tree binding",
+        short_description="Exact rate-tree backend binding for zero-coupon bond option pricing.",
+        diagnostic_label="zcb_option_tree_binding",
+    ),
+    "trellis.models.black.black76_call": BindingOperatorMetadata(
+        display_name="Black-76 analytical binding",
+        short_description="Exact Black-76 helper binding for analytical vanilla and swaption pricing.",
+        diagnostic_label="black76_analytical_binding",
+    ),
+    "pde_solver:pde_solver:fallback": BindingOperatorMetadata(
+        display_name="PDE solver fallback binding",
+        short_description="Binding-first fallback label for the generic theta-method PDE solver surface.",
+        diagnostic_label="pde_solver_fallback_binding",
+    ),
+}
+
+
+def resolve_binding_operator_metadata(
+    *,
+    binding_id: str,
+    engine_family: str = "",
+    route_family: str = "",
+    route_id: str = "",
+) -> BindingOperatorMetadata | None:
+    """Resolve operator-facing metadata for a backend binding."""
+    normalized_binding_id = str(binding_id or "").strip()
+    if not normalized_binding_id:
+        return None
+    explicit = _CANONICAL_BINDING_OPERATOR_METADATA.get(normalized_binding_id)
+    if explicit is not None:
+        return explicit
+    return _fallback_binding_operator_metadata(
+        binding_id=normalized_binding_id,
+        engine_family=engine_family,
+        route_family=route_family,
+        route_id=route_id,
+    )
+
+
+def _fallback_binding_operator_metadata(
+    *,
+    binding_id: str,
+    engine_family: str = "",
+    route_family: str = "",
+    route_id: str = "",
+) -> BindingOperatorMetadata:
+    """Return a generic metadata record derived from binding identity."""
+    symbol = str(binding_id.rsplit(".", 1)[-1] or binding_id).strip()
+    display_root = _humanize_symbol(symbol)
+    family_bits = [str(engine_family or "").strip(), str(route_family or "").strip()]
+    family_bits = [item for item in family_bits if item]
+    display_name = display_root
+    if family_bits:
+        display_name = f"{display_root} ({' / '.join(dict.fromkeys(family_bits))})"
+    route_fragment = str(route_id or "").strip() or "binding_fallback"
+    return BindingOperatorMetadata(
+        display_name=display_name,
+        short_description=(
+            f"Fallback operator metadata derived from backend binding `{binding_id}`."
+        ),
+        diagnostic_label=_slugify(route_fragment or symbol),
+    )
+
+
+def _humanize_symbol(symbol: str) -> str:
+    """Project a code symbol onto a readable operator label."""
+    text = str(symbol or "").strip()
+    for prefix in ("price_", "build_", "resolve_"):
+        if text.startswith(prefix):
+            text = text[len(prefix):]
+    for suffix in ("_from_market_state", "_helper", "_kernel"):
+        if text.endswith(suffix):
+            text = text[: -len(suffix)]
+    words = [part for part in text.replace(":", "_").split("_") if part]
+    if not words:
+        return "Backend binding"
+    acronyms = {
+        "fx": "FX",
+        "cds": "CDS",
+        "zcb": "ZCB",
+        "pde": "PDE",
+        "qmc": "QMC",
+        "fft": "FFT",
+        "mc": "MC",
+    }
+    rendered: list[str] = []
+    for word in words:
+        lower = word.lower()
+        if lower in acronyms:
+            rendered.append(acronyms[lower])
+        elif lower == "black76":
+            rendered.append("Black-76")
+        else:
+            rendered.append(word.capitalize())
+    return " ".join(rendered)
+
+
+def _slugify(text: str) -> str:
+    """Return a compact snake-case diagnostic label."""
+    normalized = [
+        char.lower() if char.isalnum() else "_"
+        for char in str(text or "").strip()
+    ]
+    slug = "".join(normalized)
+    while "__" in slug:
+        slug = slug.replace("__", "_")
+    return slug.strip("_") or "binding_fallback"

--- a/trellis/agent/binding_operator_metadata.py
+++ b/trellis/agent/binding_operator_metadata.py
@@ -21,6 +21,9 @@ class BindingOperatorMetadata:
     diagnostic_label: str
 
 
+_PDE_SOLVER_FALLBACK_BINDING_ID = "pde_solver:pde_solver:fallback"
+
+
 _CANONICAL_BINDING_OPERATOR_METADATA: dict[str, BindingOperatorMetadata] = {
     "trellis.models.quanto_option.price_quanto_option_analytical_from_market_state": BindingOperatorMetadata(
         display_name="Quanto option analytical binding",
@@ -52,7 +55,14 @@ _CANONICAL_BINDING_OPERATOR_METADATA: dict[str, BindingOperatorMetadata] = {
         short_description="Exact Black-76 helper binding for analytical vanilla and swaption pricing.",
         diagnostic_label="black76_analytical_binding",
     ),
-    "pde_solver:pde_solver:fallback": BindingOperatorMetadata(
+    "trellis.models.black.black76_put": BindingOperatorMetadata(
+        display_name="Black-76 analytical put binding",
+        short_description="Exact Black-76 put helper binding for analytical vanilla and swaption pricing.",
+        diagnostic_label="black76_put_analytical_binding",
+    ),
+    # Fallback binding ids intentionally use the shared `engine:route:fallback`
+    # shape from backend_bindings.py / route_registry.py rather than module paths.
+    _PDE_SOLVER_FALLBACK_BINDING_ID: BindingOperatorMetadata(
         display_name="PDE solver fallback binding",
         short_description="Binding-first fallback label for the generic theta-method PDE solver surface.",
         diagnostic_label="pde_solver_fallback_binding",
@@ -97,13 +107,13 @@ def _fallback_binding_operator_metadata(
     display_name = display_root
     if family_bits:
         display_name = f"{display_root} ({' / '.join(dict.fromkeys(family_bits))})"
-    route_fragment = str(route_id or "").strip() or "binding_fallback"
+    route_fragment = str(route_id or "").strip()
     return BindingOperatorMetadata(
         display_name=display_name,
         short_description=(
             f"Fallback operator metadata derived from backend binding `{binding_id}`."
         ),
-        diagnostic_label=_slugify(route_fragment or symbol),
+        diagnostic_label=_slugify(route_fragment) if route_fragment else _slugify(symbol),
     )
 
 

--- a/trellis/agent/route_registry.py
+++ b/trellis/agent/route_registry.py
@@ -22,6 +22,10 @@ from typing import Any
 
 import yaml
 
+from trellis.agent.binding_operator_metadata import (
+    BindingOperatorMetadata,
+    resolve_binding_operator_metadata,
+)
 from trellis.agent.codegen_guardrails import PrimitiveRef
 from trellis.agent.family_lowering_ir import (
     AnalyticalBlack76IR,
@@ -193,6 +197,7 @@ class RouteBindingAuthority:
     route_family: str
     authority_kind: str
     backend_binding: BackendBindingAuthority
+    operator_metadata: BindingOperatorMetadata | None = None
     compatibility_alias_policy: str = "operator_visible"
     validation_bundle_id: str = ""
     exact_validation_bundle_id: str = ""
@@ -1208,11 +1213,18 @@ def compile_route_binding_authority(
         admissibility=admissibility,
         admissibility_failures=admissibility_failures,
     )
+    operator_metadata = resolve_binding_operator_metadata(
+        binding_id=backend_binding.binding_id,
+        engine_family=backend_binding.engine_family,
+        route_family=route_family,
+        route_id=route_id or str(getattr(primitive_plan, "route", "") or ""),
+    )
     return RouteBindingAuthority(
         route_id=route_id or str(getattr(primitive_plan, "route", "") or ""),
         route_family=route_family,
         authority_kind=authority_kind,
         backend_binding=backend_binding,
+        operator_metadata=operator_metadata,
         compatibility_alias_policy=compatibility_alias_policy,
         validation_bundle_id=validation_bundle_id,
         exact_validation_bundle_id=exact_validation_bundle_id,
@@ -1229,6 +1241,7 @@ def route_binding_authority_summary(
     if authority is None:
         return None
     backend_binding = authority.backend_binding
+    operator_metadata = authority.operator_metadata
     return {
         "route_id": authority.route_id,
         "route_family": authority.route_family,
@@ -1263,6 +1276,15 @@ def route_binding_authority_summary(
             },
             "admissibility_failures": list(backend_binding.admissibility_failures),
         },
+        "operator_metadata": (
+            None
+            if operator_metadata is None
+            else {
+                "display_name": operator_metadata.display_name,
+                "short_description": operator_metadata.short_description,
+                "diagnostic_label": operator_metadata.diagnostic_label,
+            }
+        ),
         "validation_bundle_id": authority.validation_bundle_id,
         "exact_validation_bundle_id": authority.exact_validation_bundle_id,
         "validation_check_ids": list(authority.validation_check_ids),


### PR DESCRIPTION
## Summary\n- add a binding-first operator metadata catalog for operator-facing labels\n- thread operator metadata through route binding authority, request packets, and traces\n- document the operator surface split in the binding-first program docs\n\n## Validation\n- /Users/steveyang/miniforge3/bin/python3 -m py_compile trellis/agent/binding_operator_metadata.py trellis/agent/route_registry.py tests/test_agent/test_binding_operator_metadata.py tests/test_agent/test_platform_requests.py tests/test_agent/test_route_registry.py tests/test_agent/test_platform_traces.py\n- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_binding_operator_metadata.py tests/test_agent/test_platform_requests.py tests/test_agent/test_route_registry.py tests/test_agent/test_platform_traces.py -q\n- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_task_diagnostics.py tests/test_agent/test_task_run_store.py tests/test_agent/test_platform_traces.py -q\n- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_tasks/test_t01_zcb_option.py -q\n- PYTHONHASHSEED=0 /Users/steveyang/miniforge3/bin/python3 scripts/run_canary.py --task T13 --replay\n- PYTHONHASHSEED=0 /Users/steveyang/miniforge3/bin/python3 scripts/run_canary.py --task T38 --replay\n- PYTHONHASHSEED=0 /Users/steveyang/miniforge3/bin/python3 scripts/run_canary.py --task T105\n- /Users/steveyang/miniforge3/bin/python3 scripts/run_knowledge_light_proving.py --cases KL01 --output /tmp/qua803_kl01.json\n- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/ -x -q -m "not integration"