### PR TITLE
QUA-815: close out binding-first exotic proof program

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -110,6 +110,11 @@ maintenance around the deterministic engines.
   govern admissibility and lowering onto checked route families. The route
   registry is now a compatibility and admissibility surface over the binding
   catalog, not the only source of exact backend identity.
+- The binding-first runtime migration is ahead of the capability proof. The
+  current exotic proof closeout only certifies `T105` across the agreed proof
+  cohort; the remaining event/control and basket/credit/loss proof tasks are
+  tracked as open follow-ons in `docs/plans/binding-first-exotic-proof-closeout.md`
+  and `LIMITATIONS.md`.
 - `trellis/agent/quant.py`, `trellis/agent/planner.py`,
   `trellis/agent/builder.py`, `trellis/agent/critic.py`,
   `trellis/agent/arbiter.py`, and `trellis/agent/executor.py` implement the

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -59,6 +59,7 @@ ground truth until revalidated.
 
 | # | Limitation | Impact | Files |
 |---|-----------|--------|-------|
+| L38 | **Binding-first exotic proof coverage is still partial** — the checked proof closeout certifies only `T105`; the event/control cohort still has open callable-bond, swaption, cap/floor, and honest-block-sentinel gaps, and the basket/credit/loss cohort has not yet recovered its constructive proof tasks | Trellis now has the binding-first runtime architecture, but it is not yet support-contract-correct to claim broad constructable-exotic coverage across the agreed proof cohort | `docs/plans/binding-first-exotic-proof-closeout.md`, `docs/benchmarks/binding_first_exotic_proof_closeout.json`, `tests/evals/binding_first_exotic_proof.yaml`, `trellis/agent/backend_bindings.py`, `trellis/agent/family_lowering_ir.py`, `trellis/agent/dsl_lowering.py` |
 | L33 | **Book and pipeline abstractions are still thin for mixed exotic books** — book aggregation stops at MV/DV01/duration and the pipeline scenario surface remains simple | Trellis is not yet a strong book-level pricing/risk engine even before xVA enters the picture | `trellis/book.py`, `trellis/pipeline.py`, `trellis/analytics/measures.py` |
 | L34 | **There is no exposure or xVA engine** — no exposure cube, no `EE/EPE/PFE`, no `CVA/DVA/FVA/MVA/KVA`, and no implemented collateral/netting semantics | Counterparty-risk analysis is not currently supported beyond basic credit-product pricing | `docs/plans/exotic-desk-roadmap.md` |
 

