### PR TITLE
QUA-810: collapse route registry to alias shell

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -78,9 +78,9 @@ maintenance around the deterministic engines.
   `trellis/agent/valuation_context.py`, and
   `trellis/agent/market_binding.py` hold the typed semantic and valuation
   boundary.
-- `trellis/agent/backend_bindings.py` is the canonical catalog of exact helper,
-  kernel, schedule-builder, cashflow-engine, and market-binding facts used by
-  the runtime.
+- `trellis/agent/backend_bindings.py` loads the canonical exact-binding catalog
+  from `trellis/agent/knowledge/canonical/backend_bindings.yaml`, with
+  discovered-route overlays only in explicit analysis mode.
 - `trellis/agent/binding_operator_metadata.py` is the first-class catalog of
   operator-facing binding display names, short descriptions, and diagnostic
   labels, so operator wording no longer has to piggyback on route YAML prose.

--- a/docs/plans/binding-first-exotic-assembly.md
+++ b/docs/plans/binding-first-exotic-assembly.md
@@ -150,7 +150,7 @@ Status mirror last synced: `2026-04-13`
 | `QUA-798` | Backend binding: introduce canonical binding catalog beside route registry | Done |
 | `QUA-799` | Backend binding: carry binding identity through primitive and generation plans | Done |
 | `QUA-800` | Backend binding: move exact helper and kernel lookup onto binding specs | Done |
-| `QUA-810` | Route aliases: collapse route registry to transitional alias and admissibility shell | Backlog |
+| `QUA-810` | Route aliases: collapse route registry to transitional alias and admissibility shell | Done |
 
 ### Ordered Lowering And Assembly Queue
 
@@ -159,6 +159,7 @@ Status mirror last synced: `2026-04-13`
 | `QUA-801` | Family lowering: replace route-id special cases with binding-role dispatch | Done |
 | `QUA-805` | DSL lowering: resolve helpers, kernels, schedules, and controls from binding roles | Done |
 | `QUA-811` | Semantic blockers: rename route-shaped helper gaps to binding and primitive taxonomy | Done |
+| `QUA-816` | Constructive guidance: retire residual route adapters and notes from fallback lanes | Backlog |
 
 ### Ordered Validation / Replay Queue
 

--- a/tests/test_agent/test_backend_bindings.py
+++ b/tests/test_agent/test_backend_bindings.py
@@ -27,16 +27,54 @@ def test_binding_catalog_loads_core_route_backed_bindings():
 def test_binding_catalog_canonical_load_is_not_derived_from_route_registry(monkeypatch):
     from trellis.agent import route_registry as route_registry_module
 
+    clear_backend_binding_catalog_cache()
     monkeypatch.setattr(
         route_registry_module,
         "load_route_registry",
         lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("route registry should not load")),
     )
 
-    clear_backend_binding_catalog_cache()
     catalog = load_backend_binding_catalog()
 
     assert find_backend_binding_by_route_id("analytical_garman_kohlhagen", catalog) is not None
+
+
+def test_binding_catalog_skips_malformed_primitive_rows(monkeypatch):
+    from trellis.agent import backend_bindings as backend_bindings_module
+
+    clear_backend_binding_catalog_cache()
+    monkeypatch.setattr(
+        backend_bindings_module,
+        "_load_canonical_bindings",
+        lambda: (
+            backend_bindings_module._binding_from_raw(
+                {
+                    "route_id": "synthetic_binding_route",
+                    "engine_family": "analytical",
+                    "route_family": "synthetic_family",
+                    "primitives": [
+                        {"module": "trellis.models.synthetic", "symbol": "good_helper", "role": "route_helper"},
+                        {"module": "trellis.models.synthetic", "role": "route_helper"},
+                    ],
+                }
+            ),
+        ),
+    )
+
+    try:
+        catalog = load_backend_binding_catalog()
+        binding = find_backend_binding_by_route_id("synthetic_binding_route", catalog)
+
+        assert binding is not None
+        assert binding.primitives == (
+            backend_bindings_module.PrimitiveRef(
+                "trellis.models.synthetic",
+                "good_helper",
+                "route_helper",
+            ),
+        )
+    finally:
+        clear_backend_binding_catalog_cache()
 
 
 def test_resolve_backend_binding_spec_captures_helper_schedule_and_cashflow_roles():

--- a/tests/test_agent/test_backend_bindings.py
+++ b/tests/test_agent/test_backend_bindings.py
@@ -33,6 +33,7 @@ def test_binding_catalog_canonical_load_is_not_derived_from_route_registry(monke
         lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("route registry should not load")),
     )
 
+    clear_backend_binding_catalog_cache()
     catalog = load_backend_binding_catalog()
 
     assert find_backend_binding_by_route_id("analytical_garman_kohlhagen", catalog) is not None

--- a/tests/test_agent/test_backend_bindings.py
+++ b/tests/test_agent/test_backend_bindings.py
@@ -24,6 +24,20 @@ def test_binding_catalog_loads_core_route_backed_bindings():
     } <= route_ids
 
 
+def test_binding_catalog_canonical_load_is_not_derived_from_route_registry(monkeypatch):
+    from trellis.agent import route_registry as route_registry_module
+
+    monkeypatch.setattr(
+        route_registry_module,
+        "load_route_registry",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("route registry should not load")),
+    )
+
+    catalog = load_backend_binding_catalog()
+
+    assert find_backend_binding_by_route_id("analytical_garman_kohlhagen", catalog) is not None
+
+
 def test_resolve_backend_binding_spec_captures_helper_schedule_and_cashflow_roles():
     catalog = load_backend_binding_catalog()
 
@@ -94,24 +108,24 @@ def test_resolve_backend_binding_spec_uses_route_conditionals_for_exact_targets(
     )
 
 
