### PR TITLE
agent: add benchmark history scorecards and tranche-two parity coverage

### DIFF
--- a/FINANCEPY_BINDINGS.yaml
+++ b/FINANCEPY_BINDINGS.yaml
@@ -122,7 +122,6 @@ bindings:
     financepy_model: BlackScholes
     overlapping_outputs:
     - price
-    - delta
     comparison_modes:
     - price_parity
     - warm_runtime

--- a/doc/plan/active__financepy-benchmark-task-program.md
+++ b/doc/plan/active__financepy-benchmark-task-program.md
@@ -65,8 +65,21 @@ Every benchmark runner must persist append-only records with at least:
 - `scripts/run_tasks.py` runs the active pricing corpora
 - `scripts/run_financepy_benchmark.py` runs FinancePy parity tasks and persists timestamped history
 - `scripts/run_negative_benchmark.py` runs clarification / honest-block tasks and persists timestamped history
+- `scripts/run_benchmark_history_scorecard.py` builds repeated-run scorecards from append-only benchmark history
 - `scripts/run_canary.py` and `scripts/record_cassettes.py` use the rebuilt canary manifest
 - `TASKS.yaml` is removed after the cutover; retained proof-only legacy tasks live in `TASKS_PROOF_LEGACY.yaml`
+
+`QUA-834` is now materially implemented on top of that cutover:
+
+- benchmark and canary persistence carries repo and knowledge revisions alongside timestamps
+- FinancePy and negative runners emit repeated-run scorecards from append-only history
+- benchmark campaigns can be filtered and compared without mutating the underlying task-run store
+
+`QUA-831` is also now materially implemented:
+
+- tranche-two FinancePy parity coverage lives in `F009` through `F015`
+- the binding registry and FinancePy reference adapter cover barrier, digital, lookback, chooser, compound, cliquet, and variance families
+- overlap metadata is kept aligned with the actual FinancePy reference outputs
 
 ## Market Scenario Foundation
 

--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -59,6 +59,7 @@ The repo ships a small task-operations toolchain:
 - ``scripts/run_task_learning_benchmark.py``: run repeated non-canary passes at a fixed revision and emit a learning scorecard
 - ``scripts/run_financepy_benchmark.py``: run the FinancePy parity corpus with timestamped run-history persistence
 - ``scripts/run_negative_benchmark.py``: run the clarification / honest-block corpus with timestamped run-history persistence
+- ``scripts/run_benchmark_history_scorecard.py``: build a repeated-run scorecard from append-only FinancePy or negative benchmark history
 - ``scripts/remediate.py``: analyze failures, categorize knowledge gaps, and patch common knowledge issues
 - ``scripts/evaluate_shared_memory.py``: compare two task-result tranches and render a shared-memory improvement report
 - ``scripts/should_run_canary.py``: decide whether current local changes justify the focused core canary gate
@@ -123,12 +124,14 @@ instead of letting the recording run mutate later retrieval inputs.
 
 Every FinancePy benchmark run now also writes append-only timestamped records
 under ``task_runs/financepy_benchmarks/`` with explicit ``run_started_at`` and
-``run_completed_at`` fields so repeated reruns can be compared across code and
-knowledge revisions.
+``run_completed_at`` fields so repeated reruns can be compared across code,
+knowledge, and campaign revisions. The runner also emits a repeated-run
+scorecard from the matching append-only history slice.
 
 Negative-task benchmark runs do the same under
 ``task_runs/negative_benchmarks/`` so clarification and honest-block behavior
-can be tracked across repeated library and knowledge updates.
+can be tracked across repeated library and knowledge updates, again with a
+scorecard generated from append-only history.
 
 Every canary batch now also writes a dedicated aggregate telemetry record under
 ``task_runs/canary_batches/``:
@@ -137,6 +140,10 @@ Every canary batch now also writes a dedicated aggregate telemetry record under
   per-batch history
 - ``task_runs/canary_batches/latest/<scope>.json`` keeps the latest batch for a
   stable comparison scope such as ``live__full_curated__standard__default``
+
+Canary batch summaries now also persist the repo revision and normalized
+knowledge revision so replay and live batches can be compared against the
+library/knowledge state that produced them.
 
 Those records sit on top of the existing per-task run history. They do not
 replace ``task_runs/history/``; instead they provide the trustworthy canary

