### PR TITLE
QUA-807: move operator views onto binding metadata

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -84,6 +84,10 @@ maintenance around the deterministic engines.
 - `trellis/agent/binding_operator_metadata.py` is the first-class catalog of
   operator-facing binding display names, short descriptions, and diagnostic
   labels, so operator wording no longer has to piggyback on route YAML prose.
+- `trellis/agent/platform_traces.py`, `trellis/agent/task_run_store.py`, and
+  `trellis/agent/task_diagnostics.py` now consume that binding metadata when
+  they render operator-facing construction summaries, so task dossiers and
+  persisted telemetry no longer need raw route-card wording to stay readable.
 - `trellis/agent/codegen_guardrails.py` now carries those backend-binding facts
   on `PrimitivePlan` and `GenerationPlan`, so runtime plans no longer need to
   rediscover exact helper identity from route ids later in validation or trace

--- a/docs/developer/task_diagnostics.rst
+++ b/docs/developer/task_diagnostics.rst
@@ -124,6 +124,19 @@ Each batch record captures:
 - aggregate pass, elapsed-time, token, and attempt metrics
 - per-canary links back to the underlying task-run and diagnosis artifacts
 
+Binding-first operator wording
+------------------------------
+
+The diagnosis packet and dossier now prefer binding-first operator metadata
+when an exact backend binding is known. In practice that means:
+
+- trace construction labels prefer the binding display name instead of a raw
+  backend symbol
+- route-observation tables prefer the binding diagnostic label instead of a
+  route id when exact binding metadata is available
+- route ids remain only as transitional aliases when no binding metadata has
+  been resolved
+
 The deterministic loaders are:
 
 - ``load_canary_batch_records()``

--- a/docs/plans/binding-first-exotic-assembly.md
+++ b/docs/plans/binding-first-exotic-assembly.md
@@ -174,7 +174,7 @@ Status mirror last synced: `2026-04-13`
 | Ticket | Status |
 | --- | --- |
 | `QUA-803` | Operator metadata: introduce first-class binding display and diagnostic catalog | Done |
-| `QUA-807` | Operator views: use binding metadata in MCP, session, and task diagnostics surfaces | Backlog |
+| `QUA-807` | Operator views: use binding metadata in MCP, session, and task diagnostics surfaces | Done |
 | `QUA-814` | Route YAML cleanup: strip operator-facing wording after binding metadata adoption | Backlog |
 
 ### Ordered Exotic Composition Proof Queue

--- a/docs/quant/pricing_stack.rst
+++ b/docs/quant/pricing_stack.rst
@@ -213,7 +213,9 @@ Operator-facing binding wording now follows the same rule: display names,
 short descriptions, and diagnostic labels are resolved from a dedicated
 binding metadata catalog rather than route-card prose, and the compiled
 route-binding authority packet carries that metadata for downstream
-diagnostic surfaces.
+diagnostic surfaces. Platform traces, persisted task-run telemetry, and
+task-diagnosis dossiers now render those binding-first labels directly
+instead of reconstructing operator wording from route ids.
 That exact-surface contract now also drives live plan construction, DSL
 lowering, and semantic helper review: those paths resolve helpers, kernels,
 and schedule builders from ``trellis.agent.backend_bindings`` first and only

--- a/tests/test_agent/test_platform_traces.py
+++ b/tests/test_agent/test_platform_traces.py
@@ -335,12 +335,16 @@ def test_platform_trace_summarizes_event_aware_pde_family_ir(tmp_path):
     boundary = load_platform_trace_boundary(trace_path)
     lowering = boundary["generation_boundary"]["lowering"]
     construction_identity = boundary["generation_boundary"]["construction_identity"]
+    operator_metadata = boundary["generation_boundary"]["route_binding_authority"]["operator_metadata"]
     family_ir_summary = lowering["family_ir_summary"]
 
     assert lowering["family_ir_type"] == "EventAwarePDEIR"
     assert construction_identity["primary_kind"] == "backend_binding"