--- a/docs/benchmarks/binding_first_exotic_proof_closeout.json
+++ b/docs/benchmarks/binding_first_exotic_proof_closeout.json
@@ -1,0 +1,1740 @@
+{
+  "totals": {
+    "tasks": 11,
+    "passed_gate": 1,
+    "failed_gate": 10,
+    "proved": 10,
+    "honest_block": 1
+  },
+  "cohorts": {
+    "event_control_schedule": {
+      "status": "failed_gate",
+      "task_ids": [
+        "T17",
+        "T73",
+        "T105",
+        "E22",
+        "E27"
+      ],
+      "totals": {
+        "tasks": 5,
+        "passed_gate": 1,
+        "failed_gate": 4,
+        "proved": 4,
+        "honest_block": 1
+      },
+      "failure_buckets": {
+        "comparison_insufficient_results": 3,
+        "comparison_failed": 1,
+        "success": 1
+      },
+      "task_summary": {
+        "totals": {
+          "tasks": 5,
+          "successes": 1,
+          "failures": 4,
+          "avg_attempts": 2.4
+        },
+        "failure_buckets": {
+          "comparison_insufficient_results": 3,
+          "comparison_failed": 1,
+          "success": 1
+        },
+        "retry_recovery": {
+          "successful_after_retry": 0,
+          "first_attempt_successes": 1
+        },
+        "first_pass": {
+          "tasks": 5,
+          "successful_tasks": 1,
+          "first_pass_successes": 1,
+          "rate": 0.2,
+          "success_rate": 1.0
+        },
+        "attempts_to_success": {
+          "successful_tasks": 1,
+          "average": 1.0,
+          "median": 1.0,
+          "max": 1,
+          "distribution": {
+            "1": 1
+          }
+        },
+        "retry_taxonomy": {
+          "recovered_successes": 0,
+          "unattributed_recoveries": 0,
+          "by_stage": {},
+          "by_task": {}
+        },
+        "reviewer_signals": {
+          "tasks_with_reviewer_issues": 0,
+          "tasks_with_multi_reviewer_issues": 0,
+          "tasks_recovered_after_review": 0,
+          "reviewer_agent_counts": {}
+        },
+        "shared_knowledge": {
+          "tasks_with_shared_context": 5,
+          "tasks_with_lessons": 5
+        },
+        "promotion_discipline": {
+          "successful_tasks": 1,
+          "successful_tasks_with_shared_context": 1,
+          "captured_lessons": 0,
+          "tasks_with_attribution": 1,
+          "cookbook_candidates": 0,
+          "promotion_candidates": 2,
+          "knowledge_traces": 0,
+          "successful_tasks_without_reusable_artifacts": []
+        },
+        "token_usage": {
+          "call_count": 105,
+          "calls_with_usage": 105,
+          "calls_without_usage": 0,
+          "prompt_tokens": 218482,
+          "completion_tokens": 18826,
+          "total_tokens": 237308,
+          "by_stage": {
+            "reflection": {
+              "call_count": 86,
+              "calls_with_usage": 86,
+              "calls_without_usage": 0,
+              "prompt_tokens": 117480,
+              "completion_tokens": 12732,
+              "total_tokens": 130212
+            },
+            "code_generation": {
+              "call_count": 12,
+              "calls_with_usage": 12,
+              "calls_without_usage": 0,
+              "prompt_tokens": 83709,
+              "completion_tokens": 5172,
+              "total_tokens": 88881
+            },
+            "critic": {
+              "call_count": 6,
+              "calls_with_usage": 6,
+              "calls_without_usage": 0,
+              "prompt_tokens": 13086,
+              "completion_tokens": 542,
+              "total_tokens": 13628
+            },
+            "decomposition": {
+              "call_count": 1,
+              "calls_with_usage": 1,
+              "calls_without_usage": 0,
+              "prompt_tokens": 4207,
+              "completion_tokens": 380,
+              "total_tokens": 4587
+            }
+          },
+          "by_provider": {
+            "openai": {
+              "call_count": 105,
+              "calls_with_usage": 105,
+              "calls_without_usage": 0,
+              "prompt_tokens": 218482,
+              "completion_tokens": 18826,
+              "total_tokens": 237308
+            }
+          }
+        }
+      },
+      "report_json_path": "qua808_report_live.json",
+      "report_md_path": "qua808_report_live.md",
+      "raw_results_path": "qua808_results_live.json"
+    },
+    "basket_credit_loss": {
+      "status": "failed_gate",
+      "task_ids": [
+        "T49",
+        "T50",
+        "T53",
+        "E26",
+        "T102",
+        "T126"
+      ],
+      "totals": {
+        "tasks": 6,
+        "passed_gate": 0,
+        "failed_gate": 6,
+        "proved": 6,
+        "honest_block": 0
+      },
+      "failure_buckets": {
+        "comparison_insufficient_results": 6
+      },
+      "task_summary": {
+        "totals": {
+          "tasks": 6,
+          "successes": 0,
+          "failures": 6,
+          "avg_attempts": 6.17
+        },
+        "failure_buckets": {
+          "comparison_insufficient_results": 6
+        },
+        "retry_recovery": {
+          "successful_after_retry": 0,
+          "first_attempt_successes": 0
+        },
+        "first_pass": {
+          "tasks": 6,
+          "successful_tasks": 0,
+          "first_pass_successes": 0,
+          "rate": 0.0,
+          "success_rate": 0.0
+        },
+        "attempts_to_success": {
+          "successful_tasks": 0,
+          "average": 0.0,
+          "median": 0.0,
+          "max": 0,
+          "distribution": {}
+        },
+        "retry_taxonomy": {
+          "recovered_successes": 0,
+          "unattributed_recoveries": 0,
+          "by_stage": {},
+          "by_task": {}
+        },
+        "reviewer_signals": {
+          "tasks_with_reviewer_issues": 0,
+          "tasks_with_multi_reviewer_issues": 0,
+          "tasks_recovered_after_review": 0,
+          "reviewer_agent_counts": {}
+        },
+        "shared_knowledge": {
+          "tasks_with_shared_context": 6,
+          "tasks_with_lessons": 6
+        },
+        "promotion_discipline": {
+          "successful_tasks": 0,
+          "successful_tasks_with_shared_context": 0,
+          "captured_lessons": 0,
+          "tasks_with_attribution": 0,
+          "cookbook_candidates": 0,
+          "promotion_candidates": 0,
+          "knowledge_traces": 0,
+          "successful_tasks_without_reusable_artifacts": []
+        },
+        "token_usage": {
+          "call_count": 152,
+          "calls_with_usage": 152,
+          "calls_without_usage": 0,
+          "prompt_tokens": 587770,
+          "completion_tokens": 58528,
+          "total_tokens": 646298,
+          "by_stage": {
+            "code_generation": {
+              "call_count": 37,
+              "calls_with_usage": 37,
+              "calls_without_usage": 0,
+              "prompt_tokens": 396278,
+              "completion_tokens": 35120,
+              "total_tokens": 431398
+            },
+            "critic": {
+              "call_count": 2,
+              "calls_with_usage": 2,
+              "calls_without_usage": 0,
+              "prompt_tokens": 4587,
+              "completion_tokens": 365,
+              "total_tokens": 4952
+            },
+            "reflection": {
+              "call_count": 100,
+              "calls_with_usage": 100,
+              "calls_without_usage": 0,
+              "prompt_tokens": 141406,
+              "completion_tokens": 16957,
+              "total_tokens": 158363
+            },
+            "decomposition": {
+              "call_count": 10,
+              "calls_with_usage": 10,
+              "calls_without_usage": 0,
+              "prompt_tokens": 43491,
+              "completion_tokens": 3691,
+              "total_tokens": 47182
+            },
+            "spec_design": {
+              "call_count": 3,
+              "calls_with_usage": 3,
+              "calls_without_usage": 0,
+              "prompt_tokens": 2008,
+              "completion_tokens": 2395,
+              "total_tokens": 4403
+            }
+          },
+          "by_provider": {
+            "openai": {
+              "call_count": 152,
+              "calls_with_usage": 152,
+              "calls_without_usage": 0,
+              "prompt_tokens": 587770,
+              "completion_tokens": 58528,
+              "total_tokens": 646298
+            }
+          }
+        }
+      },
+      "report_json_path": "qua809_report_live.json",
+      "report_md_path": "qua809_report_live.md",
+      "raw_results_path": "qua809_results_live.json"
+    }
+  },
+  "failure_buckets": {
+    "comparison_insufficient_results": 9,
+    "comparison_failed": 1,
+    "success": 1
+  },
+  "by_task": {
+    "T17": {
+      "title": "Callable bond: HW rate PDE (PSOR) vs HW tree",
+      "cohort": "event_control_schedule",
+      "outcome_class": "proved",
+      "success": false,
+      "failure_bucket": "comparison_insufficient_results",
+      "comparison_status": "insufficient_results",
+      "elapsed_seconds": 68.5,
+      "attempts_to_success": 1,
+      "first_pass": true,
+      "retry_taxonomy": [],
+      "token_usage": {
+        "call_count": 19,
+        "calls_with_usage": 19,
+        "calls_without_usage": 0,
+        "prompt_tokens": 32473,
+        "completion_tokens": 2497,
+        "total_tokens": 34970,
+        "by_stage": {
+          "reflection": {
+            "call_count": 17,
+            "calls_with_usage": 17,
+            "calls_without_usage": 0,
+            "prompt_tokens": 23053,
+            "completion_tokens": 2444,
+            "total_tokens": 25497
+          },
+          "code_generation": {
+            "call_count": 1,
+            "calls_with_usage": 1,
+            "calls_without_usage": 0,
+            "prompt_tokens": 7186,
+            "completion_tokens": 40,
+            "total_tokens": 7226
+          },
+          "critic": {
+            "call_count": 1,
+            "calls_with_usage": 1,
+            "calls_without_usage": 0,
+            "prompt_tokens": 2234,
+            "completion_tokens": 13,
+            "total_tokens": 2247
+          }
+        },
+        "by_provider": {
+          "openai": {
+            "call_count": 19,
+            "calls_with_usage": 19,
+            "calls_without_usage": 0,
+            "prompt_tokens": 32473,
+            "completion_tokens": 2497,
+            "total_tokens": 34970
+          }
+        }
+      },
+      "binding_ids": [
+        "trellis.models.callable_bond_tree.price_callable_bond_tree"
+      ],
+      "binding_families": [
+        "pde_solver",
+        "lattice",
+        "rate_lattice"
+      ],
+      "route_ids": [
+        "exercise_lattice",
+        "unknown"
+      ],
+      "task_run_latest_path": "T17.json",
+      "task_run_history_path": "20260413T020551918938.json",
+      "diagnosis_packet_path": "20260413T020551918938.json",
+      "diagnosis_dossier_path": "20260413T020551918938.md",
+      "diagnosis_latest_packet_path": "T17.json",
+      "diagnosis_latest_dossier_path": "T17.md",
+      "preflight": {
+        "task_contract_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "market_capability_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "comparison_target_inventory": {
+          "passed": true,
+          "details": []
+        },
+        "comparison_target_separation": {
+          "passed": true,
+          "details": []
+        }
+      },
+      "live_checks": {
+        "forbidden_failure_patterns": {
+          "passed": true,
+          "details": []
+        },
+        "outcome_class_alignment": {
+          "passed": false,
+          "details": [
+            "proved task did not succeed: bucket=comparison_insufficient_results",
+            "proved task did not finish with passed comparison status: insufficient_results"
+          ]
+        },
+        "binding_identity_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "route_identity_alignment": {
+          "passed": false,
+          "details": [
+            "task surfaced non-canonical route ids: unknown"
+          ]
+        },
+        "blocker_category_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "reference_target_alignment": {
+          "passed": true,
+          "details": []
+        }
+      },
+      "passed_gate": false
+    },
+    "T73": {
+      "title": "European swaption: Black76 vs HW tree vs HW MC",
+      "cohort": "event_control_schedule",
+      "outcome_class": "proved",
+      "success": false,
+      "failure_bucket": "comparison_failed",
+      "comparison_status": "failed",
+      "elapsed_seconds": 93.8,
+      "attempts_to_success": 1,
+      "first_pass": true,
+      "retry_taxonomy": [],
+      "token_usage": {
+        "call_count": 30,
+        "calls_with_usage": 30,
+        "calls_without_usage": 0,
+        "prompt_tokens": 58792,
+        "completion_tokens": 4852,
+        "total_tokens": 63644,
+        "by_stage": {
+          "code_generation": {
+            "call_count": 3,
+            "calls_with_usage": 3,
+            "calls_without_usage": 0,
+            "prompt_tokens": 19774,
+            "completion_tokens": 1184,
+            "total_tokens": 20958
+          },
+          "critic": {
+            "call_count": 3,
+            "calls_with_usage": 3,
+            "calls_without_usage": 0,
+            "prompt_tokens": 6252,
+            "completion_tokens": 397,
+            "total_tokens": 6649
+          },
+          "reflection": {
+            "call_count": 24,
+            "calls_with_usage": 24,
+            "calls_without_usage": 0,
+            "prompt_tokens": 32766,
+            "completion_tokens": 3271,
+            "total_tokens": 36037
+          }
+        },
+        "by_provider": {
+          "openai": {
+            "call_count": 30,
+            "calls_with_usage": 30,
+            "calls_without_usage": 0,
+            "prompt_tokens": 58792,
+            "completion_tokens": 4852,
+            "total_tokens": 63644
+          }
+        }
+      },
+      "binding_ids": [
+        "trellis.models.rate_style_swaption.price_swaption_black76",
+        "trellis.models.rate_style_swaption_tree.price_swaption_tree",
+        "trellis.models.rate_style_swaption.price_swaption_monte_carlo"
+      ],
+      "binding_families": [
+        "analytical",
+        "lattice",
+        "monte_carlo",
+        "rate_lattice"
+      ],
+      "route_ids": [
+        "analytical_black76",
+        "rate_tree_backward_induction",
+        "monte_carlo_paths"
+      ],
+      "task_run_latest_path": "T73.json",
+      "task_run_history_path": "20260413T020700980363.json",
+      "diagnosis_packet_path": "20260413T020700980363.json",
+      "diagnosis_dossier_path": "20260413T020700980363.md",
+      "diagnosis_latest_packet_path": "T73.json",
+      "diagnosis_latest_dossier_path": "T73.md",
+      "preflight": {
+        "task_contract_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "market_capability_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "comparison_target_inventory": {
+          "passed": true,
+          "details": []
+        },
+        "comparison_target_separation": {
+          "passed": true,
+          "details": []
+        }
+      },
+      "live_checks": {
+        "forbidden_failure_patterns": {
+          "passed": true,
+          "details": []
+        },
+        "outcome_class_alignment": {
+          "passed": false,
+          "details": [
+            "proved task did not succeed: bucket=comparison_failed",
+            "proved task did not finish with passed comparison status: failed"
+          ]
+        },
+        "binding_identity_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "route_identity_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "blocker_category_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "reference_target_alignment": {
+          "passed": true,
+          "details": []
+        }
+      },
+      "passed_gate": false
+    },
+    "T105": {
+      "title": "Quanto option: quanto-adjusted BS vs MC cross-currency",
+      "cohort": "event_control_schedule",
+      "outcome_class": "proved",
+      "success": true,
+      "failure_bucket": "success",
+      "comparison_status": "passed",
+      "elapsed_seconds": 43.8,
+      "attempts_to_success": 1,
+      "first_pass": true,
+      "retry_taxonomy": [],
+      "token_usage": {
+        "call_count": 5,
+        "calls_with_usage": 5,
+        "calls_without_usage": 0,
+        "prompt_tokens": 21660,
+        "completion_tokens": 583,
+        "total_tokens": 22243,
+        "by_stage": {
+          "decomposition": {
+            "call_count": 1,
+            "calls_with_usage": 1,
+            "calls_without_usage": 0,
+            "prompt_tokens": 4207,
+            "completion_tokens": 380,
+            "total_tokens": 4587
+          },
+          "code_generation": {
+            "call_count": 2,
+            "calls_with_usage": 2,
+            "calls_without_usage": 0,
+            "prompt_tokens": 12853,
+            "completion_tokens": 71,
+            "total_tokens": 12924
+          },
+          "critic": {
+            "call_count": 2,
+            "calls_with_usage": 2,
+            "calls_without_usage": 0,
+            "prompt_tokens": 4600,
+            "completion_tokens": 132,
+            "total_tokens": 4732
+          }
+        },
+        "by_provider": {
+          "openai": {
+            "call_count": 5,
+            "calls_with_usage": 5,
+            "calls_without_usage": 0,
+            "prompt_tokens": 21660,
+            "completion_tokens": 583,
+            "total_tokens": 22243
+          }
+        }
+      },
+      "binding_ids": [
+        "trellis.models.quanto_option.price_quanto_option_analytical_from_market_state",
+        "trellis.models.quanto_option.price_quanto_option_monte_carlo_from_market_state"
+      ],
+      "binding_families": [
+        "analytical",
+        "monte_carlo"
+      ],
+      "route_ids": [
+        "quanto_adjustment_analytical",
+        "correlated_gbm_monte_carlo"
+      ],
+      "task_run_latest_path": "T105.json",
+      "task_run_history_path": "20260413T020835913159.json",
+      "diagnosis_packet_path": "20260413T020835913159.json",
+      "diagnosis_dossier_path": "20260413T020835913159.md",
+      "diagnosis_latest_packet_path": "T105.json",
+      "diagnosis_latest_dossier_path": "T105.md",
+      "preflight": {
+        "task_contract_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "market_capability_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "comparison_target_inventory": {
+          "passed": true,
+          "details": []
+        },
+        "comparison_target_separation": {
+          "passed": true,
+          "details": []
+        }
+      },
+      "live_checks": {
+        "forbidden_failure_patterns": {
+          "passed": true,
+          "details": []
+        },
+        "outcome_class_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "binding_identity_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "route_identity_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "blocker_category_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "reference_target_alignment": {
+          "passed": true,
+          "details": []
+        }
+      },
+      "passed_gate": true
+    },
+    "E22": {
+      "title": "Cap/floor: Black caplet stack vs MC rate simulation",
+      "cohort": "event_control_schedule",
+      "outcome_class": "proved",
+      "success": false,
+      "failure_bucket": "comparison_insufficient_results",
+      "comparison_status": "insufficient_results",
+      "elapsed_seconds": 97.2,
+      "attempts_to_success": 3,
+      "first_pass": false,
+      "retry_taxonomy": [
+        "code_generation",
+        "validation"
+      ],
+      "token_usage": {
+        "call_count": 24,
+        "calls_with_usage": 24,
+        "calls_without_usage": 0,
+        "prompt_tokens": 69106,
+        "completion_tokens": 6785,
+        "total_tokens": 75891,
+        "by_stage": {
+          "code_generation": {
+            "call_count": 6,
+            "calls_with_usage": 6,
+            "calls_without_usage": 0,
+            "prompt_tokens": 43896,
+            "completion_tokens": 3877,
+            "total_tokens": 47773
+          },
+          "reflection": {
+            "call_count": 18,
+            "calls_with_usage": 18,
+            "calls_without_usage": 0,
+            "prompt_tokens": 25210,
+            "completion_tokens": 2908,
+            "total_tokens": 28118
+          }
+        },
+        "by_provider": {
+          "openai": {
+            "call_count": 24,
+            "calls_with_usage": 24,
+            "calls_without_usage": 0,
+            "prompt_tokens": 69106,
+            "completion_tokens": 6785,
+            "total_tokens": 75891
+          }
+        }
+      },
+      "binding_ids": [
+        "trellis.models.monte_carlo.event_aware.price_event_aware_monte_carlo",
+        "trellis.models.black.black76_call"
+      ],
+      "binding_families": [
+        "monte_carlo",
+        "analytical"
+      ],
+      "route_ids": [
+        "monte_carlo_paths",
+        "analytical_black76"
+      ],
+      "task_run_latest_path": "E22.json",
+      "task_run_history_path": "20260413T020921361225.json",
+      "diagnosis_packet_path": "20260413T020921361225.json",
+      "diagnosis_dossier_path": "20260413T020921361225.md",
+      "diagnosis_latest_packet_path": "E22.json",
+      "diagnosis_latest_dossier_path": "E22.md",
+      "preflight": {
+        "task_contract_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "market_capability_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "comparison_target_inventory": {
+          "passed": true,
+          "details": []
+        },
+        "comparison_target_separation": {
+          "passed": true,
+          "details": []
+        }
+      },
+      "live_checks": {
+        "forbidden_failure_patterns": {
+          "passed": true,
+          "details": []
+        },
+        "outcome_class_alignment": {
+          "passed": false,
+          "details": [
+            "proved task did not succeed: bucket=comparison_insufficient_results",
+            "proved task did not finish with passed comparison status: insufficient_results"
+          ]
+        },
+        "binding_identity_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "route_identity_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "blocker_category_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "reference_target_alignment": {
+          "passed": false,
+          "details": [
+            "comparison reference target drifted from the proof manifest: observed=missing expected=black76_cap"
+          ]
+        }
+      },
+      "passed_gate": false
+    },
+    "E27": {
+      "title": "American Asian barrier under Heston: PDE vs MC vs FFT should block honestly",
+      "cohort": "event_control_schedule",
+      "outcome_class": "honest_block",
+      "success": false,
+      "failure_bucket": "comparison_insufficient_results",
+      "comparison_status": "insufficient_results",
+      "elapsed_seconds": 96.9,
+      "attempts_to_success": 0,
+      "first_pass": true,
+      "retry_taxonomy": [],
+      "token_usage": {
+        "call_count": 27,
+        "calls_with_usage": 27,
+        "calls_without_usage": 0,
+        "prompt_tokens": 36451,
+        "completion_tokens": 4109,
+        "total_tokens": 40560,
+        "by_stage": {
+          "reflection": {
+            "call_count": 27,
+            "calls_with_usage": 27,
+            "calls_without_usage": 0,
+            "prompt_tokens": 36451,
+            "completion_tokens": 4109,
+            "total_tokens": 40560
+          }
+        },
+        "by_provider": {
+          "openai": {
+            "call_count": 27,
+            "calls_with_usage": 27,
+            "calls_without_usage": 0,
+            "prompt_tokens": 36451,
+            "completion_tokens": 4109,
+            "total_tokens": 40560
+          }
+        }
+      },
+      "binding_ids": [
+        "exercise:exercise:fallback"
+      ],
+      "binding_families": [
+        "pde_solver",
+        "exercise",
+        "fft_pricing"
+      ],
+      "route_ids": [
+        "exercise_monte_carlo",
+        "unknown"
+      ],
+      "task_run_latest_path": "E27.json",
+      "task_run_history_path": "20260413T021059310859.json",
+      "diagnosis_packet_path": "20260413T021059310859.json",
+      "diagnosis_dossier_path": "20260413T021059310859.md",
+      "diagnosis_latest_packet_path": "E27.json",
+      "diagnosis_latest_dossier_path": "E27.md",
+      "preflight": {
+        "task_contract_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "market_capability_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "comparison_target_inventory": {
+          "passed": true,
+          "details": []
+        },
+        "comparison_target_separation": {
+          "passed": true,
+          "details": []
+        }
+      },
+      "live_checks": {
+        "forbidden_failure_patterns": {
+          "passed": true,
+          "details": []
+        },
+        "outcome_class_alignment": {
+          "passed": false,
+          "details": [
+            "honest-block sentinel did not surface blocker categories"
+          ]
+        },
+        "binding_identity_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "route_identity_alignment": {
+          "passed": false,
+          "details": [
+            "task surfaced non-canonical route ids: unknown"
+          ]
+        },
+        "blocker_category_alignment": {
+          "passed": false,
+          "details": [
+            "expected blocker categories were not surfaced in the result"
+          ]
+        },
+        "reference_target_alignment": {
+          "passed": true,
+          "details": []
+        }
+      },
+      "passed_gate": false
+    },
+    "T49": {
+      "title": "CDO tranche: Gaussian vs Student-t copula",
+      "cohort": "basket_credit_loss",
+      "outcome_class": "proved",
+      "success": false,
+      "failure_bucket": "comparison_insufficient_results",
+      "comparison_status": "insufficient_results",
+      "elapsed_seconds": 81.5,
+      "attempts_to_success": 3,
+      "first_pass": false,
+      "retry_taxonomy": [
+        "actual_market_smoke"
+      ],
+      "token_usage": {
+        "call_count": 22,
+        "calls_with_usage": 22,
+        "calls_without_usage": 0,
+        "prompt_tokens": 60739,
+        "completion_tokens": 3910,
+        "total_tokens": 64649,
+        "by_stage": {
+          "code_generation": {
+            "call_count": 4,
+            "calls_with_usage": 4,
+            "calls_without_usage": 0,
+            "prompt_tokens": 34899,
+            "completion_tokens": 1319,
+            "total_tokens": 36218
+          },
+          "critic": {
+            "call_count": 1,
+            "calls_with_usage": 1,
+            "calls_without_usage": 0,
+            "prompt_tokens": 2293,
+            "completion_tokens": 196,
+            "total_tokens": 2489
+          },
+          "reflection": {
+            "call_count": 17,
+            "calls_with_usage": 17,
+            "calls_without_usage": 0,
+            "prompt_tokens": 23547,
+            "completion_tokens": 2395,
+            "total_tokens": 25942
+          }
+        },
+        "by_provider": {
+          "openai": {
+            "call_count": 22,
+            "calls_with_usage": 22,
+            "calls_without_usage": 0,
+            "prompt_tokens": 60739,
+            "completion_tokens": 3910,
+            "total_tokens": 64649
+          }
+        }
+      },
+      "binding_ids": [
+        "trellis.models.credit_basket_copula.price_credit_basket_tranche"
+      ],
+      "binding_families": [
+        "copula"
+      ],
+      "route_ids": [
+        "copula_loss_distribution"
+      ],
+      "task_run_latest_path": "T49.json",
+      "task_run_history_path": "20260413T024219666707.json",
+      "diagnosis_packet_path": "20260413T024219666707.json",
+      "diagnosis_dossier_path": "20260413T024219666707.md",
+      "diagnosis_latest_packet_path": "T49.json",
+      "diagnosis_latest_dossier_path": "T49.md",
+      "preflight": {
+        "task_contract_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "market_capability_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "comparison_target_inventory": {
+          "passed": true,
+          "details": []
+        },
+        "comparison_target_separation": {
+          "passed": true,
+          "details": []
+        }
+      },
+      "live_checks": {
+        "forbidden_failure_patterns": {
+          "passed": true,
+          "details": []
+        },
+        "outcome_class_alignment": {
+          "passed": false,
+          "details": [
+            "proved task did not succeed: bucket=comparison_insufficient_results",
+            "proved task did not finish with passed comparison status: insufficient_results"
+          ]
+        },
+        "binding_identity_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "route_identity_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "blocker_category_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "reference_target_alignment": {
+          "passed": true,
+          "details": []
+        }
+      },
+      "passed_gate": false
+    },
+    "T50": {
+      "title": "Nth-to-default: MC correlated defaults vs semi-analytical",
+      "cohort": "basket_credit_loss",
+      "outcome_class": "proved",
+      "success": false,
+      "failure_bucket": "comparison_insufficient_results",
+      "comparison_status": "insufficient_results",
+      "elapsed_seconds": 79.7,
+      "attempts_to_success": 3,
+      "first_pass": false,
+      "retry_taxonomy": [
+        "actual_market_smoke",
+        "semantic_validation"
+      ],
+      "token_usage": {
+        "call_count": 22,
+        "calls_with_usage": 22,
+        "calls_without_usage": 0,
+        "prompt_tokens": 67888,
+        "completion_tokens": 5047,
+        "total_tokens": 72935,
+        "by_stage": {
+          "code_generation": {
+            "call_count": 4,
+            "calls_with_usage": 4,
+            "calls_without_usage": 0,
+            "prompt_tokens": 42061,
+            "completion_tokens": 2257,
+            "total_tokens": 44318
+          },
+          "reflection": {
+            "call_count": 17,
+            "calls_with_usage": 17,
+            "calls_without_usage": 0,
+            "prompt_tokens": 23533,
+            "completion_tokens": 2621,
+            "total_tokens": 26154
+          },
+          "critic": {
+            "call_count": 1,
+            "calls_with_usage": 1,
+            "calls_without_usage": 0,
+            "prompt_tokens": 2294,
+            "completion_tokens": 169,
+            "total_tokens": 2463
+          }
+        },
+        "by_provider": {
+          "openai": {
+            "call_count": 22,
+            "calls_with_usage": 22,
+            "calls_without_usage": 0,
+            "prompt_tokens": 67888,
+            "completion_tokens": 5047,
+            "total_tokens": 72935
+          }
+        }
+      },
+      "binding_ids": [
+        "trellis.instruments.nth_to_default.price_nth_to_default_basket"
+      ],
+      "binding_families": [
+        "monte_carlo",
+        "analytical",
+        "nth_to_default"
+      ],
+      "route_ids": [
+        "nth_to_default_monte_carlo",
+        "unknown"
+      ],
+      "task_run_latest_path": "T50.json",
+      "task_run_history_path": "20260413T024341517533.json",
+      "diagnosis_packet_path": "20260413T024341517533.json",
+      "diagnosis_dossier_path": "20260413T024341517533.md",
+      "diagnosis_latest_packet_path": "T50.json",
+      "diagnosis_latest_dossier_path": "T50.md",
+      "preflight": {
+        "task_contract_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "market_capability_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "comparison_target_inventory": {
+          "passed": true,
+          "details": []
+        },
+        "comparison_target_separation": {
+          "passed": true,
+          "details": []
+        }
+      },
+      "live_checks": {
+        "forbidden_failure_patterns": {
+          "passed": true,
+          "details": []
+        },
+        "outcome_class_alignment": {
+          "passed": false,
+          "details": [
+            "proved task did not succeed: bucket=comparison_insufficient_results",
+            "proved task did not finish with passed comparison status: insufficient_results"
+          ]
+        },
+        "binding_identity_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "route_identity_alignment": {
+          "passed": false,
+          "details": [
+            "task surfaced non-canonical route ids: unknown"
+          ]
+        },
+        "blocker_category_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "reference_target_alignment": {
+          "passed": true,
+          "details": []
+        }
+      },
+      "passed_gate": false
+    },
+    "T53": {
+      "title": "Multi-name portfolio loss distribution: recursive vs FFT vs MC",
+      "cohort": "basket_credit_loss",
+      "outcome_class": "proved",
+      "success": false,
+      "failure_bucket": "comparison_insufficient_results",
+      "comparison_status": "insufficient_results",
+      "elapsed_seconds": 139.2,
+      "attempts_to_success": 3,
+      "first_pass": false,
+      "retry_taxonomy": [
+        "actual_market_smoke",
+        "semantic_validation",
+        "code_generation"
+      ],
+      "token_usage": {
+        "call_count": 18,
+        "calls_with_usage": 18,
+        "calls_without_usage": 0,
+        "prompt_tokens": 113217,
+        "completion_tokens": 12634,
+        "total_tokens": 125851,
+        "by_stage": {
+          "decomposition": {
+            "call_count": 3,
+            "calls_with_usage": 3,
+            "calls_without_usage": 0,
+            "prompt_tokens": 12643,
+            "completion_tokens": 1145,
+            "total_tokens": 13788
+          },
+          "spec_design": {
+            "call_count": 3,
+            "calls_with_usage": 3,
+            "calls_without_usage": 0,
+            "prompt_tokens": 2008,
+            "completion_tokens": 2395,
+            "total_tokens": 4403
+          },
+          "code_generation": {
+            "call_count": 9,
+            "calls_with_usage": 9,
+            "calls_without_usage": 0,
+            "prompt_tokens": 92965,
+            "completion_tokens": 7966,
+            "total_tokens": 100931
+          },
+          "reflection": {
+            "call_count": 3,
+            "calls_with_usage": 3,
+            "calls_without_usage": 0,
+            "prompt_tokens": 5601,
+            "completion_tokens": 1128,
+            "total_tokens": 6729
+          }
+        },
+        "by_provider": {
+          "openai": {
+            "call_count": 18,
+            "calls_with_usage": 18,
+            "calls_without_usage": 0,
+            "prompt_tokens": 113217,
+            "completion_tokens": 12634,
+            "total_tokens": 125851
+          }
+        }
+      },
+      "binding_ids": [
+        "trellis.models.black.black76_call",
+        "fft_pricing:fft_pricing:fallback",
+        "trellis.models.monte_carlo.event_aware.price_event_aware_monte_carlo"
+      ],
+      "binding_families": [
+        "analytical",
+        "fft_pricing",
+        "monte_carlo"
+      ],
+      "route_ids": [
+        "analytical_black76",
+        "transform_fft",
+        "monte_carlo_paths"
+      ],
+      "task_run_latest_path": "T53.json",
+      "task_run_history_path": "20260413T024501887199.json",
+      "diagnosis_packet_path": "20260413T024501887199.json",
+      "diagnosis_dossier_path": "20260413T024501887199.md",
+      "diagnosis_latest_packet_path": "T53.json",
+      "diagnosis_latest_dossier_path": "T53.md",
+      "preflight": {
+        "task_contract_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "market_capability_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "comparison_target_inventory": {
+          "passed": true,
+          "details": []
+        },
+        "comparison_target_separation": {
+          "passed": true,
+          "details": []
+        }
+      },
+      "live_checks": {
+        "forbidden_failure_patterns": {
+          "passed": true,
+          "details": []
+        },
+        "outcome_class_alignment": {
+          "passed": false,
+          "details": [
+            "proved task did not succeed: bucket=comparison_insufficient_results",
+            "proved task did not finish with passed comparison status: insufficient_results"
+          ]
+        },
+        "binding_identity_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "route_identity_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "blocker_category_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "reference_target_alignment": {
+          "passed": true,
+          "details": []
+        }
+      },
+      "passed_gate": false
+    },
+    "E26": {
+      "title": "Nth-to-default basket: Gaussian copula vs default-time MC",
+      "cohort": "basket_credit_loss",
+      "outcome_class": "proved",
+      "success": false,
+      "failure_bucket": "comparison_insufficient_results",
+      "comparison_status": "insufficient_results",
+      "elapsed_seconds": 106.5,
+      "attempts_to_success": 3,
+      "first_pass": false,
+      "retry_taxonomy": [
+        "actual_market_smoke"
+      ],
+      "token_usage": {
+        "call_count": 26,
+        "calls_with_usage": 26,
+        "calls_without_usage": 0,
+        "prompt_tokens": 108330,
+        "completion_tokens": 9508,
+        "total_tokens": 117838,
+        "by_stage": {
+          "decomposition": {
+            "call_count": 2,
+            "calls_with_usage": 2,
+            "calls_without_usage": 0,
+            "prompt_tokens": 9634,
+            "completion_tokens": 698,
+            "total_tokens": 10332
+          },
+          "code_generation": {
+            "call_count": 6,
+            "calls_with_usage": 6,
+            "calls_without_usage": 0,
+            "prompt_tokens": 73490,
+            "completion_tokens": 5698,
+            "total_tokens": 79188
+          },
+          "reflection": {
+            "call_count": 18,
+            "calls_with_usage": 18,
+            "calls_without_usage": 0,
+            "prompt_tokens": 25206,
+            "completion_tokens": 3112,
+            "total_tokens": 28318
+          }
+        },
+        "by_provider": {
+          "openai": {
+            "call_count": 26,
+            "calls_with_usage": 26,
+            "calls_without_usage": 0,
+            "prompt_tokens": 108330,
+            "completion_tokens": 9508,
+            "total_tokens": 117838
+          }
+        }
+      },
+      "binding_ids": [
+        "trellis.instruments.nth_to_default.price_nth_to_default_basket"
+      ],
+      "binding_families": [
+        "analytical",
+        "monte_carlo",
+        "nth_to_default"
+      ],
+      "route_ids": [
+        "nth_to_default_monte_carlo",
+        "unknown"
+      ],
+      "task_run_latest_path": "E26.json",
+      "task_run_history_path": "20260413T024721648624.json",
+      "diagnosis_packet_path": "20260413T024721648624.json",
+      "diagnosis_dossier_path": "20260413T024721648624.md",
+      "diagnosis_latest_packet_path": "E26.json",
+      "diagnosis_latest_dossier_path": "E26.md",
+      "preflight": {
+        "task_contract_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "market_capability_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "comparison_target_inventory": {
+          "passed": true,
+          "details": []
+        },
+        "comparison_target_separation": {
+          "passed": true,
+          "details": []
+        }
+      },
+      "live_checks": {
+        "forbidden_failure_patterns": {
+          "passed": true,
+          "details": []
+        },
+        "outcome_class_alignment": {
+          "passed": false,
+          "details": [
+            "proved task did not succeed: bucket=comparison_insufficient_results",
+            "proved task did not finish with passed comparison status: insufficient_results"
+          ]
+        },
+        "binding_identity_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "route_identity_alignment": {
+          "passed": false,
+          "details": [
+            "task surfaced non-canonical route ids: unknown"
+          ]
+        },
+        "blocker_category_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "reference_target_alignment": {
+          "passed": true,
+          "details": []
+        }
+      },
+      "passed_gate": false
+    },
+    "T102": {
+      "title": "Rainbow option (best-of-two): Stulz formula vs MC",
+      "cohort": "basket_credit_loss",
+      "outcome_class": "proved",
+      "success": false,
+      "failure_bucket": "comparison_insufficient_results",
+      "comparison_status": "insufficient_results",
+      "elapsed_seconds": 131.3,
+      "attempts_to_success": 3,
+      "first_pass": false,
+      "retry_taxonomy": [
+        "lite_review",
+        "semantic_validation",
+        "actual_market_smoke",
+        "code_generation"
+      ],
+      "token_usage": {
+        "call_count": 26,
+        "calls_with_usage": 26,
+        "calls_without_usage": 0,
+        "prompt_tokens": 94102,
+        "completion_tokens": 11082,
+        "total_tokens": 105184,
+        "by_stage": {
+          "decomposition": {
+            "call_count": 2,
+            "calls_with_usage": 2,
+            "calls_without_usage": 0,
+            "prompt_tokens": 8454,
+            "completion_tokens": 769,
+            "total_tokens": 9223
+          },
+          "code_generation": {
+            "call_count": 6,
+            "calls_with_usage": 6,
+            "calls_without_usage": 0,
+            "prompt_tokens": 60252,
+            "completion_tokens": 7164,
+            "total_tokens": 67416
+          },
+          "reflection": {
+            "call_count": 18,
+            "calls_with_usage": 18,
+            "calls_without_usage": 0,
+            "prompt_tokens": 25396,
+            "completion_tokens": 3149,
+            "total_tokens": 28545
+          }
+        },
+        "by_provider": {
+          "openai": {
+            "call_count": 26,
+            "calls_with_usage": 26,
+            "calls_without_usage": 0,
+            "prompt_tokens": 94102,
+            "completion_tokens": 11082,
+            "total_tokens": 105184
+          }
+        }
+      },
+      "binding_ids": [
+        "trellis.models.black.black76_call",
+        "trellis.models.monte_carlo.event_aware.price_event_aware_monte_carlo"
+      ],
+      "binding_families": [
+        "analytical",
+        "monte_carlo"
+      ],
+      "route_ids": [
+        "analytical_black76",
+        "monte_carlo_paths"
+      ],
+      "task_run_latest_path": "T102.json",
+      "task_run_history_path": "20260413T024908561122.json",
+      "diagnosis_packet_path": "20260413T024908561122.json",
+      "diagnosis_dossier_path": "20260413T024908561122.md",
+      "diagnosis_latest_packet_path": "T102.json",
+      "diagnosis_latest_dossier_path": "T102.md",
+      "preflight": {
+        "task_contract_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "market_capability_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "comparison_target_inventory": {
+          "passed": true,
+          "details": []
+        },
+        "comparison_target_separation": {
+          "passed": true,
+          "details": []
+        }
+      },
+      "live_checks": {
+        "forbidden_failure_patterns": {
+          "passed": true,
+          "details": []
+        },
+        "outcome_class_alignment": {
+          "passed": false,
+          "details": [
+            "proved task did not succeed: bucket=comparison_insufficient_results",
+            "proved task did not finish with passed comparison status: insufficient_results"
+          ]
+        },
+        "binding_identity_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "route_identity_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "blocker_category_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "reference_target_alignment": {
+          "passed": true,
+          "details": []
+        }
+      },
+      "passed_gate": false
+    },
+    "T126": {
+      "title": "Spread option (Kirk approximation) vs 2D MC vs 2D FFT",
+      "cohort": "basket_credit_loss",
+      "outcome_class": "proved",
+      "success": false,
+      "failure_bucket": "comparison_insufficient_results",
+      "comparison_status": "insufficient_results",
+      "elapsed_seconds": 204.7,
+      "attempts_to_success": 3,
+      "first_pass": false,
+      "retry_taxonomy": [
+        "semantic_validation",
+        "actual_market_smoke"
+      ],
+      "token_usage": {
+        "call_count": 38,
+        "calls_with_usage": 38,
+        "calls_without_usage": 0,
+        "prompt_tokens": 143494,
+        "completion_tokens": 16347,
+        "total_tokens": 159841,
+        "by_stage": {
+          "decomposition": {
+            "call_count": 3,
+            "calls_with_usage": 3,
+            "calls_without_usage": 0,
+            "prompt_tokens": 12760,
+            "completion_tokens": 1079,
+            "total_tokens": 13839
+          },
+          "code_generation": {
+            "call_count": 8,
+            "calls_with_usage": 8,
+            "calls_without_usage": 0,
+            "prompt_tokens": 92611,
+            "completion_tokens": 10716,
+            "total_tokens": 103327
+          },
+          "reflection": {
+            "call_count": 27,
+            "calls_with_usage": 27,
+            "calls_without_usage": 0,
+            "prompt_tokens": 38123,
+            "completion_tokens": 4552,
+            "total_tokens": 42675
+          }
+        },
+        "by_provider": {
+          "openai": {
+            "call_count": 38,
+            "calls_with_usage": 38,
+            "calls_without_usage": 0,
+            "prompt_tokens": 143494,
+            "completion_tokens": 16347,
+            "total_tokens": 159841
+          }
+        }
+      },
+      "binding_ids": [
+        "trellis.models.black.black76_call",
+        "trellis.models.monte_carlo.event_aware.price_event_aware_monte_carlo",
+        "fft_pricing:fft_pricing:fallback"
+      ],
+      "binding_families": [
+        "analytical",
+        "monte_carlo",
+        "fft_pricing"
+      ],
+      "route_ids": [
+        "analytical_black76",
+        "monte_carlo_paths",
+        "transform_fft"
+      ],
+      "task_run_latest_path": "T126.json",
+      "task_run_history_path": "20260413T025120460436.json",
+      "diagnosis_packet_path": "20260413T025120460436.json",
+      "diagnosis_dossier_path": "20260413T025120460436.md",
+      "diagnosis_latest_packet_path": "T126.json",
+      "diagnosis_latest_dossier_path": "T126.md",
+      "preflight": {
+        "task_contract_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "market_capability_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "comparison_target_inventory": {
+          "passed": true,
+          "details": []
+        },
+        "comparison_target_separation": {
+          "passed": true,
+          "details": []
+        }
+      },
+      "live_checks": {
+        "forbidden_failure_patterns": {
+          "passed": true,
+          "details": []
+        },
+        "outcome_class_alignment": {
+          "passed": false,
+          "details": [
+            "proved task did not succeed: bucket=comparison_insufficient_results",
+            "proved task did not finish with passed comparison status: insufficient_results"
+          ]
+        },
+        "binding_identity_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "route_identity_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "blocker_category_alignment": {
+          "passed": true,
+          "details": []
+        },
+        "reference_target_alignment": {
+          "passed": true,
+          "details": []
+        }
+      },
+      "passed_gate": false
+    }
+  },
+  "elapsed_seconds_total": 1143.1,
+  "unknown_route_tasks": [
+    "E26",
+    "E27",
+    "T17",
+    "T50"
+  ],
+  "first_pass": {
+    "tasks": 11,
+    "successful_tasks": 1,
+    "first_pass_successes": 1,
+    "rate": 0.09090909090909091
+  },
+  "attempts_to_success": {
+    "successful_tasks": 1,
+    "average": 1.0,
+    "median": 1.0,
+    "max": 1
+  },
+  "token_usage": {
+    "call_count": 257,
+    "calls_with_usage": 257,
+    "calls_without_usage": 0,
+    "prompt_tokens": 806252,
+    "completion_tokens": 77354,
+    "total_tokens": 883606,
+    "by_stage": {
+      "reflection": {
+        "call_count": 186,
+        "calls_with_usage": 186,
+        "calls_without_usage": 0,
+        "prompt_tokens": 258886,
+        "completion_tokens": 29689,
+        "total_tokens": 288575
+      },
+      "code_generation": {
+        "call_count": 49,
+        "calls_with_usage": 49,
+        "calls_without_usage": 0,
+        "prompt_tokens": 479987,
+        "completion_tokens": 40292,
+        "total_tokens": 520279
+      },
+      "critic": {
+        "call_count": 8,
+        "calls_with_usage": 8,
+        "calls_without_usage": 0,
+        "prompt_tokens": 17673,
+        "completion_tokens": 907,
+        "total_tokens": 18580
+      },
+      "decomposition": {
+        "call_count": 11,
+        "calls_with_usage": 11,
+        "calls_without_usage": 0,
+        "prompt_tokens": 47698,
+        "completion_tokens": 4071,
+        "total_tokens": 51769
+      },
+      "spec_design": {
+        "call_count": 3,
+        "calls_with_usage": 3,
+        "calls_without_usage": 0,
+        "prompt_tokens": 2008,
+        "completion_tokens": 2395,
+        "total_tokens": 4403
+      }
+    },
+    "by_provider": {
+      "openai": {
+        "call_count": 257,
+        "calls_with_usage": 257,
+        "calls_without_usage": 0,
+        "prompt_tokens": 806252,
+        "completion_tokens": 77354,
+        "total_tokens": 883606
+      }
+    }
+  },
+  "honest_block_certified": 0,
+  "source_reports": [
+    "qua808_report_live.json",
+    "qua809_report_live.json"
+  ]
+}

