### PR TITLE
QUA-821 normalize proof telemetry route ids

### DIFF
--- a/docs/developer/task_diagnostics.rst
+++ b/docs/developer/task_diagnostics.rst
@@ -139,7 +139,8 @@ when an exact backend binding is known. In practice that means:
 - route-observation tables prefer the binding diagnostic label instead of a
   route id when exact binding metadata is available
 - route ids remain only as transitional aliases when no binding metadata has
-  been resolved
+  been resolved, and synthetic placeholders like ``unknown`` are normalized
+  away before task-run telemetry is persisted
 
 The deterministic loaders are:
 

--- a/docs/plans/binding-first-exotic-assembly.md
+++ b/docs/plans/binding-first-exotic-assembly.md
@@ -188,7 +188,7 @@ Status mirror last synced: `2026-04-13`
 | `QUA-818` | Proof follow-on: swaption analytical/tree/MC parity drift (`T73`) | Backlog |
 | `QUA-819` | Proof follow-on: cap/floor fresh-build stability and reference-target evidence (`E22`) | Backlog |
 | `QUA-820` | Proof follow-on: structured blocker persistence for honest-block sentinel (`E27`) | Backlog |
-| `QUA-821` | Proof telemetry: remove residual `unknown` route ids from proof traces (`T17`, `E27`, `T50`, `E26`) | Backlog |
+| `QUA-821` | Proof telemetry: remove residual `unknown` route ids from proof traces (`T17`, `E27`, `T50`, `E26`) | Done |
 | `QUA-809` | Exotic assembly: run the basket-credit-loss proof cohort and split residual gaps | Done |
 | `QUA-822` | Proof follow-on: copula tranche exact-helper contract (`T49`) | Backlog |
 | `QUA-823` | Proof follow-on: nth-to-default helper and basket-credit parsing (`T50`, `E26`) | Backlog |

--- a/docs/plans/binding-first-exotic-proof-closeout.md
+++ b/docs/plans/binding-first-exotic-proof-closeout.md
@@ -39,7 +39,9 @@ Program totals from `docs/benchmarks/binding_first_exotic_proof_closeout.json`:
 - first-pass success rate: `1 / 11` (`9.1%`)
 - total elapsed time: `1143.1s`
 - total token usage: `883,606`
-- residual `unknown` route ids still surfaced on `T17`, `E27`, `T50`, and `E26`
+- route-identity telemetry was later normalized in `QUA-821`; the residual
+  proof blockers are now the task-specific gaps listed below rather than
+  synthetic `unknown` route ids
 
 The only proved task in the current closeout is:
 
@@ -54,10 +56,10 @@ The only proved task in the current closeout is:
 | `T17` | failed gate | callable-bond PDE lane lacks exact binding or constructive steps | `QUA-817` |
 | `T73` | failed gate | analytical/tree/MC parity drift | `QUA-818` |
 | `E22` | failed gate | cap/floor fresh-build instability and missing reference-target evidence | `QUA-819` |
-| `E27` | failed gate | honest-block sentinel did not persist typed blocker categories cleanly enough for certification | `QUA-820`, `QUA-821` |
+| `E27` | failed gate | honest-block sentinel did not persist typed blocker categories cleanly enough for certification | `QUA-820` |
 | `T49` | failed gate | Student-t tranche lane rebuilt copula plumbing instead of staying on the exact helper contract | `QUA-822` |
-| `T50` | failed gate | nth-to-default helper invocation and basket-credit parsing | `QUA-823`, `QUA-821` |
-| `E26` | failed gate | basket-credit parsing plus residual unknown route telemetry | `QUA-823`, `QUA-821` |
+| `T50` | failed gate | nth-to-default helper invocation and basket-credit parsing | `QUA-823` |
+| `E26` | failed gate | basket-credit parsing | `QUA-823` |
 | `T53` | failed gate | recursive / FFT / MC constructive stability on multi-name loss distribution | `QUA-824` |
 | `T102` | failed gate | multi-underlier market parsing | `QUA-825` |
 | `T126` | failed gate | multi-underlier parsing plus FFT spread-lane instability | `QUA-825` |