--- a/scripts/run_benchmark_history_scorecard.py
+++ b/scripts/run_benchmark_history_scorecard.py
@@ -1,0 +1,83 @@
+"""Build a repeated-run scorecard from persisted benchmark history."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault("LLM_PROVIDER", "openai")
+
+from trellis.agent.benchmark_history import (
+    build_benchmark_history_scorecard,
+    load_benchmark_history_records,
+    save_benchmark_history_scorecard,
+)
+from trellis.agent.financepy_benchmark import DEFAULT_FINANCEPY_BENCHMARK_ROOT
+from trellis.agent.negative_task_benchmark import DEFAULT_NEGATIVE_BENCHMARK_ROOT
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("benchmark_kind", choices=("financepy", "negative"))
+    parser.add_argument("task_ids", nargs="*")
+    parser.add_argument("--campaign-id")
+    parser.add_argument("--history-root")
+    parser.add_argument("--report-name")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv or sys.argv[1:])
+    history_root = (
+        Path(args.history_root)
+        if args.history_root
+        else (
+            DEFAULT_FINANCEPY_BENCHMARK_ROOT
+            if args.benchmark_kind == "financepy"
+            else DEFAULT_NEGATIVE_BENCHMARK_ROOT
+        )
+    )
+    scorecard_name = str(
+        args.report_name
+        or f"{args.benchmark_kind}_{args.campaign_id or 'history'}_scorecard"
+    ).strip()
+    records = load_benchmark_history_records(
+        benchmark_root=history_root,
+        task_ids=args.task_ids or None,
+        campaign_id=args.campaign_id,
+    )
+    if not records:
+        print("No benchmark history records matched the selection.")
+        return 1
+    scorecard = build_benchmark_history_scorecard(
+        scorecard_name=scorecard_name,
+        benchmark_kind=args.benchmark_kind,
+        benchmark_runs=records,
+        campaign_id=args.campaign_id,
+    )
+    artifacts = save_benchmark_history_scorecard(
+        scorecard,
+        reports_root=history_root / "reports",
+        stem=scorecard_name,
+    )
+    print(
+        json.dumps(
+            {
+                "scorecard_json": str(artifacts.json_path),
+                "scorecard_md": str(artifacts.text_path),
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_financepy_benchmark.py
+++ b/scripts/run_financepy_benchmark.py
@@ -18,6 +18,11 @@ sys.path.insert(0, str(ROOT))
 os.environ.setdefault("LLM_PROVIDER", "openai")
 
 from trellis.agent.config import load_env
+from trellis.agent.benchmark_history import (
+    build_benchmark_history_scorecard,
+    load_benchmark_history_records,
+    save_benchmark_history_scorecard,
+)
 from trellis.agent.financepy_benchmark import (
     DEFAULT_FINANCEPY_BENCHMARK_ROOT,
     build_financepy_benchmark_report,
@@ -28,6 +33,7 @@ from trellis.agent.financepy_benchmark import (
     select_financepy_benchmark_tasks,
 )
 from trellis.agent.financepy_reference import price_financepy_reference
+from trellis.agent.runtime_revisions import runtime_revision_metadata
 from trellis.agent.task_manifests import load_financepy_bindings
 from trellis.agent.task_runtime import (
     benchmark_existing_task,
@@ -53,6 +59,7 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--output-root")
     parser.add_argument("--report-name", default="financepy_parity")
+    parser.add_argument("--campaign-id")
     return parser.parse_args(argv)
 
 
@@ -149,7 +156,10 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     output_root = Path(args.output_root) if args.output_root else DEFAULT_FINANCEPY_BENCHMARK_ROOT
-    git_revision = _git_revision()
+    revisions = runtime_revision_metadata()
+    git_revision = revisions["git_sha"] or _git_revision()
+    knowledge_revision = revisions["knowledge_revision"]
+    campaign_id = str(args.campaign_id or args.report_name).strip()
     financepy_bindings = load_financepy_bindings(root=ROOT)
     market_state = build_market_state()
     benchmark_runs: list[dict[str, Any]] = []
@@ -211,12 +221,15 @@ def main(argv: list[str] | None = None) -> int:
             "market_scenario_id": task.get("market_scenario_id"),
             "market_scenario_digest": dict(task.get("market") or {}).get("scenario_digest"),
             "financepy_binding_id": task.get("financepy_binding_id"),
+            "benchmark_campaign_id": campaign_id,
             "git_sha": git_revision,
+            "knowledge_revision": knowledge_revision,
             "run_id": f"{task['id']}_{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%S%fZ')}",
             "run_started_at": run_started_at,
             "run_completed_at": run_completed_at,
             "execution_mode": "cold_agent_plus_financepy_reference",
             "status": status,
+            "success_status": status,
             "cold_agent_elapsed_seconds": round(float(cold_result.get("elapsed_seconds") or 0.0), 6),
             "cold_agent_token_usage": dict(cold_result.get("token_usage_summary") or {}),
             "warm_agent_mean_seconds": None if warm_result is None else warm_result.get("mean_seconds"),
@@ -240,7 +253,36 @@ def main(argv: list[str] | None = None) -> int:
         ],
     )
     artifacts = save_financepy_benchmark_report(report, root=output_root, stem=args.report_name)
-    print(json.dumps({"report_json": str(artifacts.json_path), "report_md": str(artifacts.text_path)}, indent=2))
+    scorecard = build_benchmark_history_scorecard(
+        scorecard_name=f"{args.report_name}_scorecard",
+        benchmark_kind="financepy",
+        benchmark_runs=load_benchmark_history_records(
+            benchmark_root=output_root,
+            task_ids=[task["id"] for task in tasks],
+            campaign_id=campaign_id,
+        ),
+        campaign_id=campaign_id,
+        notes=[
+            "Task history is loaded from append-only benchmark records.",
+            "A task is counted as passing when the latest FinancePy comparison passes.",
+        ],
+    )
+    scorecard_artifacts = save_benchmark_history_scorecard(
+        scorecard,
+        reports_root=output_root / "reports",
+        stem=f"{args.report_name}_scorecard",
+    )
+    print(
+        json.dumps(
+            {
+                "report_json": str(artifacts.json_path),
+                "report_md": str(artifacts.text_path),
+                "scorecard_json": str(scorecard_artifacts.json_path),
+                "scorecard_md": str(scorecard_artifacts.text_path),
+            },
+            indent=2,
+        )
+    )
     return 0
 
 

--- a/scripts/run_financepy_benchmark.py
+++ b/scripts/run_financepy_benchmark.py
@@ -229,7 +229,6 @@ def main(argv: list[str] | None = None) -> int:
             "run_completed_at": run_completed_at,
             "execution_mode": "cold_agent_plus_financepy_reference",
             "status": status,
-            "success_status": status,
             "cold_agent_elapsed_seconds": round(float(cold_result.get("elapsed_seconds") or 0.0), 6),
             "cold_agent_token_usage": dict(cold_result.get("token_usage_summary") or {}),
             "warm_agent_mean_seconds": None if warm_result is None else warm_result.get("mean_seconds"),

--- a/scripts/run_negative_benchmark.py
+++ b/scripts/run_negative_benchmark.py
@@ -17,6 +17,11 @@ sys.path.insert(0, str(ROOT))
 os.environ.setdefault("LLM_PROVIDER", "openai")
 
 from trellis.agent.config import load_env
+from trellis.agent.benchmark_history import (
+    build_benchmark_history_scorecard,
+    load_benchmark_history_records,
+    save_benchmark_history_scorecard,
+)
 from trellis.agent.negative_task_benchmark import (
     DEFAULT_NEGATIVE_BENCHMARK_ROOT,
     build_negative_benchmark_report,
@@ -26,6 +31,7 @@ from trellis.agent.negative_task_benchmark import (
     save_negative_benchmark_report,
     select_negative_benchmark_tasks,
 )
+from trellis.agent.runtime_revisions import runtime_revision_metadata
 from trellis.agent.task_runtime import build_market_state, run_task
 
 
@@ -42,6 +48,7 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--output-root")
     parser.add_argument("--report-name", default="negative_task_benchmark")
+    parser.add_argument("--campaign-id")
     return parser.parse_args(argv)
 
 
@@ -81,7 +88,10 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     output_root = Path(args.output_root) if args.output_root else DEFAULT_NEGATIVE_BENCHMARK_ROOT
-    git_revision = _git_revision()
+    revisions = runtime_revision_metadata()
+    git_revision = revisions["git_sha"] or _git_revision()
+    knowledge_revision = revisions["knowledge_revision"]
+    campaign_id = str(args.campaign_id or args.report_name).strip()
     market_state = build_market_state()
     benchmark_runs: list[dict[str, object]] = []
 
@@ -104,12 +114,15 @@ def main(argv: list[str] | None = None) -> int:
             "task_definition_manifest": task.get("task_definition_manifest"),
             "market_scenario_id": task.get("market_scenario_id"),
             "market_scenario_digest": dict(task.get("market") or {}).get("scenario_digest"),
+            "benchmark_campaign_id": campaign_id,
             "git_sha": git_revision,
+            "knowledge_revision": knowledge_revision,
             "run_id": f"{task['id']}_{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%S%fZ')}",
             "run_started_at": run_started_at,
             "run_completed_at": run_completed_at,
             "execution_mode": "cold_agent_negative",
             "status": evaluation["observed_outcome"],
+            "success_status": evaluation["observed_outcome"],
             "expected_outcome": evaluation["expected_outcome"],
             "observed_outcome": evaluation["observed_outcome"],
             "passed_expectation": evaluation["passed"],
@@ -137,7 +150,36 @@ def main(argv: list[str] | None = None) -> int:
         ],
     )
     artifacts = save_negative_benchmark_report(report, root=output_root, stem=args.report_name)
-    print(json.dumps({"report_json": str(artifacts.json_path), "report_md": str(artifacts.text_path)}, indent=2))
+    scorecard = build_benchmark_history_scorecard(
+        scorecard_name=f"{args.report_name}_scorecard",
+        benchmark_kind="negative",
+        benchmark_runs=load_benchmark_history_records(
+            benchmark_root=output_root,
+            task_ids=[task["id"] for task in tasks],
+            campaign_id=campaign_id,
+        ),
+        campaign_id=campaign_id,
+        notes=[
+            "Negative-task history is loaded from append-only benchmark records.",
+            "A task is counted as passing when the latest run matches the expected clarification or honest-block behavior.",
+        ],
+    )
+    scorecard_artifacts = save_benchmark_history_scorecard(
+        scorecard,
+        reports_root=output_root / "reports",
+        stem=f"{args.report_name}_scorecard",
+    )
+    print(
+        json.dumps(
+            {
+                "report_json": str(artifacts.json_path),
+                "report_md": str(artifacts.text_path),
+                "scorecard_json": str(scorecard_artifacts.json_path),
+                "scorecard_md": str(scorecard_artifacts.text_path),
+            },
+            indent=2,
+        )
+    )
     return 0
 
 

--- a/scripts/run_negative_benchmark.py
+++ b/scripts/run_negative_benchmark.py
@@ -122,7 +122,6 @@ def main(argv: list[str] | None = None) -> int:
             "run_completed_at": run_completed_at,
             "execution_mode": "cold_agent_negative",
             "status": evaluation["observed_outcome"],
-            "success_status": evaluation["observed_outcome"],
             "expected_outcome": evaluation["expected_outcome"],
             "observed_outcome": evaluation["observed_outcome"],
             "passed_expectation": evaluation["passed"],

--- a/tests/test_agent/test_benchmark_history.py
+++ b/tests/test_agent/test_benchmark_history.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import json
+
+from trellis.agent.benchmark_history import (
+    build_benchmark_history_scorecard,
+    load_benchmark_history_records,
+    render_benchmark_history_scorecard,
+    save_benchmark_history_scorecard,
+)
+
+
+def test_load_benchmark_history_records_filters_campaign_and_task(tmp_path):
+    history_root = tmp_path / "history"
+    (history_root / "F001").mkdir(parents=True)
+    (history_root / "F002").mkdir(parents=True)
+    (history_root / "F001" / "run_a.json").write_text(
+        json.dumps(
+            {
+                "task_id": "F001",
+                "benchmark_campaign_id": "daily_suite",
+                "run_started_at": "2026-04-14T01:00:00+00:00",
+                "run_id": "run_a",
+            }
+        )
+    )
+    (history_root / "F002" / "run_b.json").write_text(
+        json.dumps(
+            {
+                "task_id": "F002",
+                "benchmark_campaign_id": "smoke",
+                "run_started_at": "2026-04-14T01:05:00+00:00",
+                "run_id": "run_b",
+            }
+        )
+    )
+
+    records = load_benchmark_history_records(
+        benchmark_root=tmp_path,
+        task_ids=["F001"],
+        campaign_id="daily_suite",
+    )
+
+    assert len(records) == 1
+    assert records[0]["task_id"] == "F001"
+
+
+def test_build_benchmark_history_scorecard_tracks_improvement(tmp_path):
+    records = [
+        {
+            "task_id": "F001",
+            "title": "Vanilla",
+            "task_corpus": "benchmark_financepy",
+            "run_id": "run_1",
+            "run_started_at": "2026-04-14T01:00:00+00:00",
+            "run_completed_at": "2026-04-14T01:00:05+00:00",
+            "execution_mode": "cold_agent_plus_financepy_reference",
+            "git_sha": "aaaa1111",
+            "knowledge_revision": "know1111",
+            "comparison_summary": {"status": "failed"},
+            "cold_agent_elapsed_seconds": 5.0,
+            "cold_agent_token_usage": {"total_tokens": 200},
+        },
+        {
+            "task_id": "F001",
+            "title": "Vanilla",
+            "task_corpus": "benchmark_financepy",
+            "run_id": "run_2",
+            "run_started_at": "2026-04-15T01:00:00+00:00",
+            "run_completed_at": "2026-04-15T01:00:03+00:00",
+            "execution_mode": "cold_agent_plus_financepy_reference",
+            "git_sha": "bbbb2222",
+            "knowledge_revision": "know2222",
+            "comparison_summary": {"status": "passed"},
+            "cold_agent_elapsed_seconds": 3.0,
+            "cold_agent_token_usage": {"total_tokens": 150},
+        },
+        {
+            "task_id": "N001",
+            "title": "Clarification",
+            "task_corpus": "negative",
+            "run_id": "run_3",
+            "run_started_at": "2026-04-15T01:00:00+00:00",
+            "run_completed_at": "2026-04-15T01:00:02+00:00",
+            "execution_mode": "cold_agent_negative",
+            "git_sha": "bbbb2222",
+            "knowledge_revision": "know2222",
+            "passed_expectation": True,
+            "observed_outcome": "clarification_requested",
+            "elapsed_seconds": 2.0,
+            "token_usage_summary": {"total_tokens": 75},
+        },
+    ]
+
+    financepy_report = build_benchmark_history_scorecard(
+        scorecard_name="financepy_daily_scorecard",
+        benchmark_kind="financepy",
+        benchmark_runs=[records[0], records[1]],
+        campaign_id="daily_suite",
+    )
+    negative_report = build_benchmark_history_scorecard(
+        scorecard_name="negative_daily_scorecard",
+        benchmark_kind="negative",
+        benchmark_runs=[records[2]],
+        campaign_id="daily_suite",
+    )
+
+    assert financepy_report["improved_count"] == 1
+    assert financepy_report["latest_pass_count"] == 1
+    assert financepy_report["tasks"][0]["transition"] == "improved"
+    assert financepy_report["tasks"][0]["latest"]["knowledge_revision"] == "know2222"
+    assert negative_report["latest_pass_count"] == 1
+    assert negative_report["tasks"][0]["latest"]["result_label"] == "passed_expectation"
+
+    rendered = render_benchmark_history_scorecard(financepy_report)
+    assert "Improved" in rendered
+
+    artifacts = save_benchmark_history_scorecard(
+        financepy_report,
+        reports_root=tmp_path,
+        stem="financepy_daily_scorecard",
+    )
+    assert artifacts.json_path.exists()
+    assert artifacts.text_path.exists()

--- a/tests/test_agent/test_benchmark_history.py
+++ b/tests/test_agent/test_benchmark_history.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from trellis.agent.benchmark_history import (
     build_benchmark_history_scorecard,
     load_benchmark_history_records,
@@ -122,3 +124,50 @@ def test_build_benchmark_history_scorecard_tracks_improvement(tmp_path):
     )
     assert artifacts.json_path.exists()
     assert artifacts.text_path.exists()
+
+
+def test_build_benchmark_history_scorecard_tracks_regression():
+    records = [
+        {
+            "task_id": "F002",
+            "title": "Barrier",
+            "task_corpus": "benchmark_financepy",
+            "run_id": "run_1",
+            "run_started_at": "2026-04-14T01:00:00+00:00",
+            "run_completed_at": "2026-04-14T01:00:04+00:00",
+            "execution_mode": "cold_agent_plus_financepy_reference",
+            "git_sha": "aaaa1111",
+            "knowledge_revision": "know1111",
+            "comparison_summary": {"status": "passed"},
+            "cold_agent_elapsed_seconds": 4.0,
+            "cold_agent_token_usage": {"total_tokens": 180},
+        },
+        {
+            "task_id": "F002",
+            "title": "Barrier",
+            "task_corpus": "benchmark_financepy",
+            "run_id": "run_2",
+            "run_started_at": "2026-04-15T01:00:00+00:00",
+            "run_completed_at": "2026-04-15T01:00:06+00:00",
+            "execution_mode": "cold_agent_plus_financepy_reference",
+            "git_sha": "bbbb2222",
+            "knowledge_revision": "know2222",
+            "comparison_summary": {"status": "failed"},
+            "cold_agent_elapsed_seconds": 6.0,
+            "cold_agent_token_usage": {"total_tokens": 220},
+        },
+    ]
+
+    report = build_benchmark_history_scorecard(
+        scorecard_name="regression_scorecard",
+        benchmark_kind="financepy",
+        benchmark_runs=records,
+        campaign_id="daily_suite",
+    )
+
+    assert report["regressed_count"] == 1
+    assert report["improved_count"] == 0
+    assert report["latest_pass_count"] == 0
+    assert report["tasks"][0]["transition"] == "regressed"
+    assert report["tasks"][0]["elapsed_seconds_delta"] == pytest.approx(2.0)
+    assert report["tasks"][0]["token_total_delta"] == 40

--- a/tests/test_agent/test_financepy_benchmark.py
+++ b/tests/test_agent/test_financepy_benchmark.py
@@ -53,6 +53,32 @@ def test_price_financepy_reference_supports_equity_vanilla_and_fx():
     assert "delta" in fx["outputs"]
 
 
+def test_financepy_benchmark_manifest_includes_tranche_two_families():
+    tasks = {task["id"]: task for task in load_financepy_benchmark_tasks(root=ROOT)}
+    assert {"F009", "F010", "F011", "F012", "F013", "F014", "F015"} <= set(tasks)
+
+
+@pytest.mark.parametrize(
+    ("task_id", "expected_outputs"),
+    [
+        ("F009", ("price",)),
+        ("F010", ("price",)),
+        ("F011", ("price",)),
+        ("F012", ("price",)),
+        ("F013", ("price",)),
+        ("F014", ("price",)),
+        ("F015", ("price",)),
+    ],
+)
+def test_price_financepy_reference_supports_tranche_two_families(task_id, expected_outputs):
+    tasks = {task["id"]: task for task in load_financepy_benchmark_tasks(root=ROOT)}
+    result = price_financepy_reference(tasks[task_id], root=ROOT)
+
+    assert result["elapsed_seconds"] >= 0.0
+    for output_name in expected_outputs:
+        assert output_name in result["outputs"]
+
+
 def test_build_financepy_benchmark_report_accumulates_totals():
     report = build_financepy_benchmark_report(
         benchmark_name="financepy_suite",

--- a/tests/test_agent/test_task_run_store.py
+++ b/tests/test_agent/test_task_run_store.py
@@ -861,6 +861,8 @@ def test_persist_canary_batch_record_writes_history_and_latest_views(tmp_path):
     assert record["summary"]["batch_scope"] == "full_curated"
     assert record["summary"]["benchmark_eligible"] is True
     assert record["summary"]["comparison_key"] == "live:full_curated:standard:default:gpt-5.4-mini"
+    assert record["summary"]["git_sha"]
+    assert record["summary"]["knowledge_revision"]
     assert record["summary"]["task_count"] == 2
     assert record["summary"]["pass_count"] == 1
     assert record["summary"]["failure_count"] == 1

--- a/tests/test_agent/test_task_run_store_manifest_metadata.py
+++ b/tests/test_agent/test_task_run_store_manifest_metadata.py
@@ -36,3 +36,7 @@ def test_build_task_run_record_carries_manifest_and_timestamp_metadata():
     assert record["summary"]["market_scenario_digest"] == "digest-flat-equity"
     assert record["summary"]["task_corpus"] == "benchmark_financepy"
     assert record["summary"]["task_definition_version"] == 2
+    assert record["git_sha"]
+    assert record["knowledge_revision"]
+    assert record["summary"]["git_sha"] == record["git_sha"]
+    assert record["summary"]["knowledge_revision"] == record["knowledge_revision"]

--- a/trellis/agent/benchmark_history.py
+++ b/trellis/agent/benchmark_history.py
@@ -1,0 +1,240 @@
+"""Repeated-run benchmark history loading and scorecard rendering."""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SCORECARD_ROOT = ROOT / "task_runs" / "benchmark_scorecards"
+
+
+@dataclass(frozen=True)
+class BenchmarkHistoryArtifacts:
+    report: dict[str, Any]
+    json_path: Path
+    text_path: Path
+
+
+def load_benchmark_history_records(
+    *,
+    benchmark_root: Path,
+    task_ids: Sequence[str] | None = None,
+    campaign_id: str | None = None,
+) -> list[dict[str, Any]]:
+    """Load append-only benchmark history records from one benchmark root."""
+    requested = {
+        str(task_id).strip()
+        for task_id in (task_ids or ())
+        if str(task_id).strip()
+    }
+    history_root = benchmark_root / "history"
+    if not history_root.exists():
+        return []
+
+    records: list[dict[str, Any]] = []
+    for path in sorted(history_root.glob("*/*.json")):
+        payload = json.loads(path.read_text())
+        task_id = str(payload.get("task_id") or "").strip()
+        if requested and task_id not in requested:
+            continue
+        if campaign_id is not None and (
+            str(payload.get("benchmark_campaign_id") or "").strip()
+            != str(campaign_id).strip()
+        ):
+            continue
+        records.append(dict(payload))
+    return sorted(records, key=_history_sort_key)
+
+
+def build_benchmark_history_scorecard(
+    *,
+    scorecard_name: str,
+    benchmark_kind: str,
+    benchmark_runs: Sequence[Mapping[str, Any]],
+    campaign_id: str | None = None,
+    notes: Sequence[str] | None = None,
+) -> dict[str, Any]:
+    """Build a repeated-run scorecard from append-only benchmark history."""
+    grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for record in benchmark_runs:
+        task_id = str(record.get("task_id") or "").strip()
+        if task_id:
+            grouped[task_id].append(dict(record))
+
+    task_summaries: list[dict[str, Any]] = []
+    improved_count = 0
+    regressed_count = 0
+    latest_pass_count = 0
+    for task_id in sorted(grouped):
+        runs = sorted(grouped[task_id], key=_history_sort_key)
+        summary = _build_task_history_summary(task_id, runs, benchmark_kind=benchmark_kind)
+        if summary["transition"] == "improved":
+            improved_count += 1
+        elif summary["transition"] == "regressed":
+            regressed_count += 1
+        if summary["latest"]["passed"]:
+            latest_pass_count += 1
+        task_summaries.append(summary)
+
+    return {
+        "scorecard_name": scorecard_name,
+        "benchmark_kind": benchmark_kind,
+        "benchmark_campaign_id": campaign_id or "",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "task_count": len(task_summaries),
+        "run_count": len(benchmark_runs),
+        "improved_count": improved_count,
+        "regressed_count": regressed_count,
+        "unchanged_count": len(task_summaries) - improved_count - regressed_count,
+        "latest_pass_count": latest_pass_count,
+        "tasks": task_summaries,
+        "notes": list(notes or ()),
+    }
+
+
+def render_benchmark_history_scorecard(report: Mapping[str, Any]) -> str:
+    lines = [
+        f"# Benchmark History Scorecard: `{report['scorecard_name']}`",
+        f"- Benchmark kind: `{report.get('benchmark_kind', '')}`",
+        f"- Campaign: `{report.get('benchmark_campaign_id', '') or 'all'}`",
+        f"- Tasks: `{report.get('task_count', 0)}`",
+        f"- Runs: `{report.get('run_count', 0)}`",
+        f"- Latest pass count: `{report.get('latest_pass_count', 0)}`",
+        f"- Improved: `{report.get('improved_count', 0)}`",
+        f"- Regressed: `{report.get('regressed_count', 0)}`",
+    ]
+    if report.get("notes"):
+        lines.extend(["", "## Notes"])
+        lines.extend(f"- {note}" for note in report["notes"])
+
+    lines.extend(["", "## Task History"])
+    for task in report.get("tasks") or ():
+        first = dict(task.get("first") or {})
+        latest = dict(task.get("latest") or {})
+        lines.extend(
+            [
+                "",
+                f"### `{task.get('task_id', '')}` {task.get('title', '')}",
+                f"- Runs: `{task.get('run_count', 0)}`",
+                f"- Transition: `{task.get('transition', 'unchanged')}`",
+                f"- First run: `{first.get('run_started_at', '')}` `{first.get('git_sha', '')}` `{first.get('knowledge_revision', '')}` `{first.get('result_label', '')}`",
+                f"- Latest run: `{latest.get('run_started_at', '')}` `{latest.get('git_sha', '')}` `{latest.get('knowledge_revision', '')}` `{latest.get('result_label', '')}`",
+                f"- Elapsed delta: `{task.get('elapsed_seconds_delta', 0.0):+.6f}`",
+                f"- Token delta: `{task.get('token_total_delta', 0):+d}`",
+                f"- Execution modes: `{', '.join(task.get('execution_modes', ())) or 'none'}`",
+            ]
+        )
+    return "\n".join(lines) + "\n"
+
+
+def save_benchmark_history_scorecard(
+    report: Mapping[str, Any],
+    *,
+    reports_root: Path = DEFAULT_SCORECARD_ROOT,
+    stem: str,
+) -> BenchmarkHistoryArtifacts:
+    reports_root.mkdir(parents=True, exist_ok=True)
+    json_path = reports_root / f"{stem}.json"
+    text_path = reports_root / f"{stem}.md"
+    payload = dict(report)
+    json_path.write_text(json.dumps(payload, indent=2, default=str))
+    text_path.write_text(render_benchmark_history_scorecard(payload))
+    return BenchmarkHistoryArtifacts(report=payload, json_path=json_path, text_path=text_path)
+
+
+def _history_sort_key(record: Mapping[str, Any]) -> tuple[str, str]:
+    return (
+        str(record.get("run_started_at") or record.get("run_completed_at") or ""),
+        str(record.get("run_id") or ""),
+    )
+
+
+def _build_task_history_summary(
+    task_id: str,
+    runs: Sequence[Mapping[str, Any]],
+    *,
+    benchmark_kind: str,
+) -> dict[str, Any]:
+    first = dict(runs[0])
+    latest = dict(runs[-1])
+    first_snapshot = _task_run_snapshot(first, benchmark_kind=benchmark_kind)
+    latest_snapshot = _task_run_snapshot(latest, benchmark_kind=benchmark_kind)
+    transition = _transition_label(first_snapshot["passed"], latest_snapshot["passed"])
+    return {
+        "task_id": task_id,
+        "title": str(latest.get("title") or first.get("title") or ""),
+        "task_corpus": str(latest.get("task_corpus") or first.get("task_corpus") or ""),
+        "run_count": len(runs),
+        "transition": transition,
+        "execution_modes": tuple(
+            dict.fromkeys(
+                str(run.get("execution_mode") or "").strip()
+                for run in runs
+                if str(run.get("execution_mode") or "").strip()
+            )
+        ),
+        "elapsed_seconds_delta": round(
+            float(latest_snapshot["elapsed_seconds"]) - float(first_snapshot["elapsed_seconds"]),
+            6,
+        ),
+        "token_total_delta": int(latest_snapshot["token_total"]) - int(first_snapshot["token_total"]),
+        "first": first_snapshot,
+        "latest": latest_snapshot,
+    }
+
+
+def _task_run_snapshot(record: Mapping[str, Any], *, benchmark_kind: str) -> dict[str, Any]:
+    return {
+        "run_id": str(record.get("run_id") or ""),
+        "run_started_at": str(record.get("run_started_at") or ""),
+        "run_completed_at": str(record.get("run_completed_at") or ""),
+        "execution_mode": str(record.get("execution_mode") or ""),
+        "git_sha": str(record.get("git_sha") or ""),
+        "knowledge_revision": str(record.get("knowledge_revision") or ""),
+        "result_label": _result_label(record, benchmark_kind=benchmark_kind),
+        "passed": _record_passed(record, benchmark_kind=benchmark_kind),
+        "elapsed_seconds": _elapsed_seconds(record),
+        "token_total": _token_total(record),
+    }
+
+
+def _result_label(record: Mapping[str, Any], *, benchmark_kind: str) -> str:
+    if benchmark_kind == "negative":
+        if bool(record.get("passed_expectation")):
+            return "passed_expectation"
+        return str(record.get("observed_outcome") or record.get("status") or "").strip()
+    comparison = dict(record.get("comparison_summary") or {})
+    return str(comparison.get("status") or record.get("status") or "").strip()
+
+
+def _record_passed(record: Mapping[str, Any], *, benchmark_kind: str) -> bool:
+    if benchmark_kind == "negative":
+        return bool(record.get("passed_expectation"))
+    return str(dict(record.get("comparison_summary") or {}).get("status") or "").strip() == "passed"
+
+
+def _elapsed_seconds(record: Mapping[str, Any]) -> float:
+    if record.get("cold_agent_elapsed_seconds") is not None:
+        return float(record.get("cold_agent_elapsed_seconds") or 0.0)
+    return float(record.get("elapsed_seconds") or 0.0)
+
+
+def _token_total(record: Mapping[str, Any]) -> int:
+    if isinstance(record.get("cold_agent_token_usage"), Mapping):
+        return int(dict(record.get("cold_agent_token_usage") or {}).get("total_tokens") or 0)
+    return int(dict(record.get("token_usage_summary") or {}).get("total_tokens") or 0)
+
+
+def _transition_label(first_passed: bool, latest_passed: bool) -> str:
+    if first_passed and not latest_passed:
+        return "regressed"
+    if not first_passed and latest_passed:
+        return "improved"
+    return "unchanged"

--- a/trellis/agent/runtime_revisions.py
+++ b/trellis/agent/runtime_revisions.py
@@ -1,0 +1,52 @@
+"""Runtime revision metadata helpers for persisted task and benchmark records."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def runtime_revision_metadata(result: Mapping[str, Any] | None = None) -> dict[str, str]:
+    """Return the best available repo and knowledge revisions for one run."""
+    environment = _environment_payload(result)
+    git_sha = str(environment.get("repo_revision") or "").strip() or _safe_repo_revision()
+    knowledge_revision = (
+        str(environment.get("knowledge_hash") or environment.get("knowledge_revision") or "").strip()
+        or _safe_knowledge_revision()
+    )
+    return {
+        "git_sha": git_sha or "unknown",
+        "knowledge_revision": knowledge_revision or "unknown",
+    }
+
+
+def _environment_payload(result: Mapping[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(result, Mapping):
+        return {}
+
+    for container_key in ("framework_result", "framework"):
+        container = result.get(container_key)
+        if not isinstance(container, Mapping):
+            continue
+        environment = container.get("environment")
+        if isinstance(environment, Mapping):
+            return dict(environment)
+    return {}
+
+
+def _safe_repo_revision() -> str:
+    try:
+        from trellis.agent.knowledge.import_registry import get_repo_revision
+
+        return str(get_repo_revision() or "").strip()
+    except Exception:
+        return ""
+
+
+def _safe_knowledge_revision() -> str:
+    try:
+        from trellis.agent.knowledge import get_store
+
+        return str(get_store().compute_knowledge_hash() or "").strip()
+    except Exception:
+        return ""

--- a/trellis/agent/task_run_store.py
+++ b/trellis/agent/task_run_store.py
@@ -12,6 +12,7 @@ from typing import Any, Mapping
 import yaml
 
 from trellis.agent.analytical_traces import AnalyticalTrace, route_health_snapshot
+from trellis.agent.runtime_revisions import runtime_revision_metadata
 from trellis.agent.task_diagnostics import (
     DIAGNOSIS_HISTORY_ROOT,
     DIAGNOSIS_LATEST_ROOT,
@@ -168,6 +169,7 @@ def persist_canary_batch_record(
     """Persist one explicit canary-batch record and stable latest view."""
     batch_id = f"canary_{started_at.astimezone(timezone.utc).strftime('%Y%m%dT%H%M%S%fZ')}"
     execution_mode = "cassette_replay" if replay else "live"
+    revisions = runtime_revision_metadata()
     batch_scope, scope_slug = _canary_batch_scope(
         requested_task_id=requested_task_id,
         requested_subset=requested_subset,
@@ -203,6 +205,8 @@ def persist_canary_batch_record(
         validation=validation,
         knowledge_profile=knowledge_profile,
         comparison_key=comparison_key,
+        git_sha=revisions["git_sha"],
+        knowledge_revision=revisions["knowledge_revision"],
         requested_task_id=requested_task_id,
         requested_subset=requested_subset,
         started_at=started_at,
@@ -223,6 +227,8 @@ def persist_canary_batch_record(
             "replay": replay,
             "execution_mode": execution_mode,
             "comparison_key": comparison_key,
+            "git_sha": revisions["git_sha"],
+            "knowledge_revision": revisions["knowledge_revision"],
             "synthetic_source": synthetic_source or None,
         },
         "manifest": {
@@ -382,6 +388,8 @@ def _summarize_canary_batch(
     validation: str,
     knowledge_profile: str,
     comparison_key: str,
+    git_sha: str,
+    knowledge_revision: str,
     requested_task_id: str | None,
     requested_subset: str | None,
     started_at: datetime,
@@ -410,6 +418,8 @@ def _summarize_canary_batch(
         "model": model,
         "validation": validation,
         "knowledge_profile": knowledge_profile,
+        "git_sha": git_sha,
+        "knowledge_revision": knowledge_revision,
         "synthetic_source": synthetic_source or None,
         "requested_task_id": requested_task_id,
         "requested_subset": requested_subset,
@@ -467,6 +477,7 @@ def build_task_run_record(
         method_runs=method_runs,
         workflow=workflow,
     )
+    revisions = runtime_revision_metadata(result)
 
     return {
         "task_id": task["id"],
@@ -475,6 +486,8 @@ def build_task_run_record(
         "persisted_at": persisted_at.astimezone(timezone.utc).isoformat(),
         "run_started_at": str(result.get("run_started_at") or result.get("start_time") or ""),
         "run_completed_at": str(result.get("run_completed_at") or ""),
+        "git_sha": revisions["git_sha"],
+        "knowledge_revision": revisions["knowledge_revision"],
         "task": _task_snapshot(task),
         "result": result_with_learning,
         "comparison": {
@@ -525,6 +538,8 @@ def build_task_run_record(
             "prices": dict((result.get("cross_validation") or {}).get("prices") or {}),
             "deviations_pct": dict((result.get("cross_validation") or {}).get("deviations_pct") or {}),
             "token_usage": dict(result.get("token_usage_summary") or {}),
+            "git_sha": revisions["git_sha"],
+            "knowledge_revision": revisions["knowledge_revision"],
             "framework_outcome": framework.get("outcome_type"),
             "execution_mode": str(result.get("execution_mode") or "live"),
             "learning": learning,


### PR DESCRIPTION
## Summary
- add benchmark history scorecards and campaign-aware run-history comparison for FinancePy and negative benchmarks
- persist repo and knowledge revisions into benchmark, task-run, and canary history records
- tighten tranche-two FinancePy parity coverage and align digital-option overlap metadata with actual reference outputs

## Validation
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_financepy_benchmark.py tests/test_agent/test_benchmark_history.py tests/test_agent/test_negative_task_benchmark.py tests/test_agent/test_task_run_store.py tests/test_agent/test_task_run_store_manifest_metadata.py -q
- /Users/steveyang/miniforge3/bin/python3 -m py_compile trellis/agent/runtime_revisions.py trellis/agent/benchmark_history.py trellis/agent/task_run_store.py scripts/run_financepy_benchmark.py scripts/run_negative_benchmark.py scripts/run_benchmark_history_scorecard.py
- /Users/steveyang/miniforge3/bin/python3 scripts/run_financepy_benchmark.py F010 --report-name qua831_f010_smoke --campaign-id qua831_tranche2