+    assert operator_metadata is not None
+    assert construction_identity["primary_label"] == operator_metadata["display_name"]
     assert construction_identity["route_alias"] == "pde_theta_1d"
     assert construction_identity["backend_binding_id"] == "trellis.models.callable_bond_pde.price_callable_bond_pde"
+    assert construction_identity["binding_diagnostic_label"] == operator_metadata["diagnostic_label"]
     assert family_ir_summary["semantic_control_style"] == "issuer_min"
     assert family_ir_summary["helper_symbol"] == "price_callable_bond_pde"
     assert family_ir_summary["semantic_transform_kinds"] == ["add_cashflow", "project_min"]
@@ -613,6 +617,10 @@ def test_platform_trace_persists_semantic_checkpoint_and_generation_boundary(
     construction_identity = trace.generation_boundary["construction_identity"]
     assert construction_identity["primary_kind"] == "backend_binding"
     assert construction_identity["backend_exact_fit"] is True
+    operator_metadata = trace.generation_boundary["route_binding_authority"]["operator_metadata"]
+    assert operator_metadata is not None
+    assert construction_identity["primary_label"] == operator_metadata["display_name"]
+    assert construction_identity["binding_diagnostic_label"] == operator_metadata["diagnostic_label"]
     assert construction_identity["route_alias"] == expected_route_alias
     assert trace.generation_boundary["lowering"]["route_id"] == expected_route_id
     assert boundary["generation_boundary"]["lowering"]["route_id"] == expected_route_id
@@ -620,7 +628,6 @@ def test_platform_trace_persists_semantic_checkpoint_and_generation_boundary(
     assert trace.generation_boundary["route_binding_authority"]["route_id"] == expected_route_id
     assert boundary["generation_boundary"]["route_binding_authority"]["route_id"] == expected_route_id
     assert trace.generation_boundary["route_binding_authority"]["authority_kind"] == "exact_backend_fit"
-    operator_metadata = trace.generation_boundary["route_binding_authority"]["operator_metadata"]
     assert operator_metadata is not None
     if expected_route_id == "quanto_adjustment_analytical":
         assert operator_metadata["display_name"] == "Quanto option analytical binding"

--- a/tests/test_agent/test_task_diagnostics.py
+++ b/tests/test_agent/test_task_diagnostics.py
@@ -466,3 +466,50 @@ def test_build_task_diagnosis_packet_keeps_platform_action_out_of_route_ids(tmp_
     assert packet["telemetry"]["route_observations"][0]["route_id"] == ""
     assert packet["telemetry"]["route_observations"][0]["route_family"] == "analytical"
     assert packet["telemetry"]["route_observations"][0]["primary_label"] == "analytical"
+
+
+def test_build_task_diagnosis_packet_uses_binding_operator_metadata_in_operator_views(tmp_path):
+    from trellis.agent.task_diagnostics import build_task_diagnosis_packet, render_task_diagnosis_dossier
+
+    record = _sample_record(tmp_path)
+    record.pop("telemetry", None)
+    trace = record["trace_summaries"][0]
+    trace["route_health"] = {
+        "route_id": "analytical_garman_kohlhagen",
+        "route_family": "analytical",
+        "trace_status": "succeeded",
+        "effective_instruction_ids": [],
+        "effective_instruction_count": 0,
+        "hard_constraint_count": 0,
+        "conflict_count": 0,
+        "canary_task_ids": ["T105"],
+    }
+    trace["construction_identity"] = {
+        "primary_kind": "backend_binding",
+        "primary_label": "FX vanilla analytical binding",
+        "backend_binding_id": "trellis.models.fx_vanilla.price_fx_vanilla_analytical",
+        "binding_display_name": "FX vanilla analytical binding",
+        "binding_short_description": "Exact Garman-Kohlhagen analytical helper binding for FX vanilla pricing.",
+        "binding_diagnostic_label": "fx_vanilla_analytical_binding",
+        "route_alias": "",
+    }
+    trace["route_binding_authority"] = {
+        "route_id": "analytical_garman_kohlhagen",
+        "route_family": "analytical",
+        "authority_kind": "exact_backend_fit",
+        "operator_metadata": {
+            "display_name": "FX vanilla analytical binding",
+            "short_description": "Exact Garman-Kohlhagen analytical helper binding for FX vanilla pricing.",
+            "diagnostic_label": "fx_vanilla_analytical_binding",
+        },
+        "canary_task_ids": ["T105"],
+    }
+
+    packet = build_task_diagnosis_packet(record)
+    rendered = render_task_diagnosis_dossier(packet)
+
+    assert packet["trace_index"][0]["construction_label"] == "FX vanilla analytical binding"
+    assert packet["telemetry"]["route_observations"][0]["primary_label"] == "FX vanilla analytical binding"
+    assert packet["telemetry"]["route_observations"][0]["binding_diagnostic_label"] == "fx_vanilla_analytical_binding"
+    assert "FX vanilla analytical binding" in rendered
+    assert "fx_vanilla_analytical_binding" in rendered

--- a/tests/test_agent/test_task_run_store.py
+++ b/tests/test_agent/test_task_run_store.py
@@ -362,6 +362,97 @@ def test_persist_task_run_record_treats_terminal_result_as_not_running_even_with
     assert latest["workflow"]["active_trace_count"] == 1
 
 
+def test_persist_task_run_record_carries_binding_operator_metadata_into_trace_health(tmp_path):
+    from trellis.agent.task_run_store import load_task_run_record, persist_task_run_record
+
+    trace_root = tmp_path / "trellis" / "agent" / "knowledge" / "traces" / "platform"
+    analytical_trace = trace_root / "executor_build_fx.yaml"
+
+    _write_trace(
+        analytical_trace,
+        {
+            "request_id": "executor_build_fx",
+            "status": "succeeded",
+            "outcome": "build_completed",
+            "action": "compile_only",
+            "route_method": "analytical",
+            "updated_at": "2026-04-10T18:00:00+00:00",
+            "request_metadata": {"task_id": "T105", "task_title": "FX vanilla analytical check"},
+            "generation_boundary": {
+                "construction_identity": {
+                    "primary_kind": "backend_binding",
+                    "primary_label": "FX vanilla analytical binding",
+                    "backend_binding_id": "trellis.models.fx_vanilla.price_fx_vanilla_analytical",
+                    "binding_display_name": "FX vanilla analytical binding",
+                    "binding_short_description": "Exact Garman-Kohlhagen analytical helper binding for FX vanilla pricing.",
+                    "binding_diagnostic_label": "fx_vanilla_analytical_binding",
+                    "route_alias": "",
+                },
+                "route_binding_authority": {
+                    "route_id": "analytical_garman_kohlhagen",
+                    "route_family": "analytical",
+                    "authority_kind": "exact_backend_fit",
+                    "operator_metadata": {
+                        "display_name": "FX vanilla analytical binding",
+                        "short_description": "Exact Garman-Kohlhagen analytical helper binding for FX vanilla pricing.",
+                        "diagnostic_label": "fx_vanilla_analytical_binding",
+                    },
+                    "backend_binding": {
+                        "binding_id": "trellis.models.fx_vanilla.price_fx_vanilla_analytical",
+                        "engine_family": "analytical",
+                        "exact_backend_fit": True,
+                        "exact_target_refs": ["trellis.models.fx_vanilla.price_fx_vanilla_analytical"],
+                        "approved_modules": ["trellis.models.fx_vanilla"],
+                        "primitive_refs": [],
+                        "helper_refs": ["trellis.models.fx_vanilla.price_fx_vanilla_analytical"],
+                        "admissibility": {},
+                        "admissibility_failures": [],
+                    },
+                    "validation_bundle_id": "analytical:fx_vanilla",
+                    "exact_validation_bundle_id": (
+                        "analytical:fx_vanilla@trellis.models.fx_vanilla.price_fx_vanilla_analytical"
+                    ),
+                    "canary_task_ids": ["T105"],
+                },
+            },
+            "events": [
+                {
+                    "event": "build_completed",
+                    "status": "ok",
+                    "timestamp": "2026-04-10T18:00:00+00:00",
+                    "details": {"attempts": 1},
+                }
+            ],
+        },
+    )
+
+    task = {"id": "T105", "title": "FX vanilla analytical check", "construct": ["analytical"]}
+    result = {
+        "task_id": "T105",
+        "title": "FX vanilla analytical check",
+        "success": True,
+        "cross_validation": {"status": "passed"},
+        "artifacts": {"platform_trace_paths": [str(analytical_trace)]},
+        "reflection": {},
+    }
+
+    persisted = persist_task_run_record(
+        task,
+        result,
+        root=tmp_path,
+        persisted_at=datetime(2026, 4, 10, 18, 1, 0, tzinfo=timezone.utc),
+    )
+    latest = load_task_run_record(persisted["latest_path"])
+
+    route_health = latest["trace_summaries"][0]["route_health"]
+    observation = latest["telemetry"]["route_observations"][0]
+
+    assert route_health["binding_display_name"] == "FX vanilla analytical binding"
+    assert route_health["binding_diagnostic_label"] == "fx_vanilla_analytical_binding"
+    assert observation["primary_label"] == "FX vanilla analytical binding"
+    assert observation["binding_diagnostic_label"] == "fx_vanilla_analytical_binding"
+
+
 def test_skill_telemetry_rollups_capture_selected_artifacts_and_route_health(tmp_path):
     from trellis.agent.task_run_store import (
         load_latest_route_ranking_inputs,

--- a/trellis/agent/checkpoints.py
+++ b/trellis/agent/checkpoints.py
@@ -234,13 +234,23 @@ def capture_checkpoint(
         construction_identity = route_metadata.get("construction_identity") or {}
         route_binding_authority = route_metadata.get("route_binding_authority") or {}
         backend_binding = route_binding_authority.get("backend_binding") or {}
-        route_decision = str(
-            construction_identity.get("primary_label")
+        exact_backend_binding_id = str(
+            construction_identity.get("backend_binding_id")
             or (
                 backend_binding.get("binding_id")
                 if route_binding_authority.get("authority_kind") == "exact_backend_fit"
+                else ""
+            )
+            or ""
+        ).strip()
+        route_decision = str(
+            (
+                exact_backend_binding_id
+                if str(construction_identity.get("primary_kind") or "").strip() == "backend_binding"
                 else None
             )
+            or construction_identity.get("primary_label")
+            or exact_backend_binding_id
             or lowering.get("family_ir_type")
             or route_metadata.get("lane_plan", {}).get("lane_family")
             or lowering.get("route_id")

--- a/trellis/agent/platform_traces.py
+++ b/trellis/agent/platform_traces.py
@@ -589,6 +589,7 @@ def _construction_identity_summary(
     from trellis.agent.route_registry import should_surface_route_alias
 
     backend_binding = dict(route_binding_authority.get("backend_binding") or {})
+    operator_metadata = dict(route_binding_authority.get("operator_metadata") or {})
     exact_backend_fit = bool(
         backend_binding.get("exact_backend_fit")
         if "exact_backend_fit" in backend_binding
@@ -609,10 +610,13 @@ def _construction_identity_summary(
         or str(route_binding_authority.get("engine_family") or "").strip()
         or None
     )
+    binding_display_name = str(operator_metadata.get("display_name") or "").strip() or None
+    binding_short_description = str(operator_metadata.get("short_description") or "").strip() or None
+    binding_diagnostic_label = str(operator_metadata.get("diagnostic_label") or "").strip() or None
 
     if exact_backend_fit and backend_binding_id:
         primary_kind = "backend_binding"
-        primary_label = backend_binding_id
+        primary_label = binding_display_name or backend_binding_id
     elif family_ir_type:
         primary_kind = "family_ir"
         primary_label = family_ir_type
@@ -635,6 +639,10 @@ def _construction_identity_summary(
         "backend_binding_id": backend_binding_id,
         "backend_engine_family": backend_engine_family,
         "backend_exact_fit": exact_backend_fit,
+        "binding_display_name": binding_display_name,
+        "binding_short_description": binding_short_description,
+        "binding_diagnostic_label": binding_diagnostic_label,
+        "operator_metadata": operator_metadata or None,
         "route_alias": route_alias,
         "route_alias_policy": str(route_binding_authority.get("compatibility_alias_policy") or "").strip() or None,
         "route_authority_kind": str(route_binding_authority.get("authority_kind") or "").strip() or None,

--- a/trellis/agent/task_diagnostics.py
+++ b/trellis/agent/task_diagnostics.py
@@ -309,11 +309,13 @@ def render_task_diagnosis_dossier(packet: Mapping[str, Any]) -> str:
         lines.extend(
             [
                 *_render_table(
-                    headers=("Primary", "Backend", "Outcome", "Health", "Trace"),
+                    headers=("Primary", "Diagnostic", "Outcome", "Health", "Trace"),
                     rows=[
                         (
                             item.get("primary_label"),
-                            item.get("backend_binding_id") or item.get("route_alias") or item.get("route_family"),
+                            item.get("binding_diagnostic_label")
+                            or item.get("route_alias")
+                            or item.get("route_family"),
                             item.get("outcome"),
                             (
                                 "effective="
@@ -625,6 +627,21 @@ def _telemetry_section(record: Mapping[str, Any]) -> dict[str, Any]:
                     or construction_identity.get("backend_binding_id")
                     or ""
                 ).strip(),
+                "binding_display_name": str(
+                    route_health.get("binding_display_name")
+                    or construction_identity.get("binding_display_name")
+                    or ""
+                ).strip(),
+                "binding_short_description": str(
+                    route_health.get("binding_short_description")
+                    or construction_identity.get("binding_short_description")
+                    or ""
+                ).strip(),
+                "binding_diagnostic_label": str(
+                    route_health.get("binding_diagnostic_label")
+                    or construction_identity.get("binding_diagnostic_label")
+                    or ""
+                ).strip(),
                 "route_alias": str(
                     route_health.get("route_alias")
                     or construction_identity.get("route_alias")
@@ -718,6 +735,21 @@ def _enrich_telemetry_route_observations(
         item["backend_binding_id"] = str(
             item.get("backend_binding_id")
             or construction_identity.get("backend_binding_id")
+            or ""
+        ).strip()
+        item["binding_display_name"] = str(
+            item.get("binding_display_name")
+            or construction_identity.get("binding_display_name")
+            or ""
+        ).strip()
+        item["binding_short_description"] = str(
+            item.get("binding_short_description")
+            or construction_identity.get("binding_short_description")
+            or ""
+        ).strip()
+        item["binding_diagnostic_label"] = str(
+            item.get("binding_diagnostic_label")
+            or construction_identity.get("binding_diagnostic_label")
             or ""
         ).strip()
         item["route_alias"] = str(

--- a/trellis/agent/task_run_store.py
+++ b/trellis/agent/task_run_store.py
@@ -686,6 +686,11 @@ def _trace_summary(path: str | None) -> dict[str, Any] | None:
         or {}
     )
     semantic_blueprint = dict(metadata.get("semantic_blueprint") or {})
+    operator_metadata = dict(
+        route_binding_authority.get("operator_metadata")
+        or construction_identity.get("operator_metadata")
+        or {}
+    )
     route_health = {
         "route_id": str(
             route_binding_authority.get("route_id")
@@ -707,6 +712,21 @@ def _trace_summary(path: str | None) -> dict[str, Any] | None:
         "primary_kind": str(construction_identity.get("primary_kind") or "").strip(),
         "primary_label": str(construction_identity.get("primary_label") or "").strip(),
         "backend_binding_id": str(construction_identity.get("backend_binding_id") or "").strip(),
+        "binding_display_name": str(
+            construction_identity.get("binding_display_name")
+            or operator_metadata.get("display_name")
+            or ""
+        ).strip(),
+        "binding_short_description": str(
+            construction_identity.get("binding_short_description")
+            or operator_metadata.get("short_description")
+            or ""
+        ).strip(),
+        "binding_diagnostic_label": str(
+            construction_identity.get("binding_diagnostic_label")
+            or operator_metadata.get("diagnostic_label")
+            or ""
+        ).strip(),
         "route_alias": str(construction_identity.get("route_alias") or "").strip(),
     }
     return {
@@ -1523,6 +1543,21 @@ def _route_observations(
                     or construction_identity.get("backend_binding_id")
                     or ""
                 ).strip(),
+                "binding_display_name": str(
+                    route_health.get("binding_display_name")
+                    or construction_identity.get("binding_display_name")
+                    or ""
+                ).strip(),
+                "binding_short_description": str(
+                    route_health.get("binding_short_description")
+                    or construction_identity.get("binding_short_description")
+                    or ""
+                ).strip(),
+                "binding_diagnostic_label": str(
+                    route_health.get("binding_diagnostic_label")
+                    or construction_identity.get("binding_diagnostic_label")
+                    or ""
+                ).strip(),
                 "route_alias": str(
                     route_health.get("route_alias")
                     or construction_identity.get("route_alias")
@@ -1562,6 +1597,9 @@ def _route_observations(
                 "primary_kind": "method_family",
                 "primary_label": route_family,
                 "backend_binding_id": "",
+                "binding_display_name": "",
+                "binding_short_description": "",
+                "binding_diagnostic_label": "",
                 "route_alias": "",
                 "trace_kind": "method_run",
                 "trace_status": "ok" if bool(payload.get("success")) else "error",


### PR DESCRIPTION
## Summary\n- switch trace, task-run, and diagnosis operator surfaces to binding display/diagnostic metadata\n- keep checkpoints machine-readable by preserving binding ids for exact-fit route-stage decisions\n- update docs and the binding-first plan mirror\n\n## Validation\n- /Users/steveyang/miniforge3/bin/python3 -m py_compile trellis/agent/platform_traces.py trellis/agent/task_run_store.py trellis/agent/task_diagnostics.py trellis/agent/checkpoints.py tests/test_agent/test_platform_traces.py tests/test_agent/test_task_run_store.py tests/test_agent/test_task_diagnostics.py\n- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_platform_traces.py tests/test_agent/test_task_run_store.py tests/test_agent/test_task_diagnostics.py -q\n- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_checkpoints.py tests/test_agent/test_platform_traces.py tests/test_agent/test_task_run_store.py tests/test_agent/test_task_diagnostics.py -q\n- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_tasks/test_t01_zcb_option.py -q\n- PYTHONHASHSEED=0 /Users/steveyang/miniforge3/bin/python3 scripts/run_canary.py --task T13 --replay\n- PYTHONHASHSEED=0 /Users/steveyang/miniforge3/bin/python3 scripts/run_canary.py --task T38 --replay\n- PYTHONHASHSEED=0 /Users/steveyang/miniforge3/bin/python3 scripts/run_canary.py --task T105\n- /Users/steveyang/miniforge3/bin/python3 scripts/run_knowledge_light_proving.py --cases KL01 --output /tmp/qua807_kl01.json\n- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/ -x -q -m "not integration"