### PR TITLE
QUA-825: stabilize basket proof bindings

### DIFF
--- a/scripts/run_binding_first_exotic_proof.py
+++ b/scripts/run_binding_first_exotic_proof.py
@@ -13,6 +13,7 @@ import argparse
 import json
 import os
 import sys
+from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 
@@ -34,6 +35,30 @@ from trellis.agent.task_runtime import load_tasks, run_task
 from trellis.cli_paths import resolve_repo_path
 
 load_env()
+
+
+@contextmanager
+def _frozen_proof_learning_surface():
+    """Freeze post-build learning while evaluating the proof cohort.
+
+    Proof runs should measure the current binding/runtime surface, not mutate it
+    mid-cohort through reflection or consolidation side effects.
+    """
+    keys = (
+        "TRELLIS_SKIP_POST_BUILD_REFLECTION",
+        "TRELLIS_SKIP_POST_BUILD_CONSOLIDATION",
+    )
+    previous = {key: os.environ.get(key) for key in keys}
+    try:
+        os.environ["TRELLIS_SKIP_POST_BUILD_REFLECTION"] = "1"
+        os.environ["TRELLIS_SKIP_POST_BUILD_CONSOLIDATION"] = "1"
+        yield
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
 
 
 def _parse_args(argv: list[str]) -> argparse.Namespace:
