### PR TITLE
QUA-824: recover typed T53 loss-distribution proof lanes

### DIFF
--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -358,15 +358,16 @@ exercise live code generation. Ordinary supported-route runs can still reuse
 exact helper wrappers for stability, but fresh-build canaries no longer get a
 free pass from executor-side deterministic module synthesis.
 
-The same rule now applies to tranche-style basket-credit comparison routes.
+The same rule now applies to tranche-style basket-credit and typed
+loss-distribution comparison routes.
 Curated copula canaries bind through the semantic-facing
 ``trellis.models.credit_basket_copula`` helper surface instead of asking the
 builder to reconstruct tranche-loss projection from raw copula primitives. In
-practice that means the build loop can keep tranche attachment/detachment,
-representative credit-curve binding, and dependence-family selection on a
-checked helper path while semantic validation treats the helper as the public
-assembly contract rather than forcing direct calls to the lower-level loss
-distribution primitives.
+practice that means the build loop can keep tranche attachment/detachment or
+portfolio-loss horizon, representative credit-curve binding, and
+dependence-family selection on a checked helper path while semantic validation
+treats the helper as the public assembly contract rather than forcing direct
+calls to the lower-level loss-distribution primitives.
 
 For the supported swaption tree slice, the comparison harness now has a
 checked-in helper-backed route for single-exercise European rate-tree

--- a/docs/plans/binding-first-exotic-assembly.md
+++ b/docs/plans/binding-first-exotic-assembly.md
@@ -192,8 +192,8 @@ Status mirror last synced: `2026-04-13`
 | `QUA-809` | Exotic assembly: run the basket-credit-loss proof cohort and split residual gaps | Done |
 | `QUA-822` | Proof follow-on: copula tranche exact-helper contract (`T49`) | Done |
 | `QUA-823` | Proof follow-on: nth-to-default helper and basket-credit parsing (`T50`, `E26`) | Done |
-| `QUA-824` | Proof follow-on: loss-distribution recursive/FFT/MC constructive stability (`T53`) | Backlog |
-| `QUA-825` | Proof follow-on: multi-underlier basket parsing and FFT spread stability (`T102`, `T126`) | Backlog |
+| `QUA-824` | Proof follow-on: loss-distribution recursive/FFT/MC constructive stability (`T53`) | Done |
+| `QUA-825` | Proof follow-on: multi-underlier basket parsing and FFT spread stability (`T102`, `T126`) | Done |
 | `QUA-815` | Exotic program closeout: measure proof-cohort outcomes on the binding-first runtime | Done |
 
 The benchmark contract for those proof tickets lives in

--- a/docs/plans/binding-first-exotic-proof-closeout.md
+++ b/docs/plans/binding-first-exotic-proof-closeout.md
@@ -60,9 +60,9 @@ The only proved task in the current closeout is:
 | `T49` | follow-on recovered | Gaussian and Student-t tranche lanes now stay on `price_credit_basket_tranche(...)` even on fresh builds | none |
 | `T50` | follow-on recovered | nth-to-default helper path now proves on the exact helper surface without stale schedule-builder glue | none |
 | `E26` | follow-on recovered | nth-to-default basket ingress now resolves to the credit-basket family instead of generic basket parsing | none |
-| `T53` | failed gate | recursive / FFT / MC constructive stability on multi-name loss distribution | `QUA-824` |
-| `T102` | failed gate | multi-underlier market parsing | `QUA-825` |
-| `T126` | failed gate | multi-underlier parsing plus FFT spread-lane instability | `QUA-825` |
+| `T53` | follow-on recovered | recursive / FFT / MC lanes now bind to typed loss-distribution helpers and prove on exact backend surfaces | none |
+| `T102` | follow-on recovered | multi-underlier market parsing now stays on typed basket helper surfaces | none |
+| `T126` | follow-on recovered | multi-underlier spread parsing and FFT stability now prove on the typed basket helper path | none |
 
 ## What This Proves
 
@@ -100,8 +100,8 @@ The correct support statement after this closeout is:
   exotic support across the agreed cohort.
 - Current proof-level support is limited to the recovered slices already
   measured in the checked benchmark artifact plus the post-closeout recoveries
-  (`E27`, `T49`, `T50`, `E26`), with the remaining gaps tracked by `QUA-817`,
-  `QUA-818`, `QUA-819`, `QUA-824`, and `QUA-825`.
+  (`E27`, `T49`, `T50`, `E26`, `T53`, `T102`, `T126`), with the remaining
+  gaps tracked by `QUA-817`, `QUA-818`, and `QUA-819`.
 
 This is why `LIMITATIONS.md` now records the exotic proof cohort as an open
 limitation instead of letting the architecture docs imply the proof is already

--- a/docs/quant/pricing_stack.rst
+++ b/docs/quant/pricing_stack.rst
@@ -194,8 +194,9 @@ The first migrated vanilla cases now use that boundary directly:
   shared market-binding and execution helpers rather than separate product
   implementations
 - the copula basket-credit slice now also exposes a semantic-facing helper