-def test_binding_catalog_cache_tracks_route_registry_freshness(monkeypatch):
+def test_binding_catalog_cache_tracks_binding_catalog_freshness(monkeypatch):
     clear_backend_binding_catalog_cache()
 
-    registry_one = SimpleNamespace(routes=())
-    registry_two = SimpleNamespace(routes=())
-    calls = iter((registry_one, registry_two))
+    from trellis.agent import backend_bindings as backend_bindings_module
 
-    from trellis.agent import route_registry as route_registry_module
+    catalog_one = SimpleNamespace(bindings=())
+    catalog_two = SimpleNamespace(bindings=())
+    calls = iter((catalog_one, catalog_two))
 
     monkeypatch.setattr(
-        route_registry_module,
+        backend_bindings_module,
         "_cache_key",
-        lambda *, include_discovered: (include_discovered, 1.0, 0.0, "rev-a"),
+        lambda *, include_discovered: (include_discovered, 1.0, "rev-a", ()),
     )
     monkeypatch.setattr(
-        route_registry_module,
-        "load_route_registry",
-        lambda *, include_discovered=False: next(calls),
+        backend_bindings_module,
+        "_load_canonical_bindings",
+        lambda: tuple(next(calls).bindings),
     )
 
     first = load_backend_binding_catalog()
@@ -119,9 +133,9 @@ def test_binding_catalog_cache_tracks_route_registry_freshness(monkeypatch):
     assert first is second
 
     monkeypatch.setattr(
-        route_registry_module,
+        backend_bindings_module,
         "_cache_key",
-        lambda *, include_discovered: (include_discovered, 2.0, 0.0, "rev-a"),
+        lambda *, include_discovered: (include_discovered, 2.0, "rev-a", ()),
     )
 
     third = load_backend_binding_catalog()

--- a/tests/test_agent/test_codegen_guardrails.py
+++ b/tests/test_agent/test_codegen_guardrails.py
@@ -118,11 +118,15 @@ def test_rank_primitive_routes_prefers_binding_spec_primitives_when_route_card_i
     monkeypatch.setattr(
         route_registry_module,
         "resolve_route_primitives",
-        lambda spec, product_ir: (stale_helper,),
+        lambda spec, product_ir, binding_spec=None: (stale_helper,),
     )
     monkeypatch.setattr(route_registry_module, "resolve_route_adapters", lambda spec, product_ir: ())
     monkeypatch.setattr(route_registry_module, "resolve_route_notes", lambda spec, product_ir: ())
-    monkeypatch.setattr(route_registry_module, "resolve_route_family", lambda spec, product_ir: "analytical")
+    monkeypatch.setattr(
+        route_registry_module,
+        "resolve_route_family",
+        lambda spec, product_ir, binding_spec=None: "analytical",
+    )
     monkeypatch.setattr(
         backend_bindings_module,
         "load_backend_binding_catalog",

--- a/tests/test_agent/test_route_registry.py
+++ b/tests/test_agent/test_route_registry.py
@@ -245,6 +245,51 @@ class TestRegistryValidation:
 
         assert tuple(route.id for route in matches) == ("family_mc",)
 
+    def test_route_resolution_prefers_binding_catalog_over_route_shell_fields(self, monkeypatch):
+        from trellis.agent import backend_bindings as backend_bindings_module
+
+        spec = RouteSpec(
+            id="synthetic_binding_route",
+            engine_family="analytical",
+            route_family="legacy_family",
+            status="promoted",
+            confidence=1.0,
+            match_methods=("analytical",),
+            match_instruments=None,
+            exclude_instruments=(),
+            match_payoff_family=None,
+            match_payoff_traits=None,
+            match_exercise=None,
+            exclude_exercise=(),
+            match_required_market_data=None,
+            exclude_required_market_data=None,
+            primitives=(
+                PrimitiveRef("trellis.models.legacy", "old_helper", "route_helper"),
+            ),
+            conditional_primitives=(),
+            conditional_route_family=None,
+            adapters=(),
+            notes=(),
+        )
+        monkeypatch.setattr(
+            backend_bindings_module,
+            "resolve_backend_binding_by_route_id",
+            lambda route_id, product_ir=None: SimpleNamespace(
+                primitives=(
+                    PrimitiveRef("trellis.models.synthetic", "fresh_helper", "route_helper"),
+                ),
+                route_family="binding_family",
+            ),
+        )
+
+        synthetic_ir = ProductIR(instrument="synthetic", payoff_family="synthetic")
+        resolved_primitives = resolve_route_primitives(spec, synthetic_ir)
+
+        assert _prim_set(resolved_primitives) == {
+            ("trellis.models.synthetic", "fresh_helper", "route_helper"),
+        }
+        assert resolve_route_family(spec, synthetic_ir) == "binding_family"
+
     def test_typed_admissibility_hydrates_for_migrated_routes(self, registry):
         analytical = find_route_by_id("analytical_black76", registry)
         lattice = find_route_by_id("exercise_lattice", registry)

--- a/tests/test_agent/test_route_registry.py
+++ b/tests/test_agent/test_route_registry.py
@@ -290,6 +290,50 @@ class TestRegistryValidation:
         }
         assert resolve_route_family(spec, synthetic_ir) == "binding_family"
 