--- a/tests/test_agent/test_analytical_traces.py
+++ b/tests/test_agent/test_analytical_traces.py
@@ -97,3 +97,15 @@ def test_route_health_snapshot_reports_instruction_counts():
     assert snapshot["hard_constraint_count"] == 0
     assert snapshot["conflict_count"] == 0
     assert "analytical_black76:schedule-builder" in snapshot["effective_instruction_ids"]
+
+
+def test_analytical_trace_route_from_dict_preserves_blank_route_name():
+    from trellis.agent.analytical_traces import AnalyticalTraceRoute
+
+    route = AnalyticalTraceRoute.from_dict(
+        {"family": "analytical", "name": "", "model": "black_scholes"}
+    )
+
+    assert route.family == "analytical"
+    assert route.name == ""
+    assert route.model == "black_scholes"

--- a/tests/test_agent/test_binding_first_exotic_closeout_runner.py
+++ b/tests/test_agent/test_binding_first_exotic_closeout_runner.py
@@ -81,7 +81,7 @@ def test_run_binding_first_exotic_closeout_writes_outputs(tmp_path):
                             "failure_bucket": "comparison_insufficient_results",
                             "comparison_status": "insufficient_results",
                             "binding_ids": ["binding.ntd"],
-                            "route_ids": ["unknown"],
+                            "route_ids": [],
                             "first_pass": False,
                             "attempts_to_success": 3,
                             "retry_taxonomy": ["code_generation"],
@@ -107,5 +107,5 @@ def test_run_binding_first_exotic_closeout_writes_outputs(tmp_path):
     summary = json.loads(output_json.read_text())
     assert summary["totals"]["tasks"] == 2
     assert summary["totals"]["passed_gate"] == 1
-    assert summary["unknown_route_tasks"] == ["T50"]
+    assert summary["unknown_route_tasks"] == []
     assert "Binding-First Exotic Program Closeout" in output_md.read_text()

--- a/tests/test_agent/test_binding_first_exotic_proof.py
+++ b/tests/test_agent/test_binding_first_exotic_proof.py
@@ -218,7 +218,7 @@ def test_summarize_binding_first_exotic_program_closeout_aggregates_cohorts():
                             "failure_bucket": "blocked",
                             "comparison_status": "insufficient_results",
                             "binding_ids": [],
-                            "route_ids": ["unknown"],
+                            "route_ids": [],
                             "first_pass": True,
                             "attempts_to_success": 0,
                             "retry_taxonomy": [],
@@ -248,7 +248,7 @@ def test_summarize_binding_first_exotic_program_closeout_aggregates_cohorts():
                             "failure_bucket": "comparison_insufficient_results",
                             "comparison_status": "insufficient_results",
                             "binding_ids": ["binding.ntd"],
-                            "route_ids": ["unknown"],
+                            "route_ids": [],
                             "first_pass": False,
                             "attempts_to_success": 3,
                             "retry_taxonomy": ["code_generation"],
@@ -270,7 +270,7 @@ def test_summarize_binding_first_exotic_program_closeout_aggregates_cohorts():
     assert closeout["attempts_to_success"]["average"] == 1.0
     assert closeout["elapsed_seconds_total"] == 35.0
     assert closeout["token_usage"]["total_tokens"] == 310
-    assert closeout["unknown_route_tasks"] == ["E27", "T50"]
+    assert closeout["unknown_route_tasks"] == []
 
 
 def test_summarize_binding_first_exotic_program_closeout_rejects_duplicate_cohorts():

--- a/tests/test_agent/test_task_run_store.py
+++ b/tests/test_agent/test_task_run_store.py
@@ -1152,3 +1152,87 @@ def test_persist_task_run_record_does_not_promote_platform_action_to_fake_route_
     assert latest["telemetry"]["binding_observations"][0]["binding_family"] == "analytical"
     assert latest["telemetry"]["binding_observations"][0]["route_id"] == ""
     assert latest["telemetry"]["binding_observations"][0]["primary_label"] == "analytical"