--- a/docs/benchmarks/binding_first_exotic_proof_closeout.md
+++ b/docs/benchmarks/binding_first_exotic_proof_closeout.md
@@ -1,0 +1,174 @@
+# Binding-First Exotic Program Closeout
+
+- Tasks: `11`
+- Passed gate: `1`
+- Failed gate: `10`
+- Proved expectations: `10`
+- Honest-block expectations: `1`
+- Certified honest blocks: `0`
+- First-pass success rate: `0.09090909090909091`
+- Average attempts to success (successful tasks): `1.0`
+- Total elapsed seconds: `1143.1`
+- Total tokens: `883606`
+- Unknown route-id tasks: `E26, E27, T17, T50`
+
+## Cohorts
+### basket_credit_loss
+- Status: `failed_gate`
+- Passed gate: `0`
+- Failed gate: `6`
+- Tasks: `T49, T50, T53, E26, T102, T126`
+- Report JSON: `qua809_report_live.json`
+- Report Markdown: `qua809_report_live.md`
+
+### event_control_schedule
+- Status: `failed_gate`
+- Passed gate: `1`
+- Failed gate: `4`
+- Tasks: `T17, T73, T105, E22, E27`
+- Report JSON: `qua808_report_live.json`
+- Report Markdown: `qua808_report_live.md`
+
+## Task View
+### E22 - Cap/floor: Black caplet stack vs MC rate simulation
+- Cohort: `event_control_schedule`
+- Expected outcome: `proved`
+- Gate passed: `False`
+- Failure bucket: `comparison_insufficient_results`
+- Comparison status: `insufficient_results`
+- Binding ids: `trellis.models.monte_carlo.event_aware.price_event_aware_monte_carlo, trellis.models.black.black76_call`
+- Route ids: `monte_carlo_paths, analytical_black76`
+- First pass: `False`
+- Attempts to success: `3`
+- Retry taxonomy: `code_generation, validation`
+- Latest diagnosis dossier: `E22.md`
+
+### E26 - Nth-to-default basket: Gaussian copula vs default-time MC
+- Cohort: `basket_credit_loss`
+- Expected outcome: `proved`
+- Gate passed: `False`
+- Failure bucket: `comparison_insufficient_results`
+- Comparison status: `insufficient_results`
+- Binding ids: `trellis.instruments.nth_to_default.price_nth_to_default_basket`
+- Route ids: `nth_to_default_monte_carlo, unknown`
+- First pass: `False`
+- Attempts to success: `3`
+- Retry taxonomy: `actual_market_smoke`
+- Latest diagnosis dossier: `E26.md`
+
+### E27 - American Asian barrier under Heston: PDE vs MC vs FFT should block honestly
+- Cohort: `event_control_schedule`
+- Expected outcome: `honest_block`
+- Gate passed: `False`
+- Failure bucket: `comparison_insufficient_results`
+- Comparison status: `insufficient_results`
+- Binding ids: `exercise:exercise:fallback`
+- Route ids: `exercise_monte_carlo, unknown`
+- First pass: `True`
+- Attempts to success: `0`
+- Retry taxonomy: `none`
+- Latest diagnosis dossier: `E27.md`
+
+### T102 - Rainbow option (best-of-two): Stulz formula vs MC
+- Cohort: `basket_credit_loss`
+- Expected outcome: `proved`
+- Gate passed: `False`
+- Failure bucket: `comparison_insufficient_results`
+- Comparison status: `insufficient_results`
+- Binding ids: `trellis.models.black.black76_call, trellis.models.monte_carlo.event_aware.price_event_aware_monte_carlo`
+- Route ids: `analytical_black76, monte_carlo_paths`
+- First pass: `False`
+- Attempts to success: `3`
+- Retry taxonomy: `lite_review, semantic_validation, actual_market_smoke, code_generation`
+- Latest diagnosis dossier: `T102.md`
+
+### T105 - Quanto option: quanto-adjusted BS vs MC cross-currency
+- Cohort: `event_control_schedule`
+- Expected outcome: `proved`
+- Gate passed: `True`
+- Failure bucket: `success`
+- Comparison status: `passed`
+- Binding ids: `trellis.models.quanto_option.price_quanto_option_analytical_from_market_state, trellis.models.quanto_option.price_quanto_option_monte_carlo_from_market_state`
+- Route ids: `quanto_adjustment_analytical, correlated_gbm_monte_carlo`
+- First pass: `True`
+- Attempts to success: `1`
+- Retry taxonomy: `none`
+- Latest diagnosis dossier: `T105.md`
+
+### T126 - Spread option (Kirk approximation) vs 2D MC vs 2D FFT
+- Cohort: `basket_credit_loss`
+- Expected outcome: `proved`
+- Gate passed: `False`
+- Failure bucket: `comparison_insufficient_results`
+- Comparison status: `insufficient_results`
+- Binding ids: `trellis.models.black.black76_call, trellis.models.monte_carlo.event_aware.price_event_aware_monte_carlo, fft_pricing:fft_pricing:fallback`
+- Route ids: `analytical_black76, monte_carlo_paths, transform_fft`
+- First pass: `False`
+- Attempts to success: `3`
+- Retry taxonomy: `semantic_validation, actual_market_smoke`
+- Latest diagnosis dossier: `T126.md`
+
+### T17 - Callable bond: HW rate PDE (PSOR) vs HW tree
+- Cohort: `event_control_schedule`
+- Expected outcome: `proved`
+- Gate passed: `False`
+- Failure bucket: `comparison_insufficient_results`
+- Comparison status: `insufficient_results`
+- Binding ids: `trellis.models.callable_bond_tree.price_callable_bond_tree`
+- Route ids: `exercise_lattice, unknown`
+- First pass: `True`
+- Attempts to success: `1`
+- Retry taxonomy: `none`
+- Latest diagnosis dossier: `T17.md`
+
+### T49 - CDO tranche: Gaussian vs Student-t copula
+- Cohort: `basket_credit_loss`
+- Expected outcome: `proved`
+- Gate passed: `False`
+- Failure bucket: `comparison_insufficient_results`
+- Comparison status: `insufficient_results`
+- Binding ids: `trellis.models.credit_basket_copula.price_credit_basket_tranche`
+- Route ids: `copula_loss_distribution`
+- First pass: `False`
+- Attempts to success: `3`
+- Retry taxonomy: `actual_market_smoke`
+- Latest diagnosis dossier: `T49.md`
+
+### T50 - Nth-to-default: MC correlated defaults vs semi-analytical
+- Cohort: `basket_credit_loss`
+- Expected outcome: `proved`
+- Gate passed: `False`
+- Failure bucket: `comparison_insufficient_results`
+- Comparison status: `insufficient_results`
+- Binding ids: `trellis.instruments.nth_to_default.price_nth_to_default_basket`
+- Route ids: `nth_to_default_monte_carlo, unknown`
+- First pass: `False`
+- Attempts to success: `3`
+- Retry taxonomy: `actual_market_smoke, semantic_validation`
+- Latest diagnosis dossier: `T50.md`
+
+### T53 - Multi-name portfolio loss distribution: recursive vs FFT vs MC
+- Cohort: `basket_credit_loss`
+- Expected outcome: `proved`
+- Gate passed: `False`
+- Failure bucket: `comparison_insufficient_results`
+- Comparison status: `insufficient_results`
+- Binding ids: `trellis.models.black.black76_call, fft_pricing:fft_pricing:fallback, trellis.models.monte_carlo.event_aware.price_event_aware_monte_carlo`
+- Route ids: `analytical_black76, transform_fft, monte_carlo_paths`
+- First pass: `False`
+- Attempts to success: `3`
+- Retry taxonomy: `actual_market_smoke, semantic_validation, code_generation`
+- Latest diagnosis dossier: `T53.md`
+
+### T73 - European swaption: Black76 vs HW tree vs HW MC
+- Cohort: `event_control_schedule`
+- Expected outcome: `proved`
+- Gate passed: `False`
+- Failure bucket: `comparison_failed`
+- Comparison status: `failed`
+- Binding ids: `trellis.models.rate_style_swaption.price_swaption_black76, trellis.models.rate_style_swaption_tree.price_swaption_tree, trellis.models.rate_style_swaption.price_swaption_monte_carlo`
+- Route ids: `analytical_black76, rate_tree_backward_induction, monte_carlo_paths`
+- First pass: `True`
+- Attempts to success: `1`
+- Retry taxonomy: `none`
+- Latest diagnosis dossier: `T73.md`

