### PR TITLE
QUA-806: close binding-first trace provenance follow-up

### DIFF
--- a/docs/plans/binding-first-exotic-assembly.md
+++ b/docs/plans/binding-first-exotic-assembly.md
@@ -165,7 +165,7 @@ Status mirror last synced: `2026-04-13`
 | Ticket | Status |
 | --- | --- |
 | `QUA-802` | Validation contract: key exact-fit validation bundles by binding identity | Done |
-| `QUA-806` | Platform traces and diagnostics: primary construction provenance is binding-first | Backlog |
+| `QUA-806` | Platform traces and diagnostics: primary construction provenance is binding-first | Done |
 | `QUA-812` | Replay and checkpoints: regenerate binding-first canary and learning artifacts | Backlog |
 | `QUA-813` | Task stores and benchmark reports: retire route-primary health summaries | Backlog |
 


### PR DESCRIPTION
## Summary\n- sync the binding-first program mirror to mark QUA-806 done\n- no new code changes; this closeout is covered by the already-merged QUA-802, QUA-803, and QUA-807 work\n\n## Evidence already landed\n- QUA-802 keyed exact-fit validation bundles by binding identity\n- QUA-803 introduced the binding operator metadata catalog\n- QUA-807 moved platform traces, task-run telemetry, and diagnosis dossiers onto binding-first operator labels while keeping route aliases secondary\n\n## Validation evidence for closeout\n- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_tasks/test_t01_zcb_option.py -q\n- PYTHONHASHSEED=0 /Users/steveyang/miniforge3/bin/python3 scripts/run_canary.py --task T13 --replay\n- PYTHONHASHSEED=0 /Users/steveyang/miniforge3/bin/python3 scripts/run_canary.py --task T38 --replay\n- PYTHONHASHSEED=0 /Users/steveyang/miniforge3/bin/python3 scripts/run_canary.py --task T105\n- /Users/steveyang/miniforge3/bin/python3 scripts/run_knowledge_light_proving.py --cases KL01 --output /tmp/qua807_kl01.json\n- /Users/steveyang/miniforge3/bin/python3 scripts/run_knowledge_light_proving.py --cases KL03 --output /tmp/qua806_kl03.json\n- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/ -x -q -m "not integration"