### PR TITLE
[codex] make task-run health summaries binding-first

### DIFF
--- a/docs/developer/audit_and_observability.rst
+++ b/docs/developer/audit_and_observability.rst
@@ -275,19 +275,22 @@ Task-Run Telemetry
 ------------------
 
 ``trellis.agent.task_run_store`` now projects selected generated skills and
-route-health observations into the persisted task-run record.
+binding-health observations into the persisted task-run record.
 
 Use:
 
 - ``load_latest_skill_telemetry_rollup()`` for artifact-level outcome counters
-- ``load_latest_route_health_rollup()`` for route and route-family counters
+- ``load_latest_binding_health_rollup()`` for binding-level health counters
 - ``load_latest_skill_ranking_inputs()`` for the stable retained ranking metrics
-- ``load_latest_route_ranking_inputs()`` for the route-level ranking metrics
+- ``load_latest_binding_ranking_inputs()`` for the binding-level ranking metrics
 
 These rollups are rebuilt from canonical run records rather than from ad hoc
 trace scraping. Diagnosis dossiers also surface the same telemetry so a human
 can move from batch failure to selected-skill attribution without opening raw
 trace files first.
+
+Route-named helpers remain as compatibility wrappers, but new dashboards and
+maintenance tooling should consume the binding-first APIs.
 
 Issue Sync
 ----------

--- a/docs/developer/knowledge_skill_layer.rst
+++ b/docs/developer/knowledge_skill_layer.rst
@@ -136,16 +136,19 @@ The first-pass telemetry surface includes:
 
 * run outcome and retry/degradation flags
 * selected-artifact observations keyed by ``artifact_id``
-* route observations keyed by route id and route family
+* binding observations keyed by backend binding identity, family, and alias
 * aggregated counters via ``load_latest_skill_telemetry_rollup()``
-* route-health counters via ``load_latest_route_health_rollup()``
+* binding-health counters via ``load_latest_binding_health_rollup()``
 * stable ranking-input projections via ``load_latest_skill_ranking_inputs()``
-  and ``load_latest_route_ranking_inputs()``
+  and ``load_latest_binding_ranking_inputs()``
 
-Route-health observations also carry instruction-resolution counts from
+Binding-health observations also carry instruction-resolution counts from
 analytical traces when they exist, so maintenance tooling can answer both
-"which skills were present for this outcome?" and "how healthy was the route
-selection that consumed them?" without reparsing raw trace markdown.
+"which skills were present for this outcome?" and "how healthy was the
+selected binding surface?" without reparsing raw trace markdown.
+
+Compatibility aliases still expose the old route-named observation fields and
+loaders, but the binding-first names are now the primary supported surface.
 
 The retained ranking-input contract is intentionally small:
 

--- a/docs/developer/task_diagnostics.rst
+++ b/docs/developer/task_diagnostics.rst
@@ -96,14 +96,18 @@ That section answers:
 - which audience surface consumed them
 - what the normalized run outcome was
 - whether the run required retries or ended in a degraded partial-success state
-- which route or route family was involved, together with any recorded
-  instruction-resolution counts
+- which backend binding was involved, together with any recorded
+  instruction-resolution counts and compatibility route aliases when they exist
 
 For maintenance tooling, the same data is also available as deterministic
 rollups through ``trellis.agent.task_run_store``:
 
 - ``load_latest_skill_telemetry_rollup()``
-- ``load_latest_route_health_rollup()``
+- ``load_latest_binding_health_rollup()``
+
+Legacy ``load_latest_route_health_rollup()`` and route-named observation fields
+remain as compatibility aliases while older tooling migrates, but binding
+identity is now the primary telemetry key.
 
 Canary batch telemetry
 ----------------------

--- a/docs/plans/binding-first-exotic-assembly.md
+++ b/docs/plans/binding-first-exotic-assembly.md
@@ -167,7 +167,7 @@ Status mirror last synced: `2026-04-13`
 | `QUA-802` | Validation contract: key exact-fit validation bundles by binding identity | Done |
 | `QUA-806` | Platform traces and diagnostics: primary construction provenance is binding-first | Done |
 | `QUA-812` | Replay and checkpoints: regenerate binding-first canary and learning artifacts | Done |
-| `QUA-813` | Task stores and benchmark reports: retire route-primary health summaries | Backlog |
+| `QUA-813` | Task stores and benchmark reports: retire route-primary health summaries | Done |
 
 ### Ordered Operator Surface Queue
 

--- a/tests/test_agent/test_task_diagnostics.py
+++ b/tests/test_agent/test_task_diagnostics.py
@@ -306,9 +306,10 @@ def test_build_task_diagnosis_packet_summarizes_failure(tmp_path):
     assert packet["post_build"]["latest_phase"] == "reflection_completed"
     assert packet["runtime_controls"]["llm_wait_log_path"] == "/tmp/t999_waits.jsonl"
     assert packet["telemetry"]["selected_artifacts"][0]["artifact_id"] == "route_hint:callable_bond_tree"
-    assert packet["telemetry"]["route_observations"][0]["route_id"] == "callable_bond_tree"
-    assert packet["telemetry"]["route_observations"][0]["primary_label"] == "EventAwarePDEIR"
-    assert packet["telemetry"]["route_observations"][0]["task_ids"] == ["T02"]
+    assert packet["telemetry"]["selected_artifacts"][0]["binding_aliases"] == ["callable_bond_tree"]
+    assert packet["telemetry"]["binding_observations"][0]["binding_alias"] == "callable_bond_tree"
+    assert packet["telemetry"]["binding_observations"][0]["primary_label"] == "EventAwarePDEIR"
+    assert packet["telemetry"]["binding_observations"][0]["task_ids"] == ["T02"]
     assert packet["trace_index"][0]["construction_label"] == "EventAwarePDEIR"
 
     rendered = render_task_diagnosis_dossier(packet)