--- a/docs/benchmarks/binding_first_exotic_proof_closeout.md
+++ b/docs/benchmarks/binding_first_exotic_proof_closeout.md
@@ -12,6 +12,11 @@
 - Total tokens: `883606`
 - Unknown route-id tasks: `E26, E27, T17, T50`
 
+## Failure Buckets
+- `comparison_failed`: `1`
+- `comparison_insufficient_results`: `9`
+- `success`: `1`
+
 ## Cohorts
 ### basket_credit_loss
 - Status: `failed_gate`

--- a/docs/plans/binding-first-exotic-assembly.md
+++ b/docs/plans/binding-first-exotic-assembly.md
@@ -194,10 +194,11 @@ Status mirror last synced: `2026-04-13`
 | `QUA-823` | Proof follow-on: nth-to-default helper and basket-credit parsing (`T50`, `E26`) | Backlog |
 | `QUA-824` | Proof follow-on: loss-distribution recursive/FFT/MC constructive stability (`T53`) | Backlog |
 | `QUA-825` | Proof follow-on: multi-underlier basket parsing and FFT spread stability (`T102`, `T126`) | Backlog |
-| `QUA-815` | Exotic program closeout: measure proof-cohort outcomes on the binding-first runtime | Backlog |
+| `QUA-815` | Exotic program closeout: measure proof-cohort outcomes on the binding-first runtime | Done |
 
 The benchmark contract for those proof tickets lives in