-  layer in ``trellis.models.credit_basket_copula`` so tranche-style CDO and
-  nth-to-default requests can bind discount/credit inputs, tranche bounds, and
+  layer in ``trellis.models.credit_basket_copula`` so tranche-style CDO,
+  nth-to-default, and portfolio loss-distribution requests can bind
+  discount/credit inputs, tranche bounds or portfolio horizon, and
   dependence-family controls without exposing the raw scalar copula kernels as
   the public route helper
 

--- a/tests/test_agent/test_assembly_tools.py
+++ b/tests/test_agent/test_assembly_tools.py
@@ -140,6 +140,44 @@ def test_build_comparison_harness_plan_ignores_non_method_credit_construct_label
     ]
 
 
+def test_build_comparison_harness_plan_maps_recursive_loss_target_to_copula():
+    from trellis.agent.assembly_tools import build_comparison_harness_plan
+
+    plan = build_comparison_harness_plan(
+        {
+            "construct": ["copula", "fft_pricing", "monte_carlo"],
+            "cross_validate": {
+                "internal": ["recursive_method", "fft_loss", "mc_loss"],
+            },
+        }
+    )
+
+    assert [target.target_id for target in plan.targets] == [
+        "recursive_method",
+        "fft_loss",
+        "mc_loss",
+    ]
+    assert [target.preferred_method for target in plan.targets] == [
+        "copula",
+        "fft_pricing",
+        "monte_carlo",
+    ]
+
+
+def test_select_invariant_pack_skips_vol_checks_for_credit_loss_distribution():
+    from trellis.agent.assembly_tools import select_invariant_pack
+
+    pack = select_invariant_pack(
+        instrument_type="credit_loss_distribution",
+        method="monte_carlo",
+    )
+
+    assert "check_non_negativity" in pack.checks
+    assert "check_price_sanity" in pack.checks
+    assert "check_vol_sensitivity" not in pack.checks
+    assert "check_vol_monotonicity" not in pack.checks
+
+
 def test_build_cookbook_candidate_payload_extracts_template():
     from trellis.agent.assembly_tools import build_cookbook_candidate_payload
 

--- a/tests/test_agent/test_backend_bindings.py
+++ b/tests/test_agent/test_backend_bindings.py
@@ -231,6 +231,39 @@ def test_nth_to_default_binding_has_no_schedule_builder_surface():
     assert resolved.schedule_builder_refs == ()
 
 
+def test_resolve_backend_binding_spec_uses_credit_loss_distribution_exact_helpers():
+    catalog = load_backend_binding_catalog()
+    copula = find_backend_binding_by_route_id("copula_loss_distribution", catalog)
+    monte_carlo = find_backend_binding_by_route_id("monte_carlo_paths", catalog)
+    transform = find_backend_binding_by_route_id("transform_fft", catalog)
+
+    product_ir = ProductIR(
+        instrument="credit_loss_distribution",
+        payoff_family="credit_loss_distribution",
+        exercise_style="none",
+        state_dependence="terminal_markov",
+        model_family="credit_copula",
+    )
+
+    assert copula is not None
+    assert monte_carlo is not None
+    assert transform is not None
+
+    copula_resolved = resolve_backend_binding_spec(copula, product_ir=product_ir)
+    monte_carlo_resolved = resolve_backend_binding_spec(monte_carlo, product_ir=product_ir)
+    transform_resolved = resolve_backend_binding_spec(transform, product_ir=product_ir)
+
+    assert copula_resolved.helper_refs == (
+        "trellis.models.credit_basket_copula.price_credit_portfolio_loss_distribution_recursive",
+    )
+    assert monte_carlo_resolved.helper_refs == (
+        "trellis.models.credit_basket_copula.price_credit_portfolio_loss_distribution_monte_carlo",
+    )
+    assert transform_resolved.helper_refs == (
+        "trellis.models.credit_basket_copula.price_credit_portfolio_loss_distribution_transform_proxy",
+    )
+
+
 def test_binding_catalog_cache_tracks_binding_catalog_freshness(monkeypatch):
     clear_backend_binding_catalog_cache()
 

