### PR TITLE
QUA-809: record basket-credit proof cohort

### DIFF
--- a/docs/plans/binding-first-exotic-assembly.md
+++ b/docs/plans/binding-first-exotic-assembly.md
@@ -189,7 +189,11 @@ Status mirror last synced: `2026-04-13`
 | `QUA-819` | Proof follow-on: cap/floor fresh-build stability and reference-target evidence (`E22`) | Backlog |
 | `QUA-820` | Proof follow-on: structured blocker persistence for honest-block sentinel (`E27`) | Backlog |
 | `QUA-821` | Proof telemetry: remove residual `unknown` route ids from proof traces | Backlog |
-| `QUA-809` | Exotic assembly: prove basket-credit and loss-distribution structures on binding roles | Backlog |
+| `QUA-809` | Exotic assembly: run the basket-credit-loss proof cohort and split residual gaps | Done |
+| `QUA-822` | Proof follow-on: copula tranche exact-helper contract (`T49`) | Backlog |
+| `QUA-823` | Proof follow-on: nth-to-default helper and basket-credit parsing (`T50`, `E26`) | Backlog |
+| `QUA-824` | Proof follow-on: loss-distribution recursive/FFT/MC constructive stability (`T53`) | Backlog |
+| `QUA-825` | Proof follow-on: multi-underlier basket parsing and FFT spread stability (`T102`, `T126`) | Backlog |
 | `QUA-815` | Exotic program closeout: measure proof-cohort outcomes on the binding-first runtime | Backlog |
 
 The benchmark contract for those proof tickets lives in

--- a/docs/plans/binding-first-exotic-assembly.md
+++ b/docs/plans/binding-first-exotic-assembly.md
@@ -188,7 +188,7 @@ Status mirror last synced: `2026-04-13`
 | `QUA-818` | Proof follow-on: swaption analytical/tree/MC parity drift (`T73`) | Backlog |
 | `QUA-819` | Proof follow-on: cap/floor fresh-build stability and reference-target evidence (`E22`) | Backlog |
 | `QUA-820` | Proof follow-on: structured blocker persistence for honest-block sentinel (`E27`) | Backlog |
-| `QUA-821` | Proof telemetry: remove residual `unknown` route ids from proof traces | Backlog |
+| `QUA-821` | Proof telemetry: remove residual `unknown` route ids from proof traces (`T17`, `E27`, `T50`, `E26`) | Backlog |
 | `QUA-809` | Exotic assembly: run the basket-credit-loss proof cohort and split residual gaps | Done |
 | `QUA-822` | Proof follow-on: copula tranche exact-helper contract (`T49`) | Backlog |
 | `QUA-823` | Proof follow-on: nth-to-default helper and basket-credit parsing (`T50`, `E26`) | Backlog |

--- a/docs/plans/binding-first-exotic-proof-cohort.md
+++ b/docs/plans/binding-first-exotic-proof-cohort.md
@@ -93,6 +93,14 @@ These tasks define the `QUA-808` proof surface.
 
 These tasks define the `QUA-809` proof surface.
 
+This sub-cohort intentionally does not add a second honest-block sentinel.
+The program-level sentinel remains `E27` in the event/control/schedule cohort.
+`E26` stays `proved` here on purpose even though
+`tests/evals/stress_tasks.yaml` currently classifies it as `honest_block` on
+the older stress surface. In the binding-first proof program, `E26` is the
+constructive basket-credit stress target that `QUA-823` is expected to recover,
+not a permanent block sentinel.
+
 | Task | Expected outcome | Binding-first capability under test | Notes |
 | --- | --- | --- | --- |
 | `T49` CDO tranche: Gaussian vs Student-t copula | `proved` | tranche attachment/detachment and copula-backed loss bindings | Baseline tranche/loss distribution proof |

--- a/docs/plans/binding-first-exotic-proof-cohort.md
+++ b/docs/plans/binding-first-exotic-proof-cohort.md
@@ -168,6 +168,37 @@ Follow-on tickets opened from that run:
 - `QUA-820` structured blocker persistence for the honest-block sentinel (`E27`)
 - `QUA-821` residual `unknown` route ids in proof telemetry (`T17`, `E27`)
 
