### PR TITLE
QUA-820: persist honest-block blocker details

### DIFF
--- a/docs/developer/task_diagnostics.rst
+++ b/docs/developer/task_diagnostics.rst
@@ -167,6 +167,11 @@ for each task:
 - latest diagnosis packet path
 - any follow-on candidate derived from repeated failures
 
+For comparison tasks, method-level blocker reports are now rolled up into the
+top-level task result as well. That keeps blocked comparison runs classified as
+``blocked`` instead of degrading into a generic ``comparison_insufficient_results``
+bucket when every method failed for a typed blocker reason.
+
 Operationally, the batch report is the front door and the per-task dossier is
 the second click. If a stress rerun looks wrong, read the batch report first,
 then open the linked dossier for the specific task instead of starting from the

--- a/docs/plans/binding-first-exotic-assembly.md
+++ b/docs/plans/binding-first-exotic-assembly.md
@@ -187,7 +187,7 @@ Status mirror last synced: `2026-04-13`
 | `QUA-817` | Proof follow-on: callable-bond PDE exact binding or constructive steps (`T17`) | Backlog |
 | `QUA-818` | Proof follow-on: swaption analytical/tree/MC parity drift (`T73`) | Backlog |
 | `QUA-819` | Proof follow-on: cap/floor fresh-build stability and reference-target evidence (`E22`) | Backlog |
-| `QUA-820` | Proof follow-on: structured blocker persistence for honest-block sentinel (`E27`) | Backlog |
+| `QUA-820` | Proof follow-on: structured blocker persistence for honest-block sentinel (`E27`) | Done |
 | `QUA-821` | Proof telemetry: remove residual `unknown` route ids from proof traces (`T17`, `E27`, `T50`, `E26`) | Done |
 | `QUA-809` | Exotic assembly: run the basket-credit-loss proof cohort and split residual gaps | Done |
 | `QUA-822` | Proof follow-on: copula tranche exact-helper contract (`T49`) | Backlog |

--- a/docs/plans/binding-first-exotic-proof-closeout.md
+++ b/docs/plans/binding-first-exotic-proof-closeout.md
@@ -35,7 +35,7 @@ Program totals from `docs/benchmarks/binding_first_exotic_proof_closeout.json`:
 - `10` tasks failed the program gate
 - `10` tasks were expected to be `proved`
 - `1` task was expected to be an `honest_block`
-- `0` honest-block sentinels were certified by the gate
+- `0` honest-block sentinels were certified by the gate in the initial closeout run
 - first-pass success rate: `1 / 11` (`9.1%`)
 - total elapsed time: `1143.1s`
 - total token usage: `883,606`
@@ -56,7 +56,7 @@ The only proved task in the current closeout is:
 | `T17` | failed gate | callable-bond PDE lane lacks exact binding or constructive steps | `QUA-817` |
 | `T73` | failed gate | analytical/tree/MC parity drift | `QUA-818` |
 | `E22` | failed gate | cap/floor fresh-build instability and missing reference-target evidence | `QUA-819` |
-| `E27` | failed gate | honest-block sentinel did not persist typed blocker categories cleanly enough for certification | `QUA-820` |
+| `E27` | follow-on recovered | honest-block sentinel is now certified after structured blocker persistence landed | none |
 | `T49` | failed gate | Student-t tranche lane rebuilt copula plumbing instead of staying on the exact helper contract | `QUA-822` |
 | `T50` | failed gate | nth-to-default helper invocation and basket-credit parsing | `QUA-823` |
 | `E26` | failed gate | basket-credit parsing | `QUA-823` |
@@ -85,7 +85,7 @@ The current measured state is:
 
 - event/control/schedule proof is partial
 - basket/credit/loss proof is largely unrecovered
-- the honest-block sentinel path is not yet certified end to end
+- the honest-block sentinel path was initially uncertified, then recovered by `QUA-820`
 - residual `unknown` route telemetry still appears in the proof runtime
 
 So the architecture migration is meaningfully ahead of the capability proof.

--- a/tests/test_agent/test_executor.py
+++ b/tests/test_agent/test_executor.py
@@ -141,6 +141,118 @@ def test_build_payoff_blocks_on_semantic_clarification(monkeypatch):
         )
 
 
