### PR TITLE
QUA-814: strip duplicate route operator wording

### DIFF
--- a/docs/developer/knowledge_skill_layer.rst
+++ b/docs/developer/knowledge_skill_layer.rst
@@ -112,7 +112,10 @@ Discovered routes remain available to analysis code paths, but they no longer
 perturb ordinary prompt skill projection unless a caller opts in explicitly.
 Migrated exact-helper routes may also mark that alias as internal-only, which
 suppresses it from operator-facing prompts while retaining the raw id for
-replay and canary history.
+replay and canary history. Once a migrated exact-helper route has first-class
+binding operator metadata, duplicate human-facing route notes should be
+removed from ``routes.yaml`` rather than projected as additional
+``historical_note`` records.
 
 Selection and trace surface
 ---------------------------

--- a/docs/plans/binding-first-exotic-assembly.md
+++ b/docs/plans/binding-first-exotic-assembly.md
@@ -130,7 +130,7 @@ ultimately targets.
 
 ## Linear Ticket Mirror
 
-Status mirror last synced: `2026-04-13`
+Status mirror last synced: `2026-04-12`
 
 ### Ordered Epic Queue
 
@@ -175,7 +175,7 @@ Status mirror last synced: `2026-04-13`
 | --- | --- |
 | `QUA-803` | Operator metadata: introduce first-class binding display and diagnostic catalog | Done |
 | `QUA-807` | Operator views: use binding metadata in MCP, session, and task diagnostics surfaces | Done |
-| `QUA-814` | Route YAML cleanup: strip operator-facing wording after binding metadata adoption | Backlog |
+| `QUA-814` | Route YAML cleanup: strip operator-facing wording after binding metadata adoption | Done |
 
 ### Ordered Exotic Composition Proof Queue
 

--- a/docs/plans/binding-first-exotic-assembly.md
+++ b/docs/plans/binding-first-exotic-assembly.md
@@ -130,7 +130,7 @@ ultimately targets.
 
 ## Linear Ticket Mirror
 
-Status mirror last synced: `2026-04-12`
+Status mirror last synced: `2026-04-13`
 
 ### Ordered Epic Queue
 

--- a/tests/test_agent/test_skill_index.py
+++ b/tests/test_agent/test_skill_index.py
@@ -80,10 +80,10 @@ def test_route_hint_projection_includes_instruction_lifecycle_records():
 
 
 def test_route_hint_lineage_links_back_to_matching_cookbook():
-    record = get_skill_record("route_hint:analytical_garman_kohlhagen:note:1")
+    record = get_skill_record("route_hint:analytical_garman_kohlhagen:route-helper")
 
     assert record is not None
-    assert record.kind == "historical_note"
+    assert record.kind == "route_hint"
     assert record.lineage_status == "derived"
     assert "route.match_method_to_cookbook" in record.lineage_evidence
     assert "cookbook:analytical" in record.parents
@@ -93,11 +93,11 @@ def test_skill_lineage_query_surfaces_children_and_same_source_records():
     lineage = get_skill_lineage("cookbook:analytical")
 
     assert lineage is not None
-    assert "route_hint:analytical_garman_kohlhagen:note:1" in lineage["children"]
+    assert "route_hint:analytical_garman_kohlhagen:route-helper" in lineage["children"]
 
-    route_lineage = get_skill_lineage("route_hint:analytical_garman_kohlhagen:note:1")
+    route_lineage = get_skill_lineage("route_hint:analytical_garman_kohlhagen:route-helper")
     assert route_lineage is not None
-    assert "route_hint:analytical_garman_kohlhagen:route-helper" in route_lineage["same_source"]
+    assert route_lineage["same_source"] == ()
 
     lineage_index = load_skill_lineage_index()
     assert lineage_index["cookbook:analytical"]["children"] == lineage["children"]
@@ -119,6 +119,13 @@ def test_route_notes_are_not_projected_as_live_route_hints():
     }
 
     assert "route_hint:analytical_garman_kohlhagen:note:1" not in route_hint_ids
+
+
+def test_migrated_exact_helper_routes_do_not_project_duplicate_note_records():
+    assert get_skill_record("route_hint:analytical_garman_kohlhagen:note:1") is None
+    assert get_skill_record("route_hint:quanto_adjustment_analytical:note:1") is None
+    assert get_skill_record("route_hint:correlated_gbm_monte_carlo:note:1") is None
+    assert get_skill_record("route_hint:monte_carlo_fx_vanilla:note:1") is None
 
 
 def test_skill_index_generation_is_deterministic():

--- a/trellis/agent/knowledge/canonical/routes.yaml
+++ b/trellis/agent/knowledge/canonical/routes.yaml
@@ -35,8 +35,7 @@ routes:
         symbol: price_quanto_option_analytical_from_market_state
         role: route_helper
     adapters: []
-    notes:
-      - "Use `trellis.models.quanto_option.price_quanto_option_analytical_from_market_state(...)` as the exact backend helper for analytical quanto requests."
+    notes: []
     market_data_access:
       required:
         discount_curve: [market_state.discount]
@@ -65,8 +64,7 @@ routes:
         symbol: price_quanto_option_monte_carlo_from_market_state
         role: route_helper
     adapters: []
-    notes:
-      - "Use `trellis.models.quanto_option.price_quanto_option_monte_carlo_from_market_state(...)` as the exact backend helper for Monte Carlo quanto requests."
+    notes: []
     market_data_access:
       required:
         discount_curve: [market_state.discount]
@@ -400,8 +398,7 @@ routes:
         symbol: price_fx_vanilla_monte_carlo
         role: route_helper
     adapters: []
-    notes:
-      - "Use `trellis.models.fx_vanilla.price_fx_vanilla_monte_carlo(...)` as the exact backend helper for vanilla FX Monte Carlo requests."
+    notes: []
     market_data_access:
       required:
         discount_curve: [market_state.discount]
@@ -871,8 +868,7 @@ routes:
         symbol: price_fx_vanilla_analytical
         role: route_helper
     adapters: []
-    notes:
-      - "Use `trellis.models.fx_vanilla.price_fx_vanilla_analytical(...)` as the exact backend helper for analytical vanilla FX requests."
+    notes: []
     market_data_access:
       required:
         discount_curve: [market_state.discount]


### PR DESCRIPTION
## Summary
- remove duplicate operator-facing exact-helper notes from migrated route cards
- update the generated skill-layer tests to treat route-helper records as the surviving lineage surface
- document that binding metadata owns operator wording and sync the binding-first plan mirror

## Testing
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_skill_index.py -q
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_codegen_guardrails.py tests/test_agent/test_prompts.py -q
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/ -x -q -m "not integration"
