### PR TITLE
agent: recover callable bond proof binding

### DIFF
--- a/docs/plans/binding-first-exotic-assembly.md
+++ b/docs/plans/binding-first-exotic-assembly.md
@@ -184,7 +184,7 @@ Status mirror last synced: `2026-04-13`
 | --- | --- | --- |
 | `QUA-804` | Exotic benchmark: define constructable proof cohort for binding-first assembly | Done |
 | `QUA-808` | Exotic assembly: run the event-control-schedule proof cohort and split residual gaps | Done |
-| `QUA-817` | Proof follow-on: callable-bond PDE exact binding or constructive steps (`T17`) | Backlog |
+| `QUA-817` | Proof follow-on: callable-bond PDE exact binding or constructive steps (`T17`) | Done |
 | `QUA-818` | Proof follow-on: swaption analytical/tree/MC parity drift (`T73`) | Backlog |
 | `QUA-819` | Proof follow-on: cap/floor fresh-build stability and reference-target evidence (`E22`) | Backlog |
 | `QUA-820` | Proof follow-on: structured blocker persistence for honest-block sentinel (`E27`) | Done |

--- a/docs/plans/binding-first-exotic-proof-closeout.md
+++ b/docs/plans/binding-first-exotic-proof-closeout.md
@@ -53,7 +53,7 @@ The only proved task in the current closeout is:
 | Task | Result | Residual gap | Follow-on |
 | --- | --- | --- | --- |
 | `T105` | proved | none in this closeout slice | none |
-| `T17` | failed gate | callable-bond PDE lane lacks exact binding or constructive steps | `QUA-817` |
+| `T17` | follow-on recovered | title-only callable-bond proof tasks now bootstrap a canonical Bermudan issuer-call schedule and bind the PDE lane to `price_callable_bond_pde(...)` exactly | none |
 | `T73` | failed gate | analytical/tree/MC parity drift | `QUA-818` |
 | `E22` | failed gate | cap/floor fresh-build instability and missing reference-target evidence | `QUA-819` |
 | `E27` | follow-on recovered | honest-block sentinel is now certified after structured blocker persistence landed | none |
@@ -83,10 +83,10 @@ constructable exotic derivatives.
 
 The current measured state is:
 
-- event/control/schedule proof is partial
-- basket/credit/loss proof is largely unrecovered
+- event/control/schedule proof is still partial because `T73` and `E22` remain open
+- basket/credit/loss proof has been recovered across the current cohort
 - the honest-block sentinel path was initially uncertified, then recovered by `QUA-820`
-- residual `unknown` route telemetry still appears in the proof runtime
+- residual `unknown` route telemetry was removed by `QUA-821`
 
 So the architecture migration is meaningfully ahead of the capability proof.
 That is acceptable for this closeout, but it must remain explicit.
@@ -100,8 +100,8 @@ The correct support statement after this closeout is:
   exotic support across the agreed cohort.
 - Current proof-level support is limited to the recovered slices already
   measured in the checked benchmark artifact plus the post-closeout recoveries
-  (`E27`, `T49`, `T50`, `E26`, `T53`, `T102`, `T126`), with the remaining
-  gaps tracked by `QUA-817`, `QUA-818`, and `QUA-819`.
+  (`T17`, `E27`, `T49`, `T50`, `E26`, `T53`, `T102`, `T126`), with the remaining
+  gaps tracked by `QUA-818` and `QUA-819`.
 
 This is why `LIMITATIONS.md` now records the exotic proof cohort as an open
 limitation instead of letting the architecture docs imply the proof is already

--- a/tests/test_agent/test_platform_requests.py
+++ b/tests/test_agent/test_platform_requests.py
@@ -978,6 +978,41 @@ def test_callable_bond_request_replays_as_supported_after_schedule_primitive_is_
     assert "semantic_gap" not in replayed.request.metadata
 
 