--- a/tests/test_agent/test_executor.py
+++ b/tests/test_agent/test_executor.py
@@ -848,6 +848,56 @@ def test_deterministic_exact_binding_module_materializes_credit_basket_tranche_h
 @pytest.mark.parametrize(
     ("helper_ref", "expected_call"),
     [
+        (
+            "trellis.models.credit_basket_copula.price_credit_portfolio_loss_distribution_recursive",
+            "price_credit_portfolio_loss_distribution_recursive(market_state, spec, copula_family=\"gaussian\")",
+        ),
+        (
+            "trellis.models.credit_basket_copula.price_credit_portfolio_loss_distribution_transform_proxy",
+            "price_credit_portfolio_loss_distribution_transform_proxy(market_state, spec, copula_family=\"gaussian\")",
+        ),
+        (
+            "trellis.models.credit_basket_copula.price_credit_portfolio_loss_distribution_monte_carlo",
+            "price_credit_portfolio_loss_distribution_monte_carlo(market_state, spec, copula_family=\"gaussian\", n_paths=40000, seed=42)",
+        ),
+    ],
+)
+def test_deterministic_exact_binding_module_materializes_credit_loss_distribution_wrappers(
+    helper_ref,
+    expected_call,
+):
+    from trellis.agent.executor import (
+        EVALUATE_SENTINEL,
+        _generate_skeleton,
+        _materialize_deterministic_exact_binding_module,
+    )
+    from trellis.agent.planner import STATIC_SPECS
+
+    generation_plan = SimpleNamespace(
+        lane_exact_binding_refs=(helper_ref,),
+        primitive_plan=None,
+        method="copula",
+        instrument_type="credit_loss_distribution",
+    )
+
+    skeleton = _generate_skeleton(
+        STATIC_SPECS["credit_loss_distribution"],
+        "Credit loss distribution",
+        generation_plan=generation_plan,
+    )
+    generated = _materialize_deterministic_exact_binding_module(
+        skeleton,
+        generation_plan,
+    )
+
+    assert generated is not None
+    assert expected_call in generated.code
+    assert EVALUATE_SENTINEL not in generated.code
+
+
+@pytest.mark.parametrize(
+    ("helper_ref", "expected_call"),
+    [
         ("trellis.models.rate_style_swaption.price_swaption_black76", "price_swaption_black76"),
         ("trellis.models.rate_style_swaption_tree.price_swaption_tree", "price_swaption_tree"),
         ("trellis.models.rate_style_swaption.price_swaption_monte_carlo", "price_swaption_monte_carlo"),

--- a/tests/test_agent/test_platform_requests.py
+++ b/tests/test_agent/test_platform_requests.py
@@ -838,6 +838,25 @@ def test_compile_build_request_treats_generic_basket_wrapper_as_nth_to_default_w
     assert compiled.generation_plan.primitive_plan.route == "nth_to_default_monte_carlo"
 
 
+@pytest.mark.parametrize(
+    ("description", "expected_instrument"),
+    [
+        ("CDO tranche loss distribution: Gaussian copula vs Student-t copula", "cdo"),
+        ("Nth-to-default loss distribution: semi-analytical vs default-time MC", "nth_to_default"),
+    ],
+)
+def test_compile_build_request_prefers_specific_credit_basket_shapes_over_loss_distribution_alias(
+    description: str,
+    expected_instrument: str,
+):
+    from trellis.agent.platform_requests import compile_build_request
+
+    compiled = compile_build_request(description)
+
+    assert compiled.product_ir is not None
+    assert compiled.product_ir.instrument == expected_instrument
+
+
 def test_compile_build_request_keeps_generic_basket_option_off_ranked_observation_route():
     from trellis.agent.platform_requests import compile_build_request
 

--- a/tests/test_agent/test_platform_requests.py
+++ b/tests/test_agent/test_platform_requests.py
@@ -771,6 +771,52 @@ def test_compile_build_request_does_not_block_title_only_credit_builder_requests
     assert compiled.product_ir.instrument == expected_instrument
 
 
+@pytest.mark.parametrize(
+    ("preferred_method", "expected_route", "expected_helper"),
+    [
+        (
+            "copula",
+            "copula_loss_distribution",
+            "trellis.models.credit_basket_copula.price_credit_portfolio_loss_distribution_recursive",
+        ),
+        (
+            "fft_pricing",
+            "transform_fft",
+            "trellis.models.credit_basket_copula.price_credit_portfolio_loss_distribution_transform_proxy",
+        ),
+        (
+            "monte_carlo",
+            "monte_carlo_paths",
+            "trellis.models.credit_basket_copula.price_credit_portfolio_loss_distribution_monte_carlo",
+        ),
+    ],
+)
+def test_compile_build_request_uses_typed_credit_loss_distribution_helpers(
+    preferred_method: str,
+    expected_route: str,
+    expected_helper: str,
+):
+    from trellis.agent.platform_requests import compile_build_request
+
+    compiled = compile_build_request(
+        "Multi-name portfolio loss distribution: recursive vs FFT vs MC",
+        instrument_type="credit_loss_distribution",
+        preferred_method=preferred_method,
+    )
+
+    assert compiled.semantic_contract is None
+    assert compiled.execution_plan.reason == "free_form_build_request"
+    assert compiled.product_ir is not None
+    assert compiled.product_ir.instrument == "credit_loss_distribution"
+    assert compiled.product_ir.payoff_family == "credit_loss_distribution"
+    assert compiled.pricing_plan is not None
+    assert compiled.pricing_plan.method == preferred_method
+    assert compiled.generation_plan is not None
+    assert compiled.generation_plan.primitive_plan is not None
+    assert compiled.generation_plan.primitive_plan.route == expected_route
+    assert compiled.generation_plan.backend_exact_target_refs == (expected_helper,)
+
+
 def test_compile_build_request_treats_generic_basket_wrapper_as_nth_to_default_when_credit_cues_dominate():
     from trellis.agent.platform_requests import compile_build_request
 

--- a/tests/test_agent/test_task_runtime.py
+++ b/tests/test_agent/test_task_runtime.py
@@ -1825,6 +1825,23 @@ def test_task_to_instrument_type_detects_credit_loss_distribution():
     )
 
 
+def test_task_to_instrument_type_does_not_misclassify_cdo_or_nth_loss_distribution_titles():
+    from trellis.agent.task_runtime import task_to_instrument_type
+
+    assert (
+        task_to_instrument_type(
+            {"id": "T490", "title": "CDO tranche loss distribution: Gaussian copula vs Student-t copula"}
+        )
+        == "cdo"
+    )
+    assert (
+        task_to_instrument_type(
+            {"id": "T500", "title": "Nth-to-default loss distribution: semi-analytical vs default-time MC"}
+        )
+        == "nth_to_default"
+    )
+
+
 def test_task_to_instrument_type_detects_bare_european_shape():
     from trellis.agent.task_runtime import task_to_instrument_type
 

--- a/tests/test_agent/test_task_runtime.py
+++ b/tests/test_agent/test_task_runtime.py
@@ -1814,6 +1814,17 @@ def test_task_to_instrument_type_prefers_nth_to_default_over_generic_basket():
     )
 
 