@@ -463,9 +464,9 @@ def test_build_task_diagnosis_packet_keeps_platform_action_out_of_route_ids(tmp_
 
     packet = build_task_diagnosis_packet(record)
 
-    assert packet["telemetry"]["route_observations"][0]["route_id"] == ""
-    assert packet["telemetry"]["route_observations"][0]["route_family"] == "analytical"
-    assert packet["telemetry"]["route_observations"][0]["primary_label"] == "analytical"
+    assert packet["telemetry"]["binding_observations"][0]["route_id"] == ""
+    assert packet["telemetry"]["binding_observations"][0]["binding_family"] == "analytical"
+    assert packet["telemetry"]["binding_observations"][0]["primary_label"] == "analytical"
 
 
 def test_build_task_diagnosis_packet_uses_binding_operator_metadata_in_operator_views(tmp_path):
@@ -509,7 +510,11 @@ def test_build_task_diagnosis_packet_uses_binding_operator_metadata_in_operator_
     rendered = render_task_diagnosis_dossier(packet)
 
     assert packet["trace_index"][0]["construction_label"] == "FX vanilla analytical binding"
-    assert packet["telemetry"]["route_observations"][0]["primary_label"] == "FX vanilla analytical binding"
-    assert packet["telemetry"]["route_observations"][0]["binding_diagnostic_label"] == "fx_vanilla_analytical_binding"
+    assert packet["telemetry"]["binding_observations"][0]["primary_label"] == (
+        "FX vanilla analytical binding"
+    )
+    assert packet["telemetry"]["binding_observations"][0]["binding_diagnostic_label"] == (
+        "fx_vanilla_analytical_binding"
+    )
     assert "FX vanilla analytical binding" in rendered
     assert "fx_vanilla_analytical_binding" in rendered

--- a/tests/test_agent/test_task_run_store.py
+++ b/tests/test_agent/test_task_run_store.py
@@ -548,6 +548,8 @@ def test_skill_telemetry_rollups_capture_selected_artifacts_and_binding_health(t
     assert skill_rollup["artifacts"][0]["retried_count"] == 1
     assert skill_rollup["artifacts"][0]["retry_count_total"] == 1
     assert skill_rollup["artifacts"][0]["audiences"] == ["builder"]
+    assert skill_rollup["artifacts"][0]["binding_aliases"] == ["analytical_black76"]
+    assert skill_rollup["artifacts"][0]["binding_families"] == ["analytical"]
     assert skill_rollup["artifacts"][0]["first_seen_at"] == "2026-03-29T12:01:00+00:00"
     assert skill_rollup["artifacts"][0]["last_seen_at"] == "2026-03-29T12:01:00+00:00"
     assert skill_rollup["ranking_inputs"][0]["success_rate"] == 1.0

--- a/tests/test_agent/test_task_run_store.py
+++ b/tests/test_agent/test_task_run_store.py
@@ -550,6 +550,7 @@ def test_skill_telemetry_rollups_capture_selected_artifacts_and_binding_health(t
     assert skill_rollup["artifacts"][0]["audiences"] == ["builder"]
     assert skill_rollup["artifacts"][0]["binding_aliases"] == ["analytical_black76"]
     assert skill_rollup["artifacts"][0]["binding_families"] == ["analytical"]
+    assert skill_rollup["artifacts"][0]["route_ids"] == ["analytical_black76"]
     assert skill_rollup["artifacts"][0]["first_seen_at"] == "2026-03-29T12:01:00+00:00"
     assert skill_rollup["artifacts"][0]["last_seen_at"] == "2026-03-29T12:01:00+00:00"
     assert skill_rollup["ranking_inputs"][0]["success_rate"] == 1.0

--- a/tests/test_agent/test_task_run_store.py
+++ b/tests/test_agent/test_task_run_store.py
@@ -444,17 +444,22 @@ def test_persist_task_run_record_carries_binding_operator_metadata_into_trace_he
     )
     latest = load_task_run_record(persisted["latest_path"])
 
-    route_health = latest["trace_summaries"][0]["route_health"]
-    observation = latest["telemetry"]["route_observations"][0]
+    binding_health = latest["trace_summaries"][0]["binding_health"]
+    observation = latest["telemetry"]["binding_observations"][0]
 
-    assert route_health["binding_display_name"] == "FX vanilla analytical binding"
-    assert route_health["binding_diagnostic_label"] == "fx_vanilla_analytical_binding"
+    assert binding_health["binding_display_name"] == "FX vanilla analytical binding"
+    assert binding_health["binding_diagnostic_label"] == "fx_vanilla_analytical_binding"
+    assert latest["trace_summaries"][0]["route_health"]["binding_display_name"] == (
+        "FX vanilla analytical binding"
+    )
     assert observation["primary_label"] == "FX vanilla analytical binding"
     assert observation["binding_diagnostic_label"] == "fx_vanilla_analytical_binding"
 
 
-def test_skill_telemetry_rollups_capture_selected_artifacts_and_route_health(tmp_path):
+def test_skill_telemetry_rollups_capture_selected_artifacts_and_binding_health(tmp_path):
     from trellis.agent.task_run_store import (
+        load_latest_binding_health_rollup,
+        load_latest_binding_ranking_inputs,
         load_latest_route_ranking_inputs,
         load_latest_route_health_rollup,
         load_latest_skill_ranking_inputs,
@@ -529,9 +534,11 @@ def test_skill_telemetry_rollups_capture_selected_artifacts_and_route_health(tmp
     )
 
     skill_rollup = load_latest_skill_telemetry_rollup(root=tmp_path)
-    route_rollup = load_latest_route_health_rollup(root=tmp_path)
+    binding_rollup = load_latest_binding_health_rollup(root=tmp_path)
     bundle = load_latest_telemetry_rollups(root=tmp_path)
     skill_ranking = load_latest_skill_ranking_inputs(root=tmp_path)
+    binding_ranking = load_latest_binding_ranking_inputs(root=tmp_path)
+    route_rollup = load_latest_route_health_rollup(root=tmp_path)
     route_ranking = load_latest_route_ranking_inputs(root=tmp_path)
 
     assert skill_rollup["run_count"] == 1
@@ -546,25 +553,29 @@ def test_skill_telemetry_rollups_capture_selected_artifacts_and_route_health(tmp
     assert skill_rollup["ranking_inputs"][0]["success_rate"] == 1.0
     assert skill_rollup["ranking_inputs"][0]["retry_rate"] == 1.0
     assert skill_rollup["ranking_inputs"][0]["avg_retry_count"] == 1.0
+    assert skill_rollup["ranking_inputs"][0]["binding_coverage_count"] == 1
 
-    assert route_rollup["run_count"] == 1
-    assert route_rollup["routes"][0]["route_id"] == "analytical_black76"
-    assert route_rollup["routes"][0]["route_family"] == "analytical"
-    assert route_rollup["routes"][0]["success_count"] == 1
-    assert route_rollup["routes"][0]["retried_count"] == 1
-    assert route_rollup["routes"][0]["retry_count_total"] == 1
-    assert route_rollup["routes"][0]["hard_constraint_count_total"] == 1
-    assert route_rollup["routes"][0]["conflict_count_total"] == 1
-    assert route_rollup["ranking_inputs"][0]["avg_effective_instruction_count"] == 1.0
-    assert route_rollup["ranking_inputs"][0]["avg_hard_constraint_count"] == 1.0
-    assert route_rollup["ranking_inputs"][0]["avg_conflict_count"] == 1.0
+    assert binding_rollup["run_count"] == 1
+    assert binding_rollup["bindings"][0]["binding_alias"] == "analytical_black76"
+    assert binding_rollup["bindings"][0]["binding_family"] == "analytical"
+    assert binding_rollup["bindings"][0]["success_count"] == 1
+    assert binding_rollup["bindings"][0]["retried_count"] == 1
+    assert binding_rollup["bindings"][0]["retry_count_total"] == 1
+    assert binding_rollup["bindings"][0]["hard_constraint_count_total"] == 1
+    assert binding_rollup["bindings"][0]["conflict_count_total"] == 1
+    assert binding_rollup["ranking_inputs"][0]["avg_effective_instruction_count"] == 1.0
+    assert binding_rollup["ranking_inputs"][0]["avg_hard_constraint_count"] == 1.0
+    assert binding_rollup["ranking_inputs"][0]["avg_conflict_count"] == 1.0
 
     assert bundle["skill_telemetry"]["artifacts"][0]["artifact_id"] == "route_hint:analytical_black76"
-    assert bundle["route_health"]["routes"][0]["route_id"] == "analytical_black76"
+    assert bundle["binding_health"]["bindings"][0]["binding_alias"] == "analytical_black76"
     assert skill_ranking["artifacts"][0]["artifact_id"] == "route_hint:analytical_black76"
     assert skill_ranking["artifacts"][0]["last_seen_at"] == "2026-03-29T12:01:00+00:00"
+    assert binding_ranking["bindings"][0]["binding_alias"] == "analytical_black76"
+    assert binding_ranking["bindings"][0]["last_seen_at"] == "2026-03-29T12:01:00+00:00"
+
+    assert route_rollup["routes"][0]["route_id"] == "analytical_black76"
     assert route_ranking["routes"][0]["route_id"] == "analytical_black76"
-    assert route_ranking["routes"][0]["last_seen_at"] == "2026-03-29T12:01:00+00:00"
 
 
 def test_persist_task_run_record_supports_framework_task_contract(tmp_path):
@@ -1133,8 +1144,8 @@ def test_persist_task_run_record_does_not_promote_platform_action_to_fake_route_
     )
     latest = load_task_run_record(persisted["latest_path"])
 
+    assert latest["trace_summaries"][0]["binding_health"]["binding_family"] == "analytical"
     assert latest["trace_summaries"][0]["route_health"]["route_id"] == ""
-    assert latest["trace_summaries"][0]["route_health"]["route_family"] == "analytical"
-    assert latest["telemetry"]["route_observations"][0]["route_id"] == ""
-    assert latest["telemetry"]["route_observations"][0]["route_family"] == "analytical"
-    assert latest["telemetry"]["route_observations"][0]["primary_label"] == "analytical"
+    assert latest["telemetry"]["binding_observations"][0]["binding_family"] == "analytical"
+    assert latest["telemetry"]["binding_observations"][0]["route_id"] == ""
+    assert latest["telemetry"]["binding_observations"][0]["primary_label"] == "analytical"

--- a/trellis/agent/task_diagnostics.py
+++ b/trellis/agent/task_diagnostics.py
@@ -288,14 +288,18 @@ def render_task_diagnosis_dossier(packet: Mapping[str, Any]) -> str:
         lines.extend(
             [
                 *_render_table(
-                    headers=("Artifact", "Kind", "Audience", "Outcome", "Routes"),
+                    headers=("Artifact", "Kind", "Audience", "Outcome", "Bindings"),
                     rows=[
                         (
                             item.get("artifact_id"),
                             item.get("kind"),
                             _join_or_none(item.get("audiences")),
                             item.get("outcome"),
-                            _join_or_none(item.get("route_ids")),
+                            _join_or_none(
+                                item.get("binding_ids")
+                                or item.get("binding_aliases")
+                                or item.get("route_ids")
+                            ),
                         )
                         for item in selected_artifacts
                     ],
@@ -304,8 +308,10 @@ def render_task_diagnosis_dossier(packet: Mapping[str, Any]) -> str:
         )
     else:
         lines.append("- Selected artifacts: none recorded")
-    route_observations = list(telemetry.get("route_observations") or [])
-    if route_observations:
+    binding_observations = list(
+        telemetry.get("binding_observations") or telemetry.get("route_observations") or []
+    )
+    if binding_observations:
         lines.extend(
             [
                 *_render_table(
@@ -327,7 +333,7 @@ def render_task_diagnosis_dossier(packet: Mapping[str, Any]) -> str:
                             ),
                             item.get("trace_kind"),
                         )
-                        for item in route_observations
+                        for item in binding_observations
                     ],
                 ),
                 "",
@@ -337,7 +343,7 @@ def render_task_diagnosis_dossier(packet: Mapping[str, Any]) -> str:
     else:
         lines.extend(
             [
-                "- Route observations: none recorded",
+                "- Binding observations: none recorded",
                 "",
                 "## Evidence",
             ]
@@ -566,6 +572,9 @@ def _telemetry_section(record: Mapping[str, Any]) -> dict[str, Any]:
                         "retried": False,
                         "retry_count": 0,
                         "degraded": False,
+                        "binding_ids": [],
+                        "binding_families": [],
+                        "binding_aliases": [],
                         "route_ids": [],
                         "route_families": [],
                     }
@@ -582,95 +591,36 @@ def _telemetry_section(record: Mapping[str, Any]) -> dict[str, Any]:
                 "retried": False,
                 "retry_count": 0,
                 "degraded": False,
+                "binding_ids": [],
+                "binding_families": [],
+                "binding_aliases": [],
                 "route_ids": [],
                 "route_families": [],
             }
             for artifact_id in learning.get("selected_artifact_ids") or []
         ]
 
-    route_observations = []
+    binding_observations = []
     for trace in record.get("trace_summaries") or []:
         if not isinstance(trace, Mapping):
             continue
-        route_health = dict(trace.get("route_health") or {})
-        construction_identity = dict(trace.get("construction_identity") or {})
-        route_binding_authority = dict(trace.get("route_binding_authority") or {})
-        trace_kind = str(trace.get("trace_kind") or "").strip()
-        route_id = str(route_health.get("route_id") or "").strip()
-        if not route_id and trace_kind != "platform":
-            route_id = str(trace.get("action") or "").strip()
-        route_family = str(
-            route_health.get("route_family")
-            or trace.get("route_method")
-            or ""
-        ).strip()
-        if not route_id and not route_family:
-            continue
-        route_observations.append(
-            {
-                "route_id": route_id,
-                "route_family": route_family,
-                "primary_kind": str(
-                    route_health.get("primary_kind")
-                    or construction_identity.get("primary_kind")
-                    or ""
-                ).strip(),
-                "primary_label": str(
-                    route_health.get("primary_label")
-                    or construction_identity.get("primary_label")
-                    or route_family
-                    or route_id
-                    or "unknown"
-                ).strip(),
-                "backend_binding_id": str(
-                    route_health.get("backend_binding_id")
-                    or construction_identity.get("backend_binding_id")
-                    or ""
-                ).strip(),
-                "binding_display_name": str(
-                    route_health.get("binding_display_name")
-                    or construction_identity.get("binding_display_name")
-                    or ""
-                ).strip(),
-                "binding_short_description": str(
-                    route_health.get("binding_short_description")
-                    or construction_identity.get("binding_short_description")
-                    or ""
-                ).strip(),
-                "binding_diagnostic_label": str(
-                    route_health.get("binding_diagnostic_label")
-                    or construction_identity.get("binding_diagnostic_label")
-                    or ""
-                ).strip(),
-                "route_alias": str(
-                    route_health.get("route_alias")
-                    or construction_identity.get("route_alias")
-                    or route_id
-                    or ""
-                ).strip(),
-                "trace_kind": str(trace.get("trace_kind") or "").strip(),
-                "trace_status": str(trace.get("status") or "").strip(),
-                "outcome": str(workflow.get("status") or "").strip(),
-                "success": bool(record.get("summary", {}).get("success")),
-                "retried": False,
-                "retry_count": 0,
-                "degraded": False,
-                "selected_artifact_ids": [
-                    item.get("artifact_id")
-                    for item in selected_artifacts
-                    if item.get("artifact_id")
-                ],
-                "instruction_ids": list(route_health.get("effective_instruction_ids") or []),
-                "effective_instruction_count": int(route_health.get("effective_instruction_count") or 0),
-                "hard_constraint_count": int(route_health.get("hard_constraint_count") or 0),
-                "conflict_count": int(route_health.get("conflict_count") or 0),
-                "task_ids": list(
-                    route_binding_authority.get("canary_task_ids")
-                    or route_health.get("canary_task_ids")
-                    or []
-                ),
-            }
+        observation = _trace_binding_observation(
+            trace,
+            outcome=str(workflow.get("status") or "").strip(),
+            success=bool(record.get("summary", {}).get("success")),
+            retried=False,
+            retry_count=0,
+            degraded=False,
+            selected_artifact_ids=[
+                item.get("artifact_id")
+                for item in selected_artifacts
+                if item.get("artifact_id")
+            ],
         )
+        if observation:
+            binding_observations.append(observation)
+
+    selected_artifacts = _enrich_selected_artifact_bindings(selected_artifacts, binding_observations)
 
     return {
         "task_kind": str(record.get("task_kind") or "").strip(),
@@ -680,7 +630,8 @@ def _telemetry_section(record: Mapping[str, Any]) -> dict[str, Any]:
         "degraded": False,
         "comparison_status": str(record.get("summary", {}).get("comparison_status") or "").strip(),
         "selected_artifacts": selected_artifacts,
-        "route_observations": route_observations,
+        "binding_observations": binding_observations,
+        "route_observations": [dict(item) for item in binding_observations],
     }
 
 
@@ -688,84 +639,286 @@ def _enrich_telemetry_route_observations(
     telemetry: dict[str, Any],
     record: Mapping[str, Any],
 ) -> dict[str, Any]:
-    """Backfill route-authority canary IDs into persisted telemetry when available."""
+    """Backfill binding-authority metadata into persisted telemetry when available."""
     traces = list(record.get("trace_summaries") or [])
-    route_task_ids: dict[tuple[str, str], list[str]] = {}
-    route_construction: dict[tuple[str, str], dict[str, Any]] = {}
+    trace_observations: dict[tuple[str, str, str, str, str], dict[str, Any]] = {}
     for trace in traces:
         if not isinstance(trace, Mapping):
             continue
-        route_health = dict(trace.get("route_health") or {})
-        construction_identity = dict(trace.get("construction_identity") or {})
-        route_binding_authority = dict(trace.get("route_binding_authority") or {})
-        trace_kind = str(trace.get("trace_kind") or "").strip()
-        route_id = str(route_health.get("route_id") or "").strip()
-        if not route_id and trace_kind != "platform":
-            route_id = str(trace.get("action") or "").strip()
-        route_family = str(route_health.get("route_family") or trace.get("route_method") or "").strip()
-        task_ids = list(
-            route_binding_authority.get("canary_task_ids")
-            or route_health.get("canary_task_ids")
-            or []
+        observation = _trace_binding_observation(
+            trace,
+            outcome=str(telemetry.get("run_outcome") or "").strip(),
+            success=bool(telemetry.get("run_outcome") == "succeeded"),
+            retried=bool(telemetry.get("retried")),
+            retry_count=int(telemetry.get("retry_count") or 0),
+            degraded=bool(telemetry.get("degraded")),
+            selected_artifact_ids=[
+                item.get("artifact_id")
+                for item in telemetry.get("selected_artifacts") or []
+                if isinstance(item, Mapping) and item.get("artifact_id")
+            ],
         )
-        if route_id or route_family:
-            route_task_ids[(route_id, route_family)] = task_ids
-            route_construction[(route_id, route_family)] = construction_identity
+        if observation:
+            trace_observations[_binding_observation_key(observation)] = observation
 
     observations = []
-    for observation in telemetry.get("route_observations") or []:
+    raw_observations = telemetry.get("binding_observations") or telemetry.get("route_observations") or []
+    for observation in raw_observations:
         if not isinstance(observation, Mapping):
             continue
-        item = dict(observation)
-        route_id = str(item.get("route_id") or "").strip()
-        route_family = str(item.get("route_family") or "").strip()
-        construction_identity = dict(route_construction.get((route_id, route_family)) or {})
-        item["primary_kind"] = str(
-            item.get("primary_kind")
+        item = _normalize_binding_observation(
+            observation,
+            run_outcome=str(telemetry.get("run_outcome") or "").strip(),
+            success=bool(telemetry.get("run_outcome") == "succeeded"),
+            retried=bool(telemetry.get("retried")),
+            retry_count=int(telemetry.get("retry_count") or 0),
+            degraded=bool(telemetry.get("degraded")),
+        )
+        trace_item = trace_observations.get(_binding_observation_key(item))
+        if trace_item:
+            for key in (
+                "primary_kind",
+                "primary_label",
+                "backend_binding_id",
+                "binding_display_name",
+                "binding_short_description",
+                "binding_diagnostic_label",
+                "route_alias",
+                "task_ids",
+                "instruction_ids",
+                "effective_instruction_count",
+                "hard_constraint_count",
+                "conflict_count",
+                "trace_status",
+            ):
+                if not item.get(key):
+                    item[key] = trace_item.get(key)
+        observations.append(item)
+    telemetry["selected_artifacts"] = _enrich_selected_artifact_bindings(
+        list(telemetry.get("selected_artifacts") or []),
+        observations,
+    )
+    telemetry["binding_observations"] = observations
+    telemetry["route_observations"] = [dict(item) for item in observations]
+    return telemetry
+
+
+def _trace_binding_observation(
+    trace: Mapping[str, Any],
+    *,
+    outcome: str,
+    success: bool,
+    retried: bool,
+    retry_count: int,
+    degraded: bool,
+    selected_artifact_ids: list[str],
+) -> dict[str, Any] | None:
+    """Project one trace summary into a binding-first telemetry observation."""
+    route_health = dict(trace.get("binding_health") or trace.get("route_health") or {})
+    construction_identity = dict(trace.get("construction_identity") or {})
+    route_binding_authority = dict(trace.get("binding_authority") or trace.get("route_binding_authority") or {})
+    trace_kind = str(trace.get("trace_kind") or "").strip()
+    route_id = str(route_health.get("route_id") or "").strip()
+    if not route_id and trace_kind != "platform":
+        route_id = str(trace.get("action") or "").strip()
+    route_family = str(route_health.get("route_family") or trace.get("route_method") or "").strip()
+    binding_id = str(
+        route_health.get("binding_id")
+        or route_health.get("backend_binding_id")
+        or construction_identity.get("backend_binding_id")
+        or ""
+    ).strip()
+    binding_family = str(
+        route_health.get("binding_family")
+        or construction_identity.get("backend_engine_family")
+        or route_family
+    ).strip()
+    binding_alias = str(
+        route_health.get("binding_alias")
+        or route_health.get("route_alias")
+        or construction_identity.get("route_alias")
+        or route_id
+        or ""
+    ).strip()
+    if not binding_id and not binding_family and not binding_alias and not route_id and not route_family:
+        return None
+    return {
+        "binding_id": binding_id,
+        "binding_family": binding_family,
+        "binding_alias": binding_alias,
+        "route_id": route_id,
+        "route_family": route_family,
+        "primary_kind": str(
+            route_health.get("primary_kind")
             or construction_identity.get("primary_kind")
             or ""
-        ).strip()
-        item["primary_label"] = str(
-            item.get("primary_label")
+        ).strip(),
+        "primary_label": str(
+            route_health.get("primary_label")
             or construction_identity.get("primary_label")
+            or binding_family
+            or binding_alias
             or route_family
             or route_id
             or "unknown"
-        ).strip()
-        item["backend_binding_id"] = str(
-            item.get("backend_binding_id")
-            or construction_identity.get("backend_binding_id")
-            or ""
-        ).strip()
-        item["binding_display_name"] = str(
-            item.get("binding_display_name")
+        ).strip(),
+        "backend_binding_id": binding_id,
+        "binding_display_name": str(
+            route_health.get("binding_display_name")
             or construction_identity.get("binding_display_name")
             or ""
-        ).strip()
-        item["binding_short_description"] = str(
-            item.get("binding_short_description")
+        ).strip(),
+        "binding_short_description": str(
+            route_health.get("binding_short_description")
             or construction_identity.get("binding_short_description")
             or ""
-        ).strip()
-        item["binding_diagnostic_label"] = str(
-            item.get("binding_diagnostic_label")
+        ).strip(),
+        "binding_diagnostic_label": str(
+            route_health.get("binding_diagnostic_label")
             or construction_identity.get("binding_diagnostic_label")
             or ""
-        ).strip()
-        item["route_alias"] = str(
-            item.get("route_alias")
+        ).strip(),
+        "route_alias": str(
+            route_health.get("route_alias")
             or construction_identity.get("route_alias")
+            or binding_alias
             or route_id
             or ""
-        ).strip()
-        item["task_ids"] = list(
-            item.get("task_ids")
-            or route_task_ids.get((route_id, route_family))
+        ).strip(),
+        "trace_kind": trace_kind,
+        "trace_status": str(trace.get("status") or "").strip(),
+        "outcome": outcome,
+        "success": success,
+        "retried": retried,
+        "retry_count": retry_count,
+        "degraded": degraded,
+        "selected_artifact_ids": list(selected_artifact_ids),
+        "instruction_ids": list(route_health.get("effective_instruction_ids") or []),
+        "effective_instruction_count": int(route_health.get("effective_instruction_count") or 0),
+        "hard_constraint_count": int(route_health.get("hard_constraint_count") or 0),
+        "conflict_count": int(route_health.get("conflict_count") or 0),
+        "task_ids": list(
+            route_binding_authority.get("canary_task_ids")
+            or route_health.get("canary_task_ids")
             or []
+        ),
+    }
+
+
+def _normalize_binding_observation(
+    observation: Mapping[str, Any],
+    *,
+    run_outcome: str,
+    success: bool,
+    retried: bool,
+    retry_count: int,
+    degraded: bool,
+) -> dict[str, Any]:
+    """Normalize persisted telemetry observations onto binding-first fields."""
+    item = dict(observation)
+    route_id = str(item.get("route_id") or "").strip()
+    route_family = str(item.get("route_family") or "").strip()
+    binding_id = str(item.get("binding_id") or item.get("backend_binding_id") or "").strip()
+    binding_family = str(item.get("binding_family") or route_family or "").strip()
+    binding_alias = str(item.get("binding_alias") or item.get("route_alias") or route_id or "").strip()
+    return {
+        "binding_id": binding_id,
+        "binding_family": binding_family,
+        "binding_alias": binding_alias,
+        "route_id": route_id,
+        "route_family": route_family or binding_family,
+        "primary_kind": str(item.get("primary_kind") or "").strip(),
+        "primary_label": str(
+            item.get("primary_label")
+            or item.get("binding_display_name")
+            or binding_family
+            or binding_alias
+            or route_family
+            or route_id
+            or "unknown"
+        ).strip(),
+        "backend_binding_id": str(item.get("backend_binding_id") or binding_id).strip(),
+        "binding_display_name": str(item.get("binding_display_name") or "").strip(),
+        "binding_short_description": str(item.get("binding_short_description") or "").strip(),
+        "binding_diagnostic_label": str(item.get("binding_diagnostic_label") or "").strip(),
+        "route_alias": str(item.get("route_alias") or binding_alias or route_id or "").strip(),
+        "trace_kind": str(item.get("trace_kind") or "").strip(),
+        "trace_status": str(item.get("trace_status") or "").strip(),
+        "outcome": str(item.get("outcome") or run_outcome).strip(),
+        "success": bool(item.get("success", success)),
+        "retried": bool(item.get("retried", retried)),
+        "retry_count": int(item.get("retry_count") or retry_count),
+        "degraded": bool(item.get("degraded", degraded)),
+        "selected_artifact_ids": [
+            str(value)
+            for value in item.get("selected_artifact_ids") or []
+            if str(value).strip()
+        ],
+        "instruction_ids": [str(value) for value in item.get("instruction_ids") or [] if str(value).strip()],
+        "effective_instruction_count": int(item.get("effective_instruction_count") or 0),
+        "hard_constraint_count": int(item.get("hard_constraint_count") or 0),
+        "conflict_count": int(item.get("conflict_count") or 0),
+        "task_ids": [str(value) for value in item.get("task_ids") or [] if str(value).strip()],
+    }
+
+
+def _binding_observation_key(item: Mapping[str, Any]) -> tuple[str, str, str, str, str]:
+    """Return the stable key used to match persisted observations back to trace summaries."""
+    return (
+        str(item.get("binding_id") or item.get("backend_binding_id") or "").strip(),
+        str(item.get("binding_family") or "").strip(),
+        str(item.get("binding_alias") or item.get("route_alias") or item.get("route_id") or "").strip(),
+        str(item.get("route_id") or "").strip(),
+        str(item.get("route_family") or "").strip(),
+    )
+
+
+def _enrich_selected_artifact_bindings(
+    selected_artifacts: list[Mapping[str, Any]],
+    observations: list[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    """Backfill binding coverage onto selected-artifact telemetry."""
+    binding_ids = _unique_strings(
+        [
+            str(item.get("binding_id") or item.get("backend_binding_id") or "").strip()
+            for item in observations
+        ]
+    )
+    binding_families = _unique_strings(
+        [str(item.get("binding_family") or "").strip() for item in observations]
+    )
+    binding_aliases = _unique_strings(
+        [
+            str(item.get("binding_alias") or item.get("route_alias") or item.get("route_id") or "").strip()
+            for item in observations
+        ]
+    )
+    route_ids = _unique_strings([str(item.get("route_id") or "").strip() for item in observations])
+    route_families = _unique_strings(
+        [str(item.get("route_family") or "").strip() for item in observations]
+    )
+    enriched: list[dict[str, Any]] = []
+    for artifact in selected_artifacts:
+        if not isinstance(artifact, Mapping):
+            continue
+        item = dict(artifact)
+        item["binding_ids"] = _unique_strings(
+            [str(value).strip() for value in item.get("binding_ids") or []] + binding_ids
         )
-        observations.append(item)
-    telemetry["route_observations"] = observations
-    return telemetry
+        item["binding_families"] = _unique_strings(
+            [str(value).strip() for value in item.get("binding_families") or []] + binding_families
+        )
+        item["binding_aliases"] = _unique_strings(
+            [str(value).strip() for value in item.get("binding_aliases") or []] + binding_aliases
+        )
+        item["route_ids"] = _unique_strings(
+            [str(value).strip() for value in item.get("route_ids") or []] + route_ids
+        )
+        item["route_families"] = _unique_strings(
+            [str(value).strip() for value in item.get("route_families") or []] + route_families
+        )
+        enriched.append(item)
+    return enriched
 
 
 def _primary_failure(

--- a/trellis/agent/task_run_store.py
+++ b/trellis/agent/task_run_store.py
@@ -1364,7 +1364,12 @@ def build_skill_ranking_inputs(rollup: Mapping[str, Any]) -> dict[str, Any]:
                 "avg_retry_count": _fraction(item.get("retry_count_total"), selection_count),
                 "last_seen_at": str(item.get("last_seen_at") or "").strip(),
                 "first_seen_at": str(item.get("first_seen_at") or "").strip(),
-                "binding_coverage_count": len(item.get("binding_ids") or []),
+                "binding_coverage_count": len(
+                    item.get("binding_ids")
+                    or item.get("binding_aliases")
+                    or item.get("binding_families")
+                    or []
+                ),
                 "route_coverage_count": len(item.get("route_ids") or []),
                 "task_coverage_count": len(item.get("task_ids") or []),
             }
@@ -1595,19 +1600,25 @@ def _selected_artifact_observations(
         if isinstance(artifacts, list)
     }
     route_ids = _unique_strings(
-        [[item.get("route_id")] for item in route_observations]
+        [str(item.get("route_id") or "").strip() for item in route_observations]
     )
     route_families = _unique_strings(
-        [[item.get("route_family")] for item in route_observations]
+        [str(item.get("route_family") or "").strip() for item in route_observations]
     )
     binding_ids = _unique_strings(
-        [[item.get("binding_id") or item.get("backend_binding_id")] for item in route_observations]
+        [
+            str(item.get("binding_id") or item.get("backend_binding_id") or "").strip()
+            for item in route_observations
+        ]
     )
     binding_families = _unique_strings(
-        [[item.get("binding_family")] for item in route_observations]
+        [str(item.get("binding_family") or "").strip() for item in route_observations]
     )
     binding_aliases = _unique_strings(
-        [[item.get("binding_alias") or item.get("route_alias")] for item in route_observations]
+        [
+            str(item.get("binding_alias") or item.get("route_alias") or "").strip()
+            for item in route_observations
+        ]
     )
 
     artifacts: dict[str, dict[str, Any]] = {}

--- a/trellis/agent/task_run_store.py
+++ b/trellis/agent/task_run_store.py
@@ -622,6 +622,15 @@ def _trace_summary(path: str | None) -> dict[str, Any] | None:
             or (runtime_contract.get("snapshot_reference") or {}).get("selected_curve_names")
             or {}
         )
+        binding_health = _normalize_binding_health(
+            raw_health=route_health_snapshot(analytical_trace),
+            construction_identity=context.get("construction_identity") or {},
+            semantic_blueprint=(context.get("semantic_blueprint") or {}),
+            trace_kind=data.get("trace_type", "analytical"),
+            trace_action=route.get("name"),
+            trace_method=route.get("family"),
+            trace_status=data.get("status"),
+        )
         return {
             "path": str(trace_path),
             "exists": True,
@@ -649,7 +658,8 @@ def _trace_summary(path: str | None) -> dict[str, Any] | None:
             "instruction_resolution_conflict_count": len(
                 instruction_resolution.get("conflicts") or []
             ),
-            "route_health": route_health_snapshot(analytical_trace),
+            "binding_health": binding_health,
+            "route_health": dict(binding_health),
             "token_usage": data.get("token_usage") or {},
             "request_metadata": context,
             "linear_issue": None,
@@ -691,44 +701,17 @@ def _trace_summary(path: str | None) -> dict[str, Any] | None:
         or construction_identity.get("operator_metadata")
         or {}
     )
-    route_health = {
-        "route_id": str(
-            route_binding_authority.get("route_id")
-            or semantic_blueprint.get("dsl_route")
-            or ""
-        ).strip(),
-        "route_family": str(
-            route_binding_authority.get("route_family")
-            or semantic_blueprint.get("dsl_route_family")
-            or data.get("route_method")
-            or ""
-        ).strip(),
-        "trace_status": str(data.get("status") or "").strip(),
-        "effective_instruction_ids": [],
-        "effective_instruction_count": 0,
-        "hard_constraint_count": 0,
-        "conflict_count": 0,
-        "canary_task_ids": list(route_binding_authority.get("canary_task_ids") or []),
-        "primary_kind": str(construction_identity.get("primary_kind") or "").strip(),
-        "primary_label": str(construction_identity.get("primary_label") or "").strip(),
-        "backend_binding_id": str(construction_identity.get("backend_binding_id") or "").strip(),
-        "binding_display_name": str(
-            construction_identity.get("binding_display_name")
-            or operator_metadata.get("display_name")
-            or ""
-        ).strip(),
-        "binding_short_description": str(
-            construction_identity.get("binding_short_description")
-            or operator_metadata.get("short_description")
-            or ""
-        ).strip(),
-        "binding_diagnostic_label": str(
-            construction_identity.get("binding_diagnostic_label")
-            or operator_metadata.get("diagnostic_label")
-            or ""
-        ).strip(),
-        "route_alias": str(construction_identity.get("route_alias") or "").strip(),
-    }
+    binding_health = _normalize_binding_health(
+        raw_health={},
+        construction_identity=construction_identity,
+        route_binding_authority=route_binding_authority,
+        semantic_blueprint=semantic_blueprint,
+        trace_kind="platform",
+        trace_action=data.get("action"),
+        trace_method=data.get("route_method"),
+        trace_status=data.get("status"),
+        operator_metadata=operator_metadata,
+    )
     return {
         "path": str(trace_path),
         "exists": True,
@@ -749,12 +732,124 @@ def _trace_summary(path: str | None) -> dict[str, Any] | None:
         "semantic_role_ownership_trigger": semantic_role_ownership.get("trigger_condition"),
         "semantic_role_ownership_artifact": semantic_role_ownership.get("artifact_kind"),
         "construction_identity": construction_identity,
+        "binding_authority": route_binding_authority,
         "route_binding_authority": route_binding_authority,
-        "route_health": route_health,
+        "binding_health": binding_health,
+        "route_health": dict(binding_health),
         "token_usage": data.get("token_usage") or {},
         "request_metadata": metadata,
         "linear_issue": linear if linear else None,
         "github_issue": github if github else None,
+    }
+
+
+def _normalize_binding_health(
+    *,
+    raw_health: Mapping[str, Any] | None,
+    construction_identity: Mapping[str, Any] | None = None,
+    route_binding_authority: Mapping[str, Any] | None = None,
+    semantic_blueprint: Mapping[str, Any] | None = None,
+    trace_kind: str = "",
+    trace_action: Any = None,
+    trace_method: Any = None,
+    trace_status: Any = None,
+    operator_metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Normalize trace health onto binding-first telemetry fields."""
+    raw_health = dict(raw_health or {})
+    construction_identity = dict(construction_identity or {})
+    route_binding_authority = dict(route_binding_authority or {})
+    semantic_blueprint = dict(semantic_blueprint or {})
+    operator_metadata = dict(operator_metadata or {})
+    route_id = str(
+        raw_health.get("route_id")
+        or route_binding_authority.get("route_id")
+        or semantic_blueprint.get("dsl_route")
+        or ""
+    ).strip()
+    if not route_id and trace_kind and trace_kind != "platform":
+        route_id = str(trace_action or "").strip()
+    route_family = str(
+        raw_health.get("route_family")
+        or route_binding_authority.get("route_family")
+        or semantic_blueprint.get("dsl_route_family")
+        or trace_method
+        or ""
+    ).strip()
+    binding_id = str(
+        raw_health.get("binding_id")
+        or raw_health.get("backend_binding_id")
+        or construction_identity.get("backend_binding_id")
+        or ""
+    ).strip()
+    binding_family = str(
+        raw_health.get("binding_family")
+        or construction_identity.get("backend_engine_family")
+        or route_family
+        or trace_method
+        or ""
+    ).strip()
+    binding_alias = str(
+        raw_health.get("binding_alias")
+        or raw_health.get("route_alias")
+        or construction_identity.get("route_alias")
+        or route_id
+        or ""
+    ).strip()
+    binding_display_name = str(
+        raw_health.get("binding_display_name")
+        or construction_identity.get("binding_display_name")
+        or operator_metadata.get("display_name")
+        or ""
+    ).strip()
+    binding_short_description = str(
+        raw_health.get("binding_short_description")
+        or construction_identity.get("binding_short_description")
+        or operator_metadata.get("short_description")
+        or ""
+    ).strip()
+    binding_diagnostic_label = str(
+        raw_health.get("binding_diagnostic_label")
+        or construction_identity.get("binding_diagnostic_label")
+        or operator_metadata.get("diagnostic_label")
+        or ""
+    ).strip()
+    primary_kind = str(
+        raw_health.get("primary_kind")
+        or construction_identity.get("primary_kind")
+        or ""
+    ).strip()
+    primary_label = str(
+        raw_health.get("primary_label")
+        or construction_identity.get("primary_label")
+        or binding_display_name
+        or binding_family
+        or binding_alias
+        or "unknown"
+    ).strip()
+    return {
+        "binding_id": binding_id,
+        "binding_family": binding_family,
+        "binding_alias": binding_alias,
+        "route_id": route_id,
+        "route_family": route_family,
+        "route_alias": binding_alias,
+        "trace_status": str(raw_health.get("trace_status") or trace_status or "").strip(),
+        "effective_instruction_ids": list(raw_health.get("effective_instruction_ids") or []),
+        "effective_instruction_count": int(raw_health.get("effective_instruction_count") or 0),
+        "hard_constraint_count": int(raw_health.get("hard_constraint_count") or 0),
+        "conflict_count": int(raw_health.get("conflict_count") or 0),
+        "canary_task_ids": list(
+            route_binding_authority.get("canary_task_ids")
+            or raw_health.get("canary_task_ids")
+            or []
+        ),
+        "primary_kind": primary_kind,
+        "primary_label": primary_label,
+        "backend_binding_id": binding_id,
+        "binding_display_name": binding_display_name,
+        "binding_short_description": binding_short_description,
+        "binding_diagnostic_label": binding_diagnostic_label,
     }
 
 
@@ -1032,7 +1127,7 @@ def summarize_skill_telemetry(
     method_runs: Mapping[str, Any],
     workflow: Mapping[str, Any],
 ) -> dict[str, Any]:
-    """Summarize selected-skill attribution and route health for one task run."""
+    """Summarize selected-skill attribution and binding health for one task run."""
     learning = dict(result.get("learning") or {})
     outcome = _telemetry_run_outcome(
         result=result,
@@ -1042,7 +1137,7 @@ def summarize_skill_telemetry(
     retry_count = _telemetry_retry_count(result=result, method_runs=method_runs)
     degraded = _telemetry_is_degraded(result=result, method_runs=method_runs)
     comparison_status = str((result.get("cross_validation") or {}).get("status") or "").strip()
-    route_observations = _route_observations(
+    binding_observations = _route_observations(
         traces=traces,
         method_runs=method_runs,
         outcome=outcome,
@@ -1052,14 +1147,14 @@ def summarize_skill_telemetry(
     )
     selected_artifacts = _selected_artifact_observations(
         learning=learning,
-        route_observations=route_observations,
+        route_observations=binding_observations,
         outcome=outcome,
         retry_count=retry_count,
         degraded=degraded,
     )
     selected_artifact_ids = [item["artifact_id"] for item in selected_artifacts]
     if selected_artifact_ids:
-        for item in route_observations:
+        for item in binding_observations:
             item["selected_artifact_ids"] = list(selected_artifact_ids)
     return {
         "task_kind": task_kind,
@@ -1069,7 +1164,8 @@ def summarize_skill_telemetry(
         "degraded": degraded,
         "comparison_status": comparison_status,
         "selected_artifacts": selected_artifacts,
-        "route_observations": route_observations,
+        "binding_observations": binding_observations,
+        "route_observations": [dict(item) for item in binding_observations],
     }
 
 
@@ -1094,6 +1190,9 @@ def aggregate_skill_telemetry(records: list[Mapping[str, Any]]) -> dict[str, Any
                     "kind": str(item.get("kind") or "").strip(),
                     "selection_count": 0,
                     "audiences": [],
+                    "binding_ids": [],
+                    "binding_families": [],
+                    "binding_aliases": [],
                     "route_ids": [],
                     "route_families": [],
                     **_rollup_counter_fields(),
@@ -1106,7 +1205,14 @@ def aggregate_skill_telemetry(records: list[Mapping[str, Any]]) -> dict[str, Any
                 task_id=task_id,
                 persisted_at=persisted_at,
             )
-            for key in ("audiences", "route_ids", "route_families"):
+            for key in (
+                "audiences",
+                "binding_ids",
+                "binding_families",
+                "binding_aliases",
+                "route_ids",
+                "route_families",
+            ):
                 for value in item.get(key) or []:
                     if value and value not in aggregate[key]:
                         aggregate[key].append(value)
@@ -1118,26 +1224,34 @@ def aggregate_skill_telemetry(records: list[Mapping[str, Any]]) -> dict[str, Any
     return rollup
 
 
-def aggregate_route_health(records: list[Mapping[str, Any]]) -> dict[str, Any]:
-    """Roll up route observations across persisted task-run records."""
-    aggregates: dict[tuple[str, str], dict[str, Any]] = {}
+def aggregate_binding_health(records: list[Mapping[str, Any]]) -> dict[str, Any]:
+    """Roll up binding observations across persisted task-run records."""
+    aggregates: dict[tuple[str, str, str], dict[str, Any]] = {}
     for record in records:
         telemetry = dict(record.get("telemetry") or {})
         task_id = str(record.get("task_id") or "").strip()
         persisted_at = str(record.get("persisted_at") or "").strip()
-        for item in telemetry.get("route_observations") or []:
+        for item in telemetry.get("binding_observations") or telemetry.get("route_observations") or []:
             if not isinstance(item, Mapping):
                 continue
-            route_id = str(item.get("route_id") or "").strip()
-            route_family = str(item.get("route_family") or "").strip()
-            if not route_id and not route_family:
+            binding_id = str(item.get("binding_id") or item.get("backend_binding_id") or "").strip()
+            binding_family = str(item.get("binding_family") or item.get("route_family") or "").strip()
+            binding_alias = str(item.get("binding_alias") or item.get("route_alias") or item.get("route_id") or "").strip()
+            if not binding_id and not binding_family and not binding_alias:
                 continue
-            key = (route_id, route_family)
+            key = (binding_id, binding_family, binding_alias)
             aggregate = aggregates.setdefault(
                 key,
                 {
-                    "route_id": route_id,
-                    "route_family": route_family,
+                    "binding_id": binding_id,
+                    "binding_family": binding_family,
+                    "binding_alias": binding_alias,
+                    "route_id": str(item.get("route_id") or "").strip(),
+                    "route_family": str(item.get("route_family") or "").strip(),
+                    "route_alias": str(item.get("route_alias") or binding_alias).strip(),
+                    "primary_label": str(item.get("primary_label") or "").strip(),
+                    "binding_display_name": str(item.get("binding_display_name") or "").strip(),
+                    "binding_diagnostic_label": str(item.get("binding_diagnostic_label") or "").strip(),
                     "observation_count": 0,
                     "trace_kinds": [],
                     "selected_artifact_ids": [],
@@ -1167,13 +1281,24 @@ def aggregate_route_health(records: list[Mapping[str, Any]]) -> dict[str, Any]:
             aggregate["conflict_count_total"] += int(item.get("conflict_count") or 0)
     rollup = {
         "run_count": len(records),
-        "routes": sorted(
+        "bindings": sorted(
             aggregates.values(),
-            key=lambda item: (item["route_family"], item["route_id"]),
+            key=lambda item: (
+                item["binding_family"],
+                item["binding_display_name"],
+                item["binding_id"],
+                item["binding_alias"],
+            ),
         ),
     }
-    rollup["ranking_inputs"] = build_route_ranking_inputs(rollup)["routes"]
+    rollup["routes"] = rollup["bindings"]
+    rollup["ranking_inputs"] = build_binding_ranking_inputs(rollup)["bindings"]
     return rollup
+
+
+def aggregate_route_health(records: list[Mapping[str, Any]]) -> dict[str, Any]:
+    """Compatibility wrapper for legacy route-health rollup callers."""
+    return aggregate_binding_health(records)
 
 
 def load_latest_skill_telemetry_rollup(
@@ -1185,13 +1310,22 @@ def load_latest_skill_telemetry_rollup(
     return load_latest_telemetry_rollups(root=root, task_kind=task_kind)["skill_telemetry"]
 
 
+def load_latest_binding_health_rollup(
+    *,
+    root: Path = ROOT,
+    task_kind: str | None = None,
+) -> dict[str, Any]:
+    """Load the latest task runs and aggregate binding-health observations."""
+    return load_latest_telemetry_rollups(root=root, task_kind=task_kind)["binding_health"]
+
+
 def load_latest_route_health_rollup(
     *,
     root: Path = ROOT,
     task_kind: str | None = None,
 ) -> dict[str, Any]:
-    """Load the latest task runs and aggregate route-health observations."""
-    return load_latest_telemetry_rollups(root=root, task_kind=task_kind)["route_health"]
+    """Compatibility wrapper for legacy route-health rollup callers."""
+    return load_latest_binding_health_rollup(root=root, task_kind=task_kind)
 
 
 def load_latest_telemetry_rollups(
@@ -1201,9 +1335,11 @@ def load_latest_telemetry_rollups(
 ) -> dict[str, Any]:
     """Load the latest task runs once and rebuild both telemetry rollups."""
     records = load_latest_task_run_records(root=root, task_kind=task_kind)
+    binding_health = aggregate_binding_health(records)
     return {
         "skill_telemetry": aggregate_skill_telemetry(records),
-        "route_health": aggregate_route_health(records),
+        "binding_health": binding_health,
+        "route_health": binding_health,
     }
 
 
@@ -1228,6 +1364,7 @@ def build_skill_ranking_inputs(rollup: Mapping[str, Any]) -> dict[str, Any]:
                 "avg_retry_count": _fraction(item.get("retry_count_total"), selection_count),
                 "last_seen_at": str(item.get("last_seen_at") or "").strip(),
                 "first_seen_at": str(item.get("first_seen_at") or "").strip(),
+                "binding_coverage_count": len(item.get("binding_ids") or []),
                 "route_coverage_count": len(item.get("route_ids") or []),
                 "task_coverage_count": len(item.get("task_ids") or []),
             }
@@ -1238,15 +1375,18 @@ def build_skill_ranking_inputs(rollup: Mapping[str, Any]) -> dict[str, Any]:
     }
 
 
-def build_route_ranking_inputs(rollup: Mapping[str, Any]) -> dict[str, Any]:
-    """Project route-health rollups into stable ranking inputs."""
-    routes = []
-    for item in rollup.get("routes") or []:
+def build_binding_ranking_inputs(rollup: Mapping[str, Any]) -> dict[str, Any]:
+    """Project binding-health rollups into stable ranking inputs."""
+    bindings = []
+    for item in rollup.get("bindings") or rollup.get("routes") or []:
         if not isinstance(item, Mapping):
             continue
         observation_count = int(item.get("observation_count") or 0)
-        routes.append(
+        bindings.append(
             {
+                "binding_id": str(item.get("binding_id") or item.get("backend_binding_id") or "").strip(),
+                "binding_family": str(item.get("binding_family") or item.get("route_family") or "").strip(),
+                "binding_alias": str(item.get("binding_alias") or item.get("route_alias") or item.get("route_id") or "").strip(),
                 "route_id": str(item.get("route_id") or "").strip(),
                 "route_family": str(item.get("route_family") or "").strip(),
                 "observation_count": observation_count,
@@ -1268,16 +1408,34 @@ def build_route_ranking_inputs(rollup: Mapping[str, Any]) -> dict[str, Any]:
                     item.get("conflict_count_total"),
                     observation_count,
                 ),
+                "primary_label": str(item.get("primary_label") or "").strip(),
+                "binding_display_name": str(item.get("binding_display_name") or "").strip(),
+                "binding_diagnostic_label": str(item.get("binding_diagnostic_label") or "").strip(),
                 "last_seen_at": str(item.get("last_seen_at") or "").strip(),
                 "first_seen_at": str(item.get("first_seen_at") or "").strip(),
                 "selected_artifact_count": len(item.get("selected_artifact_ids") or []),
                 "task_coverage_count": len(item.get("task_ids") or []),
             }
         )
-    return {
+    result = {
         "run_count": int(rollup.get("run_count") or 0),
-        "routes": sorted(routes, key=lambda item: (item["route_family"], item["route_id"])),
+        "bindings": sorted(
+            bindings,
+            key=lambda item: (
+                item["binding_family"],
+                item["binding_display_name"],
+                item["binding_id"],
+                item["binding_alias"],
+            ),
+        ),
     }
+    result["routes"] = result["bindings"]
+    return result
+
+
+def build_route_ranking_inputs(rollup: Mapping[str, Any]) -> dict[str, Any]:
+    """Compatibility wrapper for legacy route-ranking callers."""
+    return build_binding_ranking_inputs(rollup)
 
 
 def load_latest_skill_ranking_inputs(
@@ -1291,15 +1449,24 @@ def load_latest_skill_ranking_inputs(
     )
 
 
+def load_latest_binding_ranking_inputs(
+    *,
+    root: Path = ROOT,
+    task_kind: str | None = None,
+) -> dict[str, Any]:
+    """Load the latest task runs and derive binding-ranking inputs."""
+    return build_binding_ranking_inputs(
+        load_latest_telemetry_rollups(root=root, task_kind=task_kind)["binding_health"]
+    )
+
+
 def load_latest_route_ranking_inputs(
     *,
     root: Path = ROOT,
     task_kind: str | None = None,
 ) -> dict[str, Any]:
-    """Load the latest task runs and derive route-ranking inputs."""
-    return build_route_ranking_inputs(
-        load_latest_telemetry_rollups(root=root, task_kind=task_kind)["route_health"]
-    )
+    """Compatibility wrapper for legacy route-ranking callers."""
+    return load_latest_binding_ranking_inputs(root=root, task_kind=task_kind)
 
 
 def _rollup_counter_fields() -> dict[str, Any]:
@@ -1433,6 +1600,15 @@ def _selected_artifact_observations(
     route_families = _unique_strings(
         [[item.get("route_family")] for item in route_observations]
     )
+    binding_ids = _unique_strings(
+        [[item.get("binding_id") or item.get("backend_binding_id")] for item in route_observations]
+    )
+    binding_families = _unique_strings(
+        [[item.get("binding_family")] for item in route_observations]
+    )
+    binding_aliases = _unique_strings(
+        [[item.get("binding_alias") or item.get("route_alias")] for item in route_observations]
+    )
 
     artifacts: dict[str, dict[str, Any]] = {}
     for audience, items in by_audience.items():
@@ -1452,6 +1628,9 @@ def _selected_artifact_observations(
                     "retried": retry_count > 0,
                     "retry_count": retry_count,
                     "degraded": degraded,
+                    "binding_ids": list(binding_ids),
+                    "binding_families": list(binding_families),
+                    "binding_aliases": list(binding_aliases),
                     "route_ids": list(route_ids),
                     "route_families": list(route_families),
                     "task_ids": [],
@@ -1471,30 +1650,30 @@ def _route_observations(
     degraded: bool,
     selected_artifact_ids: list[str],
 ) -> list[dict[str, Any]]:
-    """Project route-health observations from trace summaries and method runs."""
+    """Project binding-health observations from trace summaries and method runs."""
     observations: list[dict[str, Any]] = []
-    seen: set[tuple[str, str, str]] = set()
+    seen: set[tuple[str, str, str, str]] = set()
 
     for trace in traces:
-        route_health = dict(trace.get("route_health") or {})
+        binding_health = _normalize_binding_health(
+            raw_health=trace.get("binding_health") or trace.get("route_health") or {},
+            construction_identity=trace.get("construction_identity") or {},
+            route_binding_authority=trace.get("binding_authority") or trace.get("route_binding_authority") or {},
+            semantic_blueprint=(dict(trace.get("request_metadata") or {}).get("semantic_blueprint") or {}),
+            trace_kind=str(trace.get("trace_kind") or "").strip(),
+            trace_action=trace.get("action"),
+            trace_method=trace.get("route_method"),
+            trace_status=trace.get("status"),
+        )
         construction_identity = dict(trace.get("construction_identity") or {})
         metadata = dict(trace.get("request_metadata") or {})
-        semantic_blueprint = dict(metadata.get("semantic_blueprint") or {})
         trace_kind = str(trace.get("trace_kind") or "").strip()
-        route_id = (
-            str(route_health.get("route_id") or "").strip()
-            or str(semantic_blueprint.get("dsl_route") or "").strip()
-        )
-        if not route_id and trace_kind != "platform":
-            route_id = str(trace.get("action") or "").strip()
-        route_family = (
-            str(route_health.get("route_family") or "").strip()
-            or str(trace.get("route_method") or "").strip()
-            or str(semantic_blueprint.get("dsl_route_family") or "").strip()
-        )
-        if not route_id and not route_family:
+        binding_id = str(binding_health.get("binding_id") or "").strip()
+        binding_family = str(binding_health.get("binding_family") or "").strip()
+        binding_alias = str(binding_health.get("binding_alias") or "").strip()
+        if not binding_id and not binding_family and not binding_alias:
             continue
-        key = (route_id, route_family, trace_kind)
+        key = (binding_id, binding_family, binding_alias, trace_kind)
         if key in seen:
             continue
         seen.add(key)
@@ -1507,61 +1686,64 @@ def _route_observations(
         instruction_ids.extend(
             [
                 value
-                for value in route_health.get("effective_instruction_ids") or []
+                for value in binding_health.get("effective_instruction_ids") or []
                 if isinstance(value, str) and value.strip() and value not in instruction_ids
             ]
         )
         effective_instruction_count = int(
-            route_health.get("effective_instruction_count")
+            binding_health.get("effective_instruction_count")
             or trace.get("instruction_resolution_effective_count")
             or len(instruction_ids)
         )
-        hard_constraint_count = int(route_health.get("hard_constraint_count") or 0)
+        hard_constraint_count = int(binding_health.get("hard_constraint_count") or 0)
         conflict_count = int(
-            route_health.get("conflict_count")
+            binding_health.get("conflict_count")
             or trace.get("instruction_resolution_conflict_count")
             or 0
         )
         observations.append(
             {
-                "route_id": route_id,
-                "route_family": route_family,
+                "binding_id": binding_id,
+                "binding_family": binding_family,
+                "binding_alias": binding_alias,
+                "route_id": str(binding_health.get("route_id") or "").strip(),
+                "route_family": str(binding_health.get("route_family") or "").strip(),
                 "primary_kind": str(
-                    route_health.get("primary_kind")
+                    binding_health.get("primary_kind")
                     or construction_identity.get("primary_kind")
                     or ""
                 ).strip(),
                 "primary_label": str(
-                    route_health.get("primary_label")
+                    binding_health.get("primary_label")
                     or construction_identity.get("primary_label")
-                    or route_family
-                    or route_id
+                    or binding_family
+                    or binding_alias
                     or "unknown"
                 ).strip(),
                 "backend_binding_id": str(
-                    route_health.get("backend_binding_id")
+                    binding_health.get("backend_binding_id")
                     or construction_identity.get("backend_binding_id")
                     or ""
                 ).strip(),
                 "binding_display_name": str(
-                    route_health.get("binding_display_name")
+                    binding_health.get("binding_display_name")
                     or construction_identity.get("binding_display_name")
                     or ""
                 ).strip(),
                 "binding_short_description": str(
-                    route_health.get("binding_short_description")
+                    binding_health.get("binding_short_description")
                     or construction_identity.get("binding_short_description")
                     or ""
                 ).strip(),
                 "binding_diagnostic_label": str(
-                    route_health.get("binding_diagnostic_label")
+                    binding_health.get("binding_diagnostic_label")
                     or construction_identity.get("binding_diagnostic_label")
                     or ""
                 ).strip(),
                 "route_alias": str(
-                    route_health.get("route_alias")
+                    binding_health.get("route_alias")
                     or construction_identity.get("route_alias")
-                    or route_id
+                    or binding_alias
                     or ""
                 ).strip(),
                 "trace_kind": trace_kind or "unknown",
@@ -1576,26 +1758,29 @@ def _route_observations(
                 "effective_instruction_count": effective_instruction_count,
                 "hard_constraint_count": hard_constraint_count,
                 "conflict_count": conflict_count,
-                "task_ids": list(route_health.get("canary_task_ids") or []),
+                "task_ids": list(binding_health.get("canary_task_ids") or []),
             }
         )
 
     for payload in method_runs.values():
         if not isinstance(payload, Mapping):
             continue
-        route_family = str(payload.get("route_method") or "").strip()
-        if not route_family:
+        binding_family = str(payload.get("route_method") or "").strip()
+        if not binding_family:
             continue
-        key = ("", route_family, "method_run")
+        key = ("", binding_family, "", "method_run")
         if key in seen:
             continue
         seen.add(key)
         observations.append(
             {
+                "binding_id": "",
+                "binding_family": binding_family,
+                "binding_alias": "",
                 "route_id": "",
-                "route_family": route_family,
+                "route_family": binding_family,
                 "primary_kind": "method_family",
-                "primary_label": route_family,
+                "primary_label": binding_family,
                 "backend_binding_id": "",
                 "binding_display_name": "",
                 "binding_short_description": "",


### PR DESCRIPTION
## Summary
- make task-run telemetry and diagnosis packets binding-first while retaining route-named compatibility aliases
- add binding-first health/ranking loaders and binding coverage counters for selected-artifact rollups
- update developer docs and the binding-first program mirror for QUA-813

## Why
Route ids are no longer supposed to be the primary runtime health key. The task-run store and diagnosis surfaces were still summarizing health primarily by route, which kept old route-first assumptions alive in observability and maintenance tooling.

## Validation
- `/Users/steveyang/miniforge3/bin/python3 -m py_compile trellis/agent/task_run_store.py trellis/agent/task_diagnostics.py tests/test_agent/test_task_run_store.py tests/test_agent/test_task_diagnostics.py`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_task_run_store.py tests/test_agent/test_task_diagnostics.py -q`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_task_learning_benchmark.py tests/test_agent/test_canary_runner.py -q`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/ -x -q -m "not integration"`