+### `QUA-809` live run on `2026-04-13`
+
+Command:
+
+```bash
+/Users/steveyang/miniforge3/bin/python3 scripts/run_binding_first_exotic_proof.py \
+  --cohort basket_credit_loss \
+  --output /tmp/qua809_results_live.json \
+  --report-json /tmp/qua809_report_live.json \
+  --report-md /tmp/qua809_report_live.md
+```
+
+Outcome summary:
+
+- no `QUA-809` cohort item reached `proved`
+- `T49` failed on the Student-t tranche lane rebuilding copula plumbing instead
+  of staying on the exact tranche helper contract
+- `T50` and `E26` failed around nth-to-default helper invocation and
+  basket-credit market parsing
+- `T53` failed across recursive, FFT, and MC loss-distribution constructions
+- `T102` and `T126` failed on multi-underlier basket market parsing, and `T126`
+  also failed its FFT spread lane
+
+Follow-on tickets opened from that run:
+
+- `QUA-822` copula tranche exact-helper contract (`T49`)
+- `QUA-823` nth-to-default helper and basket-credit parsing (`T50`, `E26`)
+- `QUA-824` loss-distribution recursive/FFT/MC constructive stability (`T53`)
+- `QUA-825` multi-underlier basket parsing and FFT spread stability (`T102`, `T126`)
+- `QUA-821` broadened to cover residual `unknown` route ids on `T50` and `E26`
+
 ## Review Notes
 
 - `T01`, `T13`, `T38`, `T94`, `T108`, and `E25` remain valuable regression

--- a/tests/evals/binding_first_exotic_proof.yaml
+++ b/tests/evals/binding_first_exotic_proof.yaml
@@ -63,3 +63,58 @@ E27:
   requires_binding_ids: false
   forbidden_failure_patterns:
     - MissingCapabilityError
+
+T49:
+  cohort: basket_credit_loss
+  outcome_class: proved
+  comparison_targets:
+    - gaussian_copula
+    - student_t_copula
+  requires_binding_ids: true
+
+T50:
+  cohort: basket_credit_loss
+  outcome_class: proved
+  comparison_targets:
+    - mc_defaults
+    - factor_copula_analytical
+  requires_binding_ids: true
+
+T53:
+  cohort: basket_credit_loss
+  outcome_class: proved
+  comparison_targets:
+    - recursive_method
+    - fft_loss
+    - mc_loss
+  requires_binding_ids: true
+
+E26:
+  cohort: basket_credit_loss
+  outcome_class: proved
+  required_mock_capabilities:
+    - discount_curve
+    - credit_curve
+  comparison_targets:
+    - gaussian_copula
+    - mc_default_times
+  requires_binding_ids: true
+  forbidden_failure_patterns:
+    - MissingCapabilityError
+
+T102:
+  cohort: basket_credit_loss
+  outcome_class: proved
+  comparison_targets:
+    - stulz_rainbow
+    - mc_rainbow
+  requires_binding_ids: true
+
+T126:
+  cohort: basket_credit_loss
+  outcome_class: proved
+  comparison_targets:
+    - kirk_spread
+    - mc_spread_2d
+    - fft_spread_2d
+  requires_binding_ids: true


### PR DESCRIPTION
## Summary
- extend the binding-first proof manifest with the basket/credit/loss cohort
- run the live `QUA-809` cohort and sync the proof-plan docs with the measured results
- split the residual failures into task-backed follow-ons (`QUA-822` to `QUA-825`) and broaden `QUA-821`

## Validation
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_binding_first_exotic_proof.py tests/test_agent/test_binding_first_exotic_proof_runner.py tests/test_agent/test_evals.py -q -k "proof or stress or blocker"`
- `/Users/steveyang/miniforge3/bin/python3 scripts/run_binding_first_exotic_proof.py --cohort basket_credit_loss --preflight-only --output /tmp/qua809_results_preflight.json --report-json /tmp/qua809_report_preflight.json --report-md /tmp/qua809_report_preflight.md`
- `/Users/steveyang/miniforge3/bin/python3 scripts/run_binding_first_exotic_proof.py --cohort basket_credit_loss --output /tmp/qua809_results_live.json --report-json /tmp/qua809_report_live.json --report-md /tmp/qua809_report_live.md`

## Live proof outcome
- Passed gate: `0/6`
- Follow-ons opened: `QUA-822`, `QUA-823`, `QUA-824`, `QUA-825`
- `QUA-821` broadened to also cover `T50` and `E26`