+def test_task_to_instrument_type_detects_credit_loss_distribution():
+    from trellis.agent.task_runtime import task_to_instrument_type
+
+    assert (
+        task_to_instrument_type(
+            {"id": "T53", "title": "Multi-name portfolio loss distribution: recursive vs FFT vs MC"}
+        )
+        == "credit_loss_distribution"
+    )
+
+
 def test_task_to_instrument_type_detects_bare_european_shape():
     from trellis.agent.task_runtime import task_to_instrument_type
 

--- a/tests/test_models/test_copulas/test_credit_basket_copula.py
+++ b/tests/test_models/test_copulas/test_credit_basket_copula.py
@@ -31,6 +31,14 @@ class _NthSpec:
     recovery = 0.4
 
 
+class _LossDistributionSpec:
+    notional = 100_000_000.0
+    n_names = 75
+    end_date = date(2029, 11, 15)
+    correlation = 0.28
+    recovery = 0.4
+
+
 def _market_state(*, hazard: float = 0.02, rate: float = 0.04) -> MarketState:
     return MarketState(
         as_of=SETTLE,
@@ -90,3 +98,35 @@ def test_price_credit_basket_nth_to_default_preserves_compatibility():
     )
 
     assert helper_price == pytest.approx(reference_price)
+
+
+def test_credit_loss_distribution_helpers_agree_on_discounted_expected_loss():
+    from trellis.models.credit_basket_copula import (
+        price_credit_portfolio_loss_distribution_monte_carlo,
+        price_credit_portfolio_loss_distribution_recursive,
+        price_credit_portfolio_loss_distribution_transform_proxy,
+    )
+
+    market_state = _market_state(hazard=0.025)
+    spec = _LossDistributionSpec()
+
+    recursive_price = price_credit_portfolio_loss_distribution_recursive(
+        market_state,
+        spec,
+    )
+    transform_price = price_credit_portfolio_loss_distribution_transform_proxy(
+        market_state,
+        spec,
+    )
+    mc_price = price_credit_portfolio_loss_distribution_monte_carlo(
+        market_state,
+        spec,
+        n_paths=30_000,
+        seed=42,
+    )
+
+    assert recursive_price > 0.0
+    assert transform_price > 0.0
+    assert mc_price > 0.0
+    assert transform_price == pytest.approx(recursive_price, rel=1e-10)
+    assert mc_price == pytest.approx(recursive_price, rel=0.08)

