### PR TITLE
QUA-877: surface multi-target harness shape in runner output

### DIFF
--- a/tests/test_agent/test_task_runtime.py
+++ b/tests/test_agent/test_task_runtime.py
@@ -3669,3 +3669,60 @@ def test_prepared_task_carries_compiled_request(monkeypatch):
     )
 
     assert prepared.compiled_request is mock_compiled
+
+
+def test_cross_validate_analytical_field_creates_two_target_harness():
+    """Documents the design discovered by QUA-877: setting
+    `cross_validate.analytical: <name>` instructs the comparison harness to
+    build TWO targets -- one general construct-method target (LLM-built) and
+    one named reference target (deterministic body when the executor has one
+    via `_deterministic_exact_binding_evaluate_body`).  The two builds are
+    then cross-validated against each other.
+
+    This is why F001 (the only pilot task with `cross_validate.analytical`)
+    spends ~16k extra tokens on the LLM codegen + reflection vs. F002/F009/
+    F012, which use a single-target harness with deterministic short-circuit.
+    The extra cost on F001 is the price of a self-test that proves the
+    LLM-built analytical path matches the deterministic Black-Scholes
+    reference.  Tasks that don't need the self-test should omit
+    `cross_validate.analytical`.
+    """
+    from trellis.agent.assembly_tools import build_comparison_harness_plan
+
+    f001_task = {
+        "id": "F001",
+        "construct": "analytical",
+        "cross_validate": {
+            "external": ["financepy"],
+            "analytical": "black_scholes",
+        },
+    }
+    plan = build_comparison_harness_plan(f001_task)
+    target_ids = [t.target_id for t in plan.targets]
+    assert target_ids == ["analytical", "black_scholes"]
+    assert plan.reference_target == "black_scholes"
+    assert plan.targets[0].is_reference is False
+    assert plan.targets[1].is_reference is True
+
+
+def test_cross_validate_without_analytical_field_creates_single_target_harness():
+    """Tasks without `cross_validate.analytical` (F002/F003/F007/F009/F012 in
+    the pilot) get a single-target harness.  The construct-method target's
+    request metadata then carries no `comparison_target`, so the executor's
+    deterministic-exact-binding gate fires only when a route's helper-body
+    lookup matches (F002 fx, F009 barrier, F012 chooser) -- not when the
+    route happens to share kernel primitives with another route (F003 cap
+    on Black76 doesn't get the european-vanilla deterministic body).
+    """
+    from trellis.agent.assembly_tools import build_comparison_harness_plan
+
+    f002_task = {
+        "id": "F002",
+        "construct": "analytical",
+        "cross_validate": {
+            "external": ["financepy"],
+        },
+    }
+    plan = build_comparison_harness_plan(f002_task)
+    assert [t.target_id for t in plan.targets] == ["analytical"]
+    assert plan.reference_target is None

--- a/tests/test_agent/test_task_runtime.py
+++ b/tests/test_agent/test_task_runtime.py
@@ -3672,21 +3672,9 @@ def test_prepared_task_carries_compiled_request(monkeypatch):
 
 
 def test_cross_validate_analytical_field_creates_two_target_harness():