+
+
+def test_persist_task_run_record_normalizes_unknown_route_id_to_blank(tmp_path):
+    from trellis.agent.task_run_store import load_task_run_record, persist_task_run_record
+
+    trace_path = (
+        tmp_path
+        / "trellis"
+        / "agent"
+        / "knowledge"
+        / "traces"
+        / "platform"
+        / "executor_build_unknown.yaml"
+    )
+    _write_trace(
+        trace_path,
+        {
+            "request_id": "executor_build_unknown",
+            "status": "failed",
+            "outcome": "request_failed",
+            "action": "compile_only",
+            "route_method": "analytical",
+            "updated_at": "2026-04-12T12:00:00+00:00",
+            "request_metadata": {
+                "task_id": "T105",
+                "task_title": "FX vanilla analytical check",
+                "semantic_blueprint": {
+                    "dsl_route": None,
+                    "dsl_route_family": "analytical",
+                },
+            },
+            "generation_boundary": {
+                "method": "analytical",
+                "construction_identity": {
+                    "primary_kind": "backend_binding",
+                    "primary_label": "FX vanilla analytical binding",
+                    "backend_binding_id": "trellis.models.fx_vanilla.price_fx_vanilla_analytical",
+                    "backend_engine_family": "analytical",
+                    "route_alias": "",
+                },
+                "route_binding_authority": {},
+                "primitive_plan": {},
+            },
+            "route_health": {
+                "route_id": "unknown",
+                "route_family": "analytical",
+                "binding_id": "trellis.models.fx_vanilla.price_fx_vanilla_analytical",
+                "binding_family": "analytical",
+                "trace_status": "failed",
+                "effective_instruction_ids": [],
+                "effective_instruction_count": 0,
+                "hard_constraint_count": 0,
+                "conflict_count": 0,
+                "canary_task_ids": [],
+            },
+        },
+    )
+
+    task = {"id": "T105", "title": "FX vanilla analytical check", "construct": ["analytical"]}
+    result = {
+        "task_id": "T105",
+        "title": "FX vanilla analytical check",
+        "success": False,
+        "cross_validation": {"status": "insufficient_results"},
+        "artifacts": {"platform_trace_paths": [str(trace_path)]},
+        "reflection": {},
+    }
+
+    persisted = persist_task_run_record(
+        task,
+        result,
+        root=tmp_path,
+        persisted_at=datetime(2026, 4, 12, 12, 1, 0, tzinfo=timezone.utc),
+    )
+    latest = load_task_run_record(persisted["latest_path"])
+
+    assert latest["trace_summaries"][0]["binding_health"]["binding_id"] == (
+        "trellis.models.fx_vanilla.price_fx_vanilla_analytical"
+    )
+    assert latest["trace_summaries"][0]["route_health"]["route_id"] == ""
+    assert latest["telemetry"]["binding_observations"][0]["route_id"] == ""
+    assert latest["telemetry"]["binding_observations"][0]["binding_id"] == (
+        "trellis.models.fx_vanilla.price_fx_vanilla_analytical"
+    )

--- a/trellis/agent/analytical_traces.py
+++ b/trellis/agent/analytical_traces.py
@@ -31,9 +31,9 @@ class AnalyticalTraceRoute:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "AnalyticalTraceRoute":
         return cls(
-            family=str(data.get("family") or "unknown"),
-            name=str(data.get("name") or "unknown"),
-            model=str(data.get("model") or "unknown"),
+            family=str(data.get("family")) if data.get("family") is not None else "unknown",
+            name=str(data.get("name")) if data.get("name") is not None else "unknown",
+            model=str(data.get("model")) if data.get("model") is not None else "unknown",
         )
 
 