-`docs/plans/binding-first-exotic-proof-cohort.md`.
+`docs/plans/binding-first-exotic-proof-cohort.md`, and the measured closeout
+now lives in `docs/plans/binding-first-exotic-proof-closeout.md`.
 
 ## Cross-Epic Sequencing Constraints
 

--- a/docs/plans/binding-first-exotic-proof-closeout.md
+++ b/docs/plans/binding-first-exotic-proof-closeout.md
@@ -1,0 +1,116 @@
+# Binding-First Exotic Proof Closeout
+
+## Purpose
+
+This document closes the first proof pass for the binding-first exotic
+assembly program.
+
+It is not another implementation ticket. It is the measured capability
+statement for the current binding-first runtime, grounded in the checked proof
+artifacts and the follow-on tickets opened from them.
+
+The machine-readable summary lives in:
+
+- `docs/benchmarks/binding_first_exotic_proof_closeout.json`
+- `docs/benchmarks/binding_first_exotic_proof_closeout.md`
+
+## Evidence Basis
+
+The closeout summary is generated from the reviewed proof bundles produced by:
+
+- `QUA-808` event/control/schedule cohort
+- `QUA-809` basket/credit/loss cohort
+
+Those bundles were generated on consecutive 2026-04-13 binding-first proof
+runs with fresh builds. `QUA-809` only changed proof docs and follow-on
+tracking relative to the underlying runtime evidence, so the combined closeout
+still reflects one coherent support-contract surface.
+
+## Measured Outcome
+
+Program totals from `docs/benchmarks/binding_first_exotic_proof_closeout.json`:
+
+- `11` proof tasks
+- `1` task passed the program gate
+- `10` tasks failed the program gate
+- `10` tasks were expected to be `proved`
+- `1` task was expected to be an `honest_block`
+- `0` honest-block sentinels were certified by the gate
+- first-pass success rate: `1 / 11` (`9.1%`)
+- total elapsed time: `1143.1s`
+- total token usage: `883,606`
+- residual `unknown` route ids still surfaced on `T17`, `E27`, `T50`, and `E26`
+
+The only proved task in the current closeout is:
+
+- `T105` quanto option: analytical plus Monte Carlo parity with stable binding
+  ids and no route-card rescue logic
+
+## Task-Level Outcome Map
+
+| Task | Result | Residual gap | Follow-on |
+| --- | --- | --- | --- |
+| `T105` | proved | none in this closeout slice | none |
+| `T17` | failed gate | callable-bond PDE lane lacks exact binding or constructive steps | `QUA-817` |
+| `T73` | failed gate | analytical/tree/MC parity drift | `QUA-818` |
+| `E22` | failed gate | cap/floor fresh-build instability and missing reference-target evidence | `QUA-819` |
+| `E27` | failed gate | honest-block sentinel did not persist typed blocker categories cleanly enough for certification | `QUA-820`, `QUA-821` |
+| `T49` | failed gate | Student-t tranche lane rebuilt copula plumbing instead of staying on the exact helper contract | `QUA-822` |
+| `T50` | failed gate | nth-to-default helper invocation and basket-credit parsing | `QUA-823`, `QUA-821` |
+| `E26` | failed gate | basket-credit parsing plus residual unknown route telemetry | `QUA-823`, `QUA-821` |
+| `T53` | failed gate | recursive / FFT / MC constructive stability on multi-name loss distribution | `QUA-824` |
+| `T102` | failed gate | multi-underlier market parsing | `QUA-825` |
+| `T126` | failed gate | multi-underlier parsing plus FFT spread-lane instability | `QUA-825` |
+
+## What This Proves
+
+The proof program did establish several important facts:
+
+- route is no longer required as the primary semantic authority for the proof
+  cohort
+- binding ids survive into live proof telemetry
+- the runtime can support at least one fully binding-first exotic-style parity
+  request (`T105`)
+- failure surfaces are now concrete enough to split into task-backed
+  implementation tickets instead of vague “route is weird” cleanup work
+
+## What This Does Not Prove
+
+This closeout does **not** justify claiming broad support for arbitrary
+constructable exotic derivatives.
+
+The current measured state is:
+
+- event/control/schedule proof is partial
+- basket/credit/loss proof is largely unrecovered
+- the honest-block sentinel path is not yet certified end to end
+- residual `unknown` route telemetry still appears in the proof runtime
+
+So the architecture migration is meaningfully ahead of the capability proof.
+That is acceptable for this closeout, but it must remain explicit.
+
+## Support Contract Decision
+
+The correct support statement after this closeout is:
+
+- Trellis now ships a binding-first runtime architecture for exotic assembly.
+- Trellis does **not** yet have proof-level evidence for general constructable
+  exotic support across the agreed cohort.
+- Current proof-level support is limited to the recovered slices already
+  measured in the checked benchmark artifact, with the remaining gaps tracked
+  by `QUA-817` through `QUA-825`.
+
+This is why `LIMITATIONS.md` now records the exotic proof cohort as an open
+limitation instead of letting the architecture docs imply the proof is already
+complete.
+
+## Closeout Decision
+
+`QUA-815` should be treated as complete once:
+
+- the checked closeout artifacts are committed
+- the measured support contract is reflected in docs and `LIMITATIONS.md`
+- the residual proof gaps remain as concrete follow-on tickets
+
+The closeout ticket ends the measurement tranche. It does not imply the
+follow-ons are done.

