### PR TITLE
QUA-812: make replay checkpoints binding-first

### DIFF
--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -73,6 +73,12 @@ step still depends on a latest available decision checkpoint for the replayed
 task, so the runner will explicitly report when no checkpoint exists yet and
 the drift probe was skipped.
 
+Decision checkpoints are now binding-first at the generation boundary. Fresh
+artifacts emit a ``binding`` stage plus binding validation identity, while
+legacy route-era checkpoint YAML is normalized on load so drift comparison can
+still compare old and new runs without treating the stage rename itself as a
+meaningful divergence.
+
 For curated canaries specifically, ``scripts/run_canary.py`` now executes the
 live task entry plus any richer canary-only fields from ``CANARY_TASKS.yaml``.
 That lets sparse manifest rows keep their normal task-inventory shape while
@@ -251,6 +257,11 @@ for run diagnosis; the dossier is the human-facing view that opens first when
 you need to understand a failure or confirm a success. The batch runner now
 surfaces those packet paths directly on the task result so you do not have to
 reconstruct them from traces or summary files.
+
+That packet/checkpoint surface also now treats backend binding identity as the
+primary implementation provenance. Compatibility route aliases may still
+appear, but only as secondary metadata so replay, canary drift, and learning
+artifacts no longer rely on route-primary checkpoint joins.
 
 For cassette-backed canary replays, the task result and persisted task-run
 record now carry explicit execution metadata:

--- a/docs/developer/test_gates.md
+++ b/docs/developer/test_gates.md
@@ -69,6 +69,11 @@ task. If no latest checkpoint exists yet, the runner reports that the drift
 check was skipped. Treat that as a signal to refresh the task with a live
 canary run before leaning on drift output for a release claim.
 
+Those checkpoints are now binding-first. Fresh replay and live artifacts emit
+binding identity at the generation boundary, and older route-era checkpoint
+files are normalized on load so drift output is not polluted by the route to
+binding stage rename itself.
+
 If you only want to smoke-test the `gate-canary` wiring without spending
 tokens, use:
 

--- a/docs/plans/binding-first-exotic-assembly.md
+++ b/docs/plans/binding-first-exotic-assembly.md
@@ -166,7 +166,7 @@ Status mirror last synced: `2026-04-13`
 | --- | --- |
 | `QUA-802` | Validation contract: key exact-fit validation bundles by binding identity | Done |
 | `QUA-806` | Platform traces and diagnostics: primary construction provenance is binding-first | Done |
-| `QUA-812` | Replay and checkpoints: regenerate binding-first canary and learning artifacts | Backlog |
+| `QUA-812` | Replay and checkpoints: regenerate binding-first canary and learning artifacts | Done |
 | `QUA-813` | Task stores and benchmark reports: retire route-primary health summaries | Backlog |
 
 ### Ordered Operator Surface Queue

--- a/tests/test_agent/test_checkpoints.py
+++ b/tests/test_agent/test_checkpoints.py
@@ -218,9 +218,22 @@ def _validation_contract(
     route_id: str | None = "analytical_black76",
     bundle_id: str = "analytical:vanilla_option",
 ):