-    """Documents the design discovered by QUA-877: setting
-    `cross_validate.analytical: <name>` instructs the comparison harness to
-    build TWO targets -- one general construct-method target (LLM-built) and
-    one named reference target (deterministic body when the executor has one
-    via `_deterministic_exact_binding_evaluate_body`).  The two builds are
-    then cross-validated against each other.
-
-    This is why F001 (the only pilot task with `cross_validate.analytical`)
-    spends ~16k extra tokens on the LLM codegen + reflection vs. F002/F009/
-    F012, which use a single-target harness with deterministic short-circuit.
-    The extra cost on F001 is the price of a self-test that proves the
-    LLM-built analytical path matches the deterministic Black-Scholes
-    reference.  Tasks that don't need the self-test should omit
-    `cross_validate.analytical`.
-    """
+    """`cross_validate.analytical: <name>` adds a named reference target on
+    top of the construct-method target, marking the named one with
+    `is_reference=True` and exposing it as `reference_target` on the plan."""
     from trellis.agent.assembly_tools import build_comparison_harness_plan
 
     f001_task = {
@@ -3706,14 +3694,8 @@ def test_cross_validate_analytical_field_creates_two_target_harness():
 
 
 def test_cross_validate_without_analytical_field_creates_single_target_harness():
-    """Tasks without `cross_validate.analytical` (F002/F003/F007/F009/F012 in
-    the pilot) get a single-target harness.  The construct-method target's
-    request metadata then carries no `comparison_target`, so the executor's
-    deterministic-exact-binding gate fires only when a route's helper-body
-    lookup matches (F002 fx, F009 barrier, F012 chooser) -- not when the
-    route happens to share kernel primitives with another route (F003 cap
-    on Black76 doesn't get the european-vanilla deterministic body).
-    """
+    """Without `cross_validate.analytical`, the harness emits a single
+    construct-method target and `reference_target` is `None`."""
     from trellis.agent.assembly_tools import build_comparison_harness_plan
 
     f002_task = {

--- a/trellis/agent/task_runtime.py
+++ b/trellis/agent/task_runtime.py
@@ -1098,7 +1098,7 @@ def run_task(
     print(f"  instrument_type={instrument_type}")
     if construct_methods:
         print(f"  construct_methods={construct_methods}")
-    if len(comparison_targets) > 1:
+    if comparison_task:
         # Surface the multi-target harness shape so the per-task token cost
         # is interpretable in context: a 2-target harness builds twice (e.g.
         # one LLM-built construct-method target plus one named reference

--- a/trellis/agent/task_runtime.py
+++ b/trellis/agent/task_runtime.py
@@ -1098,6 +1098,18 @@ def run_task(
     print(f"  instrument_type={instrument_type}")
     if construct_methods:
         print(f"  construct_methods={construct_methods}")
+    if len(comparison_targets) > 1:
+        # Surface the multi-target harness shape so the per-task token cost
+        # is interpretable in context: a 2-target harness builds twice (e.g.
+        # one LLM-built construct-method target plus one named reference
+        # target) and the costs aggregate.  See QUA-877 for the F001 case
+        # study where this caused legitimate self-test work to look like a
+        # short-circuit asymmetry.
+        target_summary = ", ".join(
+            f"{t.target_id}{'(ref)' if t.is_reference else ''}"
+            for t in comparison_targets
+        )
+        print(f"  harness_targets={len(comparison_targets)} [{target_summary}]")
     print(f"{'=' * 60}")
 
     t0 = timer()


### PR DESCRIPTION
## Summary

Closes the QUA-877 investigation into the F001-vs-F012 LLM-call asymmetry surfaced by the 2026-04-15 pilot run. The asymmetry is **by design**, not a bug — but the runner output didn't make that obvious. This PR adds a one-line disclosure so future readers don't chase a phantom optimization.

### Finding

F001 spends ~16k extra tokens on LLM codegen + reflection vs F012's all-deterministic path because F001 is the *only* pilot task that sets `cross_validate.analytical: black_scholes`. That field instructs `build_comparison_harness_plan` to emit **two** harness targets:

- `("analytical", is_reference=False)` — the LLM-built construct-method build that exercises the agent's analytical path
- `("black_scholes", is_reference=True)` — the deterministic Black-Scholes reference build (executor's `_deterministic_exact_binding_evaluate_body` short-circuits the LLM)

The two builds are then cross-validated against each other. The LLM call IS the self-test that proves the agent-built analytical pricer matches the deterministic Black-Scholes reference.

### Per-task harness shapes (verified)

| Task | Harness | LLM codegen | Notes |
|------|---------|-------------|-------|
| F001 | 2 targets (analytical + black_scholes ref) | 1 (one target uses LLM, one uses det body) | self-test by design |
| F002 | 1 target | 0 | helper `price_fx_vanilla_analytical` short-circuits |
| F003 | 1 target | 1 | no helper for cap on Black76 |
| F007 | 1 target | 1 | no helper for CDS analytical |
| F009 | 1 target | 0 | helper `barrier_option_price` short-circuits |
| F012 | 1 target | 0 | helper `price_equity_chooser_option_analytical` short-circuits |

### Action

- **Runner console line** now emits `harness_targets=N [target1, target2(ref)]` whenever the harness has more than one target, so operators can see the shape at a glance.
- **Two new tests** pin the harness-shape contract:
  - `test_cross_validate_analytical_field_creates_two_target_harness`
  - `test_cross_validate_without_analytical_field_creates_single_target_harness`
- **No executor change.** The deterministic gate is correct: it fires for the *named* reference target (where the body is unambiguous) and defers to the LLM for the construct-method target (where the agent is the thing under test).

If a future task wants to skip the LLM self-test and just use the deterministic path, it should omit `cross_validate.analytical`.

## Test plan

- [x] `pytest tests/test_agent/ -q -m \"not integration\"` — 1839 passed (+2 vs post-#590 baseline of 1837)
- [x] Existing `test_run_task_passes_force_rebuild_and_validation` and other 87 task_runtime tests still pass
- [ ] Live pilot rerun deferred — no behavioral change to runner outputs that would invalidate the 2026-04-15 baseline scorecard

## Scope notes

- No change to `LIMITATIONS.md` — support contract is unchanged.
- The investigation revealed that F001's LLM tokens are unavoidable cost-of-self-validation, not a fixable inefficiency. Documenting this prevents future readers from filing the same ticket again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)