--- a/docs/plans/binding-first-exotic-proof-cohort.md
+++ b/docs/plans/binding-first-exotic-proof-cohort.md
@@ -143,6 +143,12 @@ not a permanent block sentinel.
 - time and token cost
 - any remaining blocker families that still prevent the claimed end state
 
+The checked closeout summary lives in:
+
+- `docs/plans/binding-first-exotic-proof-closeout.md`
+- `docs/benchmarks/binding_first_exotic_proof_closeout.json`
+- `docs/benchmarks/binding_first_exotic_proof_closeout.md`
+
 ## Latest Evidence
 
 ### `QUA-808` live run on `2026-04-13`

--- a/docs/quant/pricing_stack.rst
+++ b/docs/quant/pricing_stack.rst
@@ -237,6 +237,14 @@ minimized feature surface instead of emitting its own route-id or
 route-family one-hots, so future retraining work cannot silently regress the
 live scorer contract.
 
+That architectural migration should not be overstated. The checked proof
+closeout in ``docs/plans/binding-first-exotic-proof-closeout.md`` and
+``docs/benchmarks/binding_first_exotic_proof_closeout.json`` currently
+certifies only the ``T105`` proof task end to end; the remaining
+event/control and basket-credit/loss cohort items still sit behind concrete
+follow-on tickets. The runtime is binding-first, but broad constructable-exotic
+support is not yet a checked support-contract claim.
+
 For rate-style swaption comparison builds, the semantic compiler now also keeps
 the contract-level convention surface attached to each method-specific plan.
 Fixed-leg and floating-leg day-count terms, rate-index bindings, and the