+def test_build_payoff_persists_structured_blockers_when_pre_generation_gate_blocks(monkeypatch):
+    from trellis.agent.executor import build_payoff
+    from trellis.agent.knowledge.schema import BuildGateDecision
+
+    @dataclass
+    class _Blocker:
+        id: str
+        category: str
+        primitive_kind: str
+        severity: str
+        summary: str
+
+    @dataclass
+    class _WorkflowItem:
+        title: str
+
+    @dataclass
+    class _Workflow:
+        summary: str
+        items: tuple[_WorkflowItem, ...]
+
+    @dataclass
+    class _BlockerReport:
+        should_block: bool
+        summary: str
+        blockers: tuple[_Blocker, ...]
+
+    build_meta: dict[str, object] = {}
+    pricing_plan = SimpleNamespace(
+        method="monte_carlo",
+        method_modules=(),
+        required_market_data=set(),
+        model_to_build=None,
+        reasoning="blocked",
+        selection_reason="blocked",
+        assumption_summary=(),
+        sensitivity_support=None,
+    )
+    blocker = _Blocker(
+        id="path_dependent_early_exercise_under_stochastic_vol",
+        category="unsupported_composite",
+        primitive_kind="exercise_control",
+        severity="high",
+        summary="Missing exercise/control primitive for path-dependent early exercise under stochastic volatility.",
+    )
+    generation_plan = SimpleNamespace(
+        method="monte_carlo",
+        instrument_type="barrier_option",
+        primitive_plan=SimpleNamespace(
+            route="exercise_monte_carlo",
+            route_family="monte_carlo",
+            engine_family="monte_carlo",
+            blockers=("path_dependent_early_exercise_under_stochastic_vol",),
+        ),
+        blocker_report=_BlockerReport(
+            should_block=True,
+            summary="Missing exercise/control primitive for path-dependent early exercise under stochastic volatility.",
+            blockers=(blocker,),
+        ),
+        new_primitive_workflow=_Workflow(
+            summary="Implement the missing stochastic-vol exercise primitive.",
+            items=(_WorkflowItem(title="exercise primitive"),),
+        ),
+    )
+    compiled_request = SimpleNamespace(
+        product_ir=SimpleNamespace(instrument="barrier_option"),
+        pricing_plan=pricing_plan,
+        request=SimpleNamespace(request_id="executor_build_blocked_123", request_type="build"),
+        linear_issue_identifier="QUA-820",
+        generation_plan=generation_plan,
+        knowledge_summary={},
+        semantic_blueprint=None,
+    )
+    plan = SimpleNamespace(
+        steps=[SimpleNamespace(module_path="trellis/instruments/_agent/demo.py")],
+        spec_schema=SimpleNamespace(spec_name="DemoSpec", class_name="DemoPayoff", fields=()),
+    )
+
+    monkeypatch.setattr("trellis.agent.executor._record_platform_event", lambda *args, **kwargs: None)
+    monkeypatch.setattr("trellis.agent.planner.plan_build", lambda *args, **kwargs: plan)
+    monkeypatch.setattr("trellis.agent.executor.build_generation_plan", lambda **kwargs: generation_plan)
+    monkeypatch.setattr("trellis.agent.executor._emit_analytical_trace_metadata", lambda **kwargs: None)
+    monkeypatch.setattr(
+        "trellis.agent.build_gate.evaluate_pre_generation_gate",
+        lambda *args, **kwargs: BuildGateDecision(
+            decision="block",
+            reason="Hard blockers detected.",
+            gap_confidence=1.0,
+            gate_source="pre_generation",
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="Build gate blocked pre-generation"):
+        build_payoff(
+            "Blocked build",
+            compiled_request=compiled_request,
+            build_meta=build_meta,
+            market_state=SimpleNamespace(
+                selected_curve_names={},
+                available_capabilities=set(),
+            ),
+            model="gpt-5-mini",
+        )
+
+    blocker_details = build_meta["blocker_details"]
+    assert blocker_details["blocker_codes"] == [
+        "path_dependent_early_exercise_under_stochastic_vol"
+    ]
+    assert blocker_details["blocker_report"]["blockers"][0]["category"] == "unsupported_composite"
+    assert blocker_details["new_primitive_workflow"]["items"][0]["title"] == "exercise primitive"
+
+
 def test_record_lesson_maps_fields_into_canonical_payload(monkeypatch):
     from trellis.agent.test_resolution import Lesson, record_lesson
 

--- a/tests/test_agent/test_task_runtime.py
+++ b/tests/test_agent/test_task_runtime.py
@@ -1570,6 +1570,72 @@ def test_run_task_skips_promotion_candidates_when_cross_validation_fails(monkeyp
     assert result["artifacts"]["promotion_candidate_paths"] == []
 
 
+def test_run_task_aggregates_method_blockers_for_comparison_failures():
+    from trellis.agent.evals import classify_task_result
+    from trellis.agent.task_runtime import run_task
+
+    class FakeResult:
+        def __init__(self, target: str, blocker_details: dict[str, object] | None = None):
+            self.success = False
+            self.attempts = 0
+            self.gap_confidence = 1.0
+            self.knowledge_gaps = []
+            self.payoff_cls = None
+            self.failures = [f"{target} blocked"]
+            self.agent_observations = []
+            self.knowledge_summary = {}
+            self.platform_request_id = f"executor_build_{target}"
+            self.platform_trace_path = f"/tmp/{target}_trace.yaml"
+            self.analytical_trace_path = None
+            self.analytical_trace_text_path = None
+            self.blocker_details = blocker_details
+            self.post_build_tracking = {}
+            self.reflection = {}
+
+    def fake_build(**kwargs):
+        target = kwargs["comparison_target"]
+        if target == "american_pathdep_mc":
+            return FakeResult(
+                target,
+                blocker_details={
+                    "blocker_codes": ["path_dependent_early_exercise_under_stochastic_vol"],
+                    "blocker_report": {
+                        "summary": "Missing stochastic-vol exercise primitive.",
+                        "blockers": [
+                            {
+                                "id": "path_dependent_early_exercise_under_stochastic_vol",
+                                "category": "unsupported_composite",
+                            }
+                        ],
+                    },
+                },
+            )
+        return FakeResult(target)
+
+    result = run_task(
+        {
+            "id": "E27",
+            "title": "American Asian barrier under Heston: PDE vs MC vs FFT should block honestly",
+            "construct": ["pde_solver", "monte_carlo", "fft_pricing"],
+            "cross_validate": {
+                "internal": [
+                    "american_pathdep_pde",
+                    "american_pathdep_mc",
+                    "american_pathdep_fft",
+                ],
+            },
+        },
+        market_state=object(),
+        build_fn=fake_build,
+    )
+
+    assert result["blocker_details"]["method_targets"] == ["american_pathdep_mc"]
+    assert result["blocker_details"]["blocker_report"]["blockers"][0]["category"] == (
+        "unsupported_composite"
+    )
+    assert classify_task_result(result) == "blocked"
+
+
 def test_build_result_payload_includes_blocker_details(tmp_path):
     from trellis.agent.task_runtime import _build_result_payload
 

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -625,6 +625,72 @@ def _semantic_clarification_blocker_details(compiled_request) -> dict[str, objec
     }
 
 
+def _pre_generation_gate_blocker_details(
+    generation_plan,
+    *,
+    gate_decision=None,
+) -> dict[str, object] | None:
+    """Project generation-plan blockers into a persisted structured payload.
+
+    Pre-generation gate blocks happen before the later primitive-blocker branch,
+    so persist the same blocker taxonomy here when it is already available.
+    """
+    from dataclasses import asdict
+
+    details: dict[str, object] = {}
+    primitive_plan = getattr(generation_plan, "primitive_plan", None)
+    raw_blockers = tuple(getattr(primitive_plan, "blockers", ()) or ())
+    if raw_blockers:
+        details["blockers"] = list(raw_blockers)
+
+    blocker_report = getattr(generation_plan, "blocker_report", None)
+    if blocker_report is not None:
+        details["blocker_codes"] = [
+            blocker.id for blocker in getattr(blocker_report, "blockers", ())
+        ]
+        details["blocker_report"] = {
+            "summary": getattr(blocker_report, "summary", ""),
+            "should_block": bool(getattr(blocker_report, "should_block", False)),
+            "blockers": [
+                asdict(blocker)
+                for blocker in getattr(blocker_report, "blockers", ())
+            ],
+        }
+
+    new_primitive_workflow = getattr(generation_plan, "new_primitive_workflow", None)
+    if new_primitive_workflow is not None:
+        details["new_primitive_workflow"] = {
+            "summary": getattr(new_primitive_workflow, "summary", ""),
+            "items": [asdict(item) for item in getattr(new_primitive_workflow, "items", ())],
+        }
+
+    if gate_decision is not None:
+        details["gate_decision"] = asdict(gate_decision)
+        route_admissibility = tuple(
+            getattr(gate_decision, "route_admissibility_failures", ()) or ()
+        )
+        if route_admissibility:
+            details["route_admissibility_failures"] = list(route_admissibility)
+        reason = str(getattr(gate_decision, "reason", "") or "").strip()
+        if reason and "blocker_report" not in details and "route guessing" in reason.lower():
+            details["blocker_codes"] = ["missing_binding_surface:lane_without_exact_binding"]
+            details["blocker_report"] = {
+                "summary": reason,
+                "should_block": True,
+                "blockers": [
+                    {
+                        "id": "missing_binding_surface:lane_without_exact_binding",
+                        "category": "missing_binding_surface",
+                        "primitive_kind": "backend_binding",
+                        "severity": "high",
+                        "summary": reason,
+                    }
+                ],
+            }
+
+    return details or None
+
+
 # ---------------------------------------------------------------------------
 # Audit record writer (non-blocking helper called at build success)
 # ---------------------------------------------------------------------------
@@ -1124,12 +1190,21 @@ def build_payoff(
         from dataclasses import asdict as _gate_asdict
         build_meta["build_gate_decision"] = _gate_asdict(_pre_gen_gate)
     if _pre_gen_gate.decision == "block":
+        blocker_details = _pre_generation_gate_blocker_details(
+            generation_plan,
+            gate_decision=_pre_gen_gate,
+        )
+        if build_meta is not None and blocker_details is not None:
+            build_meta["blocker_details"] = blocker_details
         _record_platform_event(
             compiled_request,
             "build_gate_blocked",
             status="error",
             success=False,
-            details={"gate_decision": _pre_gen_gate.decision, "reason": _pre_gen_gate.reason},
+            details=blocker_details or {
+                "gate_decision": _pre_gen_gate.decision,
+                "reason": _pre_gen_gate.reason,
+            },
         )
         raise RuntimeError(
             f"Build gate blocked pre-generation: {_pre_gen_gate.reason}"

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -7,7 +7,7 @@ import json
 import subprocess
 import textwrap
 import time
-from dataclasses import asdict, dataclass, replace as replace_dataclass
+from dataclasses import asdict, dataclass, is_dataclass, replace as replace_dataclass
 from datetime import date, datetime
 from pathlib import Path
 from typing import Any, Callable, Mapping
@@ -39,6 +39,7 @@ from trellis.agent.knowledge.api_map import format_api_map_for_prompt
 
 # Sentinel in the skeleton that gets replaced by the LLM-generated body.
 EVALUATE_SENTINEL = '        raise NotImplementedError("evaluate not yet implemented")'
+_ROUTE_GUESSING_BLOCKER_REASON = "route guessing"
 
 _REPO_REVISION: str | None = None
 
@@ -635,9 +636,17 @@ def _pre_generation_gate_blocker_details(
     Pre-generation gate blocks happen before the later primitive-blocker branch,
     so persist the same blocker taxonomy here when it is already available.
     """
-    from dataclasses import asdict
-
     details: dict[str, object] = {}
+
+    def _serialize_structured_entry(entry: object) -> dict[str, object]:
+        if is_dataclass(entry):
+            return asdict(entry)
+        if isinstance(entry, Mapping):
+            return dict(entry)
+        if hasattr(entry, "__dict__"):
+            return dict(vars(entry))
+        raise TypeError(f"Unsupported structured blocker entry: {type(entry)!r}")
+
     primitive_plan = getattr(generation_plan, "primitive_plan", None)
     raw_blockers = tuple(getattr(primitive_plan, "blockers", ()) or ())
     if raw_blockers:
@@ -652,7 +661,7 @@ def _pre_generation_gate_blocker_details(
             "summary": getattr(blocker_report, "summary", ""),
             "should_block": bool(getattr(blocker_report, "should_block", False)),
             "blockers": [
-                asdict(blocker)
+                _serialize_structured_entry(blocker)
                 for blocker in getattr(blocker_report, "blockers", ())
             ],
         }
@@ -661,7 +670,10 @@ def _pre_generation_gate_blocker_details(
     if new_primitive_workflow is not None:
         details["new_primitive_workflow"] = {
             "summary": getattr(new_primitive_workflow, "summary", ""),
-            "items": [asdict(item) for item in getattr(new_primitive_workflow, "items", ())],
+            "items": [
+                _serialize_structured_entry(item)
+                for item in getattr(new_primitive_workflow, "items", ())
+            ],
         }
 
     if gate_decision is not None:
@@ -672,7 +684,11 @@ def _pre_generation_gate_blocker_details(
         if route_admissibility:
             details["route_admissibility_failures"] = list(route_admissibility)
         reason = str(getattr(gate_decision, "reason", "") or "").strip()
-        if reason and "blocker_report" not in details and "route guessing" in reason.lower():
+        if (
+            reason
+            and "blocker_report" not in details
+            and _ROUTE_GUESSING_BLOCKER_REASON in reason.lower()
+        ):
             details["blocker_codes"] = ["missing_binding_surface:lane_without_exact_binding"]
             details["blocker_report"] = {
                 "summary": reason,

--- a/trellis/agent/task_runtime.py
+++ b/trellis/agent/task_runtime.py
@@ -1125,6 +1125,9 @@ def run_task(
                 "reflection": reflection_payload,
                 "cross_validation": cross_validation,
             })
+            aggregated_blockers = _aggregate_blocker_details(method_results)
+            if aggregated_blockers is not None:
+                result_data["blocker_details"] = aggregated_blockers
             result_data["learning"] = summarize_task_learning(
                 result_data,
                 task_kind="pricing",
@@ -1573,6 +1576,92 @@ def _aggregate_artifacts(method_payloads: dict[str, dict[str, Any]]) -> dict[str
             for payload in method_payloads.values()
         ),
     }
+
+
+def _aggregate_blocker_details(
+    method_payloads: dict[str, dict[str, Any]],
+) -> dict[str, Any] | None:
+    """Merge structured blocker details across comparison-target builds."""
+    method_targets: list[str] = []
+    blocker_codes: list[str] = []
+    raw_blockers: list[str] = []
+    report_summaries: list[str] = []
+    report_blockers: list[dict[str, Any]] = []
+    seen_report_blockers: set[str] = set()
+    workflow_summaries: list[str] = []
+    workflow_items: list[dict[str, Any]] = []
+    seen_workflow_items: set[str] = set()
+    reasons: list[str] = []
+
+    for method, payload in method_payloads.items():
+        details = payload.get("blocker_details")
+        if not isinstance(details, Mapping) or not details:
+            continue
+        method_targets.append(str(method))
+        blocker_codes.extend(
+            str(code).strip()
+            for code in (details.get("blocker_codes") or ())
+            if str(code).strip()
+        )
+        raw_blockers.extend(
+            str(blocker).strip()
+            for blocker in (details.get("blockers") or ())
+            if str(blocker).strip()
+        )
+        blocker_report = details.get("blocker_report") or {}
+        summary = str(blocker_report.get("summary") or "").strip()
+        if summary:
+            report_summaries.append(summary)
+        for blocker in blocker_report.get("blockers") or ():
+            if not isinstance(blocker, Mapping):
+                continue
+            normalized = dict(blocker)
+            dedupe_key = json.dumps(normalized, sort_keys=True, default=str)
+            if dedupe_key in seen_report_blockers:
+                continue
+            seen_report_blockers.add(dedupe_key)
+            report_blockers.append(normalized)
+        workflow = details.get("new_primitive_workflow") or {}
+        workflow_summary = str(workflow.get("summary") or "").strip()
+        if workflow_summary:
+            workflow_summaries.append(workflow_summary)
+        for item in workflow.get("items") or ():
+            if not isinstance(item, Mapping):
+                continue
+            normalized = dict(item)
+            dedupe_key = json.dumps(normalized, sort_keys=True, default=str)
+            if dedupe_key in seen_workflow_items:
+                continue
+            seen_workflow_items.add(dedupe_key)
+            workflow_items.append(normalized)
+        reason = str(details.get("reason") or "").strip()
+        if reason:
+            reasons.append(reason)
+
+    if not method_targets:
+        return None
+
+    aggregated: dict[str, Any] = {
+        "method_targets": sorted(set(method_targets)),
+    }
+    if blocker_codes:
+        aggregated["blocker_codes"] = _unique_strings(blocker_codes)
+    if raw_blockers:
+        aggregated["blockers"] = _unique_strings(raw_blockers)
+    if report_blockers:
+        aggregated["blocker_report"] = {
+            "summary": "; ".join(_unique_strings(report_summaries)),
+            "should_block": True,
+            "blockers": report_blockers,
+        }
+    if workflow_items:
+        aggregated["new_primitive_workflow"] = {
+            "summary": "; ".join(_unique_strings(workflow_summaries)),
+            "items": workflow_items,
+        }
+    if reasons:
+        aggregated["reasons"] = _unique_strings(reasons)
+    return aggregated
 
 
 def _write_benchmark_sidecars(


### PR DESCRIPTION
## Summary
- persist structured blocker details for pre-generation gate blocks in the executor
- roll method-level blocker details up to comparison-task results so blocked comparison runs classify as blocked
- add executor/runtime regressions and sync the proof/diagnostic docs

## Validation
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_executor.py tests/test_agent/test_task_runtime.py tests/test_agent/test_binding_first_exotic_proof.py tests/test_agent/test_binding_first_exotic_proof_runner.py tests/test_agent/test_evals.py -q
- /Users/steveyang/miniforge3/bin/python3 scripts/run_binding_first_exotic_proof.py --task-id E27 --output /tmp/qua820_e27_results_after_fix.json --report-json /tmp/qua820_e27_report_after_fix.json --report-md /tmp/qua820_e27_report_after_fix.md