@@ -170,23 +195,24 @@ def run_binding_first_exotic_proof(
 
     results = []
     market_state = None
-    for task_id in ordered_task_ids:
-        task = tasks[task_id]
-        print(f"{task_id}: {task['title']}", flush=True)
-        if market_state is None:
-            from trellis.agent.task_runtime import build_market_state
+    with _frozen_proof_learning_surface():
+        for task_id in ordered_task_ids:
+            task = tasks[task_id]
+            print(f"{task_id}: {task['title']}", flush=True)
+            if market_state is None:
+                from trellis.agent.task_runtime import build_market_state
 
-            market_state = build_market_state()
-        result = run_task(
-            task,
-            market_state,
-            model=effective_model,
-            force_rebuild=fresh_build,
-            fresh_build=fresh_build,
-            validation=validation,
-        )
-        results.append(result)
-        output_path.write_text(json.dumps(results, indent=2, default=str))
+                market_state = build_market_state()
+            result = run_task(
+                task,
+                market_state,
+                model=effective_model,
+                force_rebuild=fresh_build,
+                fresh_build=fresh_build,
+                validation=validation,
+            )
+            results.append(result)
+            output_path.write_text(json.dumps(results, indent=2, default=str))
 
     proof_summary = summarize_binding_first_exotic_proof(
         tasks,

--- a/tests/test_agent/test_autonomous.py
+++ b/tests/test_agent/test_autonomous.py
@@ -169,6 +169,73 @@ def test_build_with_knowledge_forwards_request_metadata(monkeypatch):
     }
 
 
+def test_build_with_knowledge_resets_deterministic_planning_caches(monkeypatch):
+    from trellis.agent.knowledge.gap_check import GapReport
+    from trellis.agent.knowledge.schema import ProductDecomposition
+    from trellis.agent.knowledge.autonomous import build_with_knowledge
+    decompose_mod = import_module("trellis.agent.knowledge.decompose")
+
+    decomposition = ProductDecomposition(
+        instrument="basket_option",
+        features=("vanilla",),
+        method="fft_pricing",
+        learned=False,
+    )
+    observed: dict[str, object] = {"cache_reset_calls": 0}
+
+    monkeypatch.setattr(decompose_mod, "decompose", lambda *args, **kwargs: decomposition)
+    monkeypatch.setattr(
+        decompose_mod,
+        "decompose_to_ir",
+        lambda *args, **kwargs: SimpleNamespace(instrument="basket_option"),
+    )
+    monkeypatch.setattr(
+        "trellis.agent.knowledge.gap_check.gap_check",
+        lambda decomposition: GapReport(confidence=0.8, retrieved_lesson_ids=[]),
+    )
+    monkeypatch.setattr(
+        "trellis.agent.knowledge.autonomous._reset_deterministic_planning_caches",
+        lambda: observed.__setitem__(
+            "cache_reset_calls",
+            int(observed["cache_reset_calls"]) + 1,
+        ),
+    )
+    monkeypatch.setattr(
+        "trellis.agent.knowledge.reflect.reflect_on_build",
+        lambda **kwargs: {},
+    )
+
+    def fake_build_payoff(*args, **kwargs):
+        return type("FakeBasketPayoff", (), {})
+
+    monkeypatch.setattr("trellis.agent.executor.build_payoff", fake_build_payoff)
+    monkeypatch.setattr(
+        "trellis.agent.knowledge.retrieve_for_product_ir",
+        lambda *args, **kwargs: [],
+    )
+    monkeypatch.setattr(
+        "trellis.agent.knowledge.build_shared_knowledge_payload",
+        lambda knowledge: {
+            "summary": {},
+            "builder_text_distilled": "",
+            "builder_text": "",
+            "builder_text_expanded": "",
+            "review_text_distilled": "",
+            "review_text_expanded": "",
+        },
+    )
+
+    result = build_with_knowledge(
+        "Spread option (Kirk approximation) vs 2D MC vs 2D FFT",
+        instrument_type="basket_option",
+        preferred_method="fft_pricing",
+        comparison_target="fft_spread_2d",
+    )
+
+    assert result.success is True
+    assert observed["cache_reset_calls"] == 1
+
+
 def test_build_with_knowledge_preserves_platform_trace_metadata_on_failure(monkeypatch):
     from trellis.agent.knowledge.gap_check import GapReport
     from trellis.agent.knowledge.schema import ProductDecomposition

--- a/tests/test_agent/test_backend_bindings.py
+++ b/tests/test_agent/test_backend_bindings.py
@@ -156,7 +156,7 @@ def test_resolve_backend_binding_spec_uses_basket_option_exact_helpers():
     product_ir = ProductIR(
         instrument="basket_option",
         payoff_family="basket_option",
-        payoff_traits=("vanilla_option",),
+        payoff_traits=("two_asset_terminal_basket", "vanilla_option"),
         exercise_style="european",
         state_dependence="terminal_markov",
         model_family="equity_diffusion",
@@ -177,6 +177,34 @@ def test_resolve_backend_binding_spec_uses_basket_option_exact_helpers():
         "trellis.models.basket_option.price_basket_option_monte_carlo",
     )
     assert transform_resolved.helper_refs == (
+        "trellis.models.basket_option.price_basket_option_transform_proxy",
+    )
+
+
+def test_resolve_backend_binding_spec_keeps_generic_multi_asset_baskets_off_two_asset_exact_helpers():
+    catalog = load_backend_binding_catalog()
+    analytical = find_backend_binding_by_route_id("analytical_black76", catalog)
+    transform = find_backend_binding_by_route_id("transform_fft", catalog)
+
+    product_ir = ProductIR(
+        instrument="basket_option",
+        payoff_family="basket_option",
+        payoff_traits=("vanilla_option",),
+        exercise_style="european",
+        state_dependence="terminal_markov",
+        model_family="equity_diffusion",
+    )
+
+    assert analytical is not None
+    assert transform is not None
+
+    analytical_resolved = resolve_backend_binding_spec(analytical, product_ir=product_ir)
+    transform_resolved = resolve_backend_binding_spec(transform, product_ir=product_ir)
+
+    assert analytical_resolved.helper_refs != (
+        "trellis.models.basket_option.price_basket_option_analytical",
+    )
+    assert transform_resolved.helper_refs != (
         "trellis.models.basket_option.price_basket_option_transform_proxy",
     )
 

--- a/tests/test_agent/test_backend_bindings.py
+++ b/tests/test_agent/test_backend_bindings.py
@@ -147,6 +147,40 @@ def test_resolve_backend_binding_spec_uses_route_conditionals_for_exact_targets(
     )
 
 
+def test_resolve_backend_binding_spec_uses_basket_option_exact_helpers():
+    catalog = load_backend_binding_catalog()
+    analytical = find_backend_binding_by_route_id("analytical_black76", catalog)
+    monte_carlo = find_backend_binding_by_route_id("monte_carlo_paths", catalog)
+    transform = find_backend_binding_by_route_id("transform_fft", catalog)
+
+    product_ir = ProductIR(
+        instrument="basket_option",
+        payoff_family="basket_option",
+        payoff_traits=("vanilla_option",),
+        exercise_style="european",
+        state_dependence="terminal_markov",
+        model_family="equity_diffusion",
+    )
+
+    assert analytical is not None
+    assert monte_carlo is not None
+    assert transform is not None
+
+    analytical_resolved = resolve_backend_binding_spec(analytical, product_ir=product_ir)
+    monte_carlo_resolved = resolve_backend_binding_spec(monte_carlo, product_ir=product_ir)
+    transform_resolved = resolve_backend_binding_spec(transform, product_ir=product_ir)
+
+    assert analytical_resolved.helper_refs == (
+        "trellis.models.basket_option.price_basket_option_analytical",
+    )
+    assert monte_carlo_resolved.helper_refs == (
+        "trellis.models.basket_option.price_basket_option_monte_carlo",
+    )
+    assert transform_resolved.helper_refs == (
+        "trellis.models.basket_option.price_basket_option_transform_proxy",
+    )
+
+
 def test_nth_to_default_binding_has_no_schedule_builder_surface():
     catalog = load_backend_binding_catalog()
     binding = find_backend_binding_by_route_id("nth_to_default_monte_carlo", catalog)

--- a/tests/test_agent/test_binding_first_exotic_proof_runner.py
+++ b/tests/test_agent/test_binding_first_exotic_proof_runner.py
@@ -237,3 +237,79 @@ def test_run_binding_first_exotic_proof_rejects_unknown_selected_task_ids(tmp_pa
     )
 
     assert exit_code == 1
+
+
+def test_run_binding_first_exotic_proof_freezes_post_build_learning_surface(tmp_path, monkeypatch):
+    module = _load_module()
+
+    manifest = {
+        "T105": {
+            "cohort": "event_control_schedule",
+            "outcome_class": "proved",
+            "required_mock_capabilities": [],
+            "comparison_targets": [],
+        }
+    }
+    tasks = {
+        "T105": {
+            "id": "T105",
+            "title": "Quanto option: quanto-adjusted BS vs MC cross-currency",
+            "cross_validate": {"internal": []},
+            "market_assertions": {"requires": []},
+        }
+    }
+    observed_env: list[tuple[str | None, str | None]] = []
+
+    monkeypatch.setattr(module, "load_binding_first_exotic_proof_manifest", lambda: manifest)
+    monkeypatch.setattr(module, "_load_selected_tasks", lambda task_ids: {task_id: tasks[task_id] for task_id in task_ids})
+    monkeypatch.setattr(
+        module,
+        "grade_binding_first_exotic_proof_preflight",
+        lambda *args, **kwargs: {
+            "task_contract_alignment": SimpleNamespace(passed=True, details=()),
+            "market_capability_alignment": SimpleNamespace(passed=True, details=()),
+            "comparison_target_inventory": SimpleNamespace(passed=True, details=()),
+            "comparison_target_separation": SimpleNamespace(passed=True, details=()),
+        },
+    )
+
+    monkeypatch.setenv("TRELLIS_SKIP_POST_BUILD_REFLECTION", "0")
+    monkeypatch.delenv("TRELLIS_SKIP_POST_BUILD_CONSOLIDATION", raising=False)
+
+    def _fake_run_task(*args, **kwargs):
+        import os
+
+        observed_env.append(
+            (
+                os.environ.get("TRELLIS_SKIP_POST_BUILD_REFLECTION"),
+                os.environ.get("TRELLIS_SKIP_POST_BUILD_CONSOLIDATION"),
+            )
+        )
+        return {
+            "task_id": "T105",
+            "success": True,
+            "attempts": 1,
+            "elapsed_seconds": 1.0,
+            "cross_validation": {"status": "passed"},
+            "token_usage_summary": {"total_tokens": 1, "call_count": 1},
+        }
+
+    monkeypatch.setattr(module, "run_task", _fake_run_task)
+
+    exit_code = module.run_binding_first_exotic_proof(
+        cohort="event_control_schedule",
+        task_ids=[],
+        model="test-model",
+        validation="standard",
+        fresh_build=True,
+        preflight_only=False,
+        output_path=tmp_path / "proof_results.json",
+        report_json_path=tmp_path / "proof_report.json",
+        report_md_path=tmp_path / "proof_report.md",
+    )
+
+    assert exit_code == 1
+    assert observed_env == [("1", "1")]
+    import os
+    assert os.environ.get("TRELLIS_SKIP_POST_BUILD_REFLECTION") == "0"
+    assert os.environ.get("TRELLIS_SKIP_POST_BUILD_CONSOLIDATION") is None

--- a/tests/test_agent/test_executor.py
+++ b/tests/test_agent/test_executor.py
@@ -915,6 +915,59 @@ def test_deterministic_exact_binding_module_threads_explicit_swaption_comparison
         assert f"{expected_call}(market_state, spec, mean_reversion=0.05, sigma=0.01)" in generated.code
 
 
+@pytest.mark.parametrize(
+    ("helper_ref", "comparison_target", "expected_call"),
+    [
+        (
+            "trellis.models.basket_option.price_basket_option_analytical",
+            "stulz_rainbow",
+            'price_basket_option_analytical(market_state, spec, comparison_target="stulz_rainbow")',
+        ),
+        (
+            "trellis.models.basket_option.price_basket_option_monte_carlo",
+            "mc_spread_2d",
+            'price_basket_option_monte_carlo(market_state, spec, comparison_target="mc_spread_2d", seed=42)',
+        ),
+        (
+            "trellis.models.basket_option.price_basket_option_transform_proxy",
+            "fft_spread_2d",
+            'price_basket_option_transform_proxy(market_state, spec, comparison_target="fft_spread_2d")',
+        ),
+    ],
+)
+def test_deterministic_exact_binding_module_materializes_typed_basket_helpers(
+    helper_ref,
+    comparison_target,
+    expected_call,
+):
+    from trellis.agent.executor import (
+        _generate_skeleton,
+        _materialize_deterministic_exact_binding_module,
+    )
+    from trellis.agent.planner import STATIC_SPECS
+
+    generation_plan = SimpleNamespace(
+        lane_exact_binding_refs=(helper_ref,),
+        primitive_plan=None,
+        method="analytical",
+        instrument_type="basket_option",
+    )
+    skeleton = _generate_skeleton(
+        STATIC_SPECS["basket_option"],
+        "Generic basket option",
+        generation_plan=generation_plan,
+    )
+
+    generated = _materialize_deterministic_exact_binding_module(
+        skeleton,
+        generation_plan,
+        comparison_target=comparison_target,
+    )
+
+    assert generated is not None
+    assert expected_call in generated.code
+
+
 def test_extract_instrument_type_uses_shared_lower_layer_mapping():
     from trellis.agent.executor import _extract_instrument_type
 

--- a/tests/test_agent/test_family_lowering_ir.py
+++ b/tests/test_agent/test_family_lowering_ir.py
@@ -397,6 +397,36 @@ def test_vanilla_option_transform_compiles_to_bounded_transform_family_ir():
     assert unsupported_family_ir is None
 
 
+def test_transform_lane_accepts_exact_basket_transform_helper():
+    from trellis.agent.family_lowering_ir import (
+        _binding_supports_transform_pricing,
+        _transform_helper_symbol_for_product,
+        TransformCharacteristicSpec,
+    )
+    from types import SimpleNamespace
+
+    binding_spec = _resolved_binding_spec(
+        PrimitiveRef(
+            module="trellis.models.basket_option",
+            symbol="price_basket_option_transform_proxy",
+            role="route_helper",
+            required=True,
+        ),
+        route_id="transform_fft",
+        route_family="fft_pricing",
+        engine_family="fft_pricing",
+    )
+
+    assert _binding_supports_transform_pricing(
+        binding_spec,
+        route_id="transform_fft",
+    )
+    assert _transform_helper_symbol_for_product(
+        SimpleNamespace(payoff_family="basket_option"),
+        TransformCharacteristicSpec(model_family="equity_diffusion"),
+    ) == "price_basket_option_transform_proxy"
+
+
 def test_callable_bond_compiles_to_exercise_lattice_family_ir():
     from trellis.agent.semantic_contract_compiler import compile_semantic_contract
     from trellis.agent.semantic_contracts import make_callable_bond_contract

--- a/tests/test_agent/test_platform_requests.py
+++ b/tests/test_agent/test_platform_requests.py
@@ -811,6 +811,19 @@ def test_compile_build_request_keeps_generic_basket_option_off_ranked_observatio
     assert compiled.generation_plan.primitive_plan.route == "monte_carlo_paths"
 
 
+def test_compile_build_request_marks_two_asset_terminal_baskets_for_exact_helper_binding():
+    from trellis.agent.platform_requests import compile_build_request
+
+    compiled = compile_build_request(
+        "Spread option (Kirk approximation) vs 2D MC vs 2D FFT",
+        instrument_type="basket_option",
+        preferred_method="analytical",
+    )
+
+    assert compiled.product_ir is not None
+    assert "two_asset_terminal_basket" in compiled.product_ir.payoff_traits
+
+
 def test_novel_request_persists_semantic_extension_trace(monkeypatch, tmp_path):
     from trellis.agent.platform_requests import compile_build_request
     import trellis.agent.knowledge.promotion as promotion_mod

--- a/tests/test_agent/test_task_runtime.py
+++ b/tests/test_agent/test_task_runtime.py
@@ -2674,6 +2674,70 @@ def test_make_test_payoff_uses_basket_specific_schedule_defaults(monkeypatch):
     assert payoff.spec.kwargs["expiry_date"] == date(2025, 11, 15)
 
 
+def test_make_test_payoff_uses_typed_multi_underlier_defaults_for_basket_options(monkeypatch):
+    """Generic basket smoke tests should get valid multi-underlier defaults."""
+    from trellis.agent.task_runtime import _make_test_payoff
+
+    class BasketSpec:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    module_name = "dummy_generic_basket_adapter"
+    module = ModuleType(module_name)
+    module.BasketOptionSpec = BasketSpec
+    monkeypatch.setitem(sys.modules, module_name, module)
+
+    RainbowBasketPayoff = type(
+        "RainbowBasketPayoff",
+        (),
+        {
+            "__doc__": "Rainbow option (best-of-two): Stulz formula vs MC",
+            "__init__": lambda self, spec: setattr(self, "spec", spec),
+            "__module__": module_name,
+        },
+    )
+    SpreadBasketPayoff = type(
+        "SpreadBasketPayoff",
+        (),
+        {
+            "__doc__": "Spread option (Kirk approximation) vs 2D MC vs 2D FFT",
+            "__init__": lambda self, spec: setattr(self, "spec", spec),
+            "__module__": module_name,
+        },
+    )
+
+    spec_schema = SimpleNamespace(
+        spec_name="BasketOptionSpec",
+        fields=[
+            SimpleNamespace(name="underliers", type="str", default=None),
+            SimpleNamespace(name="spots", type="str", default=None),
+            SimpleNamespace(name="correlation", type="str", default=None),
+            SimpleNamespace(name="weights", type="str | None", default=None),
+            SimpleNamespace(name="vols", type="str | None", default=None),
+            SimpleNamespace(name="basket_style", type="str", default=None),
+            SimpleNamespace(name="strike", type="float", default=None),
+            SimpleNamespace(name="expiry_date", type="date", default=None),
+            SimpleNamespace(name="notional", type="float", default=None),
+        ],
+    )
+
+    rainbow = _make_test_payoff(RainbowBasketPayoff, spec_schema, date(2024, 11, 15))
+    spread = _make_test_payoff(SpreadBasketPayoff, spec_schema, date(2024, 11, 15))
+
+    assert rainbow.spec.kwargs["underliers"] == "SPX,NDX"
+    assert rainbow.spec.kwargs["spots"] == "100.0,95.0"
+    assert rainbow.spec.kwargs["correlation"] == "1.0,0.35;0.35,1.0"
+    assert rainbow.spec.kwargs["basket_style"] == "best_of"
+    assert rainbow.spec.kwargs["weights"] is None
+    assert rainbow.spec.kwargs["vols"] is None
+    assert rainbow.spec.kwargs["strike"] == pytest.approx(100.0)
+
+    assert spread.spec.kwargs["basket_style"] == "spread"
+    assert spread.spec.kwargs["weights"] == "1.0,-1.0"
+    assert spread.spec.kwargs["vols"] is None
+    assert spread.spec.kwargs["strike"] == pytest.approx(5.0)
+
+
 def test_make_test_payoff_uses_atm_strike_for_spot_based_options(monkeypatch):
     """Spot-based option smoke tests should default to an at-the-money strike."""
     from trellis.agent.task_runtime import _make_test_payoff

--- a/tests/test_models/test_basket_option.py
+++ b/tests/test_models/test_basket_option.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from datetime import date
+from dataclasses import replace
+
+import pytest
+
+from trellis.core.market_state import MarketState
+from trellis.core.runtime_contract import wrap_market_state_with_contract
+from trellis.curves.yield_curve import YieldCurve
+from trellis.models.vol_surface import FlatVol
+
+
+SETTLE = date(2024, 11, 15)
+
+
+def _market_state() -> MarketState:
+    return MarketState(
+        as_of=SETTLE,
+        settlement=SETTLE,
+        discount=YieldCurve.flat(0.05),
+        spot=100.0,
+        underlier_spots={"SPX": 100.0, "NDX": 95.0},
+        vol_surface=FlatVol(0.20),
+        local_vol_surface=lambda spot, time: 0.01,
+        local_vol_surfaces={"spx_local_vol": lambda spot, time: 0.01},
+        model_parameters={"correlation_matrix": ((1.0, 0.35), (0.35, 1.0))},
+    )
+
+
+class _BestOfSpec:
+    notional = 100.0
+    underliers = "SPX,NDX"
+    spots = "100.0,95.0"
+    strike = 100.0
+    expiry_date = date(2025, 11, 15)
+    correlation = "1.0,0.35;0.35,1.0"
+    weights = None
+    vols = None
+    dividend_yields = None
+    basket_style = "best_of"
+    option_type = "call"
+    day_count = None
+    n_paths = 40_000
+
+
+class _SpreadSpec:
+    notional = 100.0
+    underliers = "SPX,NDX"
+    spots = "100.0,95.0"
+    strike = 5.0
+    expiry_date = date(2025, 11, 15)
+    correlation = "1.0,0.35;0.35,1.0"
+    weights = "1.0,-1.0"
+    vols = None
+    dividend_yields = None
+    basket_style = "spread"
+    option_type = "call"
+    day_count = None
+    n_paths = 40_000
+
+
+def test_resolve_basket_option_inputs_parses_underliers_and_explicit_correlation():
+    from trellis.models.basket_option import resolve_basket_option_inputs
+
+    resolved = resolve_basket_option_inputs(_market_state(), _SpreadSpec())
+
+    assert resolved.semantics.constituent_names == ("SPX", "NDX")
+    assert resolved.semantics.constituent_spots == pytest.approx((100.0, 95.0))
+    assert resolved.correlation_matrix[0] == pytest.approx((1.0, 0.35))
+    assert resolved.correlation_matrix[1] == pytest.approx((0.35, 1.0))
+    assert resolved.weights == pytest.approx((1.0, -1.0))
+    assert resolved.basket_style == "spread"
+
+
+def test_resolve_basket_option_inputs_accepts_runtime_contract_proxy():
+    from trellis.models.basket_option import resolve_basket_option_inputs
+
+    proxied_market_state = wrap_market_state_with_contract(
+        _market_state(),
+        requirements={"discount_curve", "spot", "vol_surface"},
+        context="BasketOptionPayoff",
+    )
+
+    resolved = resolve_basket_option_inputs(
+        proxied_market_state,
+        _SpreadSpec(),
+        comparison_target="kirk_spread",
+    )
+
+    assert resolved.correlation_matrix[0] == pytest.approx((1.0, 0.35))
+    assert resolved.correlation_matrix[1] == pytest.approx((0.35, 1.0))
+
+
+def test_basket_option_helpers_keep_best_of_analytical_and_mc_within_tolerance():
+    from trellis.models.basket_option import (
+        price_basket_option_analytical,
+        price_basket_option_monte_carlo,
+    )
+
+    market_state = _market_state()
+    analytical = price_basket_option_analytical(
+        market_state,
+        _BestOfSpec(),
+        comparison_target="stulz_rainbow",
+    )
+    monte_carlo = price_basket_option_monte_carlo(
+        market_state,
+        _BestOfSpec(),
+        comparison_target="mc_rainbow",
+        n_paths=20_000,
+        seed=42,
+    )
+
+    assert analytical > 0.0
+    assert monte_carlo > 0.0
+    assert monte_carlo == pytest.approx(analytical, rel=0.12)
+
+
+def test_spread_transform_proxy_matches_stabilized_analytical_kernel():
+    from trellis.models.basket_option import (
+        price_basket_option_analytical,
+        price_basket_option_transform_proxy,
+    )
+
+    market_state = _market_state()
+    analytical = price_basket_option_analytical(
+        market_state,
+        _SpreadSpec(),
+        comparison_target="kirk_spread",
+    )
+    transform = price_basket_option_transform_proxy(
+        market_state,
+        _SpreadSpec(),
+        comparison_target="fft_spread_2d",
+    )
+
+    assert transform == pytest.approx(analytical, rel=1e-12)
+
+
+def test_basket_option_helpers_prefer_explicit_vol_surface_over_local_vol_overlay():
+    from trellis.models.basket_option import price_basket_option_analytical
+
+    market_state = _market_state()
+    low_vol = price_basket_option_analytical(
+        replace(market_state, vol_surface=FlatVol(0.05)),
+        _SpreadSpec(),
+        comparison_target="kirk_spread",
+    )
+    high_vol = price_basket_option_analytical(
+        replace(market_state, vol_surface=FlatVol(0.40)),
+        _SpreadSpec(),
+        comparison_target="kirk_spread",
+    )
+
+    assert high_vol > low_vol

--- a/tests/test_models/test_basket_option.py
+++ b/tests/test_models/test_basket_option.py
@@ -60,6 +60,10 @@ class _SpreadSpec:
     n_paths = 40_000
 
 
+class _WeightedSpreadSpec(_SpreadSpec):
+    weights = "2.0,-1.0"
+
+
 def test_resolve_basket_option_inputs_parses_underliers_and_explicit_correlation():
     from trellis.models.basket_option import resolve_basket_option_inputs
 
@@ -136,6 +140,31 @@ def test_spread_transform_proxy_matches_stabilized_analytical_kernel():
     )
 
     assert transform == pytest.approx(analytical, rel=1e-12)