+    def test_route_resolution_reuses_preloaded_binding_spec(self, monkeypatch):
+        from trellis.agent import backend_bindings as backend_bindings_module
+
+        spec = RouteSpec(
+            id="synthetic_binding_route",
+            engine_family="analytical",
+            route_family="legacy_family",
+            status="promoted",
+            confidence=1.0,
+            match_methods=("analytical",),
+            match_instruments=None,
+            exclude_instruments=(),
+            match_payoff_family=None,
+            match_payoff_traits=None,
+            match_exercise=None,
+            exclude_exercise=(),
+            match_required_market_data=None,
+            exclude_required_market_data=None,
+            primitives=(
+                PrimitiveRef("trellis.models.legacy", "old_helper", "route_helper"),
+            ),
+            conditional_primitives=(),
+            conditional_route_family=None,
+            adapters=(),
+            notes=(),
+        )
+        monkeypatch.setattr(
+            backend_bindings_module,
+            "resolve_backend_binding_by_route_id",
+            lambda *args, **kwargs: (_ for _ in ()).throw(
+                AssertionError("binding lookup should not run when binding_spec is supplied")
+            ),
+        )
+
+        binding_spec = SimpleNamespace(
+            primitives=(
+                PrimitiveRef("trellis.models.synthetic", "fresh_helper", "route_helper"),
+            ),
+            route_family="binding_family",
+        )
+
+        assert resolve_route_primitives(spec, None, binding_spec=binding_spec) == binding_spec.primitives
+        assert resolve_route_family(spec, None, binding_spec=binding_spec) == "binding_family"
+
     def test_typed_admissibility_hydrates_for_migrated_routes(self, registry):
         analytical = find_route_by_id("analytical_black76", registry)
         lattice = find_route_by_id("exercise_lattice", registry)

--- a/trellis/agent/backend_bindings.py
+++ b/trellis/agent/backend_bindings.py
@@ -302,7 +302,10 @@ def _parse_primitives(raw: Any) -> tuple[PrimitiveRef, ...]:
     return tuple(
         _parse_primitive(item)
         for item in raw
-        if isinstance(item, dict) and item.get("module") and item.get("symbol") and item.get("role")
+        if isinstance(item, dict)
+        and item.get("module")
+        and item.get("symbol")
+        and item.get("role")
     )
 
 

--- a/trellis/agent/backend_bindings.py
+++ b/trellis/agent/backend_bindings.py
@@ -299,7 +299,11 @@ def _str_tuple(values) -> tuple[str, ...]:
 def _parse_primitives(raw: Any) -> tuple[PrimitiveRef, ...]:
     if not raw:
         return ()
-    return tuple(_parse_primitive(item) for item in raw if isinstance(item, dict))
+    return tuple(
+        _parse_primitive(item)
+        for item in raw
+        if isinstance(item, dict) and item.get("module") and item.get("symbol") and item.get("role")
+    )
 
 
 def _parse_primitive(raw: dict[str, Any]) -> PrimitiveRef:

--- a/trellis/agent/backend_bindings.py
+++ b/trellis/agent/backend_bindings.py
@@ -1,17 +1,23 @@
-"""Canonical backend-binding catalog derived from the current route registry.
+"""Canonical backend-binding catalog independent from the route registry.
 
-This module is the first structural step in replacing route cards as the
-primary exact-backend identity surface. The catalog is intentionally loaded
-beside the route registry for now and resolves the exact helper/kernel/schedule
-facts without changing the downstream lowering or validation contracts yet.
+The binding catalog is now the authoritative source for exact runtime binding
+facts: helper/kernel primitives, conditional binding-family overrides, and the
+stable binding identity derived from those surfaces. The route registry remains
+responsible for matching, aliases, admissibility, and temporary transition
+guidance, while discovered routes can still be overlaid into the catalog for
+analysis mode.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
+import yaml
+
 from trellis.agent.codegen_guardrails import PrimitiveRef
+from trellis.agent.knowledge.import_registry import get_repo_revision
 from trellis.agent.knowledge.schema import ProductIR
 
 
@@ -74,12 +80,17 @@ class BackendBindingCatalog:
 
 
 _CATALOG_CACHE: dict[tuple, BackendBindingCatalog] = {}
+_CANONICAL_PATH = Path(__file__).resolve().parent / "knowledge" / "canonical" / "backend_bindings.yaml"
 
 
 def _cache_key(*, include_discovered: bool) -> tuple:
-    from trellis.agent import route_registry as route_registry_module
+    canonical_mtime = _CANONICAL_PATH.stat().st_mtime_ns if _CANONICAL_PATH.exists() else 0
+    discovered_key: tuple[object, ...] = ()
+    if include_discovered:
+        from trellis.agent import route_registry as route_registry_module
 