@@ -152,7 +152,7 @@ def build_analytical_trace_from_generation_plan(
     """Construct an analytical trace from a deterministic generation plan."""
     primitive_plan = plan.primitive_plan
     route_family = route_family or plan.method
-    route_name = primitive_plan.route if primitive_plan is not None else "unknown"
+    route_name = str(getattr(primitive_plan, "route", "") or "").strip()
     model = model or (primitive_plan.engine_family if primitive_plan is not None else plan.method)
     trace_id = trace_id or _default_trace_id(route_family, route_name, plan.instrument_type)
     created_at = _now_utc()

--- a/trellis/agent/task_diagnostics.py
+++ b/trellis/agent/task_diagnostics.py
@@ -714,13 +714,18 @@ def _trace_binding_observation(
     selected_artifact_ids: list[str],
 ) -> dict[str, Any] | None:
     """Project one trace summary into a binding-first telemetry observation."""
+    from trellis.agent.route_registry import should_surface_route_alias
+
     route_health = dict(trace.get("binding_health") or trace.get("route_health") or {})
     construction_identity = dict(trace.get("construction_identity") or {})
     route_binding_authority = dict(trace.get("binding_authority") or trace.get("route_binding_authority") or {})
     trace_kind = str(trace.get("trace_kind") or "").strip()
-    route_id = str(route_health.get("route_id") or "").strip()
-    if not route_id and trace_kind != "platform":
-        route_id = str(trace.get("action") or "").strip()
+    authority_route_id = str(route_binding_authority.get("route_id") or "").strip()
+    if authority_route_id and not should_surface_route_alias(route_binding_authority):
+        authority_route_id = ""
+    route_id = str(route_health.get("route_id") or authority_route_id or "").strip()
+    if route_id == "unknown":
+        route_id = ""
     route_family = str(route_health.get("route_family") or trace.get("route_method") or "").strip()
     binding_id = str(
         route_health.get("binding_id")

--- a/trellis/agent/task_run_store.py
+++ b/trellis/agent/task_run_store.py
@@ -756,19 +756,24 @@ def _normalize_binding_health(
     operator_metadata: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Normalize trace health onto binding-first telemetry fields."""
+    from trellis.agent.route_registry import should_surface_route_alias
+
     raw_health = dict(raw_health or {})
     construction_identity = dict(construction_identity or {})
     route_binding_authority = dict(route_binding_authority or {})
     semantic_blueprint = dict(semantic_blueprint or {})
     operator_metadata = dict(operator_metadata or {})
+    authority_route_id = str(route_binding_authority.get("route_id") or "").strip()
+    if authority_route_id and not should_surface_route_alias(route_binding_authority):
+        authority_route_id = ""
     route_id = str(
         raw_health.get("route_id")
-        or route_binding_authority.get("route_id")
+        or authority_route_id
         or semantic_blueprint.get("dsl_route")
         or ""
     ).strip()
-    if not route_id and trace_kind and trace_kind != "platform":
-        route_id = str(trace_action or "").strip()
+    if route_id == "unknown":
+        route_id = ""
     route_family = str(
         raw_health.get("route_family")
         or route_binding_authority.get("route_family")


### PR DESCRIPTION
## Summary
- stop proof telemetry from manufacturing fake or placeholder route ids when binding-first traces intentionally omit a surfaced alias
- preserve blank analytical trace names and normalize `unknown` placeholders away in task-run and diagnosis projections
- update proof/closeout expectations and plan docs, then rerun the affected proof tasks (`T17`, `E27`, `T50`, `E26`)

## Validation
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_task_run_store.py tests/test_agent/test_task_diagnostics.py tests/test_agent/test_analytical_traces.py tests/test_agent/test_binding_first_exotic_proof.py tests/test_agent/test_binding_first_exotic_closeout_runner.py -q`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_binding_first_exotic_proof.py tests/test_agent/test_binding_first_exotic_proof_runner.py tests/test_agent/test_binding_first_exotic_closeout_runner.py tests/test_agent/test_task_run_store.py tests/test_agent/test_task_diagnostics.py tests/test_agent/test_analytical_traces.py -q`
- `/Users/steveyang/miniforge3/bin/python3 -m py_compile trellis/agent/task_run_store.py trellis/agent/task_diagnostics.py trellis/agent/analytical_traces.py trellis/agent/evals.py`
- `/Users/steveyang/miniforge3/bin/python3 scripts/run_binding_first_exotic_proof.py --cohort event_control_schedule --task-id T17 --task-id E27 --output /tmp/qua821_event_results.json --report-json /tmp/qua821_event_report.json --report-md /tmp/qua821_event_report.md`
- `/Users/steveyang/miniforge3/bin/python3 scripts/run_binding_first_exotic_proof.py --cohort basket_credit_loss --task-id T50 --task-id E26 --output /tmp/qua821_basket_results.json --report-json /tmp/qua821_basket_report.json --report-md /tmp/qua821_basket_report.md`

## Evidence
- route-identity alignment now passes on all four rerun tasks
- residual task failures remain under the existing follow-ons (`QUA-817`, `QUA-820`, `QUA-823`)