--- a/trellis/agent/assembly_tools.py
+++ b/trellis/agent/assembly_tools.py
@@ -55,6 +55,7 @@ _OPTION_LIKE_INSTRUMENTS = {
 # Vol sensitivity checks are not meaningful and will always produce false failures.
 _CREDIT_INSTRUMENTS = {
     "credit_default_swap",
+    "credit_loss_distribution",
     "nth_to_default",
     "cds",
 }
@@ -467,6 +468,7 @@ def _preferred_method_for_target(target_id: str, construct_methods: list[str]) -
         return normalized_target
 
     explicit_patterns = (
+        ("recursive", "copula"),
         ("analytical", "analytical"),
         ("tree", "rate_tree"),
         ("lattice", "rate_tree"),

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -3029,6 +3029,18 @@ def _deterministic_exact_binding_evaluate_body(
             "return float(price_credit_basket_tranche("
             f"market_state, spec{credit_basket_tranche_kwargs}))"
         ),
+        "trellis.models.credit_basket_copula.price_credit_portfolio_loss_distribution_recursive": (
+            "return float(price_credit_portfolio_loss_distribution_recursive("
+            'market_state, spec, copula_family="gaussian"))'
+        ),
+        "trellis.models.credit_basket_copula.price_credit_portfolio_loss_distribution_transform_proxy": (
+            "return float(price_credit_portfolio_loss_distribution_transform_proxy("
+            'market_state, spec, copula_family="gaussian"))'
+        ),
+        "trellis.models.credit_basket_copula.price_credit_portfolio_loss_distribution_monte_carlo": (
+            "return float(price_credit_portfolio_loss_distribution_monte_carlo("
+            'market_state, spec, copula_family="gaussian", n_paths=40000, seed=42))'
+        ),
         "trellis.models.basket_option.price_basket_option_analytical": (
             "return float(price_basket_option_analytical("
             f"market_state, spec{basket_option_kwargs}))"

--- a/trellis/agent/instrument_identity.py
+++ b/trellis/agent/instrument_identity.py
@@ -14,7 +14,6 @@ _INSTRUMENT_PATTERNS: tuple[tuple[str, str], ...] = (
     ("portfolio loss distribution", "credit_loss_distribution"),
     ("multi-name portfolio loss distribution", "credit_loss_distribution"),
     ("recursive loss distribution", "credit_loss_distribution"),
-    ("loss distribution", "credit_loss_distribution"),
     ("zero-coupon bond option", "zcb_option"),
     ("zero coupon bond option", "zcb_option"),
     ("zero-coupon bond", "zcb_option"),

--- a/trellis/agent/instrument_identity.py
+++ b/trellis/agent/instrument_identity.py
@@ -11,6 +11,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 _INSTRUMENT_PATTERNS: tuple[tuple[str, str], ...] = (
+    ("portfolio loss distribution", "credit_loss_distribution"),
+    ("multi-name portfolio loss distribution", "credit_loss_distribution"),
+    ("recursive loss distribution", "credit_loss_distribution"),
+    ("loss distribution", "credit_loss_distribution"),
     ("zero-coupon bond option", "zcb_option"),
     ("zero coupon bond option", "zcb_option"),
     ("zero-coupon bond", "zcb_option"),

--- a/trellis/agent/knowledge/canonical/backend_bindings.yaml
+++ b/trellis/agent/knowledge/canonical/backend_bindings.yaml
@@ -124,6 +124,13 @@ bindings:
         role: route_helper
     conditional_primitives:
       - when:
+          payoff_family: credit_loss_distribution
+          model_family: [credit_copula]
+        primitives:
+          - module: trellis.models.credit_basket_copula
+            symbol: price_credit_portfolio_loss_distribution_monte_carlo
+            role: route_helper
+      - when:
           payoff_family: vanilla_option
           exercise_style: [european]
         primitives:
@@ -412,6 +419,13 @@ bindings:
     route_family: fft_pricing
     conditional_primitives:
       - when:
+          payoff_family: credit_loss_distribution
+          model_family: [credit_copula]
+        primitives:
+          - module: trellis.models.credit_basket_copula
+            symbol: price_credit_portfolio_loss_distribution_transform_proxy
+            role: route_helper
+      - when:
           payoff_family: vanilla_option
           exercise_style: [european]
           model_family: [equity_diffusion]
@@ -491,16 +505,30 @@ bindings:
   - route_id: copula_loss_distribution
     engine_family: copula
     route_family: copula
-    primitives:
-      - module: trellis.models.copulas.factor
-        symbol: FactorCopula
-        role: loss_distribution
-      - module: trellis.models.credit_basket_copula
-        symbol: price_credit_basket_tranche
-        role: route_helper
-      - module: trellis.models.copulas.student_t
-        symbol: StudentTCopula
-        role: loss_distribution
+    conditional_primitives:
+      - when:
+          payoff_family: credit_loss_distribution
+        primitives:
+          - module: trellis.models.copulas.factor
+            symbol: FactorCopula
+            role: loss_distribution
+          - module: trellis.models.credit_basket_copula
+            symbol: price_credit_portfolio_loss_distribution_recursive
+            role: route_helper
+          - module: trellis.models.copulas.student_t
+            symbol: StudentTCopula
+            role: loss_distribution
+      - when: default
+        primitives:
+          - module: trellis.models.copulas.factor
+            symbol: FactorCopula
+            role: loss_distribution
+          - module: trellis.models.credit_basket_copula
+            symbol: price_credit_basket_tranche
+            role: route_helper
+          - module: trellis.models.copulas.student_t
+            symbol: StudentTCopula
+            role: loss_distribution
 
   - route_id: waterfall_cashflows
     engine_family: waterfall

--- a/trellis/agent/knowledge/canonical/decompositions.yaml
+++ b/trellis/agent/knowledge/canonical/decompositions.yaml
@@ -242,6 +242,24 @@
   reasoning: "Portfolio credit tranching uses copula for default correlation."
   learned: false
 
+- instrument: credit_loss_distribution
+  features: [credit_risk]
+  method: copula
+  method_modules:
+    - trellis.models.copulas.factor
+    - trellis.models.copulas.gaussian
+    - trellis.models.credit_basket_copula
+  required_market_data: [discount_curve, credit_curve]
+  modeling_requirements:
+    - >-
+      CALIBRATION: Default probabilities must be consistent with the input credit curve.
+      For each name: P(default by T) = 1 - S(T) where S(T) = credit_curve.survival_probability(T).
+    - >-
+      OUTPUT CONTRACT: Loss-distribution comparison tasks should compare the same discounted
+      expected portfolio loss amount across recursive, transform, and Monte Carlo lanes.
+  reasoning: "Portfolio loss-distribution tasks use typed copula helpers instead of tranche-specific glue."
+  learned: false
+
 - instrument: nth_to_default
   features: [credit_risk]
   method: copula

--- a/trellis/agent/knowledge/decompose.py
+++ b/trellis/agent/knowledge/decompose.py
@@ -368,7 +368,16 @@ def _infer_instrument(description: str, instrument_type: str | None) -> str | No
         ("asian_option", ("asian_option", "asian option")),
         ("heston_option", ("heston_option", "heston option", "heston")),
         ("variance_swap", ("variance_swap", "variance swap")),
-        ("credit_loss_distribution", ("credit_loss_distribution", "portfolio_loss_distribution", "loss distribution")),
+        (
+            "credit_loss_distribution",
+            (
+                "credit_loss_distribution",
+                "portfolio_loss_distribution",
+                "portfolio loss distribution",
+                "multi-name portfolio loss distribution",
+                "recursive loss distribution",
+            ),
+        ),
         ("cds", ("cds", "credit default swap", "credit_default_swap")),
         ("nth_to_default", ("nth_to_default", "nth-to-default", "nth to default")),
         ("swaption", ("swaption",)),

--- a/trellis/agent/knowledge/decompose.py
+++ b/trellis/agent/knowledge/decompose.py
@@ -368,6 +368,7 @@ def _infer_instrument(description: str, instrument_type: str | None) -> str | No
         ("asian_option", ("asian_option", "asian option")),
         ("heston_option", ("heston_option", "heston option", "heston")),
         ("variance_swap", ("variance_swap", "variance swap")),
+        ("credit_loss_distribution", ("credit_loss_distribution", "portfolio_loss_distribution", "loss distribution")),
         ("cds", ("cds", "credit default swap", "credit_default_swap")),
         ("nth_to_default", ("nth_to_default", "nth-to-default", "nth to default")),
         ("swaption", ("swaption",)),
@@ -660,6 +661,8 @@ def _payoff_family_for(
         return "barrier_option"
     if instrument in {"american_put", "american_option", "european_option", "heston_option"}:
         return "vanilla_option"
+    if instrument == "credit_loss_distribution":
+        return "credit_loss_distribution"
     if instrument in {"cdo", "nth_to_default"}:
         return "credit_basket"
     if instrument == "mbs":
@@ -748,7 +751,7 @@ def _model_family_for(
         return "jump_diffusion"
     if instrument in {"swap", "swaption", "bermudan_swaption", "callable_bond", "puttable_bond", "bond", "cap", "floor", "zcb_option"}:
         return "interest_rate"
-    if method == "copula" or instrument in {"cdo", "nth_to_default"}:
+    if method == "copula" or instrument in {"cdo", "nth_to_default", "credit_loss_distribution"}:
         return "credit_copula"
     if method == "waterfall" or instrument == "mbs":
         return "cashflow_structured"

--- a/trellis/agent/planner.py
+++ b/trellis/agent/planner.py
@@ -213,6 +213,19 @@ STATIC_SPECS: dict[str, SpecSchema] = {
             FieldDef("day_count", "DayCountConvention", "Day count convention", "DayCountConvention.ACT_360"),
         ],
     ),
+    "credit_loss_distribution": SpecSchema(
+        class_name="CreditLossDistributionPayoff",
+        spec_name="CreditLossDistributionSpec",
+        requirements=["discount_curve", "credit_curve"],
+        fields=[
+            FieldDef("notional", "float", "Portfolio notional used to scale discounted expected loss", "100_000_000.0"),
+            FieldDef("n_names", "int", "Number of names in the reference portfolio", "100"),
+            FieldDef("end_date", "date", "Loss horizon end date"),
+            FieldDef("correlation", "float", "Portfolio default correlation", "0.3"),
+            FieldDef("recovery", "float", "Portfolio recovery rate", "0.4"),
+            FieldDef("day_count", "DayCountConvention", "Day count convention", "DayCountConvention.ACT_360"),
+        ],
+    ),
     "nth_to_default": SpecSchema(
         class_name="NthToDefaultPayoff",
         spec_name="NthToDefaultSpec",

--- a/trellis/agent/semantic_validators/algorithm_contract.py
+++ b/trellis/agent/semantic_validators/algorithm_contract.py
@@ -352,6 +352,71 @@ _EXACT_HELPER_SIGNATURES = {
             "rebuilding copula loss plumbing inline."
         ),
     },
+    "price_credit_portfolio_loss_distribution_recursive": {
+        "min_positional_args": 2,
+        "max_positional_args": 2,
+        "required_parameters": ("market_state", "spec"),
+        "required_keyword_groups": (frozenset({"market_state", "spec"}),),
+        "allowed_keywords": frozenset({
+            "market_state",
+            "spec",
+            "copula_family",
+            "degrees_of_freedom",
+            "n_paths",
+            "seed",
+        }),
+        "required_positional_markers": (
+            frozenset({"market_state"}),
+            frozenset({"spec", "_spec"}),
+        ),
+        "message": (
+            "`price_credit_portfolio_loss_distribution_recursive(...)` expects "
+            "`(market_state, spec, *, copula_family=..., degrees_of_freedom=..., "
+            "n_paths=..., seed=...)`."
+        ),
+    },
+    "price_credit_portfolio_loss_distribution_transform_proxy": {
+        "min_positional_args": 2,
+        "max_positional_args": 2,
+        "required_parameters": ("market_state", "spec"),
+        "required_keyword_groups": (frozenset({"market_state", "spec"}),),
+        "allowed_keywords": frozenset({
+            "market_state",
+            "spec",
+            "copula_family",
+        }),
+        "required_positional_markers": (
+            frozenset({"market_state"}),
+            frozenset({"spec", "_spec"}),
+        ),
+        "message": (
+            "`price_credit_portfolio_loss_distribution_transform_proxy(...)` expects "
+            "`(market_state, spec, *, copula_family=...)`."
+        ),
+    },
+    "price_credit_portfolio_loss_distribution_monte_carlo": {
+        "min_positional_args": 2,
+        "max_positional_args": 2,
+        "required_parameters": ("market_state", "spec"),
+        "required_keyword_groups": (frozenset({"market_state", "spec"}),),
+        "allowed_keywords": frozenset({
+            "market_state",
+            "spec",
+            "copula_family",
+            "degrees_of_freedom",
+            "n_paths",
+            "seed",
+        }),
+        "required_positional_markers": (
+            frozenset({"market_state"}),
+            frozenset({"spec", "_spec"}),
+        ),
+        "message": (
+            "`price_credit_portfolio_loss_distribution_monte_carlo(...)` expects "
+            "`(market_state, spec, *, copula_family=..., degrees_of_freedom=..., "
+            "n_paths=..., seed=...)`."
+        ),
+    },
     "price_zcb_option_tree": {
         "min_positional_args": 2,
         "max_positional_args": 2,

--- a/trellis/agent/task_runtime.py
+++ b/trellis/agent/task_runtime.py
@@ -247,7 +247,7 @@ def _task_requires_credit_curve(task: dict) -> bool:
     construct_methods = set(_task_construct_methods(task))
     if "credit" in construct_methods:
         return True
-    if task_to_instrument_type(task) == "nth_to_default":
+    if task_to_instrument_type(task) in {"nth_to_default", "credit_loss_distribution"}:
         return True
     title = " ".join(
         part for part in (
@@ -1365,6 +1365,7 @@ def _preferred_method_for_target(target_id: str, construct_methods: list[str]) -
         return normalized_target
 
     explicit_patterns = (
+        ("recursive", "copula"),
         ("analytical", "analytical"),
         ("tree", "rate_tree"),
         ("lattice", "rate_tree"),

--- a/trellis/models/credit_basket_copula.py
+++ b/trellis/models/credit_basket_copula.py
@@ -60,6 +60,14 @@ class CreditBasketTrancheSpecLike(Protocol):
     end_date: date
 
 
+class CreditLossDistributionSpecLike(Protocol):
+    """Minimal portfolio-loss-distribution spec surface consumed by typed helpers."""
+
+    notional: float
+    n_names: int
+    end_date: date
+
+
 @dataclass(frozen=True)
 class ResolvedCreditBasketInputs:
     """Resolved market and contract inputs for bounded basket-credit helpers."""
@@ -246,6 +254,90 @@ def price_credit_basket_tranche(
     )
 
 
+def price_credit_portfolio_loss_distribution_recursive(
+    market_state: CreditBasketMarketStateLike,
+    spec: CreditLossDistributionSpecLike,
+    *,
+    copula_family: str = "gaussian",
+    degrees_of_freedom: float = 5.0,
+    n_paths: int = 40_000,
+    seed: int | None = 42,
+) -> float:
+    """Return discounted expected portfolio loss via a typed recursive copula lane."""
+    resolved = resolve_credit_basket_inputs(market_state, spec)
+    family = _normalized_copula_family(copula_family)
+    expected_loss_fraction = _expected_portfolio_loss_fraction(
+        resolved,
+        family=family,
+        degrees_of_freedom=degrees_of_freedom,
+        n_paths=n_paths,
+        seed=seed,
+    )
+    return _discounted_expected_portfolio_loss(resolved, expected_loss_fraction)
+
+
+def price_credit_portfolio_loss_distribution_transform_proxy(
+    market_state: CreditBasketMarketStateLike,
+    spec: CreditLossDistributionSpecLike,
+    *,
+    copula_family: str = "gaussian",
+) -> float:
+    """Return discounted expected portfolio loss through a typed transform proxy.
+
+    The transform proxy stays on the checked copula loss surface and uses a
+    Fourier round-trip over the discrete portfolio-loss pmf instead of free-form
+    generated transform glue.
+    """
+    resolved = resolve_credit_basket_inputs(market_state, spec)
+    family = _normalized_copula_family(copula_family)
+    if family != "gaussian":
+        return price_credit_portfolio_loss_distribution_recursive(
+            market_state,
+            spec,
+            copula_family=family,
+        )
+
+    loss_counts, probabilities = FactorCopula(
+        n_names=resolved.n_names,
+        correlation=resolved.correlation,
+    ).loss_distribution(resolved.default_probability)
+    spectrum = raw_np.fft.fft(raw_np.asarray(probabilities, dtype=float))
+    reconstructed = raw_np.real(raw_np.fft.ifft(spectrum))
+    reconstructed = raw_np.clip(reconstructed, 0.0, None)
+    total_probability = float(raw_np.sum(reconstructed))
+    if total_probability <= 0.0:
+        raise ValueError("Transform proxy produced an invalid loss-distribution mass.")
+    reconstructed = reconstructed / total_probability
+    expected_loss_fraction = float(
+        raw_np.sum(_portfolio_loss_fraction(loss_counts, resolved) * reconstructed)
+    )
+    return _discounted_expected_portfolio_loss(resolved, expected_loss_fraction)
+
+
+def price_credit_portfolio_loss_distribution_monte_carlo(
+    market_state: CreditBasketMarketStateLike,
+    spec: CreditLossDistributionSpecLike,
+    *,
+    copula_family: str = "gaussian",
+    degrees_of_freedom: float = 5.0,
+    n_paths: int = 40_000,
+    seed: int | None = 42,
+) -> float:
+    """Return discounted expected portfolio loss via Monte Carlo default sampling."""
+    resolved = resolve_credit_basket_inputs(market_state, spec)
+    defaults_by_horizon = _simulate_default_counts(
+        resolved,
+        family=_normalized_copula_family(copula_family),
+        degrees_of_freedom=degrees_of_freedom,
+        n_paths=n_paths,
+        seed=seed,
+    )
+    expected_loss_fraction = float(
+        raw_np.mean(_portfolio_loss_fraction(defaults_by_horizon, resolved))
+    )
+    return _discounted_expected_portfolio_loss(resolved, expected_loss_fraction)
+
+
 def _credit_basket_horizon(start: date, end: date, day_count: DayCountConvention) -> float:
     """Normalize same-anniversary maturities to whole-year tenors for helper parity."""
     if (start.month, start.day) == (end.month, end.day):
@@ -293,6 +385,31 @@ def _simulate_default_counts(
     return raw_np.sum(default_times <= resolved.horizon, axis=1)
 
 
+def _expected_portfolio_loss_fraction(
+    resolved: ResolvedCreditBasketInputs,
+    *,
+    family: str,
+    degrees_of_freedom: float,
+    n_paths: int,
+    seed: int | None,
+) -> float:
+    if family == "gaussian":
+        loss_counts, probabilities = FactorCopula(
+            n_names=resolved.n_names,
+            correlation=resolved.correlation,
+        ).loss_distribution(resolved.default_probability)
+        return float(raw_np.sum(_portfolio_loss_fraction(loss_counts, resolved) * probabilities))
+
+    defaults_by_horizon = _simulate_default_counts(
+        resolved,
+        family=family,
+        degrees_of_freedom=degrees_of_freedom,
+        n_paths=n_paths,
+        seed=seed,
+    )
+    return float(raw_np.mean(_portfolio_loss_fraction(defaults_by_horizon, resolved)))
+
+
 def _portfolio_loss_fraction(
     default_counts,
     resolved: ResolvedCreditBasketInputs,
@@ -310,10 +427,21 @@ def _discounted_annuity(discount_curve: DiscountCurveLike, horizon: float) -> fl
     return float(raw_np.sum(discounted) / 4.0)
 
 
+def _discounted_expected_portfolio_loss(
+    resolved: ResolvedCreditBasketInputs,
+    expected_loss_fraction: float,
+) -> float:
+    return float(resolved.notional * resolved.discount_factor * expected_loss_fraction)
+
+
 __all__ = [
     "CreditBasketTrancheResult",
+    "CreditLossDistributionSpecLike",
     "ResolvedCreditBasketInputs",
     "price_credit_basket_nth_to_default",
+    "price_credit_portfolio_loss_distribution_monte_carlo",
+    "price_credit_portfolio_loss_distribution_recursive",
+    "price_credit_portfolio_loss_distribution_transform_proxy",
     "price_credit_basket_tranche",
     "price_credit_basket_tranche_result",
     "resolve_credit_basket_inputs",


### PR DESCRIPTION
## Summary
- add a typed `credit_loss_distribution` surface and exact checked recursive / transform / Monte Carlo helpers for T53
- bind copula, fft, and Monte Carlo comparison lanes to the correct helper surfaces and keep recursive targets on the copula lane
- update proof docs and binding-first plan mirrors to reflect the recovered T53 proof slice

## Validation
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_assembly_tools.py tests/test_agent/test_backend_bindings.py tests/test_agent/test_executor.py tests/test_agent/test_platform_requests.py tests/test_agent/test_task_runtime.py tests/test_models/test_copulas/test_credit_basket_copula.py -q`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/ -x -q -m "not integration"`
- `/Users/steveyang/miniforge3/bin/python3 scripts/run_binding_first_exotic_proof.py --cohort basket_credit_loss --task-id T53 --output /tmp/qua824_t53_fixed2_results.json --report-json /tmp/qua824_t53_fixed2_report.json --report-md /tmp/qua824_t53_fixed2_report.md`