-    return tuple(route_registry_module._cache_key(include_discovered=include_discovered))
+        discovered_key = tuple(route_registry_module._cache_key(include_discovered=True))
+    return (include_discovered, canonical_mtime, get_repo_revision(), discovered_key)
 
 
 def load_backend_binding_catalog(
@@ -87,27 +98,30 @@ def load_backend_binding_catalog(
     include_discovered: bool = False,
     registry=None,
 ) -> BackendBindingCatalog:
-    """Load the canonical backend-binding catalog beside the route registry."""
+    """Load the canonical backend-binding catalog with optional discovered overlays."""
+    key = None
     if registry is None:
         key = _cache_key(include_discovered=include_discovered)
         cached = _CATALOG_CACHE.get(key)
         if cached is not None:
             return cached
+
+    bindings = list(_load_canonical_bindings())
+    if registry is None and include_discovered:
         from trellis.agent.route_registry import load_route_registry
 
-        registry = load_route_registry(include_discovered=include_discovered)
-    else:
-        key = None
+        registry = load_route_registry(include_discovered=True)
+    if registry is not None:
+        bindings = _overlay_registry_bindings(bindings, registry)
 
-    bindings = tuple(_binding_from_route(route) for route in registry.routes)
     route_index: dict[str, list[int]] = {}
     for idx, binding in enumerate(bindings):
         route_index.setdefault(binding.route_id, []).append(idx)
         for alias in binding.aliases:
             route_index.setdefault(alias, []).append(idx)
     catalog = BackendBindingCatalog(
-        bindings=bindings,
-        _route_index={key_: tuple(value) for key_, value in route_index.items()},
+        bindings=tuple(bindings),
+        _route_index={name: tuple(indexes) for name, indexes in route_index.items()},
     )
     if key is not None:
         _CATALOG_CACHE[key] = catalog
@@ -200,6 +214,46 @@ def resolve_backend_binding_by_route_id(
     )
 
 
+def _load_canonical_bindings() -> tuple[BackendBindingSpec, ...]:
+    raw = _load_yaml(_CANONICAL_PATH, default={})
+    entries = raw.get("bindings") if isinstance(raw, dict) else ()
+    if not isinstance(entries, list):
+        return ()
+    return tuple(_binding_from_raw(entry) for entry in entries if isinstance(entry, dict) and entry.get("route_id"))
+
+
+def _overlay_registry_bindings(
+    bindings: list[BackendBindingSpec],
+    registry,
+) -> list[BackendBindingSpec]:
+    existing = {binding.route_id for binding in bindings}
+    aliases = {
+        alias
+        for binding in bindings
+        for alias in binding.aliases
+    }
+    overlaid = list(bindings)
+    for route in getattr(registry, "routes", ()) or ():
+        route_id = str(getattr(route, "id", "") or "").strip()
+        if not route_id or route_id in existing or route_id in aliases:
+            continue
+        overlaid.append(_binding_from_route(route))
+    return overlaid
+
+
+def _binding_from_raw(raw: dict[str, Any]) -> BackendBindingSpec:
+    return BackendBindingSpec(
+        route_id=str(raw.get("route_id") or "").strip(),
+        engine_family=str(raw.get("engine_family") or "").strip(),
+        route_family=str(raw.get("route_family") or "").strip(),
+        aliases=_str_tuple(raw.get("aliases")),
+        compatibility_alias_policy=str(raw.get("compatibility_alias_policy") or "operator_visible").strip() or "operator_visible",
+        primitives=_parse_primitives(raw.get("primitives")),
+        conditional_primitives=_parse_conditional_primitives(raw.get("conditional_primitives")),
+        conditional_route_family=_parse_conditional_route_family(raw.get("conditional_route_family")),
+    )
+
+
 def _binding_from_route(route) -> BackendBindingSpec:
     return BackendBindingSpec(
         route_id=str(route.id),
@@ -225,6 +279,69 @@ def _binding_from_route(route) -> BackendBindingSpec:
             for block in (getattr(route, "conditional_route_family", ()) or ())
         ),
     )