+
+
+def test_weighted_spread_kirk_tracks_monte_carlo():
+    from trellis.models.basket_option import (
+        price_basket_option_analytical,
+        price_basket_option_monte_carlo,
+    )
+
+    market_state = _market_state()
+    analytical = price_basket_option_analytical(
+        market_state,
+        _WeightedSpreadSpec(),
+        comparison_target="kirk_spread",
+    )
+    monte_carlo = price_basket_option_monte_carlo(
+        market_state,
+        _WeightedSpreadSpec(),
+        comparison_target="mc_spread_2d",
+        n_paths=24_000,
+        seed=42,
+    )
+
+    assert analytical > 0.0
+    assert monte_carlo > 0.0
+    assert monte_carlo == pytest.approx(analytical, rel=0.15)
 
 
 def test_basket_option_helpers_prefer_explicit_vol_surface_over_local_vol_overlay():

--- a/trellis/agent/backend_bindings.py
+++ b/trellis/agent/backend_bindings.py
@@ -489,12 +489,24 @@ def _matches_condition(
     product_ir: ProductIR | None,
 ) -> bool:
     payoff_families = _expanded_payoff_families(payoff_family, product_ir)
+    payoff_traits = {
+        str(item).strip().lower()
+        for item in getattr(product_ir, "payoff_traits", ()) or ()
+    }
     for key, expected in when.items():
         if key == "payoff_family":
             if isinstance(expected, list):
                 if not any(candidate in payoff_families for candidate in expected):
                     return False
             elif expected not in payoff_families:
+                return False
+        elif key == "payoff_traits":
+            expected_traits = (
+                {str(item).strip().lower() for item in expected}
+                if isinstance(expected, list)
+                else {str(expected).strip().lower()}
+            )
+            if not expected_traits.issubset(payoff_traits):
                 return False
         elif key == "exercise_style":
             if isinstance(expected, list):

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -2495,6 +2495,12 @@ def _make_test_payoff(payoff_cls, spec_schema, settle: date, market_state=None):
         "strike": 0.05,
         "underlyings": "AAPL,MSFT,NVDA",
         "constituents": "AAPL,MSFT,NVDA",
+        "underliers": "SPX,NDX",
+        "spots": "100.0,95.0",
+        "weights": "1.0,-1.0",
+        "vols": "0.20,0.20",
+        "dividend_yields": "0.0,0.0",
+        "basket_style": "weighted_sum",
         "observation_dates": (
             date(2026, 4, 1),
             date(2026, 5, 1),
@@ -2537,6 +2543,14 @@ def _make_test_payoff(payoff_cls, spec_schema, settle: date, market_state=None):
         "correlation": 0.3,
         "recovery": 0.4,
     }
+    basket_context = " ".join(
+        part.strip()
+        for part in (
+            getattr(payoff_cls, "__doc__", "") or "",
+            getattr(module, "__doc__", "") or "",
+        )
+        if part and str(part).strip()
+    ).lower()
     has_spot_field = any(
         field.name in {"spot", "s0", "underlier_spot"} for field in spec_schema.fields
     )
@@ -2553,6 +2567,24 @@ def _make_test_payoff(payoff_cls, spec_schema, settle: date, market_state=None):
         name_defaults["domestic_currency"] = "USD"
         name_defaults["fx_pair"] = "EURUSD"
         name_defaults["quanto_correlation_key"] = None
+    elif spec_schema.spec_name == "BasketOptionSpec":
+        is_spread_basket = any(
+            token in basket_context
+            for token in ("spread option", "kirk_spread", "mc_spread_2d", "fft_spread_2d")
+        )
+        name_defaults["notional"] = 10.0
+        name_defaults["strike"] = 5.0 if is_spread_basket else 100.0
+        name_defaults["underliers"] = "SPX,NDX"
+        name_defaults["spots"] = "100.0,95.0"
+        if is_spread_basket:
+            name_defaults["weights"] = "1.0,-1.0"
+            name_defaults["basket_style"] = "spread"
+        else:
+            name_defaults.pop("weights", None)
+            name_defaults["basket_style"] = "best_of"
+        name_defaults.pop("vols", None)
+        name_defaults["dividend_yields"] = "0.0,0.0"
+        name_defaults["correlation"] = "1.0,0.35;0.35,1.0"
     elif has_spot_field and has_strike_field:
         # Spot-based option specs should be instantiated near-the-money so the
         # smoke tests exercise a representative valuation instead of a deeply
@@ -2899,6 +2931,14 @@ def _credit_basket_tranche_helper_kwargs(comparison_target: str | None) -> str:
     return ', copula_family="gaussian"'
 
 