+    binding_ids = {
+        "analytical_black76": "trellis.models.black.black76_call",
+        "quanto_adjustment_analytical": "trellis.models.quanto_option.price_quanto_option_analytical_from_market_state",
+        "analytical_garman_kohlhagen": "trellis.models.fx_vanilla.price_fx_vanilla_analytical",
+        "correlated_basket_monte_carlo": "trellis.models.monte_carlo.semantic_basket.price_ranked_observation_basket_monte_carlo",
+    }
+    backend_binding_id = binding_ids.get(route_id)
     return {
         "contract_id": "analytical:vanilla_option",
         "bundle_id": bundle_id,
+        "backend_binding_id": backend_binding_id,
+        "exact_bundle_id": (
+            f"{bundle_id}::{backend_binding_id}"
+            if backend_binding_id
+            else None
+        ),
         "route_id": route_id,
         "route_family": "analytical",
         "required_market_data": ["discount_curve", "underlier_spot", "black_vol_surface"],
@@ -293,7 +306,7 @@ class TestDecisionCheckpoint:
         assert cp.stages[0].agent == "quant"
 
 
-def test_capture_checkpoint_threads_route_binding_authority_into_route_stage():
+def test_capture_checkpoint_threads_binding_authority_into_binding_stage():
     checkpoint = capture_checkpoint(
         task_id="T73",
         instrument_type="swaption",
@@ -303,15 +316,16 @@ def test_capture_checkpoint_threads_route_binding_authority_into_route_stage():
         outcome="pass",
     )
 
-    route_stage = next(stage for stage in checkpoint.stages if stage.agent == "route")
+    binding_stage = next(stage for stage in checkpoint.stages if stage.agent == "binding")
 
-    assert route_stage.decision == "trellis.models.black.black76_call"
-    assert route_stage.metadata["route_binding_authority"]["authority_kind"] == "exact_backend_fit"
-    assert route_stage.metadata["route_binding_authority"]["canary_task_ids"] == ["T73"]
-    assert route_stage.metadata["construction_identity"]["route_alias"] == "analytical_black76"
+    assert binding_stage.decision == "trellis.models.black.black76_call"
+    assert binding_stage.metadata["binding_authority"]["authority_kind"] == "exact_backend_fit"
+    assert binding_stage.metadata["binding_authority"]["canary_task_ids"] == ["T73"]
+    assert binding_stage.metadata["binding_authority"]["binding_route_alias"] == "analytical_black76"
+    assert binding_stage.metadata["construction_identity"]["route_alias"] == "analytical_black76"
 
 
-def test_capture_checkpoint_keeps_route_stage_unknown_when_lowering_has_no_route():
+def test_capture_checkpoint_keeps_binding_stage_unknown_when_lowering_has_no_route():
     checkpoint = capture_checkpoint(
         task_id="T301",
         instrument_type="range_accrual",
@@ -338,12 +352,12 @@ def test_capture_checkpoint_keeps_route_stage_unknown_when_lowering_has_no_route
         outcome="fail_build",
     )
 
-    route_stage = next(stage for stage in checkpoint.stages if stage.agent == "route")
+    binding_stage = next(stage for stage in checkpoint.stages if stage.agent == "binding")
 
-    assert route_stage.decision == "VanillaOptionIR"
-    assert route_stage.metadata["method"] == "analytical"
-    assert route_stage.metadata["lowering"]["route_id"] is None
-    assert "route_binding_authority" not in route_stage.metadata
+    assert binding_stage.decision == "VanillaOptionIR"
+    assert binding_stage.metadata["method"] == "analytical"
+    assert binding_stage.metadata["lowering"]["route_id"] is None
+    assert "binding_authority" not in binding_stage.metadata
 
 
 # ---------------------------------------------------------------------------
@@ -441,7 +455,7 @@ class TestCaptureCheckpoint:
         assert validator.decision == "fail"
         assert validator.metadata["failure_count"] == 2
 
-    def test_capture_semantic_route_boundary(self):
+    def test_capture_semantic_binding_boundary(self):
         cp = capture_checkpoint(
             task_id="T74",
             instrument_type="european_option",
@@ -456,15 +470,16 @@ class TestCaptureCheckpoint:
         )
 
         agents = [stage.agent for stage in cp.stages]
-        assert agents == ["quant", "semantic", "route", "builder", "validator"]
+        assert agents == ["quant", "semantic", "binding", "builder", "validator"]
 
         semantic = [stage for stage in cp.stages if stage.agent == "semantic"][0]
         assert semantic.decision == "vanilla_option"
         assert semantic.metadata["compatibility_bridge_status"] == "thin_compatibility_wrapper"
 
-        route = [stage for stage in cp.stages if stage.agent == "route"][0]
-        assert route.decision == "trellis.models.black.black76_call"
-        assert route.metadata["valuation_context"]["market_source"] == "unbound_market_snapshot"
+        binding = [stage for stage in cp.stages if stage.agent == "binding"][0]
+        assert binding.decision == "trellis.models.black.black76_call"
+        assert binding.metadata["valuation_context"]["market_source"] == "unbound_market_snapshot"
+        assert binding.metadata["binding_authority"]["binding_route_alias"] == "analytical_black76"
 
         builder = [stage for stage in cp.stages if stage.agent == "builder"][0]
         assert "trellis.models.black" in builder.metadata["approved_modules"]
@@ -472,6 +487,8 @@ class TestCaptureCheckpoint:
         validator = [stage for stage in cp.stages if stage.agent == "validator"][0]
         assert validator.decision == "pass"
         assert validator.metadata["bundle_id"] == "analytical:vanilla_option"
+        assert validator.metadata["backend_binding_id"] == "trellis.models.black.black76_call"
+        assert validator.metadata["binding_route_alias"] == "analytical_black76"
 
 
 # ---------------------------------------------------------------------------
@@ -591,7 +608,7 @@ class TestDiffCheckpoints:
         divs = diff_checkpoints(a, b)
         assert any(d.agent == "semantic" and d.severity == "metadata" for d in divs)
 
-    def test_route_and_approved_module_drift_are_detected(self):
+    def test_binding_and_approved_module_drift_are_detected(self):
         baseline = capture_checkpoint(
             task_id="T105",
             instrument_type="quanto_option",
@@ -637,7 +654,7 @@ class TestDiffCheckpoints:
         )
 
         divs = diff_checkpoints(baseline, changed)
-        assert any(d.agent == "route" and d.severity == "decision" for d in divs)
+        assert any(d.agent == "binding" and d.severity == "decision" for d in divs)
         assert any(d.agent == "builder" and d.severity == "metadata" for d in divs)
 
 
@@ -662,6 +679,45 @@ class TestPersistence:
         for orig, loaded_s in zip(cp.stages, loaded.stages):
             assert orig.agent == loaded_s.agent
             assert orig.decision == loaded_s.decision
+
+    def test_load_checkpoint_normalizes_legacy_route_stage(self, tmp_path):
+        legacy_path = tmp_path / "legacy.yaml"
+        legacy_path.write_text(
+            yaml.dump(
+                {
+                    "task_id": "T73",
+                    "instrument_type": "swaption",
+                    "timestamp": "2026-04-13T00:00:00+00:00",
+                    "outcome": "pass",
+                    "stages": [
+                        {
+                            "agent": "route",
+                            "decision": "trellis.models.black.black76_call",
+                            "metadata": _generation_boundary(),
+                            "output_hash": "legacy-binding",
+                        },
+                        {
+                            "agent": "validator",
+                            "decision": "pass",
+                            "metadata": _validation_contract(),
+                            "output_hash": "legacy-validator",
+                        },
+                    ],
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+
+        loaded = load_checkpoint(legacy_path)
+
+        binding = next(stage for stage in loaded.stages if stage.agent == "binding")
+        validator = next(stage for stage in loaded.stages if stage.agent == "validator")
+
+        assert binding.metadata["binding_authority"]["binding_route_alias"] == "analytical_black76"
+        assert "route_binding_authority" not in binding.metadata
+        assert validator.metadata["binding_route_alias"] == "analytical_black76"
+        assert "route_id" not in validator.metadata
 
     def test_save_creates_directory(self, tmp_path):
         cp = _make_checkpoint()
@@ -869,7 +925,7 @@ class TestEmitDecisionCheckpoint:
         )
 
     def test_emit_uses_platform_trace_boundary(self, tmp_path, monkeypatch):
-        """Checkpoint emission should pull semantic/route/validation boundary from the trace."""
+        """Checkpoint emission should pull semantic/binding/validation boundary from the trace."""
         from trellis.agent.knowledge.autonomous import BuildResult, _emit_decision_checkpoint
         from trellis.agent.platform_requests import compile_build_request
         from trellis.agent.platform_traces import record_platform_trace
@@ -924,13 +980,18 @@ class TestEmitDecisionCheckpoint:
         assert len(files) == 1
         loaded = load_checkpoint(files[0])
         semantic = [stage for stage in loaded.stages if stage.agent == "semantic"][0]
-        route = [stage for stage in loaded.stages if stage.agent == "route"][0]
+        binding = [stage for stage in loaded.stages if stage.agent == "binding"][0]
         builder = [stage for stage in loaded.stages if stage.agent == "builder"][0]
         validator = [stage for stage in loaded.stages if stage.agent == "validator"][0]
 
         assert semantic.decision == "ranked_observation_basket"
         assert semantic.metadata["compatibility_bridge_status"] == "thin_compatibility_wrapper"
-        assert route.decision == "trellis.models.monte_carlo.semantic_basket.price_ranked_observation_basket_monte_carlo"
+        assert binding.decision == "trellis.models.monte_carlo.semantic_basket.price_ranked_observation_basket_monte_carlo"
+        assert binding.metadata["binding_authority"]["binding_route_alias"] == "correlated_basket_monte_carlo"
         assert "trellis.models.monte_carlo.semantic_basket" in builder.metadata["approved_modules"]
-        assert validator.metadata["route_id"] == "correlated_basket_monte_carlo"
+        assert (
+            validator.metadata["backend_binding_id"]
+            == "trellis.models.monte_carlo.semantic_basket.price_ranked_observation_basket_monte_carlo"
+        )
+        assert validator.metadata["binding_route_alias"] == "correlated_basket_monte_carlo"
         assert validator.metadata["bundle_id"] == "monte_carlo:basket_option"

--- a/trellis/agent/checkpoints.py
+++ b/trellis/agent/checkpoints.py
@@ -170,9 +170,9 @@ def capture_checkpoint(
 
     This extracts decision boundaries from the artifacts that already exist
     in the pipeline (pricing_plan, spec_schema, generated code, build_meta)
-    without requiring changes to executor.py internals. Semantic-route callers
-    can additionally pass compact semantic, generation, and validation
-    summaries to make route drift diffable across reruns.
+    without requiring changes to executor.py internals. Semantic and binding
+    callers can additionally pass compact semantic, generation, and validation
+    summaries to make checkpoint drift diffable across reruns.
     """
     stages: list[StageDecision] = []
     semantic_checkpoint_data = dict(semantic_checkpoint or {})
@@ -215,9 +215,9 @@ def capture_checkpoint(
             }),
         ))
 
-    # Stage 3: Route / lowering boundary.
+    # Stage 3: Binding / lowering boundary.
     if generation_boundary_data:
-        route_metadata = _nonempty_mapping(
+        binding_metadata = _nonempty_mapping(
             source=generation_boundary_data,
             keys=(
                 "method",
@@ -227,12 +227,13 @@ def capture_checkpoint(
                 "construction_identity",
                 "lowering",
                 "route_binding_authority",
+                "lane_plan",
                 "primitive_plan",
             ),
         )
-        lowering = route_metadata.get("lowering") or {}
-        construction_identity = route_metadata.get("construction_identity") or {}
-        route_binding_authority = route_metadata.get("route_binding_authority") or {}
+        lowering = binding_metadata.get("lowering") or {}
+        construction_identity = binding_metadata.get("construction_identity") or {}
+        route_binding_authority = binding_metadata.get("route_binding_authority") or {}
         backend_binding = route_binding_authority.get("backend_binding") or {}
         exact_backend_binding_id = str(
             construction_identity.get("backend_binding_id")
@@ -243,7 +244,16 @@ def capture_checkpoint(
             )
             or ""
         ).strip()
-        route_decision = str(
+        binding_authority = _normalize_binding_authority(
+            construction_identity=construction_identity,
+            lowering=lowering,
+            primitive_plan=binding_metadata.get("primitive_plan") or {},
+            route_binding_authority=route_binding_authority,
+        )
+        if binding_authority:
+            binding_metadata["binding_authority"] = binding_authority
+        binding_metadata.pop("route_binding_authority", None)
+        binding_decision = str(
             (
                 exact_backend_binding_id
                 if str(construction_identity.get("primary_kind") or "").strip() == "backend_binding"
@@ -252,18 +262,18 @@ def capture_checkpoint(
             or construction_identity.get("primary_label")
             or exact_backend_binding_id
             or lowering.get("family_ir_type")
-            or route_metadata.get("lane_plan", {}).get("lane_family")
+            or binding_metadata.get("lane_plan", {}).get("lane_family")
             or lowering.get("route_id")
             or route_binding_authority.get("route_id")
             or "unknown"
         )
         stages.append(StageDecision(
-            agent="route",
-            decision=route_decision,
-            metadata=route_metadata,
+            agent="binding",
+            decision=binding_decision,
+            metadata=binding_metadata,
             output_hash=_hash_value({
-                "decision": route_decision,
-                "metadata": route_metadata,
+                "decision": binding_decision,
+                "metadata": binding_metadata,
             }),
         ))
 
@@ -327,6 +337,8 @@ def capture_checkpoint(
             keys=(
                 "contract_id",
                 "bundle_id",
+                "backend_binding_id",
+                "exact_bundle_id",
                 "route_id",
                 "route_family",
                 "required_market_data",
@@ -337,6 +349,12 @@ def capture_checkpoint(
                 "residual_risks",
             ),
         )
+        route_alias = str(validation_meta.pop("route_id", "") or "").strip()
+        route_family = str(validation_meta.pop("route_family", "") or "").strip()
+        if route_alias:
+            validation_meta["binding_route_alias"] = route_alias
+        if route_family:
+            validation_meta["binding_route_family"] = route_family
         if final_price is not None:
             validation_meta["final_price"] = final_price
         if tolerance is not None:
@@ -356,8 +374,10 @@ def capture_checkpoint(
             keys=(
                 "contract_id",
                 "bundle_id",
-                "route_id",
-                "route_family",
+                "backend_binding_id",
+                "exact_bundle_id",
+                "binding_route_alias",
+                "binding_route_family",
                 "required_market_data",
                 "deterministic_checks",
                 "comparison_relations",
@@ -522,13 +542,21 @@ def _dict_to_checkpoint(d: dict[str, Any]) -> DecisionCheckpoint:
     """Reconstruct a checkpoint from a plain dict."""
     stages = tuple(
         StageDecision(
-            agent=s["agent"],
+            agent=_normalize_loaded_stage_agent(s.get("agent", "")),
             decision=s["decision"],
-            metadata=s.get("metadata", {}),
+            metadata=_normalize_loaded_stage_metadata(
+                agent=s.get("agent", ""),
+                metadata=s.get("metadata", {}),
+            ),
             tokens_used=s.get("tokens_used", 0),
             latency_ms=s.get("latency_ms", 0),
             input_hash=s.get("input_hash", ""),
-            output_hash=s.get("output_hash", ""),
+            output_hash=_normalized_stage_output_hash(
+                agent=s.get("agent", ""),
+                decision=s["decision"],
+                metadata=s.get("metadata", {}),
+                stored_hash=s.get("output_hash", ""),
+            ),
         )
         for s in d.get("stages", [])
     )
@@ -545,6 +573,148 @@ def _dict_to_checkpoint(d: dict[str, Any]) -> DecisionCheckpoint:
         provider=d.get("provider", ""),
         model=d.get("model", ""),
     )
+
+
+def _normalize_binding_authority(
+    *,
+    construction_identity: Mapping[str, Any] | None,
+    lowering: Mapping[str, Any] | None,
+    primitive_plan: Mapping[str, Any] | None,
+    route_binding_authority: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Project legacy route-bound authority into binding-first checkpoint metadata."""
+    construction_identity = construction_identity or {}
+    lowering = lowering or {}
+    primitive_plan = primitive_plan or {}
+    route_binding_authority = route_binding_authority or {}
+    backend_binding = route_binding_authority.get("backend_binding") or {}
+    binding_authority = _nonempty_mapping(
+        source={
+            "authority_kind": route_binding_authority.get("authority_kind")
+            or construction_identity.get("route_authority_kind"),
+            "binding_id": construction_identity.get("backend_binding_id")
+            or backend_binding.get("binding_id"),
+            "binding_engine_family": backend_binding.get("engine_family")
+            or construction_identity.get("backend_engine_family")
+            or primitive_plan.get("engine_family"),
+            "binding_route_alias": route_binding_authority.get("route_id")
+            or lowering.get("route_id")
+            or construction_identity.get("route_alias"),
+            "binding_route_family": route_binding_authority.get("route_family")
+            or lowering.get("route_family")
+            or primitive_plan.get("route_family"),
+            "exact_backend_fit": backend_binding.get("exact_backend_fit")
+            if backend_binding
+            else construction_identity.get("backend_exact_fit"),
+            "helper_refs": backend_binding.get("helper_refs"),
+            "primitive_refs": backend_binding.get("primitive_refs"),
+            "exact_target_refs": backend_binding.get("exact_target_refs"),
+            "approved_modules": backend_binding.get("approved_modules"),
+            "validation_bundle_id": route_binding_authority.get("validation_bundle_id"),
+            "canary_task_ids": route_binding_authority.get("canary_task_ids"),
+        },
+        keys=(
+            "authority_kind",
+            "binding_id",
+            "binding_engine_family",
+            "binding_route_alias",
+            "binding_route_family",
+            "exact_backend_fit",
+            "helper_refs",
+            "primitive_refs",
+            "exact_target_refs",
+            "approved_modules",
+            "validation_bundle_id",
+            "canary_task_ids",
+        ),
+    )
+    if binding_authority == {"exact_backend_fit": False}:
+        return {}
+    return binding_authority
+
+
+def _normalize_validator_metadata(metadata: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Normalize validator metadata onto binding-first identity keys."""
+    normalized = dict(metadata or {})
+    route_alias = str(normalized.get("binding_route_alias") or normalized.get("route_id") or "").strip()
+    route_family = str(
+        normalized.get("binding_route_family") or normalized.get("route_family") or ""
+    ).strip()
+    normalized.pop("route_id", None)
+    normalized.pop("route_family", None)
+    if route_alias:
+        normalized["binding_route_alias"] = route_alias
+    if route_family:
+        normalized["binding_route_family"] = route_family
+    return normalized
+
+
+def _normalize_binding_stage_metadata(metadata: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Normalize legacy route-stage metadata onto binding-first keys."""
+    normalized = dict(metadata or {})
+    route_binding_authority = normalized.pop("route_binding_authority", {}) or {}
+    binding_authority = normalized.get("binding_authority") or {}
+    if not binding_authority:
+        binding_authority = _normalize_binding_authority(
+            construction_identity=normalized.get("construction_identity"),
+            lowering=normalized.get("lowering"),
+            primitive_plan=normalized.get("primitive_plan"),
+            route_binding_authority=route_binding_authority,
+        )
+    if binding_authority:
+        normalized["binding_authority"] = binding_authority
+    return normalized
+
+
+def _normalize_loaded_stage_agent(agent: str) -> str:
+    """Map legacy checkpoint stage names onto current binding-first names."""
+    return "binding" if agent == "route" else agent
+
+
+def _normalize_loaded_stage_metadata(*, agent: str, metadata: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Normalize persisted stage metadata onto the current checkpoint schema."""
+    normalized_agent = _normalize_loaded_stage_agent(agent)
+    if normalized_agent == "binding":
+        return _normalize_binding_stage_metadata(metadata)
+    if normalized_agent == "validator":
+        return _normalize_validator_metadata(metadata)
+    return dict(metadata or {})
+
+
+def _normalized_stage_output_hash(
+    *,
+    agent: str,
+    decision: str,
+    metadata: Mapping[str, Any] | None,
+    stored_hash: str,
+) -> str:
+    """Recompute hashes for normalized legacy stages to keep drift diffs stable."""
+    normalized_agent = _normalize_loaded_stage_agent(agent)
+    normalized_metadata = _normalize_loaded_stage_metadata(agent=agent, metadata=metadata)
+    if normalized_agent == "binding":
+        return _hash_value({"decision": decision, "metadata": normalized_metadata})
+    if normalized_agent == "validator":
+        return _hash_value({
+            "decision": decision,
+            "metadata": _nonempty_mapping(
+                source=normalized_metadata,
+                keys=(
+                    "contract_id",
+                    "bundle_id",
+                    "backend_binding_id",
+                    "exact_bundle_id",
+                    "binding_route_alias",
+                    "binding_route_family",
+                    "required_market_data",
+                    "deterministic_checks",
+                    "comparison_relations",
+                    "lowering_errors",
+                    "admissibility_failures",
+                    "residual_risks",
+                ),
+            ),
+        })
+    return stored_hash
 
 
 def save_checkpoint(


### PR DESCRIPTION
## Summary
- rename the checkpoint generation stage from `route` to `binding`
- emit binding-first checkpoint and validator metadata while preserving route aliases as compatibility fields
- normalize legacy route-era checkpoint YAML on load so replay drift comparisons stay stable

## Validation
- `/Users/steveyang/miniforge3/bin/python3 -m py_compile trellis/agent/checkpoints.py tests/test_agent/test_checkpoints.py`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_checkpoints.py -x -q`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_canary_runner.py -q`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_contracts/test_canary_replay_contracts.py -q`
- `PYTHONHASHSEED=0 /Users/steveyang/miniforge3/bin/python3 scripts/run_canary.py --task T13 --replay`
- `PYTHONHASHSEED=0 /Users/steveyang/miniforge3/bin/python3 scripts/run_canary.py --task T38 --replay`
- `/Users/steveyang/miniforge3/bin/python3 scripts/run_knowledge_light_proving.py --cases KL01 --output /tmp/qua812_kl01.json`
- `/Users/steveyang/miniforge3/bin/python3 scripts/run_knowledge_light_proving.py --cases KL03 --output /tmp/qua812_kl03.json`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/ -x -q -m "not integration"`

## Notes
- `KL01` succeeded first pass after the checkpoint migration.
- `KL03` still succeeds only after one `actual_market_smoke` retry; that is a pre-existing proving reliability tail, not a checkpoint/replay regression.