+
+
+def _load_yaml(path: Path, *, default):
+    if not path.exists():
+        return default
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return default if data is None else data
+
+
+def _str_tuple(values) -> tuple[str, ...]:
+    if not values:
+        return ()
+    if isinstance(values, (str, bytes)):
+        return (str(values),)
+    return tuple(str(value) for value in values if str(value).strip())
+
+
+def _parse_primitives(raw: Any) -> tuple[PrimitiveRef, ...]:
+    if not raw:
+        return ()
+    return tuple(_parse_primitive(item) for item in raw if isinstance(item, dict))
+
+
+def _parse_primitive(raw: dict[str, Any]) -> PrimitiveRef:
+    return PrimitiveRef(
+        module=str(raw["module"]),
+        symbol=str(raw["symbol"]),
+        role=str(raw["role"]),
+        required=raw.get("required", True),
+        excluded=raw.get("excluded", False),
+    )
+
+
+def _parse_conditional_primitives(raw: Any) -> tuple[ConditionalBindingPrimitives, ...]:
+    if not raw:
+        return ()
+    rows: list[ConditionalBindingPrimitives] = []
+    for entry in raw:
+        if not isinstance(entry, dict) or "when" not in entry:
+            continue
+        rows.append(
+            ConditionalBindingPrimitives(
+                when=entry.get("when", "default"),
+                primitives=_parse_primitives(entry.get("primitives")),
+            )
+        )
+    return tuple(rows)
+
+
+def _parse_conditional_route_family(raw: Any) -> tuple[ConditionalBindingFamily, ...]:
+    if not raw:
+        return ()
+    rows: list[ConditionalBindingFamily] = []
+    for entry in raw:
+        if not isinstance(entry, dict) or "when" not in entry or "route_family" not in entry:
+            continue
+        rows.append(
+            ConditionalBindingFamily(
+                when=entry.get("when", "default"),
+                route_family=str(entry.get("route_family") or "").strip(),
+            )
+        )
+    return tuple(rows)
 
 
 def _resolve_binding_primitives(

--- a/trellis/agent/codegen_guardrails.py
+++ b/trellis/agent/codegen_guardrails.py
@@ -1519,20 +1519,33 @@ def rank_primitive_routes(
 
     ranked: list[PrimitivePlan] = []
     for spec in candidates:
-        route_primitives = list(resolve_route_primitives(spec, product_ir))
-        adapters = resolve_route_adapters(spec, product_ir)
-        notes = resolve_route_notes(spec, product_ir)
-        route = spec.id
         binding_spec = resolve_backend_binding_by_route_id(
-            route,
+            spec.id,
             product_ir=product_ir,
             catalog=binding_catalog,
         )
+        route_primitives = list(
+            resolve_route_primitives(
+                spec,
+                product_ir,
+                binding_spec=binding_spec,
+            )
+        )
+        adapters = resolve_route_adapters(spec, product_ir)
+        notes = resolve_route_notes(spec, product_ir)
+        route = spec.id
         primitives = list(getattr(binding_spec, "primitives", ()) or route_primitives)
         blockers = list(product_ir.unresolved_primitives if product_ir is not None else ())
         blockers.extend(_verify_primitives(primitives))
         engine_family = str(getattr(binding_spec, "engine_family", "") or spec.engine_family)
-        route_family = str(getattr(binding_spec, "route_family", "") or resolve_route_family(spec, product_ir))
+        route_family = str(
+            getattr(binding_spec, "route_family", "")
+            or resolve_route_family(
+                spec,
+                product_ir,
+                binding_spec=binding_spec,
+            )
+        )
         if route == "exercise_lattice" and route_family == "equity_tree":
             engine_family = "tree"
 

--- a/trellis/agent/dsl_lowering.py
+++ b/trellis/agent/dsl_lowering.py
@@ -176,7 +176,10 @@ def lower_semantic_blueprint(
             binding_spec=binding_spec,
         )
 
-        route_family = str(getattr(binding_spec, "route_family", "") or resolve_route_family(route, product_ir))
+        route_family = str(
+            getattr(binding_spec, "route_family", "")
+            or resolve_route_family(route, product_ir, binding_spec=binding_spec)
+        )
         adapters = resolve_route_adapters(route, product_ir)
         notes = resolve_route_notes(route, product_ir)
         try:
@@ -314,7 +317,10 @@ def _target_bindings_for_route(
     binding_spec,
 ) -> tuple[DslTargetBinding, ...]:
     """Resolve DSL bindings from the binding catalog before falling back to route cards."""
-    primitives = tuple(getattr(binding_spec, "primitives", ()) or resolve_route_primitives(route, product_ir))
+    primitives = tuple(
+        getattr(binding_spec, "primitives", ())
+        or resolve_route_primitives(route, product_ir, binding_spec=binding_spec)
+    )
     return tuple(
         DslTargetBinding(
             module=primitive.module,

--- a/trellis/agent/knowledge/canonical/backend_bindings.yaml
+++ b/trellis/agent/knowledge/canonical/backend_bindings.yaml
@@ -1,0 +1,492 @@
+bindings:
+  - route_id: quanto_adjustment_analytical
+    engine_family: analytical
+    route_family: analytical
+    compatibility_alias_policy: internal_only
+    primitives:
+      - module: trellis.models.quanto_option
+        symbol: price_quanto_option_analytical_from_market_state
+        role: route_helper
+
+  - route_id: correlated_gbm_monte_carlo
+    engine_family: monte_carlo
+    route_family: monte_carlo
+    primitives:
+      - module: trellis.models.quanto_option
+        symbol: price_quanto_option_monte_carlo_from_market_state
+        role: route_helper
+
+  - route_id: credit_default_swap_analytical
+    engine_family: analytical
+    route_family: credit_default_swap
+    primitives:
+      - module: trellis.models.credit_default_swap
+        symbol: build_cds_schedule
+        role: schedule_builder
+        required: false
+      - module: trellis.models.credit_default_swap
+        symbol: price_cds_analytical
+        role: route_helper
+
+  - route_id: credit_default_swap_monte_carlo
+    engine_family: monte_carlo
+    route_family: credit_default_swap
+    primitives:
+      - module: trellis.models.credit_default_swap
+        symbol: build_cds_schedule
+        role: schedule_builder
+        required: false
+      - module: trellis.models.credit_default_swap
+        symbol: interval_default_probability
+        role: event_probability
+      - module: trellis.models.credit_default_swap
+        symbol: price_cds_monte_carlo
+        role: route_helper
+      - module: trellis.core.differentiable
+        symbol: get_numpy
+        role: array_backend
+
+  - route_id: nth_to_default_monte_carlo
+    engine_family: monte_carlo
+    route_family: nth_to_default
+    primitives:
+      - module: trellis.core.date_utils
+        symbol: generate_schedule
+        role: schedule_builder
+        required: false
+      - module: trellis.core.date_utils
+        symbol: year_fraction
+        role: time_measure
+      - module: trellis.core.differentiable
+        symbol: get_numpy
+        role: array_backend
+      - module: trellis.models.copulas.gaussian
+        symbol: GaussianCopula
+        role: default_time_sampler
+      - module: trellis.instruments.nth_to_default
+        symbol: price_nth_to_default_basket
+        role: route_helper
+      - module: trellis.models.monte_carlo.engine
+        symbol: MonteCarloEngine
+        role: path_simulation
+        required: false
+        excluded: true
+
+  - route_id: correlated_basket_monte_carlo
+    engine_family: monte_carlo
+    route_family: monte_carlo
+    primitives:
+      - module: trellis.models.resolution.basket_semantics
+        symbol: resolve_basket_semantics
+        role: market_binding
+      - module: trellis.models.monte_carlo.semantic_basket
+        symbol: price_ranked_observation_basket_monte_carlo
+        role: route_helper
+
+  - route_id: exercise_monte_carlo
+    engine_family: exercise
+    route_family: exercise
+    primitives:
+      - module: trellis.models.processes.gbm
+        symbol: GBM
+        role: state_process
+      - module: trellis.models.monte_carlo.engine
+        symbol: MonteCarloEngine
+        role: path_simulation
+      - module: trellis.models.monte_carlo.lsm
+        symbol: longstaff_schwartz
+        role: exercise_control
+        required: false
+      - module: trellis.models.monte_carlo.tv_regression
+        symbol: tsitsiklis_van_roy
+        role: exercise_control
+        required: false
+      - module: trellis.models.monte_carlo.primal_dual
+        symbol: primal_dual_mc
+        role: exercise_control
+        required: false
+      - module: trellis.models.monte_carlo.stochastic_mesh
+        symbol: stochastic_mesh
+        role: exercise_control
+        required: false
+
+  - route_id: monte_carlo_paths
+    engine_family: monte_carlo
+    route_family: monte_carlo
+    primitives:
+      - module: trellis.models.processes.gbm
+        symbol: GBM
+        role: state_process
+      - module: trellis.models.processes.hull_white
+        symbol: HullWhite
+        role: state_process
+      - module: trellis.models.monte_carlo.engine
+        symbol: MonteCarloEngine
+        role: path_simulation
+      - module: trellis.models.monte_carlo.event_aware
+        symbol: price_event_aware_monte_carlo
+        role: route_helper
+    conditional_primitives:
+      - when:
+          payoff_family: vanilla_option
+          exercise_style: [european]
+        primitives:
+          - module: trellis.models.equity_option_monte_carlo
+            symbol: price_vanilla_equity_option_monte_carlo
+            role: route_helper
+      - when:
+          payoff_family: swaption
+          exercise_style: [european]
+          model_family: [interest_rate, short_rate]
+        primitives:
+          - module: trellis.models.rate_style_swaption
+            symbol: price_swaption_monte_carlo
+            role: route_helper
+      - when: default
+
+  - route_id: monte_carlo_fx_vanilla
+    engine_family: monte_carlo
+    route_family: monte_carlo
+    primitives:
+      - module: trellis.models.fx_vanilla
+        symbol: price_fx_vanilla_monte_carlo
+        role: route_helper
+
+  - route_id: local_vol_monte_carlo
+    engine_family: monte_carlo
+    route_family: monte_carlo
+    primitives:
+      - module: trellis.models.processes.local_vol
+        symbol: LocalVol
+        role: state_process
+      - module: trellis.models.monte_carlo.engine
+        symbol: MonteCarloEngine
+        role: path_simulation
+      - module: trellis.models.monte_carlo.local_vol
+        symbol: local_vol_european_vanilla_price
+        role: pricing_kernel
+
+  - route_id: qmc_sobol_paths
+    engine_family: qmc
+    route_family: qmc
+    primitives:
+      - module: trellis.models.qmc
+        symbol: sobol_normals
+        role: low_discrepancy_sampler
+      - module: trellis.models.qmc
+        symbol: brownian_bridge
+        role: path_construction
+        required: false
+      - module: trellis.models.processes.gbm
+        symbol: GBM
+        role: state_process
+
+  - route_id: exercise_lattice
+    engine_family: lattice
+    route_family: lattice
+    conditional_primitives:
+      - when:
+          payoff_family: vanilla_option
+          exercise_style: [american, bermudan]
+        primitives:
+          - module: trellis.models.equity_option_tree
+            symbol: price_vanilla_equity_option_tree
+            role: route_helper
+      - when:
+          payoff_family: [bond, callable_bond, callable_fixed_income]
+          exercise_style: [issuer_call, holder_put, bermudan]
+          model_family: [interest_rate, short_rate]
+        primitives:
+          - module: trellis.models.callable_bond_tree
+            symbol: price_callable_bond_tree
+            role: route_helper
+      - when:
+          payoff_family: swaption
+          exercise_style: [bermudan]
+          model_family: [interest_rate, short_rate]
+        primitives:
+          - module: trellis.models.bermudan_swaption_tree
+            symbol: price_bermudan_swaption_tree
+            role: route_helper
+      - when: default
+        primitives:
+          - module: trellis.models.trees.lattice
+            symbol: build_rate_lattice
+            role: lattice_builder
+          - module: trellis.models.trees.lattice
+            symbol: build_generic_lattice
+            role: generic_lattice_builder
+            required: false
+          - module: trellis.models.trees.lattice
+            symbol: lattice_backward_induction
+            role: backward_induction
+          - module: trellis.models.trees.models
+            symbol: MODEL_REGISTRY
+            role: model_registry
+            required: false
+          - module: trellis.models.trees.control
+            symbol: build_payment_timeline
+            role: payment_timeline_builder
+            required: false
+          - module: trellis.models.trees.control
+            symbol: build_exercise_timeline_from_dates
+            role: exercise_timeline_builder
+            required: false
+          - module: trellis.models.trees.control
+            symbol: resolve_lattice_exercise_policy
+            role: control_policy
+            required: false
+          - module: trellis.models.trees.control
+            symbol: lattice_step_from_time
+            role: single_step_mapper
+            required: false
+          - module: trellis.models.trees.control
+            symbol: lattice_steps_from_timeline
+            role: step_mapper
+            required: false
+    conditional_route_family:
+      - when:
+          payoff_family: vanilla_option
+          exercise_style: [american, bermudan]
+          model_family: equity_diffusion
+        route_family: equity_tree
+      - when:
+          exercise_style: [issuer_call, holder_put, bermudan]
+          model_family: interest_rate
+        route_family: rate_lattice
+      - when: default
+        route_family: lattice
+
+  - route_id: rate_tree_backward_induction
+    engine_family: lattice
+    route_family: rate_lattice
+    primitives:
+      - module: trellis.models.trees.lattice
+        symbol: build_rate_lattice
+        role: lattice_builder
+      - module: trellis.models.trees.lattice
+        symbol: lattice_backward_induction
+        role: backward_induction
+    conditional_primitives:
+      - when:
+          payoff_family: swaption
+          exercise_style: [european]
+        primitives:
+          - module: trellis.models.rate_style_swaption_tree
+            symbol: price_swaption_tree
+            role: route_helper
+      - when: default
+        primitives:
+          - module: trellis.models.trees.lattice
+            symbol: build_rate_lattice
+            role: lattice_builder
+          - module: trellis.models.trees.lattice
+            symbol: lattice_backward_induction
+            role: backward_induction
+
+  - route_id: zcb_option_rate_tree
+    engine_family: lattice
+    route_family: rate_lattice
+    primitives:
+      - module: trellis.models.zcb_option_tree
+        symbol: price_zcb_option_tree
+        role: route_helper
+
+  - route_id: analytical_black76
+    engine_family: analytical
+    route_family: analytical
+    compatibility_alias_policy: internal_only
+    conditional_primitives:
+      - when:
+          payoff_family: vanilla_option
+        primitives:
+          - module: trellis.models.black
+            symbol: black76_call
+            role: pricing_kernel
+          - module: trellis.models.black
+            symbol: black76_put
+            role: pricing_kernel
+          - module: trellis.models.black
+            symbol: black76_asset_or_nothing_call
+            role: pricing_kernel
+            required: false
+          - module: trellis.models.black
+            symbol: black76_asset_or_nothing_put
+            role: pricing_kernel
+            required: false
+          - module: trellis.models.black
+            symbol: black76_cash_or_nothing_call
+            role: pricing_kernel
+            required: false
+          - module: trellis.models.black
+            symbol: black76_cash_or_nothing_put
+            role: pricing_kernel
+            required: false
+          - module: trellis.models.analytical
+            symbol: terminal_vanilla_from_basis
+            role: assembly_helper
+            required: false
+          - module: trellis.core.date_utils
+            symbol: year_fraction
+            role: time_measure
+      - when:
+          payoff_family: swaption
+          exercise_style: [bermudan]
+        primitives:
+          - module: trellis.models.rate_style_swaption
+            symbol: price_bermudan_swaption_black76_lower_bound
+            role: route_helper
+      - when:
+          payoff_family: swaption
+          exercise_style: [european]
+        primitives:
+          - module: trellis.models.rate_style_swaption
+            symbol: price_swaption_black76
+            role: route_helper
+      - when: default
+        primitives:
+          - module: trellis.models.black
+            symbol: black76_call
+            role: pricing_kernel
+          - module: trellis.models.black
+            symbol: black76_put
+            role: pricing_kernel
+          - module: trellis.models.black
+            symbol: black76_asset_or_nothing_call
+            role: pricing_kernel
+            required: false
+          - module: trellis.models.black
+            symbol: black76_asset_or_nothing_put
+            role: pricing_kernel
+            required: false
+          - module: trellis.models.black
+            symbol: black76_cash_or_nothing_call
+            role: pricing_kernel
+            required: false
+          - module: trellis.models.black
+            symbol: black76_cash_or_nothing_put
+            role: pricing_kernel
+            required: false
+          - module: trellis.models.analytical
+            symbol: terminal_vanilla_from_basis
+            role: assembly_helper
+            required: false
+          - module: trellis.core.date_utils
+            symbol: build_payment_timeline
+            role: schedule_builder
+          - module: trellis.core.date_utils
+            symbol: year_fraction
+            role: time_measure
+
+  - route_id: zcb_option_analytical
+    engine_family: analytical
+    route_family: analytical
+    primitives:
+      - module: trellis.models.zcb_option
+        symbol: price_zcb_option_jamshidian
+        role: route_helper
+
+  - route_id: analytical_garman_kohlhagen
+    engine_family: analytical
+    route_family: analytical
+    primitives:
+      - module: trellis.models.fx_vanilla
+        symbol: price_fx_vanilla_analytical
+        role: route_helper
+
+  - route_id: transform_fft
+    engine_family: fft_pricing
+    route_family: fft_pricing
+    conditional_primitives:
+      - when:
+          payoff_family: vanilla_option
+          exercise_style: [european]
+          model_family: [equity_diffusion]
+        primitives:
+          - module: trellis.models.equity_option_transforms
+            symbol: price_vanilla_equity_option_transform
+            role: route_helper
+      - when: default
+        primitives:
+          - module: trellis.models.transforms.fft_pricer
+            symbol: fft_price
+            role: transform_pricer
+          - module: trellis.models.transforms.cos_method
+            symbol: cos_price
+            role: transform_pricer
+            required: false
+
+  - route_id: vanilla_equity_theta_pde
+    engine_family: pde_solver
+    route_family: pde_solver
+    primitives:
+      - module: trellis.models.equity_option_pde
+        symbol: price_vanilla_equity_option_pde
+        role: route_helper
+
+  - route_id: pde_theta_1d
+    engine_family: pde_solver
+    route_family: pde_solver
+    primitives:
+      - module: trellis.models.pde.grid
+        symbol: Grid
+        role: grid
+      - module: trellis.models.pde.operator
+        symbol: BlackScholesOperator
+        role: spatial_operator
+      - module: trellis.models.pde.theta_method
+        symbol: theta_method_1d
+        role: time_stepping
+    conditional_primitives:
+      - when:
+          payoff_family: vanilla_option
+          exercise_style: [american, bermudan]
+          model_family: [equity, equity_diffusion]
+        primitives:
+          - module: trellis.models.equity_option_pde
+            symbol: price_event_aware_equity_option_pde
+            role: route_helper
+      - when:
+          payoff_family: callable_fixed_income
+          exercise_style: [issuer_call]
+          model_family: [interest_rate, short_rate]
+        primitives:
+          - module: trellis.models.callable_bond_pde
+            symbol: price_callable_bond_pde
+            role: route_helper
+      - when: default
+        primitives:
+          - module: trellis.models.pde.grid
+            symbol: Grid
+            role: grid
+          - module: trellis.models.pde.operator
+            symbol: BlackScholesOperator
+            role: spatial_operator
+          - module: trellis.models.pde.theta_method
+            symbol: theta_method_1d
+            role: time_stepping
+
+  - route_id: copula_loss_distribution
+    engine_family: copula
+    route_family: copula
+    primitives:
+      - module: trellis.models.copulas.factor
+        symbol: FactorCopula
+        role: loss_distribution
+      - module: trellis.models.credit_basket_copula
+        symbol: price_credit_basket_tranche
+        role: route_helper
+      - module: trellis.models.copulas.student_t
+        symbol: StudentTCopula
+        role: loss_distribution
+
+  - route_id: waterfall_cashflows
+    engine_family: waterfall
+    route_family: waterfall
+    primitives:
+      - module: trellis.models.cashflow_engine.waterfall
+        symbol: Waterfall
+        role: cashflow_engine
+      - module: trellis.models.cashflow_engine.waterfall
+        symbol: Tranche
+        role: cashflow_engine

--- a/trellis/agent/route_registry.py
+++ b/trellis/agent/route_registry.py
@@ -8,8 +8,10 @@ two tiers:
 * **Tier 1 — Canonical seed** routes in ``knowledge/canonical/routes.yaml``
 * **Tier 2 — Discovered** routes in ``knowledge/routes/entries/*.yaml``
 
-The registry is cached per authority mode and validated against the live import
-registry at load time.
+The route registry now owns matching, aliases, admissibility, and temporary
+transition guidance. Exact binding primitives and conditional binding-family
+facts live in ``knowledge/canonical/backend_bindings.yaml`` and are resolved
+through ``trellis.agent.backend_bindings``.
 """
 
 from __future__ import annotations
@@ -843,10 +845,16 @@ def resolve_route_primitives(
     spec: RouteSpec,
     product_ir: ProductIR | None,
 ) -> tuple[PrimitiveRef, ...]:
-    """Apply conditional_primitives based on ProductIR traits.
+    """Return resolved primitives from the binding catalog, falling back to the route shell."""
+    try:
+        from trellis.agent.backend_bindings import resolve_backend_binding_by_route_id
 
-    Returns the final set of primitives for this route + product combination.
-    """
+        binding_spec = resolve_backend_binding_by_route_id(spec.id, product_ir=product_ir)
+        if binding_spec is not None and binding_spec.primitives:
+            return tuple(binding_spec.primitives)
+    except Exception:
+        pass
+
     if not spec.conditional_primitives:
         return spec.primitives
 
@@ -941,7 +949,17 @@ def resolve_route_family(
     spec: RouteSpec,
     product_ir: ProductIR | None,
 ) -> str:
-    """Resolve the route family, applying conditional overrides."""
+    """Resolve the route family from the binding catalog, falling back to the route shell."""
+    try:
+        from trellis.agent.backend_bindings import resolve_backend_binding_by_route_id
+
+        binding_spec = resolve_backend_binding_by_route_id(spec.id, product_ir=product_ir)
+        resolved_family = str(getattr(binding_spec, "route_family", "") or "").strip()
+        if resolved_family:
+            return resolved_family
+    except Exception:
+        pass
+
     if not spec.conditional_route_family:
         return spec.route_family
 
@@ -967,7 +985,14 @@ def get_route_modules(route_id: str, registry: RouteRegistry | None = None) -> t
         registry = load_route_registry()
     for route in registry.routes:
         if route.id == route_id or route_id in route.aliases:
-            return tuple(sorted({p.module for p in route.primitives}))
+            return tuple(
+                sorted(
+                    {
+                        primitive.module
+                        for primitive in resolve_route_primitives(route, None)
+                    }
+                )
+            )
     return ()
 
 

--- a/trellis/agent/route_registry.py
+++ b/trellis/agent/route_registry.py
@@ -844,12 +844,15 @@ def _state_requirement_satisfied(
 def resolve_route_primitives(
     spec: RouteSpec,
     product_ir: ProductIR | None,
+    *,
+    binding_spec=None,
 ) -> tuple[PrimitiveRef, ...]:
     """Return resolved primitives from the binding catalog, falling back to the route shell."""
     try:
-        from trellis.agent.backend_bindings import resolve_backend_binding_by_route_id
+        if binding_spec is None:
+            from trellis.agent.backend_bindings import resolve_backend_binding_by_route_id
 
-        binding_spec = resolve_backend_binding_by_route_id(spec.id, product_ir=product_ir)
+            binding_spec = resolve_backend_binding_by_route_id(spec.id, product_ir=product_ir)
         if binding_spec is not None and binding_spec.primitives:
             return tuple(binding_spec.primitives)
     except Exception:
@@ -948,12 +951,15 @@ def resolve_route_notes(
 def resolve_route_family(
     spec: RouteSpec,
     product_ir: ProductIR | None,
+    *,
+    binding_spec=None,
 ) -> str:
     """Resolve the route family from the binding catalog, falling back to the route shell."""
     try:
-        from trellis.agent.backend_bindings import resolve_backend_binding_by_route_id
+        if binding_spec is None:
+            from trellis.agent.backend_bindings import resolve_backend_binding_by_route_id
 
-        binding_spec = resolve_backend_binding_by_route_id(spec.id, product_ir=product_ir)
+            binding_spec = resolve_backend_binding_by_route_id(spec.id, product_ir=product_ir)
         resolved_family = str(getattr(binding_spec, "route_family", "") or "").strip()
         if resolved_family:
             return resolved_family


### PR DESCRIPTION
## Summary
- add a canonical backend binding catalog in `trellis/agent/knowledge/canonical/backend_bindings.yaml`
- make `trellis.agent.backend_bindings` load exact binding facts from that catalog instead of deriving them from the route registry
- reduce `route_registry` to matching/alias/admissibility shell behavior, with exact primitive and route-family resolution delegated to the binding catalog

## Validation
- `/Users/steveyang/miniforge3/bin/python3 -m py_compile trellis/agent/backend_bindings.py trellis/agent/route_registry.py`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_backend_bindings.py tests/test_agent/test_route_registry.py tests/test_agent/test_codegen_guardrails.py tests/test_agent/test_semantic_validators.py -q`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_family_lowering_ir.py tests/test_agent/test_platform_requests.py tests/test_agent/test_validation_contract.py tests/test_agent/test_platform_traces.py -q`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/ -x -q -m "not integration"`

## Docs
- `ARCHITECTURE.md`
- `docs/plans/binding-first-exotic-assembly.md`

## Limitations
- `LIMITATIONS.md` unchanged