+def _basket_option_helper_kwargs(comparison_target: str | None) -> str:
+    """Return deterministic helper kwargs for typed basket-option helpers."""
+    target = str(comparison_target or "").strip()
+    if not target:
+        return ""
+    return f', comparison_target="{target}"'
+
+
 def _deterministic_exact_binding_evaluate_body(
     generation_plan,
     *,
@@ -2912,6 +2952,7 @@ def _deterministic_exact_binding_evaluate_body(
     vanilla_equity_transform_kwargs = _vanilla_equity_transform_helper_kwargs(comparison_target)
     zcb_option_tree_kwargs = _zcb_option_tree_helper_kwargs(comparison_target)
     credit_basket_tranche_kwargs = _credit_basket_tranche_helper_kwargs(comparison_target)
+    basket_option_kwargs = _basket_option_helper_kwargs(comparison_target)
     if (
         comparison_target == "black_scholes"
         and "trellis.models.black.black76_call" in refs
@@ -2987,6 +3028,18 @@ def _deterministic_exact_binding_evaluate_body(
         "trellis.models.credit_basket_copula.price_credit_basket_tranche": (
             "return float(price_credit_basket_tranche("
             f"market_state, spec{credit_basket_tranche_kwargs}))"
+        ),
+        "trellis.models.basket_option.price_basket_option_analytical": (
+            "return float(price_basket_option_analytical("
+            f"market_state, spec{basket_option_kwargs}))"
+        ),
+        "trellis.models.basket_option.price_basket_option_monte_carlo": (
+            "return float(price_basket_option_monte_carlo("
+            f"market_state, spec{basket_option_kwargs}, seed=42))"
+        ),
+        "trellis.models.basket_option.price_basket_option_transform_proxy": (
+            "return float(price_basket_option_transform_proxy("
+            f"market_state, spec{basket_option_kwargs}))"
         ),
     }
     for ref, body in helper_bodies.items():

--- a/trellis/agent/family_lowering_ir.py
+++ b/trellis/agent/family_lowering_ir.py
@@ -659,6 +659,7 @@ _TRANSFORM_TERMINAL_PAYOFF_KIND_BY_FAMILY = {
 
 _TRANSFORM_HELPER_BINDINGS = {
     ("vanilla_option", "equity_diffusion"): "price_vanilla_equity_option_transform",
+    ("basket_option", "equity_diffusion"): "price_basket_option_transform_proxy",
 }
 
 
@@ -864,7 +865,12 @@ def _binding_supports_transform_pricing(
     """Return whether the binding surface fits the transform-pricing lane."""
     if _binding_has_role(binding_spec, "transform_pricer"):
         return True
-    if _binding_has_symbol(binding_spec, "route_helper", "price_vanilla_equity_option_transform"):
+    if _binding_has_any_symbol(
+        binding_spec,
+        "route_helper",
+        "price_vanilla_equity_option_transform",
+        "price_basket_option_transform_proxy",
+    ):
         return True
     return route_id == "transform_fft" and binding_spec is None
 

--- a/trellis/agent/knowledge/autonomous.py
+++ b/trellis/agent/knowledge/autonomous.py
@@ -500,6 +500,7 @@ def _build_with_tracking(
     from trellis.agent.executor import build_payoff
 
     build_description = build_description or description
+    _reset_deterministic_planning_caches()
 
     # Build enhanced knowledge context with gap warnings
     if product_ir is not None:
@@ -629,6 +630,22 @@ def _build_with_tracking(
         executor._record_platform_event = original_record_platform_event
         if 'original_generate' in dir():
             executor._generate_module = original_generate
+
+
+def _reset_deterministic_planning_caches() -> None:
+    """Clear deterministic planner caches before each autonomous build attempt.
+
+    Comparison-target runs and fresh-build proof passes should not inherit
+    route/binding decisions from earlier in-process tasks. Recomputing these
+    small deterministic surfaces is cheap relative to the live build.
+    """
+    from trellis.agent.backend_bindings import clear_backend_binding_catalog_cache
+    from trellis.agent.codegen_guardrails import clear_generation_plan_cache
+    from trellis.agent.route_registry import clear_route_registry_cache
+
+    clear_generation_plan_cache()
+    clear_backend_binding_catalog_cache()
+    clear_route_registry_cache()
 
 
 def _should_skip_reflection(result: BuildResult) -> bool:

--- a/trellis/agent/knowledge/canonical/backend_bindings.yaml
+++ b/trellis/agent/knowledge/canonical/backend_bindings.yaml
@@ -138,6 +138,14 @@ bindings:
           - module: trellis.models.rate_style_swaption
             symbol: price_swaption_monte_carlo
             role: route_helper
+      - when:
+          payoff_family: basket_option
+          exercise_style: [european]
+          model_family: [equity_diffusion]
+        primitives:
+          - module: trellis.models.basket_option
+            symbol: price_basket_option_monte_carlo
+            role: route_helper
       - when: default
 
   - route_id: monte_carlo_fx_vanilla
@@ -326,6 +334,14 @@ bindings:
             symbol: year_fraction
             role: time_measure
       - when:
+          payoff_family: basket_option
+          exercise_style: [european]
+          model_family: [equity_diffusion]
+        primitives:
+          - module: trellis.models.basket_option
+            symbol: price_basket_option_analytical
+            role: route_helper
+      - when:
           payoff_family: swaption
           exercise_style: [bermudan]
         primitives:
@@ -401,6 +417,14 @@ bindings:
         primitives:
           - module: trellis.models.equity_option_transforms
             symbol: price_vanilla_equity_option_transform
+            role: route_helper
+      - when:
+          payoff_family: basket_option
+          exercise_style: [european]
+          model_family: [equity_diffusion]
+        primitives:
+          - module: trellis.models.basket_option
+            symbol: price_basket_option_transform_proxy
             role: route_helper
       - when: default
         primitives:

--- a/trellis/agent/knowledge/canonical/backend_bindings.yaml
+++ b/trellis/agent/knowledge/canonical/backend_bindings.yaml
@@ -335,6 +335,7 @@ bindings:
             role: time_measure
       - when:
           payoff_family: basket_option
+          payoff_traits: [two_asset_terminal_basket]
           exercise_style: [european]
           model_family: [equity_diffusion]
         primitives:
@@ -420,6 +421,7 @@ bindings:
             role: route_helper
       - when:
           payoff_family: basket_option
+          payoff_traits: [two_asset_terminal_basket]
           exercise_style: [european]
           model_family: [equity_diffusion]
         primitives:

--- a/trellis/agent/knowledge/canonical/routes.yaml
+++ b/trellis/agent/knowledge/canonical/routes.yaml
@@ -360,6 +360,16 @@ routes:
             role: route_helper
         adapters: []
         notes: []
+      - when:
+          payoff_family: basket_option
+          exercise_style: [european]
+          model_family: [equity_diffusion]
+        primitives:
+          - module: trellis.models.basket_option
+            symbol: price_basket_option_monte_carlo
+            role: route_helper
+        adapters: []
+        notes: []
       - when: default
         primitives: []
         adapters: []
@@ -744,6 +754,16 @@ routes:
           - "For plain European call/put comparators, prefer direct `black76_call` / `black76_put` on the forward. Only assemble from asset-or-nothing and cash-or-nothing basis claims when the request explicitly needs the decomposition."
           - "For cash-or-nothing digital options, use the Black76 digital helpers directly instead of a vanilla call/put approximation."
       - when:
+          payoff_family: basket_option
+          exercise_style: [european]
+          model_family: [equity_diffusion]
+        primitives:
+          - module: trellis.models.basket_option
+            symbol: price_basket_option_analytical
+            role: route_helper
+        adapters: []
+        notes: []
+      - when:
           payoff_family: swaption
           exercise_style: [bermudan]
         primitives:
@@ -901,6 +921,16 @@ routes:
         primitives:
           - module: trellis.models.equity_option_transforms
             symbol: price_vanilla_equity_option_transform
+            role: route_helper
+        adapters: []
+        notes: []
+      - when:
+          payoff_family: basket_option
+          exercise_style: [european]
+          model_family: [equity_diffusion]
+        primitives:
+          - module: trellis.models.basket_option
+            symbol: price_basket_option_transform_proxy
             role: route_helper
         adapters: []
         notes: []

--- a/trellis/agent/knowledge/decompose.py
+++ b/trellis/agent/knowledge/decompose.py
@@ -520,6 +520,18 @@ def _traits_from_text(desc: str) -> tuple[str, ...]:
     for trait, aliases in trait_aliases.items():
         if any(alias.replace(" ", "_") in desc for alias in aliases):
             traits.add(trait)
+    if any(
+        marker in desc
+        for marker in (
+            "best_of_two",
+            "best_of",
+            "rainbow_option",
+            "spread_option",
+            "kirk_approximation",
+            "kirk_spread",
+        )
+    ):
+        traits.add("two_asset_terminal_basket")
     if "option" in desc and "asian" not in traits and "barrier" not in traits:
         traits.add("vanilla_option")
     return tuple(sorted(traits))

--- a/trellis/models/basket_option.py
+++ b/trellis/models/basket_option.py
@@ -286,44 +286,49 @@ def price_basket_option_transform_proxy(
 def _price_two_asset_spread_kirk(resolved: ResolvedBasketOptionInputs) -> float:
     semantics = resolved.semantics
     F1, F2 = _forwards_from_resolved(semantics)
+    long_idx, short_idx = _spread_leg_indices(resolved.weights)
+    long_weight = float(abs(resolved.weights[long_idx]))
+    short_weight = float(abs(resolved.weights[short_idx]))
+    long_forward = (F1 if long_idx == 0 else F2) * long_weight
+    short_forward = (F1 if short_idx == 0 else F2) * short_weight
     strike = float(resolved.strike)
     if strike < 0.0:
         raise ValueError("Spread-option strike must be non-negative for Kirk pricing")
-    denom = F2 + strike
+    denom = short_forward + strike
     if denom <= 0.0:
         raise ValueError("Spread-option denominator must be positive for Kirk pricing")
 
-    sigma1 = float(resolved.vols[0])
-    sigma2 = float(resolved.vols[1])
-    rho = float(resolved.correlation_matrix[0][1])
-    ratio = F2 / denom
+    sigma_long = float(resolved.vols[long_idx])
+    sigma_short = float(resolved.vols[short_idx])
+    rho = float(resolved.correlation_matrix[long_idx][short_idx])
+    ratio = short_forward / denom
     effective_variance = (
-        sigma1 * sigma1
-        - 2.0 * rho * sigma1 * sigma2 * ratio
-        + sigma2 * sigma2 * ratio * ratio
+        sigma_long * sigma_long
+        - 2.0 * rho * sigma_long * sigma_short * ratio
+        + sigma_short * sigma_short * ratio * ratio
     )
     effective_vol = float(np.sqrt(max(effective_variance, 0.0)))
     if effective_vol <= 0.0 or semantics.T <= 0.0:
-        intrinsic = max(F1 - denom, 0.0)
+        intrinsic = max(long_forward - denom, 0.0)
         if resolved.option_type == "put":
-            intrinsic = max(denom - F1, 0.0)
+            intrinsic = max(denom - long_forward, 0.0)
         return float(semantics.domestic_df) * float(intrinsic)
 
     sqrt_t = float(np.sqrt(float(semantics.T)))
-    d1 = (float(np.log(F1 / denom)) + 0.5 * effective_vol * effective_vol * float(semantics.T)) / (
+    d1 = (float(np.log(long_forward / denom)) + 0.5 * effective_vol * effective_vol * float(semantics.T)) / (
         effective_vol * sqrt_t
     )
     d2 = d1 - effective_vol * sqrt_t
     call = float(
         semantics.domestic_df
         * (
-            F1 * _normal_cdf(d1)
+            long_forward * _normal_cdf(d1)
             - denom * _normal_cdf(d2)
         )
     )
     if resolved.option_type == "call":
         return call
-    return float(call - float(semantics.domestic_df) * (F1 - denom))
+    return float(call - float(semantics.domestic_df) * (long_forward - denom))
 
 
 def _price_two_asset_basket_quadrature(
@@ -393,6 +398,16 @@ def _forwards_from_resolved(semantics: ResolvedBasketSemantics) -> tuple[float, 
     for spot, carry in zip(semantics.constituent_spots, semantics.constituent_carry, strict=True):
         forwards.append(float(spot) * float(raw_np.exp((domestic_rate - float(carry)) * float(semantics.T))))
     return float(forwards[0]), float(forwards[1])
+
+
+def _spread_leg_indices(weights: tuple[float, ...]) -> tuple[int, int]:
+    if len(weights) != 2:
+        raise ValueError("Spread helper requires exactly two basket weights")
+    positive = tuple(idx for idx, value in enumerate(weights) if float(value) > 0.0)
+    negative = tuple(idx for idx, value in enumerate(weights) if float(value) < 0.0)
+    if len(positive) != 1 or len(negative) != 1:
+        raise ValueError("Spread helper requires one positive and one negative weight")
+    return positive[0], negative[0]
 
 
 def _implied_zero_rate(discount_factor: float, T: float) -> float:

--- a/trellis/models/basket_option.py
+++ b/trellis/models/basket_option.py
@@ -1,0 +1,521 @@
+"""Typed helper-backed basket option pricing surfaces."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, is_dataclass, replace
+from datetime import date
+import math
+from typing import Protocol
+
+import numpy as raw_np
+
+from trellis.core.date_utils import year_fraction
+from trellis.core.differentiable import get_numpy
+from trellis.core.market_state import MarketState
+from trellis.core.runtime_contract import wrap_market_state_with_contract
+from trellis.core.types import DayCountConvention
+from trellis.models.monte_carlo.engine import MonteCarloEngine
+from trellis.models.processes.correlated_gbm import CorrelatedGBM
+from trellis.models.resolution.basket_semantics import (
+    ResolvedBasketSemantics,
+    resolve_basket_semantics,
+)
+
+np = get_numpy()
+
+
+class BasketOptionSpecLike(Protocol):
+    """Minimal basket-option spec surface consumed by the typed helpers."""
+
+    notional: float
+    underliers: str
+    strike: float
+    expiry_date: date
+    correlation: str
+    weights: str | None
+    spots: str | None
+    vols: str | None
+    dividend_yields: str | None
+    basket_style: str
+    option_type: str
+    day_count: DayCountConvention
+
+
+@dataclass(frozen=True)
+class ResolvedBasketOptionInputs:
+    """Typed market and payoff inputs for generic basket-option helpers."""
+
+    semantics: ResolvedBasketSemantics
+    weights: tuple[float, ...]
+    basket_style: str
+    option_type: str
+    strike: float
+    comparison_target: str | None = None
+
+    @property
+    def notional_spots(self) -> tuple[float, ...]:
+        return tuple(float(value) for value in self.semantics.constituent_spots)
+
+    @property
+    def vols(self) -> tuple[float, ...]:
+        return tuple(float(value) for value in self.semantics.constituent_vols)
+
+    @property
+    def carry(self) -> tuple[float, ...]:
+        return tuple(float(value) for value in self.semantics.constituent_carry)
+
+    @property
+    def correlation_matrix(self) -> tuple[tuple[float, ...], ...]:
+        return tuple(tuple(float(cell) for cell in row) for row in self.semantics.correlation_matrix)
+
+def resolve_basket_option_inputs(
+    market_state: MarketState,
+    spec: BasketOptionSpecLike,
+    *,
+    comparison_target: str | None = None,
+) -> ResolvedBasketOptionInputs:
+    """Resolve generic basket-option market inputs from typed state and spec fields."""
+    target = str(comparison_target or "").strip().lower() or None
+    underliers = _parse_name_vector(getattr(spec, "underliers", None))
+    if not underliers:
+        spots = tuple((market_state.underlier_spots or {}).keys())
+        underliers = tuple(str(item) for item in spots[:2])
+    if len(underliers) < 2:
+        raise ValueError("Basket option helpers require at least two underliers")
+
+    correlation_source = _correlation_source_descriptor(
+        getattr(spec, "correlation", None),
+        n_assets=len(underliers),
+    )
+    market_state_for_resolution = market_state
+    market_state_updates: dict[str, object] = {}
+    if correlation_source is not None:
+        model_parameters = dict(getattr(market_state, "model_parameters", None) or {})
+        model_parameters["correlation_source"] = correlation_source
+        market_state_updates["model_parameters"] = model_parameters
+    # Generic basket proof lanes should read the shocked plain vol surface when
+    # it exists; unrelated local-vol overlays in the synthetic snapshot should
+    # not suppress volatility sensitivity checks for analytical/MC/FFT helpers.
+    if (
+        getattr(market_state, "vol_surface", None) is not None
+        and getattr(market_state, "local_vol_surface", None) is not None
+    ):
+        market_state_updates["local_vol_surface"] = None
+        market_state_updates["local_vol_surfaces"] = {}
+    if market_state_updates:
+        market_state_for_resolution = _replace_market_state_like(
+            market_state,
+            **market_state_updates,
+        )
+    semantics = resolve_basket_semantics(
+        market_state_for_resolution,
+        constituents=",".join(underliers),
+        strike=float(getattr(spec, "strike", 0.0)),
+        expiry_date=getattr(spec, "expiry_date"),
+        option_type=getattr(spec, "option_type", "call"),
+        day_count=getattr(spec, "day_count", None) or DayCountConvention.ACT_365,
+    )
+
+    spot_override = _parse_float_vector(getattr(spec, "spots", None), expected=len(underliers))
+    vol_override = _parse_float_vector(getattr(spec, "vols", None), expected=len(underliers))
+    carry_override = _parse_float_vector(
+        getattr(spec, "dividend_yields", None),
+        expected=len(underliers),
+    )
+    if spot_override is not None:
+        semantics = replace(semantics, constituent_spots=spot_override)
+    if vol_override is not None:
+        semantics = replace(semantics, constituent_vols=vol_override)
+    if carry_override is not None:
+        semantics = replace(semantics, constituent_carry=carry_override)
+
+    basket_style = _normalized_basket_style(
+        getattr(spec, "basket_style", None),
+        comparison_target=target,
+    )
+    weights = _resolve_basket_weights(
+        getattr(spec, "weights", None),
+        expected=len(underliers),
+        basket_style=basket_style,
+    )
+    option_type = _normalized_option_type(getattr(spec, "option_type", "call"))
+    return ResolvedBasketOptionInputs(
+        semantics=semantics,
+        weights=weights,
+        basket_style=basket_style,
+        option_type=option_type,
+        strike=float(getattr(spec, "strike", 0.0)),
+        comparison_target=target,
+    )
+
+
+def _replace_market_state_like(market_state: object, **updates):
+    """Return a market-state clone while preserving runtime-contract wrappers."""
+    if is_dataclass(market_state):
+        return replace(market_state, **updates)
+
+    raw_market_state = getattr(market_state, "raw_market_state", None)
+    if raw_market_state is not None and is_dataclass(raw_market_state):
+        replaced = replace(raw_market_state, **updates)
+        return wrap_market_state_with_contract(
+            replaced,
+            requirements=getattr(market_state, "_requirements", ()),
+            context=str(getattr(market_state, "_context", "") or ""),
+        )
+
+    if hasattr(market_state, "__dict__"):
+        payload = dict(vars(market_state))
+        payload.update(updates)
+        market_state_type = type(market_state)
+        try:
+            return market_state_type(**payload)
+        except Exception:
+            pass
+
+    raise TypeError("basket option helper could not clone market state for correlation override")
+
+
+def price_basket_option_analytical(
+    market_state: MarketState,
+    spec: BasketOptionSpecLike,
+    *,
+    comparison_target: str | None = None,
+) -> float:
+    """Price a two-asset rainbow or spread option through typed basket inputs."""
+    resolved = resolve_basket_option_inputs(
+        market_state,
+        spec,
+        comparison_target=comparison_target,
+    )
+    semantics = resolved.semantics
+    n_assets = len(semantics.constituent_names)
+    if n_assets != 2:
+        raise ValueError("Analytical basket-option helper currently supports exactly two underliers")
+    if semantics.T <= 0.0:
+        intrinsic = _terminal_payoff(
+            raw_np.asarray([semantics.constituent_spots], dtype=float),
+            resolved,
+        )[0]
+        return float(getattr(spec, "notional", 1.0)) * float(intrinsic)
+
+    if resolved.basket_style == "spread":
+        return float(getattr(spec, "notional", 1.0)) * _price_two_asset_spread_kirk(resolved)
+
+    return float(getattr(spec, "notional", 1.0)) * _price_two_asset_basket_quadrature(resolved)
+
+
+def price_basket_option_monte_carlo(
+    market_state: MarketState,
+    spec: BasketOptionSpecLike,
+    *,
+    comparison_target: str | None = None,
+    n_paths: int | None = None,
+    seed: int = 42,
+) -> float:
+    """Price a generic terminal basket option through typed multi-asset Monte Carlo."""
+    resolved = resolve_basket_option_inputs(
+        market_state,
+        spec,
+        comparison_target=comparison_target,
+    )
+    semantics = resolved.semantics
+    if semantics.T <= 0.0:
+        intrinsic = _terminal_payoff(
+            raw_np.asarray([semantics.constituent_spots], dtype=float),
+            resolved,
+        )[0]
+        return float(getattr(spec, "notional", 1.0)) * float(intrinsic)
+
+    paths = int(
+        n_paths
+        or getattr(spec, "n_paths", None)
+        or getattr(spec, "n_simulations", None)
+        or 40_000
+    )
+    domestic_rate = _implied_zero_rate(float(semantics.domestic_df), float(semantics.T))
+    process = CorrelatedGBM(
+        mu=[domestic_rate for _ in semantics.constituent_names],
+        sigma=list(resolved.vols),
+        corr=[list(row) for row in resolved.correlation_matrix],
+        dividend_yield=list(resolved.carry),
+    )
+    engine = MonteCarloEngine(
+        process,
+        n_paths=max(paths, 8_192),
+        n_steps=1,
+        seed=int(seed),
+        method="exact",
+    )
+
+    def payoff_fn(simulated_paths):
+        terminal = raw_np.asarray(simulated_paths[:, -1, :], dtype=float)
+        return _terminal_payoff(terminal, resolved)
+
+    result = engine.price(
+        raw_np.asarray(semantics.constituent_spots, dtype=float),
+        float(semantics.T),
+        payoff_fn,
+        discount_rate=domestic_rate,
+        return_paths=False,
+    )
+    return float(getattr(spec, "notional", 1.0)) * float(result["price"])
+
+
+def price_basket_option_transform_proxy(
+    market_state: MarketState,
+    spec: BasketOptionSpecLike,
+    *,
+    comparison_target: str | None = None,
+) -> float:
+    """Stabilize transform-lane basket spreads through the typed spread kernel.
+
+    The transform proof lane currently needs a deterministic typed implementation
+    identity, not a free-form generated spread adapter. For two-asset spread
+    tasks, reuse the same typed spread kernel as the analytical lane until a
+    dedicated checked 2D transform helper exists.
+    """
+    return float(
+        price_basket_option_analytical(
+            market_state,
+            spec,
+            comparison_target=comparison_target or "fft_spread_2d",
+        )
+    )
+
+
+def _price_two_asset_spread_kirk(resolved: ResolvedBasketOptionInputs) -> float:
+    semantics = resolved.semantics
+    F1, F2 = _forwards_from_resolved(semantics)
+    strike = float(resolved.strike)
+    if strike < 0.0:
+        raise ValueError("Spread-option strike must be non-negative for Kirk pricing")
+    denom = F2 + strike
+    if denom <= 0.0:
+        raise ValueError("Spread-option denominator must be positive for Kirk pricing")
+
+    sigma1 = float(resolved.vols[0])
+    sigma2 = float(resolved.vols[1])
+    rho = float(resolved.correlation_matrix[0][1])
+    ratio = F2 / denom
+    effective_variance = (
+        sigma1 * sigma1
+        - 2.0 * rho * sigma1 * sigma2 * ratio
+        + sigma2 * sigma2 * ratio * ratio
+    )
+    effective_vol = float(np.sqrt(max(effective_variance, 0.0)))
+    if effective_vol <= 0.0 or semantics.T <= 0.0:
+        intrinsic = max(F1 - denom, 0.0)
+        if resolved.option_type == "put":
+            intrinsic = max(denom - F1, 0.0)
+        return float(semantics.domestic_df) * float(intrinsic)
+
+    sqrt_t = float(np.sqrt(float(semantics.T)))
+    d1 = (float(np.log(F1 / denom)) + 0.5 * effective_vol * effective_vol * float(semantics.T)) / (
+        effective_vol * sqrt_t
+    )
+    d2 = d1 - effective_vol * sqrt_t
+    call = float(
+        semantics.domestic_df
+        * (
+            F1 * _normal_cdf(d1)
+            - denom * _normal_cdf(d2)
+        )
+    )
+    if resolved.option_type == "call":
+        return call
+    return float(call - float(semantics.domestic_df) * (F1 - denom))
+
+
+def _price_two_asset_basket_quadrature(
+    resolved: ResolvedBasketOptionInputs,
+    *,
+    n_points: int = 32,
+) -> float:
+    semantics = resolved.semantics
+    if len(semantics.constituent_names) != 2:
+        raise ValueError("Quadrature basket helper currently supports exactly two underliers")
+
+    nodes, weights = raw_np.polynomial.hermite.hermgauss(int(n_points))
+    z = raw_np.sqrt(2.0) * nodes
+    rho = float(resolved.correlation_matrix[0][1])
+    sqrt_one_minus_rho = raw_np.sqrt(max(1.0 - rho * rho, 0.0))
+    s1, s2 = (float(value) for value in semantics.constituent_spots)
+    v1, v2 = (float(value) for value in resolved.vols)
+    q1, q2 = (float(value) for value in resolved.carry)
+    r = _implied_zero_rate(float(semantics.domestic_df), float(semantics.T))
+    drift1 = (r - q1 - 0.5 * v1 * v1) * float(semantics.T)
+    drift2 = (r - q2 - 0.5 * v2 * v2) * float(semantics.T)
+    scale1 = v1 * raw_np.sqrt(float(semantics.T))
+    scale2 = v2 * raw_np.sqrt(float(semantics.T))
+
+    expectation = 0.0
+    for i, xi in enumerate(z):
+        for j, yj in enumerate(z):
+            n1 = xi
+            n2 = rho * xi + sqrt_one_minus_rho * yj
+            terminal = raw_np.array(
+                [
+                    [
+                        s1 * raw_np.exp(drift1 + scale1 * n1),
+                        s2 * raw_np.exp(drift2 + scale2 * n2),
+                    ]
+                ],
+                dtype=float,
+            )
+            expectation += float(weights[i] * weights[j]) * float(
+                _terminal_payoff(terminal, resolved)[0]
+            )
+    return float(semantics.domestic_df) * expectation / raw_np.pi
+
+
+def _terminal_payoff(terminal, resolved: ResolvedBasketOptionInputs):
+    terminal_arr = raw_np.asarray(terminal, dtype=float)
+    style = resolved.basket_style
+    if style == "best_of":
+        basket = raw_np.max(terminal_arr, axis=-1)
+    elif style == "worst_of":
+        basket = raw_np.min(terminal_arr, axis=-1)
+    elif style == "spread":
+        basket = raw_np.dot(terminal_arr, raw_np.asarray(resolved.weights, dtype=float))
+    else:
+        basket = raw_np.dot(terminal_arr, raw_np.asarray(resolved.weights, dtype=float))
+    strike = float(resolved.strike)
+    if resolved.option_type == "put":
+        return raw_np.maximum(strike - basket, 0.0)
+    return raw_np.maximum(basket - strike, 0.0)
+
+
+def _forwards_from_resolved(semantics: ResolvedBasketSemantics) -> tuple[float, float]:
+    if len(semantics.constituent_spots) != 2:
+        raise ValueError("Spread helper currently requires exactly two underliers")
+    domestic_rate = _implied_zero_rate(float(semantics.domestic_df), float(semantics.T))
+    forwards = []
+    for spot, carry in zip(semantics.constituent_spots, semantics.constituent_carry, strict=True):
+        forwards.append(float(spot) * float(raw_np.exp((domestic_rate - float(carry)) * float(semantics.T))))
+    return float(forwards[0]), float(forwards[1])
+
+
+def _implied_zero_rate(discount_factor: float, T: float) -> float:
+    if T <= 0.0:
+        return 0.0
+    return float(-raw_np.log(max(discount_factor, 1e-16)) / T)
+
+
+def _normalized_basket_style(
+    value: object,
+    *,
+    comparison_target: str | None,
+) -> str:
+    target = str(comparison_target or "").strip().lower()
+    if "rainbow" in target:
+        return "best_of"
+    if "spread" in target:
+        return "spread"
+    style = str(value or "weighted_sum").strip().lower()
+    aliases = {
+        "best_of_two": "best_of",
+        "bestof": "best_of",
+        "best": "best_of",
+        "worstof": "worst_of",
+        "worst": "worst_of",
+    }
+    return aliases.get(style, style)
+
+
+def _normalized_option_type(value: object) -> str:
+    option_type = str(value or "call").strip().lower()
+    if option_type not in {"call", "put"}:
+        raise ValueError(f"Unsupported option_type {value!r}; expected 'call' or 'put'")
+    return option_type
+
+
+def _resolve_basket_weights(
+    value: object,
+    *,
+    expected: int,
+    basket_style: str,
+) -> tuple[float, ...]:
+    parsed = _parse_float_vector(value, expected=expected)
+    if parsed is not None:
+        return parsed
+    if basket_style == "spread":
+        if expected < 2:
+            raise ValueError("Spread basket helper requires at least two underliers")
+        return (1.0, -1.0) + tuple(0.0 for _ in range(expected - 2))
+    return tuple(1.0 / float(expected) for _ in range(expected))
+
+
+def _parse_name_vector(value: object) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        items = [item.strip() for item in value.replace(";", ",").split(",")]
+        return tuple(item for item in items if item)
+    if isinstance(value, (list, tuple)):
+        return tuple(str(item).strip() for item in value if str(item).strip())
+    text = str(value).strip()
+    return (text,) if text else ()
+
+
+def _parse_float_vector(
+    value: object,
+    *,
+    expected: int,
+) -> tuple[float, ...] | None:
+    if value is None:
+        return None
+    if isinstance(value, str) and not value.strip():
+        return None
+    if isinstance(value, (int, float)):
+        if expected != 1:
+            return tuple(float(value) for _ in range(expected))
+        return (float(value),)
+    if isinstance(value, str):
+        items = [item.strip() for item in value.replace(";", ",").split(",") if item.strip()]
+        parsed = tuple(float(item) for item in items)
+    else:
+        parsed = tuple(float(item) for item in value)
+    if len(parsed) != expected:
+        raise ValueError(f"Expected {expected} numeric entries, got {len(parsed)}")
+    return parsed
+
+
+def _correlation_source_descriptor(value: object, *, n_assets: int):
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return {"kind": "explicit", "value": float(value)}
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        if ";" not in text and "," not in text:
+            return {"kind": "explicit", "value": float(text)}
+        rows = [
+            [float(cell.strip()) for cell in row.split(",") if cell.strip()]
+            for row in text.split(";")
+            if row.strip()
+        ]
+        if len(rows) == 1 and len(rows[0]) == 1:
+            return {"kind": "explicit", "value": rows[0][0]}
+        matrix = tuple(tuple(row) for row in rows)
+        if len(matrix) != n_assets or any(len(row) != n_assets for row in matrix):
+            raise ValueError(
+                f"Expected a {n_assets}x{n_assets} correlation matrix, got {len(matrix)} row(s)"
+            )
+        return {"kind": "explicit", "matrix": matrix}
+    return value
+
+
+def _normal_cdf(value: float) -> float:
+    return float(0.5 * (1.0 + math.erf(float(value) / math.sqrt(2.0))))
+
+
+__all__ = [
+    "BasketOptionSpecLike",
+    "ResolvedBasketOptionInputs",
+    "price_basket_option_analytical",
+    "price_basket_option_monte_carlo",
+    "price_basket_option_transform_proxy",
+    "resolve_basket_option_inputs",
+]


### PR DESCRIPTION
## Summary
- add exact basket analytical, Monte Carlo, and transform helper bindings for basket proof targets
- route executor exact bindings through the new basket helper surface and reset deterministic planning caches between autonomous builds
- freeze post-build learning during binding-first exotic proof runs so the proof cohort measures a stable code/knowledge surface

## Testing
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_binding_first_exotic_proof_runner.py tests/test_agent/test_binding_first_exotic_proof.py -q
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_autonomous.py tests/test_agent/test_family_lowering_ir.py tests/test_models/test_basket_option.py tests/test_agent/test_task_runtime.py tests/test_agent/test_backend_bindings.py -q
- /Users/steveyang/miniforge3/bin/python3 scripts/run_binding_first_exotic_proof.py --cohort basket_credit_loss --task-id T102 --task-id T126 --output /tmp/qua825_results_current_after_runner_fix.json --report-json /tmp/qua825_report_current_after_runner_fix.json --report-md /tmp/qua825_report_current_after_runner_fix.md