+def test_compile_build_request_uses_exact_callable_bond_pde_binding_for_bootstrapped_task_prompt():
+    from trellis.agent.platform_requests import compile_build_request
+    from trellis.agent.task_runtime import _effective_task_description
+
+    description = _effective_task_description(
+        {
+            "id": "T17",
+            "title": "Callable bond: HW rate PDE (PSOR) vs HW tree",
+            "construct": ["pde", "lattice"],
+            "cross_validate": {"internal": ["hw_pde_psor", "hw_rate_tree"]},
+        }
+    )
+    compiled = compile_build_request(
+        description,
+        instrument_type="callable_bond",
+        preferred_method="pde_solver",
+    )
+
+    assert compiled.execution_plan.reason == "semantic_contract_request"
+    assert compiled.semantic_contract is not None
+    assert compiled.semantic_contract.semantic_id == "callable_bond"
+    assert compiled.pricing_plan is not None
+    assert compiled.pricing_plan.method == "pde_solver"
+    assert compiled.generation_plan is not None
+    assert compiled.generation_plan.backend_binding_id == "trellis.models.callable_bond_pde.price_callable_bond_pde"
+    assert compiled.generation_plan.lane_plan_kind == "exact_target_binding"
+    assert compiled.generation_plan.lane_exact_binding_refs == (
+        "trellis.models.callable_bond_pde.price_callable_bond_pde"
+    ,)
+    assert compiled.validation_contract is not None
+    assert compiled.validation_contract.backend_binding_id == (
+        "trellis.models.callable_bond_pde.price_callable_bond_pde"
+    )
+
+
 @pytest.mark.parametrize(
     "description,instrument_type,expected_reason,expected_route_method,expected_semantic_id,expected_instrument,expected_payoff_family,expected_pricing_module,expected_generation_module,expected_primitive_route",
     [

--- a/tests/test_agent/test_task_runtime.py
+++ b/tests/test_agent/test_task_runtime.py
@@ -2307,6 +2307,23 @@ def test_prepare_existing_task_uses_quanto_family_compiled_requirements(monkeypa
     }]
 
 
+def test_effective_task_description_bootstraps_title_only_callable_bond_tasks():
+    from trellis.agent.task_runtime import _effective_task_description
+
+    description = _effective_task_description(
+        {
+            "id": "T17",
+            "title": "Callable bond: HW rate PDE (PSOR) vs HW tree",
+            "construct": ["pde", "lattice"],
+            "cross_validate": {"internal": ["hw_pde_psor", "hw_rate_tree"]},
+        }
+    )
+
+    assert "issuer call dates 2028-01-15, 2030-01-15, and 2032-01-15" in description
+    assert "5% semi-annual coupon" in description
+    assert "Comparison targets: hw_pde_psor (pde_solver), hw_rate_tree (rate_tree)" in description
+
+
 def test_prepare_existing_task_infers_schema_for_matching_generic_module(monkeypatch):
     """Generic cached modules should be benchmarkable when they clearly match the task."""
     from dataclasses import dataclass

--- a/trellis/agent/task_runtime.py
+++ b/trellis/agent/task_runtime.py
@@ -596,9 +596,36 @@ def _bootstrap_ranked_observation_basket_description(task: dict) -> str | None:
     )
 
 
+def _bootstrap_callable_bond_description(task: dict) -> str | None:
+    """Return a canonical callable-bond prompt for title-only proof tasks."""
+    if str(task.get("description") or "").strip():
+        return None
+
+    title = " ".join(
+        part for part in (
+            str(task.get("title") or ""),
+            str(task.get("description") or ""),
+        )
+        if part
+    ).lower()
+    if "callable bond" not in title:
+        return None
+
+    return (
+        "Build a pricer for: Callable bond with a Bermudan issuer call schedule\n\n"
+        "USD fixed-rate bond with face 100, 5% semi-annual coupon, start date "
+        "2025-01-15, issuer call dates 2028-01-15, 2030-01-15, and "
+        "2032-01-15 at par, and maturity 2035-01-15."
+    )
+
+
 def _effective_task_description(task: dict) -> str:
     """Return the task description after applying any canonical bootstrap prompt."""
-    description = _bootstrap_ranked_observation_basket_description(task) or task_to_description(task)
+    description = (
+        _bootstrap_ranked_observation_basket_description(task)
+        or _bootstrap_callable_bond_description(task)
+        or task_to_description(task)
+    )
     context_lines: list[str] = []
 
     construct_methods = _task_construct_methods(task)


### PR DESCRIPTION
## Summary
- bootstrap title-only callable-bond proof requests with a canonical Bermudan issuer-call schedule
- ensure the T17 PDE lane resolves to the exact callable-bond PDE backend binding
- sync the binding-first proof mirrors to reflect the recovered T17 state

## Validation
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_task_runtime.py tests/test_agent/test_platform_requests.py -q
- /Users/steveyang/miniforge3/bin/python3 scripts/run_binding_first_exotic_proof.py --cohort event_control_schedule --task-id T17 --output /tmp/qua817_t17_rebased_results.json --report-json /tmp/qua817_t17_rebased_report.json --report-md /tmp/qua817_t17_rebased_report.md
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/ -x -q -m 'not integration'  # run on the same functional diff before rebasing onto merged main; rebased branch reran the targeted suite and live T17 proof on top of green main