--- a/scripts/run_binding_first_exotic_closeout.py
+++ b/scripts/run_binding_first_exotic_closeout.py
@@ -1,0 +1,77 @@
+"""Summarize the binding-first exotic proof program from cohort reports.
+
+Usage:
+    /Users/steveyang/miniforge3/bin/python3 scripts/run_binding_first_exotic_closeout.py \
+        --report-json /tmp/qua808_report_live.json \
+        --report-json /tmp/qua809_report_live.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from trellis.agent.evals import (
+    render_binding_first_exotic_program_closeout,
+    summarize_binding_first_exotic_program_closeout,
+)
+from trellis.cli_paths import resolve_repo_path
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--report-json",
+        action="append",
+        dest="report_json_paths",
+        required=True,
+        help="Path to one cohort report JSON. May be repeated.",
+    )
+    parser.add_argument("--output-json")
+    parser.add_argument("--output-md")
+    return parser.parse_args(argv)
+
+
+def run_binding_first_exotic_closeout(
+    *,
+    report_json_paths: list[Path],
+    output_json_path: Path,
+    output_md_path: Path,
+) -> int:
+    reports = [json.loads(path.read_text()) for path in report_json_paths]
+    summary = summarize_binding_first_exotic_program_closeout(reports)
+    summary["source_reports"] = [path.name for path in report_json_paths]
+    output_json_path.write_text(json.dumps(summary, indent=2, default=str))
+    output_md_path.write_text(render_binding_first_exotic_program_closeout(summary))
+    print(f"Closeout JSON saved to: {output_json_path}")
+    print(f"Closeout Markdown saved to: {output_md_path}")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    args = _parse_args(argv)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    output_json_path = resolve_repo_path(
+        args.output_json,
+        ROOT / f"task_results_binding_first_exotic_closeout_{timestamp}.json",
+    )
+    output_md_path = resolve_repo_path(
+        args.output_md,
+        ROOT / f"task_results_binding_first_exotic_closeout_{timestamp}.md",
+    )
+    return run_binding_first_exotic_closeout(
+        report_json_paths=[resolve_repo_path(path, ROOT / path) for path in args.report_json_paths],
+        output_json_path=output_json_path,
+        output_md_path=output_md_path,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/run_binding_first_exotic_closeout.py
+++ b/scripts/run_binding_first_exotic_closeout.py
@@ -67,7 +67,7 @@ def main(argv: list[str]) -> int:
         ROOT / f"task_results_binding_first_exotic_closeout_{timestamp}.md",
     )
     return run_binding_first_exotic_closeout(
-        report_json_paths=[resolve_repo_path(path, ROOT / path) for path in args.report_json_paths],
+        report_json_paths=[resolve_repo_path(path) for path in args.report_json_paths],
         output_json_path=output_json_path,
         output_md_path=output_md_path,
     )

--- a/tests/test_agent/test_binding_first_exotic_closeout_runner.py
+++ b/tests/test_agent/test_binding_first_exotic_closeout_runner.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = ROOT / "scripts" / "run_binding_first_exotic_closeout.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "run_binding_first_exotic_closeout",
+        SCRIPT_PATH,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_run_binding_first_exotic_closeout_writes_outputs(tmp_path):
+    module = _load_module()
+
+    report_one = tmp_path / "qua808_report.json"
+    report_two = tmp_path / "qua809_report.json"
+    report_one.write_text(
+        json.dumps(
+            {
+                "cohort": "event_control_schedule",
+                "status": "failed_gate",
+                "task_ids": ["T105"],
+                "report_json_path": str(report_one),
+                "report_md_path": str(tmp_path / "qua808_report.md"),
+                "raw_results_path": str(tmp_path / "qua808_results.json"),
+                "proof_summary": {
+                    "totals": {"tasks": 1, "passed_gate": 1, "failed_gate": 0, "proved": 1, "honest_block": 0},
+                    "failure_buckets": {"success": 1},
+                    "by_task": {
+                        "T105": {
+                            "title": "Quanto option",
+                            "cohort": "event_control_schedule",
+                            "outcome_class": "proved",
+                            "passed_gate": True,
+                            "failure_bucket": "success",
+                            "comparison_status": "passed",
+                            "binding_ids": ["binding.quanto"],
+                            "route_ids": [],
+                            "first_pass": True,
+                            "attempts_to_success": 1,
+                            "retry_taxonomy": [],
+                            "elapsed_seconds": 10.0,
+                            "token_usage": {"total_tokens": 100, "call_count": 2},
+                        }
+                    },
+                },
+                "task_summary": {},
+            }
+        )
+    )
+    report_two.write_text(
+        json.dumps(
+            {
+                "cohort": "basket_credit_loss",
+                "status": "failed_gate",
+                "task_ids": ["T50"],
+                "report_json_path": str(report_two),
+                "report_md_path": str(tmp_path / "qua809_report.md"),
+                "raw_results_path": str(tmp_path / "qua809_results.json"),
+                "proof_summary": {
+                    "totals": {"tasks": 1, "passed_gate": 0, "failed_gate": 1, "proved": 1, "honest_block": 0},
+                    "failure_buckets": {"comparison_insufficient_results": 1},
+                    "by_task": {
+                        "T50": {
+                            "title": "Nth-to-default",
+                            "cohort": "basket_credit_loss",
+                            "outcome_class": "proved",
+                            "passed_gate": False,
+                            "failure_bucket": "comparison_insufficient_results",
+                            "comparison_status": "insufficient_results",
+                            "binding_ids": ["binding.ntd"],
+                            "route_ids": ["unknown"],
+                            "first_pass": False,
+                            "attempts_to_success": 3,
+                            "retry_taxonomy": ["code_generation"],
+                            "elapsed_seconds": 20.0,
+                            "token_usage": {"total_tokens": 200, "call_count": 3},
+                        }
+                    },
+                },
+                "task_summary": {},
+            }
+        )
+    )
+
+    output_json = tmp_path / "closeout.json"
+    output_md = tmp_path / "closeout.md"
+    exit_code = module.run_binding_first_exotic_closeout(
+        report_json_paths=[report_one, report_two],
+        output_json_path=output_json,
+        output_md_path=output_md,
+    )
+
+    assert exit_code == 0
+    summary = json.loads(output_json.read_text())
+    assert summary["totals"]["tasks"] == 2
+    assert summary["totals"]["passed_gate"] == 1
+    assert summary["unknown_route_tasks"] == ["T50"]
+    assert "Binding-First Exotic Program Closeout" in output_md.read_text()

--- a/tests/test_agent/test_binding_first_exotic_proof.py
+++ b/tests/test_agent/test_binding_first_exotic_proof.py
@@ -267,7 +267,28 @@ def test_summarize_binding_first_exotic_program_closeout_aggregates_cohorts():
     assert closeout["totals"]["failed_gate"] == 1
     assert closeout["honest_block_certified"] == 1
     assert closeout["first_pass"]["first_pass_successes"] == 2
-    assert closeout["attempts_to_success"]["average"] == 0.5
+    assert closeout["attempts_to_success"]["average"] == 1.0
     assert closeout["elapsed_seconds_total"] == 35.0
     assert closeout["token_usage"]["total_tokens"] == 310
     assert closeout["unknown_route_tasks"] == ["E27", "T50"]
+
+
+def test_summarize_binding_first_exotic_program_closeout_rejects_duplicate_cohorts():
+    from trellis.agent.evals import summarize_binding_first_exotic_program_closeout
+
+    report = {
+        "cohort": "event_control_schedule",
+        "proof_summary": {
+            "totals": {"tasks": 0, "passed_gate": 0, "failed_gate": 0, "proved": 0, "honest_block": 0},
+            "failure_buckets": {},
+            "by_task": {},
+        },
+        "task_summary": {},
+    }
+
+    try:
+        summarize_binding_first_exotic_program_closeout([report, report])
+    except ValueError as exc:
+        assert "duplicate" in str(exc)
+    else:
+        raise AssertionError("duplicate cohort names should raise ValueError")

--- a/tests/test_agent/test_binding_first_exotic_proof.py
+++ b/tests/test_agent/test_binding_first_exotic_proof.py
@@ -177,3 +177,97 @@ def test_summarize_binding_first_exotic_proof_captures_binding_ids_and_honest_bl
         "trellis.models.fx_vanilla.price_quanto_option_analytical_from_market_state"
     ]
     assert summary["by_task"]["E27"]["failure_bucket"] == "blocked"
+
+
+def test_summarize_binding_first_exotic_program_closeout_aggregates_cohorts():
+    from trellis.agent.evals import summarize_binding_first_exotic_program_closeout
+
+    closeout = summarize_binding_first_exotic_program_closeout(
+        [
+            {
+                "cohort": "event_control_schedule",
+                "status": "failed_gate",
+                "task_ids": ["T105", "E27"],
+                "report_json_path": "/tmp/qua808.json",
+                "report_md_path": "/tmp/qua808.md",
+                "raw_results_path": "/tmp/qua808_results.json",
+                "proof_summary": {
+                    "totals": {"tasks": 2, "passed_gate": 2, "failed_gate": 0, "proved": 1, "honest_block": 1},
+                    "failure_buckets": {"success": 1, "blocked": 1},
+                    "by_task": {
+                        "T105": {
+                            "title": "Quanto option",
+                            "cohort": "event_control_schedule",
+                            "outcome_class": "proved",
+                            "passed_gate": True,
+                            "failure_bucket": "success",
+                            "comparison_status": "passed",
+                            "binding_ids": ["binding.quanto"],
+                            "route_ids": ["quanto_adjustment_analytical"],
+                            "first_pass": True,
+                            "attempts_to_success": 1,
+                            "retry_taxonomy": [],
+                            "elapsed_seconds": 10.0,
+                            "token_usage": {"total_tokens": 100, "call_count": 2},
+                        },
+                        "E27": {
+                            "title": "American Asian barrier",
+                            "cohort": "event_control_schedule",
+                            "outcome_class": "honest_block",
+                            "passed_gate": True,
+                            "failure_bucket": "blocked",
+                            "comparison_status": "insufficient_results",
+                            "binding_ids": [],
+                            "route_ids": ["unknown"],
+                            "first_pass": True,
+                            "attempts_to_success": 0,
+                            "retry_taxonomy": [],
+                            "elapsed_seconds": 5.0,
+                            "token_usage": {"total_tokens": 10, "call_count": 1},
+                        },
+                    },
+                },
+                "task_summary": {},
+            },
+            {
+                "cohort": "basket_credit_loss",
+                "status": "failed_gate",
+                "task_ids": ["T50"],
+                "report_json_path": "/tmp/qua809.json",
+                "report_md_path": "/tmp/qua809.md",
+                "raw_results_path": "/tmp/qua809_results.json",
+                "proof_summary": {
+                    "totals": {"tasks": 1, "passed_gate": 0, "failed_gate": 1, "proved": 1, "honest_block": 0},
+                    "failure_buckets": {"comparison_insufficient_results": 1},
+                    "by_task": {
+                        "T50": {
+                            "title": "Nth-to-default",
+                            "cohort": "basket_credit_loss",
+                            "outcome_class": "proved",
+                            "passed_gate": False,
+                            "failure_bucket": "comparison_insufficient_results",
+                            "comparison_status": "insufficient_results",
+                            "binding_ids": ["binding.ntd"],
+                            "route_ids": ["unknown"],
+                            "first_pass": False,
+                            "attempts_to_success": 3,
+                            "retry_taxonomy": ["code_generation"],
+                            "elapsed_seconds": 20.0,
+                            "token_usage": {"total_tokens": 200, "call_count": 3},
+                        }
+                    },
+                },
+                "task_summary": {},
+            },
+        ]
+    )
+
+    assert closeout["totals"]["tasks"] == 3
+    assert closeout["totals"]["passed_gate"] == 2
+    assert closeout["totals"]["failed_gate"] == 1
+    assert closeout["honest_block_certified"] == 1
+    assert closeout["first_pass"]["first_pass_successes"] == 2
+    assert closeout["attempts_to_success"]["average"] == 0.5
+    assert closeout["elapsed_seconds_total"] == 35.0
+    assert closeout["token_usage"]["total_tokens"] == 310
+    assert closeout["unknown_route_tasks"] == ["E27", "T50"]

--- a/trellis/agent/evals.py
+++ b/trellis/agent/evals.py
@@ -988,6 +988,8 @@ def summarize_binding_first_exotic_program_closeout(
     for raw_report in reports:
         report = dict(raw_report or {})
         cohort = str(report.get("cohort") or "").strip() or "unknown"
+        if cohort in cohort_summaries:
+            raise ValueError(f"duplicate binding-first closeout cohort: {cohort}")
         proof_summary = dict(report.get("proof_summary") or {})
         task_summary = dict(report.get("task_summary") or {})
         cohort_summaries[cohort] = {
@@ -1017,7 +1019,8 @@ def summarize_binding_first_exotic_program_closeout(
             totals["tasks"] += 1
             if task_report.get("passed_gate"):
                 totals["passed_gate"] += 1
-                successful_attempts.append(int(task_report.get("attempts_to_success") or 0))
+                if str(task_report.get("outcome_class") or "").strip() != PROOF_OUTCOME_HONEST_BLOCK:
+                    successful_attempts.append(int(task_report.get("attempts_to_success") or 0))
             else:
                 totals["failed_gate"] += 1
             outcome_class = str(task_report.get("outcome_class") or "").strip()
@@ -1089,8 +1092,16 @@ def render_binding_first_exotic_program_closeout(report: Mapping[str, Any]) -> s
         f"- Total tokens: `{token_usage.get('total_tokens', 0)}`",
         f"- Unknown route-id tasks: `{', '.join(report.get('unknown_route_tasks') or []) or 'none'}`",
         "",
-        "## Cohorts",
+        "## Failure Buckets",
     ]
+    for bucket, count in sorted(dict(report.get("failure_buckets") or {}).items()):
+        lines.append(f"- `{bucket}`: `{count}`")
+    lines.extend(
+        [
+            "",
+        "## Cohorts",
+        ]
+    )
     for cohort, summary_raw in sorted(dict(report.get("cohorts") or {}).items()):
         summary = dict(summary_raw or {})
         cohort_totals = dict(summary.get("totals") or {})

--- a/trellis/agent/evals.py
+++ b/trellis/agent/evals.py
@@ -925,6 +925,210 @@ def render_binding_first_exotic_proof_report(report: Mapping[str, Any]) -> str:
     return "\n".join(lines).rstrip() + "\n"
 
 
+def summarize_binding_first_exotic_program_closeout(
+    reports: Iterable[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Aggregate multiple proof-cohort reports into one program closeout summary."""
+    cohort_summaries: dict[str, dict[str, Any]] = {}
+    by_task: dict[str, dict[str, Any]] = {}
+    failure_buckets: dict[str, int] = {}
+    unknown_route_tasks: list[str] = []
+    elapsed_total = 0.0
+    successful_attempts: list[int] = []
+    token_usage = {
+        "call_count": 0,
+        "calls_with_usage": 0,
+        "calls_without_usage": 0,
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "total_tokens": 0,
+        "by_stage": {},
+        "by_provider": {},
+    }
+    totals = {
+        "tasks": 0,
+        "passed_gate": 0,
+        "failed_gate": 0,
+        PROOF_OUTCOME_PROVED: 0,
+        PROOF_OUTCOME_HONEST_BLOCK: 0,
+    }
+
+    def _display_artifact_path(value: Any) -> str | None:
+        text = str(value or "").strip()
+        if not text:
+            return None
+        return Path(text).name if text.startswith("/") else text
+
+    def _merge_token_usage(target: dict[str, Any], source: Mapping[str, Any]) -> None:
+        for key in (
+            "call_count",
+            "calls_with_usage",
+            "calls_without_usage",
+            "prompt_tokens",
+            "completion_tokens",
+            "total_tokens",
+        ):
+            target[key] = int(target.get(key, 0) or 0) + int(source.get(key, 0) or 0)
+        for bucket_name in ("by_stage", "by_provider"):
+            target_bucket = dict(target.get(bucket_name) or {})
+            for name, payload in dict(source.get(bucket_name) or {}).items():
+                existing = dict(target_bucket.get(name) or {})
+                for key in (
+                    "call_count",
+                    "calls_with_usage",
+                    "calls_without_usage",
+                    "prompt_tokens",
+                    "completion_tokens",
+                    "total_tokens",
+                ):
+                    existing[key] = int(existing.get(key, 0) or 0) + int(payload.get(key, 0) or 0)
+                target_bucket[name] = existing
+            target[bucket_name] = target_bucket
+
+    for raw_report in reports:
+        report = dict(raw_report or {})
+        cohort = str(report.get("cohort") or "").strip() or "unknown"
+        proof_summary = dict(report.get("proof_summary") or {})
+        task_summary = dict(report.get("task_summary") or {})
+        cohort_summaries[cohort] = {
+            "status": report.get("status"),
+            "task_ids": list(report.get("task_ids") or []),
+            "totals": dict(proof_summary.get("totals") or {}),
+            "failure_buckets": dict(proof_summary.get("failure_buckets") or {}),
+            "task_summary": task_summary,
+            "report_json_path": _display_artifact_path(report.get("report_json_path")),
+            "report_md_path": _display_artifact_path(report.get("report_md_path")),
+            "raw_results_path": _display_artifact_path(report.get("raw_results_path")),
+        }
+
+        for bucket, count in dict(proof_summary.get("failure_buckets") or {}).items():
+            failure_buckets[str(bucket)] = failure_buckets.get(str(bucket), 0) + int(count or 0)
+
+        for task_id, task_report_raw in dict(proof_summary.get("by_task") or {}).items():
+            task_report = {
+                key: (
+                    _display_artifact_path(value)
+                    if key.endswith("_path")
+                    else value
+                )
+                for key, value in dict(task_report_raw or {}).items()
+            }
+            by_task[str(task_id)] = task_report
+            totals["tasks"] += 1
+            if task_report.get("passed_gate"):
+                totals["passed_gate"] += 1
+                successful_attempts.append(int(task_report.get("attempts_to_success") or 0))
+            else:
+                totals["failed_gate"] += 1
+            outcome_class = str(task_report.get("outcome_class") or "").strip()
+            if outcome_class in totals:
+                totals[outcome_class] += 1
+
+            elapsed_total += float(task_report.get("elapsed_seconds") or 0.0)
+            _merge_token_usage(token_usage, dict(task_report.get("token_usage") or {}))
+            if "unknown" in set(task_report.get("route_ids") or ()):
+                unknown_route_tasks.append(str(task_id))
+
+    first_pass_successes = sum(
+        1
+        for task_report in by_task.values()
+        if task_report.get("passed_gate") and task_report.get("first_pass")
+    )
+    honest_block_certified = sum(
+        1
+        for task_report in by_task.values()
+        if task_report.get("passed_gate")
+        and str(task_report.get("outcome_class") or "").strip() == PROOF_OUTCOME_HONEST_BLOCK
+    )
+    return {
+        "totals": totals,
+        "cohorts": cohort_summaries,
+        "failure_buckets": failure_buckets,
+        "by_task": by_task,
+        "elapsed_seconds_total": round(elapsed_total, 1),
+        "unknown_route_tasks": sorted(set(unknown_route_tasks)),
+        "first_pass": {
+            "tasks": totals["tasks"],
+            "successful_tasks": totals["passed_gate"],
+            "first_pass_successes": first_pass_successes,
+            "rate": (first_pass_successes / totals["tasks"]) if totals["tasks"] else 0.0,
+        },
+        "attempts_to_success": {
+            "successful_tasks": len(successful_attempts),
+            "average": (
+                round(sum(successful_attempts) / len(successful_attempts), 2)
+                if successful_attempts
+                else 0.0
+            ),
+            "median": float(median(successful_attempts)) if successful_attempts else 0.0,
+            "max": max(successful_attempts) if successful_attempts else 0,
+        },
+        "token_usage": token_usage,
+        "honest_block_certified": honest_block_certified,
+    }
+
+
+def render_binding_first_exotic_program_closeout(report: Mapping[str, Any]) -> str:
+    """Render the program-level proof closeout as operator-facing Markdown."""
+    totals = dict(report.get("totals") or {})
+    first_pass = dict(report.get("first_pass") or {})
+    attempts = dict(report.get("attempts_to_success") or {})
+    token_usage = dict(report.get("token_usage") or {})
+    lines = [
+        "# Binding-First Exotic Program Closeout",
+        "",
+        f"- Tasks: `{totals.get('tasks', 0)}`",
+        f"- Passed gate: `{totals.get('passed_gate', 0)}`",
+        f"- Failed gate: `{totals.get('failed_gate', 0)}`",
+        f"- Proved expectations: `{totals.get(PROOF_OUTCOME_PROVED, 0)}`",
+        f"- Honest-block expectations: `{totals.get(PROOF_OUTCOME_HONEST_BLOCK, 0)}`",
+        f"- Certified honest blocks: `{report.get('honest_block_certified', 0)}`",
+        f"- First-pass success rate: `{first_pass.get('rate', 0.0)}`",
+        f"- Average attempts to success (successful tasks): `{attempts.get('average', 0.0)}`",
+        f"- Total elapsed seconds: `{report.get('elapsed_seconds_total', 0.0)}`",
+        f"- Total tokens: `{token_usage.get('total_tokens', 0)}`",
+        f"- Unknown route-id tasks: `{', '.join(report.get('unknown_route_tasks') or []) or 'none'}`",
+        "",
+        "## Cohorts",
+    ]
+    for cohort, summary_raw in sorted(dict(report.get("cohorts") or {}).items()):
+        summary = dict(summary_raw or {})
+        cohort_totals = dict(summary.get("totals") or {})
+        lines.extend(
+            [
+                f"### {cohort}",
+                f"- Status: `{summary.get('status', '')}`",
+                f"- Passed gate: `{cohort_totals.get('passed_gate', 0)}`",
+                f"- Failed gate: `{cohort_totals.get('failed_gate', 0)}`",
+                f"- Tasks: `{', '.join(summary.get('task_ids') or [])}`",
+                f"- Report JSON: `{summary.get('report_json_path', '')}`",
+                f"- Report Markdown: `{summary.get('report_md_path', '')}`",
+                "",
+            ]
+        )
+    lines.append("## Task View")
+    for task_id, task_report_raw in sorted(dict(report.get("by_task") or {}).items()):
+        task_report = dict(task_report_raw or {})
+        lines.extend(
+            [
+                f"### {task_id} - {task_report.get('title', '')}",
+                f"- Cohort: `{task_report.get('cohort', '')}`",
+                f"- Expected outcome: `{task_report.get('outcome_class', '')}`",
+                f"- Gate passed: `{task_report.get('passed_gate', '')}`",
+                f"- Failure bucket: `{task_report.get('failure_bucket', '')}`",
+                f"- Comparison status: `{task_report.get('comparison_status', '') or 'missing'}`",
+                f"- Binding ids: `{', '.join(task_report.get('binding_ids') or []) or 'none'}`",
+                f"- Route ids: `{', '.join(task_report.get('route_ids') or []) or 'none'}`",
+                f"- First pass: `{task_report.get('first_pass', False)}`",
+                f"- Attempts to success: `{task_report.get('attempts_to_success', 0)}`",
+                f"- Retry taxonomy: `{', '.join(task_report.get('retry_taxonomy') or []) or 'none'}`",
+                f"- Latest diagnosis dossier: `{task_report.get('diagnosis_latest_dossier_path', '') or task_report.get('diagnosis_dossier_path', '') or 'missing'}`",
+                "",
+            ]
+        )
+    return "\n".join(lines).rstrip() + "\n"
+
+
 def classify_task_result(result: Mapping[str, Any]) -> str:
     """Bucket one task result into a stable outcome/failure class."""
     if result.get("success"):


### PR DESCRIPTION
## Summary
- add a program-level binding-first exotic closeout summarizer and CLI
- check in the generated closeout benchmark artifacts and closeout doc
- update architecture, pricing-stack, plan, and limitation docs to match the measured proof result

## Testing
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_binding_first_exotic_proof.py tests/test_agent/test_binding_first_exotic_closeout_runner.py tests/test_agent/test_binding_first_exotic_proof_runner.py -q
- /Users/steveyang/miniforge3/bin/python3 -m py_compile trellis/agent/evals.py scripts/run_binding_first_exotic_closeout.py
- /Users/steveyang/miniforge3/bin/python3 scripts/run_binding_first_exotic_closeout.py --report-json /tmp/qua808_report_live.json --report-json /tmp/qua809_report_live.json --output-json docs/benchmarks/binding_first_exotic_proof_closeout.json --output-md docs/benchmarks/binding_first_exotic_proof_closeout.md
