### PR TITLE
QUA-861: honest Greek coverage reporting in benchmark parity

### DIFF
--- a/scripts/run_financepy_benchmark.py
+++ b/scripts/run_financepy_benchmark.py
@@ -38,10 +38,7 @@ from trellis.agent.financepy_benchmark import (
     select_financepy_benchmark_tasks,
 )
 from trellis.agent.benchmark_runner_dispatch import dispatch_benchmark_tasks
-from trellis.agent.financepy_output_comparison import (
-    compare_benchmark_outputs,
-    output_value as _output_value,
-)
+from trellis.agent.financepy_output_comparison import compare_benchmark_outputs
 from trellis.agent.fresh_generated_boundary import (
     FreshGeneratedBoundaryError,
     enforce_fresh_generated_boundary,

--- a/scripts/run_financepy_benchmark.py
+++ b/scripts/run_financepy_benchmark.py
@@ -38,6 +38,10 @@ from trellis.agent.financepy_benchmark import (
     select_financepy_benchmark_tasks,
 )
 from trellis.agent.benchmark_runner_dispatch import dispatch_benchmark_tasks
+from trellis.agent.financepy_output_comparison import (
+    compare_benchmark_outputs,
+    output_value as _output_value,
+)
 from trellis.agent.fresh_generated_boundary import (
     FreshGeneratedBoundaryError,
     enforce_fresh_generated_boundary,
@@ -128,113 +132,7 @@ def _read_generated_artifact_source(generated_artifact: dict[str, Any]) -> str |
         return None
 
 
-def _output_value(outputs: dict[str, Any], key: str) -> Any:
-    if key in outputs:
-        return outputs.get(key)
-    greeks = outputs.get("greeks") or {}
-    if isinstance(greeks, dict):
-        return greeks.get(key)
-    return None
-
-
-def _compare_outputs(
-    *,
-    task: dict[str, Any],
-    binding: dict[str, Any],
-    trellis_outputs: dict[str, Any],
-    financepy_outputs: dict[str, Any] | None,
-) -> dict[str, Any]:
-    """Compare Trellis vs FinancePy outputs, reporting Greek coverage honestly.
-
-    Refs: QUA-861.  The older shape silently skipped declared outputs that
-    one side didn't emit, so a task could "pass" on `price` alone while
-    quietly missing every Greek.  This version records
-    ``missing_trellis_outputs`` / ``missing_financepy_outputs`` and
-    per-side Greek coverage + Greek-only parity so scorecards can surface
-    the gap.
-    """
-    tolerance_pct = float(((task.get("cross_validate") or {}).get("tolerance_pct") or 5.0))
-    financepy_outputs = financepy_outputs or {}
-    overlapping_outputs = tuple(
-        str(name).strip()
-        for name in (binding.get("overlapping_outputs") or ())
-        if str(name).strip()
-    )
-    compared_outputs: list[str] = []
-    output_deltas: dict[str, float] = {}
-    failures: list[str] = []
-    missing_trellis: list[str] = []
-    missing_financepy: list[str] = []
-    greek_failures: list[str] = []
-    trellis_greek_count = 0
-    financepy_greek_count = 0
-    compared_greek_count = 0
-    compared_greeks = False
-    for output_name in overlapping_outputs:
-        is_greek = output_name != "price"
-        trellis_value = _output_value(trellis_outputs, output_name)
-        financepy_value = _output_value(financepy_outputs, output_name)
-        if trellis_value is not None and is_greek:
-            trellis_greek_count += 1
-        if financepy_value is not None and is_greek:
-            financepy_greek_count += 1
-        if trellis_value is None:
-            missing_trellis.append(output_name)
-        if financepy_value is None:
-            missing_financepy.append(output_name)
-        if trellis_value is None or financepy_value is None:
-            continue
-        compared_outputs.append(output_name)
-        if is_greek:
-            compared_greek_count += 1
-            compared_greeks = True
-        denominator = max(abs(float(financepy_value)), 1e-12)
-        deviation_pct = abs(float(trellis_value) - float(financepy_value)) / denominator * 100.0
-        output_deltas[output_name] = round(deviation_pct, 6)
-        if deviation_pct > tolerance_pct:
-            failures.append(output_name)
-            if is_greek:
-                greek_failures.append(output_name)
-
-    greek_coverage = {
-        "trellis_greek_count": trellis_greek_count,
-        "financepy_greek_count": financepy_greek_count,
-        "compared_greek_count": compared_greek_count,
-    }
-    if not compared_greeks:
-        greek_parity = "not_applicable"
-    elif greek_failures:
-        greek_parity = "failed"
-    else:
-        greek_parity = "passed"
-
-    if not compared_outputs:
-        return {
-            "status": "insufficient_overlap",
-            "tolerance_pct": tolerance_pct,
-            "compared_outputs": (),
-            "expected_overlapping_outputs": overlapping_outputs,
-            "missing_trellis_outputs": tuple(missing_trellis),
-            "missing_financepy_outputs": tuple(missing_financepy),
-            "greek_coverage": greek_coverage,
-            "greek_parity": greek_parity,
-            "trellis_outputs": trellis_outputs,
-            "financepy_outputs": financepy_outputs,
-        }
-    return {
-        "status": "passed" if not failures else "failed",
-        "tolerance_pct": tolerance_pct,
-        "compared_outputs": tuple(compared_outputs),
-        "expected_overlapping_outputs": overlapping_outputs,
-        "output_deviation_pct": output_deltas,
-        "missing_trellis_outputs": tuple(missing_trellis),
-        "missing_financepy_outputs": tuple(missing_financepy),
-        "greek_coverage": greek_coverage,
-        "greek_parity": greek_parity,
-        "greek_failures": tuple(greek_failures),
-        "trellis_outputs": trellis_outputs,
-        "financepy_outputs": financepy_outputs,
-    }
+_compare_outputs = compare_benchmark_outputs
 
 
 def _execute_single_benchmark_task(

--- a/scripts/run_financepy_benchmark.py
+++ b/scripts/run_financepy_benchmark.py
@@ -144,6 +144,15 @@ def _compare_outputs(
     trellis_outputs: dict[str, Any],
     financepy_outputs: dict[str, Any] | None,
 ) -> dict[str, Any]:
+    """Compare Trellis vs FinancePy outputs, reporting Greek coverage honestly.
+
+    Refs: QUA-861.  The older shape silently skipped declared outputs that
+    one side didn't emit, so a task could "pass" on `price` alone while
+    quietly missing every Greek.  This version records
+    ``missing_trellis_outputs`` / ``missing_financepy_outputs`` and
+    per-side Greek coverage + Greek-only parity so scorecards can surface
+    the gap.
+    """
     tolerance_pct = float(((task.get("cross_validate") or {}).get("tolerance_pct") or 5.0))
     financepy_outputs = financepy_outputs or {}
     overlapping_outputs = tuple(
@@ -154,23 +163,61 @@ def _compare_outputs(
     compared_outputs: list[str] = []
     output_deltas: dict[str, float] = {}
     failures: list[str] = []
+    missing_trellis: list[str] = []
+    missing_financepy: list[str] = []
+    greek_failures: list[str] = []
+    trellis_greek_count = 0
+    financepy_greek_count = 0
+    compared_greek_count = 0
+    compared_greeks = False
     for output_name in overlapping_outputs:
+        is_greek = output_name != "price"
         trellis_value = _output_value(trellis_outputs, output_name)
         financepy_value = _output_value(financepy_outputs, output_name)
+        if trellis_value is not None and is_greek:
+            trellis_greek_count += 1
+        if financepy_value is not None and is_greek:
+            financepy_greek_count += 1
+        if trellis_value is None:
+            missing_trellis.append(output_name)
+        if financepy_value is None:
+            missing_financepy.append(output_name)
         if trellis_value is None or financepy_value is None:
             continue
         compared_outputs.append(output_name)
+        if is_greek:
+            compared_greek_count += 1
+            compared_greeks = True
         denominator = max(abs(float(financepy_value)), 1e-12)
         deviation_pct = abs(float(trellis_value) - float(financepy_value)) / denominator * 100.0
         output_deltas[output_name] = round(deviation_pct, 6)
         if deviation_pct > tolerance_pct:
             failures.append(output_name)
+            if is_greek:
+                greek_failures.append(output_name)
+
+    greek_coverage = {
+        "trellis_greek_count": trellis_greek_count,
+        "financepy_greek_count": financepy_greek_count,
+        "compared_greek_count": compared_greek_count,
+    }
+    if not compared_greeks:
+        greek_parity = "not_applicable"
+    elif greek_failures:
+        greek_parity = "failed"
+    else:
+        greek_parity = "passed"
+
     if not compared_outputs:
         return {
             "status": "insufficient_overlap",
             "tolerance_pct": tolerance_pct,
             "compared_outputs": (),
             "expected_overlapping_outputs": overlapping_outputs,
+            "missing_trellis_outputs": tuple(missing_trellis),
+            "missing_financepy_outputs": tuple(missing_financepy),
+            "greek_coverage": greek_coverage,
+            "greek_parity": greek_parity,
             "trellis_outputs": trellis_outputs,
             "financepy_outputs": financepy_outputs,
         }
@@ -180,6 +227,11 @@ def _compare_outputs(
         "compared_outputs": tuple(compared_outputs),
         "expected_overlapping_outputs": overlapping_outputs,
         "output_deviation_pct": output_deltas,
+        "missing_trellis_outputs": tuple(missing_trellis),
+        "missing_financepy_outputs": tuple(missing_financepy),
+        "greek_coverage": greek_coverage,
+        "greek_parity": greek_parity,
+        "greek_failures": tuple(greek_failures),
         "trellis_outputs": trellis_outputs,
         "financepy_outputs": financepy_outputs,
     }

--- a/tests/test_agent/test_financepy_greek_coverage.py
+++ b/tests/test_agent/test_financepy_greek_coverage.py
@@ -14,7 +14,9 @@ reporting shape distinguishes:
 
 from __future__ import annotations
 
-from scripts.run_financepy_benchmark import _compare_outputs
+from trellis.agent.financepy_output_comparison import (
+    compare_benchmark_outputs as _compare_outputs,
+)
 
 
 def _task(tolerance_pct: float = 1.0):
@@ -125,3 +127,59 @@ def test_compare_outputs_treats_price_as_non_greek():
         "financepy_greek_count": 1,
         "compared_greek_count": 1,
     }
+
+
+def test_compare_outputs_does_not_count_payoff_specific_outputs_as_greeks():
+    """`fair_strike_variance` is a variance-swap payoff output, not a Greek.
+
+    The earlier heuristic `is_greek = output_name != "price"` mis-classified
+    it as a Greek and falsely inflated Greek coverage counts.  The explicit
+    allowlist in `GREEK_OUTPUT_NAMES` keeps accounting honest.
+    (PR #593 round 1 Codex review.)
+    """
+    summary = _compare_outputs(
+        task=_task(),
+        binding=_binding("price", "fair_strike_variance"),
+        trellis_outputs={"price": 12.3, "fair_strike_variance": 0.048},
+        financepy_outputs={"price": 12.31, "fair_strike_variance": 0.048},
+    )
+    assert set(summary["compared_outputs"]) == {"price", "fair_strike_variance"}
+    assert summary["greek_coverage"] == {
+        "trellis_greek_count": 0,
+        "financepy_greek_count": 0,
+        "compared_greek_count": 0,
+    }
+    assert summary["greek_parity"] == "not_applicable"
+
+
+def test_compare_outputs_insufficient_overlap_shape_includes_greek_failures_tuple():
+    """Shape consistency: `greek_failures` is present in every return path
+    so downstream consumers never branch on key presence.
+    (PR #593 round 1 Copilot review.)
+    """
+    summary = _compare_outputs(
+        task=_task(),
+        binding=_binding("price", "delta"),
+        trellis_outputs={},
+        financepy_outputs={},
+    )
+    assert summary["status"] == "insufficient_overlap"
+    assert "greek_failures" in summary
+    assert summary["greek_failures"] == ()
+
+
+def test_comparison_library_has_no_import_side_effects():
+    """Importing `trellis.agent.financepy_output_comparison` must not mutate
+    `sys.path`, invoke `load_env()`, or touch the environment.
+    (PR #593 round 1 Copilot review.)
+    """
+    import importlib
+    import sys
+
+    original_path = list(sys.path)
+    # Force a re-import to exercise the import-time codepath.
+    module_name = "trellis.agent.financepy_output_comparison"
+    if module_name in sys.modules:
+        del sys.modules[module_name]
+    importlib.import_module(module_name)
+    assert sys.path == original_path

--- a/tests/test_agent/test_financepy_greek_coverage.py
+++ b/tests/test_agent/test_financepy_greek_coverage.py
@@ -1,0 +1,127 @@
+"""Greek coverage reporting for the FinancePy parity comparison (QUA-861).
+
+The old `_compare_outputs` collapsed silently to `price` when Trellis did
+not emit the Greeks declared in a binding's `overlapping_outputs`.  This
+hid missing Trellis Greek coverage inside a "passed" comparison.  The new
+reporting shape distinguishes:
+
+* `compared_outputs`  -- outputs where both sides emitted a value
+* `missing_trellis_outputs`   -- declared-overlap outputs where Trellis was silent
+* `missing_financepy_outputs` -- declared-overlap outputs where FinancePy was silent
+* `greek_coverage` -- per-side count of Greek outputs emitted
+* `greek_parity`   -- pass/fail across compared Greeks only (price excluded)
+"""
+
+from __future__ import annotations
+
+from scripts.run_financepy_benchmark import _compare_outputs
+
+
+def _task(tolerance_pct: float = 1.0):
+    return {"cross_validate": {"tolerance_pct": tolerance_pct}}
+
+
+def _binding(*outputs: str):
+    return {"overlapping_outputs": list(outputs)}
+
+
+def test_compare_outputs_records_missing_trellis_greeks_explicitly():
+    summary = _compare_outputs(
+        task=_task(),
+        binding=_binding("price", "delta", "gamma", "vega", "theta"),
+        trellis_outputs={"price": 10.45},
+        financepy_outputs={
+            "price": 10.46,
+            "delta": 0.55,
+            "gamma": 0.04,
+            "vega": 0.42,
+            "theta": -0.03,
+        },
+    )
+    assert summary["status"] == "passed"
+    assert summary["compared_outputs"] == ("price",)
+    assert set(summary["missing_trellis_outputs"]) == {"delta", "gamma", "vega", "theta"}
+    assert summary["missing_financepy_outputs"] == ()
+    # Greek parity is "not_applicable" when no Greek was compared on both sides.
+    assert summary["greek_parity"] == "not_applicable"
+    assert summary["greek_coverage"] == {
+        "trellis_greek_count": 0,
+        "financepy_greek_count": 4,
+        "compared_greek_count": 0,
+    }
+
+
+def test_compare_outputs_records_missing_financepy_greeks():
+    summary = _compare_outputs(
+        task=_task(),
+        binding=_binding("price", "delta"),
+        trellis_outputs={"price": 10.45, "delta": 0.55},
+        financepy_outputs={"price": 10.46},
+    )
+    assert set(summary["compared_outputs"]) == {"price"}
+    assert summary["missing_financepy_outputs"] == ("delta",)
+    assert summary["missing_trellis_outputs"] == ()
+
+
+def test_compare_outputs_computes_greek_parity_when_both_sides_emit_greek():
+    summary = _compare_outputs(
+        task=_task(tolerance_pct=2.0),
+        binding=_binding("price", "delta", "vega"),
+        trellis_outputs={"price": 10.45, "delta": 0.55, "vega": 0.40},
+        financepy_outputs={"price": 10.46, "delta": 0.556, "vega": 0.42},
+    )
+    assert set(summary["compared_outputs"]) == {"price", "delta", "vega"}
+    # delta deviation ~1.08%, vega deviation ~4.76%.  Under 2% tolerance vega fails.
+    assert summary["greek_parity"] == "failed"
+    assert "vega" in summary.get("greek_failures", ())
+    assert summary["greek_coverage"] == {
+        "trellis_greek_count": 2,
+        "financepy_greek_count": 2,
+        "compared_greek_count": 2,
+    }
+
+
+def test_compare_outputs_greek_parity_passes_when_all_compared_greeks_within_tolerance():
+    summary = _compare_outputs(
+        task=_task(tolerance_pct=5.0),
+        binding=_binding("price", "delta"),
+        trellis_outputs={"price": 10.45, "delta": 0.550},
+        financepy_outputs={"price": 10.46, "delta": 0.556},
+    )
+    assert summary["greek_parity"] == "passed"
+    assert summary["greek_coverage"]["compared_greek_count"] == 1
+
+
+def test_compare_outputs_preserves_insufficient_overlap_shape():
+    """When neither side emits anything in the declared overlap the status
+    stays `insufficient_overlap` and missing-output lists describe what was
+    expected but absent from each side."""
+    summary = _compare_outputs(
+        task=_task(),
+        binding=_binding("price", "delta"),
+        trellis_outputs={},
+        financepy_outputs={},
+    )
+    assert summary["status"] == "insufficient_overlap"
+    assert set(summary["missing_trellis_outputs"]) == {"price", "delta"}
+    assert set(summary["missing_financepy_outputs"]) == {"price", "delta"}
+    assert summary["greek_coverage"] == {
+        "trellis_greek_count": 0,
+        "financepy_greek_count": 0,
+        "compared_greek_count": 0,
+    }
+
+
+def test_compare_outputs_treats_price_as_non_greek():
+    """`price` is not a Greek; coverage counters must exclude it."""
+    summary = _compare_outputs(
+        task=_task(),
+        binding=_binding("price", "delta"),
+        trellis_outputs={"price": 10.45, "delta": 0.55},
+        financepy_outputs={"price": 10.46, "delta": 0.556},
+    )
+    assert summary["greek_coverage"] == {
+        "trellis_greek_count": 1,
+        "financepy_greek_count": 1,
+        "compared_greek_count": 1,
+    }

--- a/tests/test_agent/test_financepy_greek_coverage.py
+++ b/tests/test_agent/test_financepy_greek_coverage.py
@@ -183,3 +183,19 @@ def test_comparison_library_has_no_import_side_effects():
         del sys.modules[module_name]
     importlib.import_module(module_name)
     assert sys.path == original_path
+
+
+def test_compare_outputs_preserves_explicit_zero_tolerance():
+    """An explicit `tolerance_pct: 0.0` on the task is strict-parity, not
+    "fall back to the 5% default".  The `... or 5.0` idiom would silently
+    upgrade 0 to 5.  (PR #593 round 3 Copilot review.)"""
+    task = {"cross_validate": {"tolerance_pct": 0.0}}
+    summary = _compare_outputs(
+        task=task,
+        binding=_binding("price"),
+        trellis_outputs={"price": 10.0},
+        financepy_outputs={"price": 10.01},
+    )
+    assert summary["tolerance_pct"] == 0.0
+    # 0.1% deviation exceeds a 0% tolerance, so the comparison fails.
+    assert summary["status"] == "failed"

--- a/tests/test_agent/test_pilot_parity_scorecard.py
+++ b/tests/test_agent/test_pilot_parity_scorecard.py
@@ -400,3 +400,135 @@ def test_pilot_parity_scorecard_cli_writes_artifacts(tmp_path, monkeypatch, caps
     assert payload["pilot_summary"]["fresh_generated_enforced_count"] == len(
         PILOT_SCORECARD_TASK_IDS
     )
+
+
+def _record_with_greek_coverage(task_id, *, trellis_greeks, financepy_greeks, greek_parity):
+    """Build a record whose comparison_summary reports QUA-861 Greek fields."""
+    record = _fresh_record(task_id)
+    missing_trellis = [g for g in financepy_greeks if g not in trellis_greeks]
+    missing_financepy = [g for g in trellis_greeks if g not in financepy_greeks]
+    compared = [g for g in trellis_greeks if g in financepy_greeks]
+    record["comparison_summary"] = dict(record["comparison_summary"])
+    record["comparison_summary"].update(
+        {
+            "missing_trellis_outputs": missing_trellis,
+            "missing_financepy_outputs": missing_financepy,
+            "greek_coverage": {
+                "trellis_greek_count": len(trellis_greeks),
+                "financepy_greek_count": len(financepy_greeks),
+                "compared_greek_count": len(compared),
+            },
+            "greek_parity": greek_parity,
+            "greek_failures": [],
+        }
+    )
+    return record
+
+
+def test_pilot_scorecard_aggregates_greek_coverage_across_tasks(tmp_path):
+    # Two tasks expose Trellis Greeks, four do not; five have financepy Greeks.
+    records = {
+        "F001": _record_with_greek_coverage(
+            "F001",
+            trellis_greeks=["delta", "vega"],
+            financepy_greeks=["delta", "vega", "gamma"],
+            greek_parity="passed",
+        ),
+        "F002": _record_with_greek_coverage(
+            "F002",
+            trellis_greeks=["delta"],
+            financepy_greeks=["delta"],
+            greek_parity="passed",
+        ),
+        "F003": _record_with_greek_coverage(
+            "F003",
+            trellis_greeks=[],
+            financepy_greeks=["delta"],
+            greek_parity="not_applicable",
+        ),
+        "F007": _record_with_greek_coverage(
+            "F007",
+            trellis_greeks=[],
+            financepy_greeks=[],
+            greek_parity="not_applicable",
+        ),
+        "F009": _record_with_greek_coverage(
+            "F009",
+            trellis_greeks=[],
+            financepy_greeks=["delta", "gamma"],
+            greek_parity="not_applicable",
+        ),
+        "F012": _record_with_greek_coverage(
+            "F012",
+            trellis_greeks=[],
+            financepy_greeks=[],
+            greek_parity="not_applicable",
+        ),
+    }
+    for rec in records.values():
+        _write_history_record(tmp_path, rec)
+
+    scorecard = build_pilot_parity_scorecard(
+        scorecard_name="financepy_pilot",
+        benchmark_runs=load_pilot_benchmark_records(benchmark_root=tmp_path),
+    )
+    summary = scorecard["pilot_summary"]
+    assert summary["tasks_with_trellis_greek_coverage"] == 2
+    assert summary["tasks_with_greek_overlap"] == 2
+    assert summary["greek_parity_passed_count"] == 2
+    assert summary["greek_parity_failed_count"] == 0
+
+    # Tasks where financepy declared Greeks but Trellis emitted none become
+    # residual misses with category `missing_greek_coverage`.
+    missing_coverage_misses = {
+        miss["task_id"]: miss
+        for miss in scorecard["residual_misses"]
+        if miss["category"] == "missing_greek_coverage"
+    }
+    assert set(missing_coverage_misses) == {"F003", "F009"}
+
+
+def test_pilot_scorecard_does_not_flag_missing_greeks_when_binding_has_no_greek_overlap(tmp_path):
+    for task_id in sorted(PILOT_SCORECARD_TASK_IDS):
+        _write_history_record(
+            tmp_path,
+            _record_with_greek_coverage(
+                task_id,
+                trellis_greeks=[],
+                financepy_greeks=[],
+                greek_parity="not_applicable",
+            ),
+        )
+    scorecard = build_pilot_parity_scorecard(
+        scorecard_name="financepy_pilot",
+        benchmark_runs=load_pilot_benchmark_records(benchmark_root=tmp_path),
+    )
+    assert scorecard["pilot_summary"]["tasks_with_trellis_greek_coverage"] == 0
+    assert [
+        miss for miss in scorecard["residual_misses"]
+        if miss["category"] == "missing_greek_coverage"
+    ] == []
+
+
+def test_pilot_scorecard_render_surfaces_greek_coverage_fields(tmp_path):
+    for task_id in sorted(PILOT_SCORECARD_TASK_IDS):
+        record = _record_with_greek_coverage(
+            task_id,
+            trellis_greeks=["delta"] if task_id == "F001" else [],
+            financepy_greeks=["delta", "gamma"] if task_id == "F001" else [],
+            greek_parity="passed" if task_id == "F001" else "not_applicable",
+        )
+        _write_history_record(tmp_path, record)
+
+    scorecard = build_pilot_parity_scorecard(
+        scorecard_name="financepy_pilot",
+        benchmark_runs=load_pilot_benchmark_records(benchmark_root=tmp_path),
+    )
+    text = render_pilot_parity_scorecard(scorecard)
+    assert "Tasks with Trellis Greek coverage" in text
+    assert "Tasks with Greek overlap" in text
+    assert "Greek parity passed" in text
+    assert "Greek coverage: trellis=" in text
+    # F001 is the only task with a compared Greek; its Greek parity should be
+    # surfaced per-task.
+    assert "Greek parity: `passed`" in text

--- a/tests/test_agent/test_pilot_parity_scorecard.py
+++ b/tests/test_agent/test_pilot_parity_scorecard.py
@@ -608,3 +608,23 @@ def test_pilot_scorecard_render_surfaces_greek_coverage_fields(tmp_path):
     # F001 is the only task with a compared Greek; its Greek parity should be
     # surfaced per-task.
     assert "Greek parity: `passed`" in text
+
+
+def test_pilot_scorecard_handles_corrupted_comparison_summary_gracefully(tmp_path):
+    """A history record with a non-mapping `comparison_summary` (e.g. a
+    list or a string slipped through a bad write) must not raise during
+    scorecard generation.  The scorecard treats the record as if it had
+    no Greek coverage information and keeps going.
+    (PR #593 round 4 Copilot review.)"""
+    for task_id in sorted(PILOT_SCORECARD_TASK_IDS):
+        rec = _fresh_record(task_id)
+        # Pathological shape: `comparison_summary` is a bare string.
+        rec["comparison_summary"] = "malformed"
+        _write_history_record(tmp_path, rec)
+    scorecard = build_pilot_parity_scorecard(
+        scorecard_name="financepy_pilot",
+        benchmark_runs=load_pilot_benchmark_records(benchmark_root=tmp_path),
+    )
+    # No raise, and the aggregator falls back to safe defaults.
+    assert scorecard["pilot_summary"]["tasks_with_trellis_greek_coverage"] == 0
+    assert scorecard["pilot_summary"]["tasks_with_greek_overlap"] == 0

--- a/tests/test_agent/test_pilot_parity_scorecard.py
+++ b/tests/test_agent/test_pilot_parity_scorecard.py
@@ -402,12 +402,39 @@ def test_pilot_parity_scorecard_cli_writes_artifacts(tmp_path, monkeypatch, caps
     )
 
 
-def _record_with_greek_coverage(task_id, *, trellis_greeks, financepy_greeks, greek_parity):
-    """Build a record whose comparison_summary reports QUA-861 Greek fields."""
+def _record_with_greek_coverage(
+    task_id,
+    *,
+    trellis_greeks,
+    financepy_greeks,
+    greek_parity,
+    declared_greeks=None,
+):
+    """Build a record whose comparison_summary reports QUA-861 Greek fields.
+
+    Matches the real comparison layer's semantics: `missing_trellis_outputs`
+    lists every declared overlap absent from the Trellis side (regardless of
+    whether FinancePy emitted it), and `missing_financepy_outputs` is the
+    symmetric set for the other side.  `declared_greeks` defaults to the
+    union of trellis+financepy Greeks; pass explicitly to simulate a binding
+    that declares a Greek neither side emitted.
+    """
     record = _fresh_record(task_id)
-    missing_trellis = [g for g in financepy_greeks if g not in trellis_greeks]
-    missing_financepy = [g for g in trellis_greeks if g not in financepy_greeks]
+    declared = (
+        list(declared_greeks)
+        if declared_greeks is not None
+        else sorted(set(trellis_greeks) | set(financepy_greeks))
+    )
+    missing_trellis = [g for g in declared if g not in trellis_greeks]
+    missing_financepy = [g for g in declared if g not in financepy_greeks]
     compared = [g for g in trellis_greeks if g in financepy_greeks]
+    # The runner also populates `financepy_outputs` in the comparison
+    # summary; the scorecard's `missing_greek_coverage` derivation reads
+    # those keys to determine which Greeks FinancePy actually emitted.
+    financepy_outputs_map = {g: 1.0 for g in financepy_greeks}
+    trellis_outputs_map = {g: 1.0 for g in trellis_greeks}
+    financepy_outputs_map["price"] = 10.0
+    trellis_outputs_map["price"] = 10.0
     record["comparison_summary"] = dict(record["comparison_summary"])
     record["comparison_summary"].update(
         {
@@ -420,9 +447,58 @@ def _record_with_greek_coverage(task_id, *, trellis_greeks, financepy_greeks, gr
             },
             "greek_parity": greek_parity,
             "greek_failures": [],
+            "trellis_outputs": trellis_outputs_map,
+            "financepy_outputs": financepy_outputs_map,
         }
     )
     return record
+
+
+def test_pilot_scorecard_missing_greek_coverage_excludes_greeks_financepy_did_not_emit(tmp_path):
+    """The scorecard's `missing_greek_coverage` reason must only list Greeks
+    FinancePy actually emitted.  If the binding declared a Greek that
+    *neither* side emitted, that's a binding-reference gap, not a
+    Trellis-coverage gap, and the reason text should not blame Trellis.
+    (PR #593 round 2 Copilot review.)"""
+    # Binding declares [delta, gamma, vega] but FinancePy only emits delta.
+    # Trellis emits nothing.  The Trellis-coverage gap is specifically
+    # `delta` (the one FinancePy did emit).  `gamma` and `vega` are
+    # binding-reference gaps and should not appear in the miss reason.
+    record = _record_with_greek_coverage(
+        "F001",
+        trellis_greeks=[],
+        financepy_greeks=["delta"],
+        greek_parity="not_applicable",
+        declared_greeks=["delta", "gamma", "vega"],
+    )
+    for task_id in sorted(PILOT_SCORECARD_TASK_IDS):
+        _write_history_record(
+            tmp_path,
+            record
+            if task_id == "F001"
+            else _record_with_greek_coverage(
+                task_id,
+                trellis_greeks=[],
+                financepy_greeks=[],
+                greek_parity="not_applicable",
+            ),
+        )
+    scorecard = build_pilot_parity_scorecard(
+        scorecard_name="financepy_pilot",
+        benchmark_runs=load_pilot_benchmark_records(benchmark_root=tmp_path),
+    )
+    misses = {
+        m["task_id"]: m
+        for m in scorecard["residual_misses"]
+        if m["category"] == "missing_greek_coverage"
+    }
+    assert "F001" in misses
+    reason = misses["F001"]["reason"]
+    # Only `delta` (the Greek FinancePy actually emitted) should appear;
+    # `gamma` and `vega` are binding-reference gaps.
+    assert "delta" in reason
+    assert "gamma" not in reason
+    assert "vega" not in reason
 
 
 def test_pilot_scorecard_aggregates_greek_coverage_across_tasks(tmp_path):

--- a/trellis/agent/benchmark_history.py
+++ b/trellis/agent/benchmark_history.py
@@ -221,19 +221,28 @@ def _task_run_snapshot(record: Mapping[str, Any], *, benchmark_kind: str) -> dic
     }
 
 
+def _comparison_summary_of(record: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Return the record's comparison_summary or an empty mapping.
+
+    Resilient to pathological history records whose `comparison_summary`
+    is a non-mapping (e.g. a string or list).  (QUA-861 / PR #593 round 4.)
+    """
+    raw = record.get("comparison_summary")
+    return raw if isinstance(raw, Mapping) else {}
+
+
 def _result_label(record: Mapping[str, Any], *, benchmark_kind: str) -> str:
     if benchmark_kind == "negative":
         if bool(record.get("passed_expectation")):
             return "passed_expectation"
         return str(record.get("observed_outcome") or record.get("status") or "").strip()
-    comparison = dict(record.get("comparison_summary") or {})
-    return str(comparison.get("status") or record.get("status") or "").strip()
+    return str(_comparison_summary_of(record).get("status") or record.get("status") or "").strip()
 
 
 def _record_passed(record: Mapping[str, Any], *, benchmark_kind: str) -> bool:
     if benchmark_kind == "negative":
         return bool(record.get("passed_expectation"))
-    return str(dict(record.get("comparison_summary") or {}).get("status") or "").strip() == "passed"
+    return str(_comparison_summary_of(record).get("status") or "").strip() == "passed"
 
 
 def _elapsed_seconds(record: Mapping[str, Any]) -> float:

--- a/trellis/agent/financepy_output_comparison.py
+++ b/trellis/agent/financepy_output_comparison.py
@@ -1,0 +1,163 @@
+"""Pure comparison helpers for FinancePy parity outputs (QUA-861).
+
+Factored out of ``scripts/run_financepy_benchmark.py`` so tests and other
+consumers can import the comparison logic without picking up the runner
+script's import-time side effects (``sys.path`` mutation, ``load_env()``,
+``os.environ.setdefault``).  No I/O, no network, no environment access.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+# Explicit allowlist of output-name tokens that should be accounted as Greeks
+# for coverage reporting.  `price` and payoff-specific outputs like
+# `fair_strike_variance` intentionally stay out -- the earlier heuristic
+# `is_greek = name != "price"` mis-labeled variance-swap outputs as Greeks.
+# Add to this set when a binding introduces a new canonical Greek name.
+# Refs: QUA-861 round-1 Codex review.
+GREEK_OUTPUT_NAMES: frozenset[str] = frozenset(
+    {
+        "delta",
+        "gamma",
+        "vega",
+        "theta",
+        "rho",
+        "vanna",
+        "volga",
+        "charm",
+        "credit_delta",
+        "credit_gamma",
+        "dv01",
+        "duration",
+        "convexity",
+        "key_rate_durations",
+    }
+)
+
+
+def is_greek_output(name: str) -> bool:
+    """Return whether *name* is one of the canonical Greek output tokens."""
+    return str(name or "").strip() in GREEK_OUTPUT_NAMES
+
+
+def output_value(outputs: Mapping[str, Any], key: str) -> Any:
+    """Look up ``key`` in an outputs dict with a fallback into ``greeks``."""
+    if key in outputs:
+        return outputs.get(key)
+    greeks = outputs.get("greeks") or {}
+    if isinstance(greeks, Mapping):
+        return greeks.get(key)
+    return None
+
+
+def compare_benchmark_outputs(
+    *,
+    task: Mapping[str, Any],
+    binding: Mapping[str, Any],
+    trellis_outputs: Mapping[str, Any],
+    financepy_outputs: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Compare Trellis vs FinancePy outputs, reporting Greek coverage honestly.
+
+    Refs: QUA-861.  The older shape silently skipped declared outputs that
+    one side didn't emit, so a task could "pass" on `price` alone while
+    quietly missing every Greek.  This version records
+    ``missing_trellis_outputs`` / ``missing_financepy_outputs`` and
+    per-side Greek coverage + Greek-only parity so scorecards can surface
+    the gap.
+    """
+    tolerance_pct = float(((task.get("cross_validate") or {}).get("tolerance_pct") or 5.0))
+    trellis_outputs = dict(trellis_outputs or {})
+    financepy_outputs = dict(financepy_outputs or {})
+    overlapping_outputs = tuple(
+        str(name).strip()
+        for name in (binding.get("overlapping_outputs") or ())
+        if str(name).strip()
+    )
+    compared_outputs: list[str] = []
+    output_deltas: dict[str, float] = {}
+    failures: list[str] = []
+    missing_trellis: list[str] = []
+    missing_financepy: list[str] = []
+    greek_failures: list[str] = []
+    trellis_greek_count = 0
+    financepy_greek_count = 0
+    compared_greek_count = 0
+    compared_greeks = False
+    for output_name in overlapping_outputs:
+        is_greek = is_greek_output(output_name)
+        trellis_value = output_value(trellis_outputs, output_name)
+        financepy_value = output_value(financepy_outputs, output_name)
+        if trellis_value is not None and is_greek:
+            trellis_greek_count += 1
+        if financepy_value is not None and is_greek:
+            financepy_greek_count += 1
+        if trellis_value is None:
+            missing_trellis.append(output_name)
+        if financepy_value is None:
+            missing_financepy.append(output_name)
+        if trellis_value is None or financepy_value is None:
+            continue
+        compared_outputs.append(output_name)
+        if is_greek:
+            compared_greek_count += 1
+            compared_greeks = True
+        denominator = max(abs(float(financepy_value)), 1e-12)
+        deviation_pct = abs(float(trellis_value) - float(financepy_value)) / denominator * 100.0
+        output_deltas[output_name] = round(deviation_pct, 6)
+        if deviation_pct > tolerance_pct:
+            failures.append(output_name)
+            if is_greek:
+                greek_failures.append(output_name)
+
+    greek_coverage = {
+        "trellis_greek_count": trellis_greek_count,
+        "financepy_greek_count": financepy_greek_count,
+        "compared_greek_count": compared_greek_count,
+    }
+    if not compared_greeks:
+        greek_parity = "not_applicable"
+    elif greek_failures:
+        greek_parity = "failed"
+    else:
+        greek_parity = "passed"
+
+    if not compared_outputs:
+        return {
+            "status": "insufficient_overlap",
+            "tolerance_pct": tolerance_pct,
+            "compared_outputs": (),
+            "expected_overlapping_outputs": overlapping_outputs,
+            "missing_trellis_outputs": tuple(missing_trellis),
+            "missing_financepy_outputs": tuple(missing_financepy),
+            "greek_coverage": greek_coverage,
+            "greek_parity": greek_parity,
+            "greek_failures": (),
+            "trellis_outputs": trellis_outputs,
+            "financepy_outputs": financepy_outputs,
+        }
+    return {
+        "status": "passed" if not failures else "failed",
+        "tolerance_pct": tolerance_pct,
+        "compared_outputs": tuple(compared_outputs),
+        "expected_overlapping_outputs": overlapping_outputs,
+        "output_deviation_pct": output_deltas,
+        "missing_trellis_outputs": tuple(missing_trellis),
+        "missing_financepy_outputs": tuple(missing_financepy),
+        "greek_coverage": greek_coverage,
+        "greek_parity": greek_parity,
+        "greek_failures": tuple(greek_failures),
+        "trellis_outputs": trellis_outputs,
+        "financepy_outputs": financepy_outputs,
+    }
+
+
+__all__ = (
+    "GREEK_OUTPUT_NAMES",
+    "compare_benchmark_outputs",
+    "is_greek_output",
+    "output_value",
+)

--- a/trellis/agent/financepy_output_comparison.py
+++ b/trellis/agent/financepy_output_comparison.py
@@ -69,7 +69,11 @@ def compare_benchmark_outputs(
     per-side Greek coverage + Greek-only parity so scorecards can surface
     the gap.
     """
-    tolerance_pct = float(((task.get("cross_validate") or {}).get("tolerance_pct") or 5.0))
+    cross_validate = task.get("cross_validate") or {}
+    raw_tolerance_pct = cross_validate.get("tolerance_pct")
+    # Preserve `0.0` as an explicit strict-parity tolerance.  `... or 5.0`
+    # would silently overwrite it.  (PR #593 round 3 Copilot review.)
+    tolerance_pct = 5.0 if raw_tolerance_pct is None else float(raw_tolerance_pct)
     trellis_outputs = dict(trellis_outputs or {})
     financepy_outputs = dict(financepy_outputs or {})
     overlapping_outputs = tuple(

--- a/trellis/agent/financepy_output_comparison.py
+++ b/trellis/agent/financepy_output_comparison.py
@@ -18,6 +18,14 @@ from typing import Any
 # `is_greek = name != "price"` mis-labeled variance-swap outputs as Greeks.
 # Add to this set when a binding introduces a new canonical Greek name.
 # Refs: QUA-861 round-1 Codex review.
+#
+# Non-scalar Greek outputs (e.g. `key_rate_durations`, which in Trellis is a
+# tenor-to-sensitivity mapping rather than a float) are intentionally NOT in
+# this set.  `compare_benchmark_outputs` casts every compared value via
+# `float()`, so declaring a dict-valued Greek here would raise.  If we ever
+# want to compare a non-scalar Greek, the comparison layer needs dict-aware
+# handling and this allowlist can be extended at the same time.  (PR #593
+# round 4 Copilot review.)
 GREEK_OUTPUT_NAMES: frozenset[str] = frozenset(
     {
         "delta",
@@ -33,7 +41,6 @@ GREEK_OUTPUT_NAMES: frozenset[str] = frozenset(
         "dv01",
         "duration",
         "convexity",
-        "key_rate_durations",
     }
 )
 

--- a/trellis/agent/pilot_parity_scorecard.py
+++ b/trellis/agent/pilot_parity_scorecard.py
@@ -323,17 +323,46 @@ def build_pilot_parity_scorecard(
         elif greek_parity == "failed":
             tasks_with_greek_parity_failed += 1
         # Missing-Greek residual miss: derive the expected-but-missing set
-        # from the intersection of "declared Greek overlap" (canonical Greek
-        # names in `missing_trellis_outputs`) and "FinancePy actually emitted
-        # Greeks".  Without the financepy-count guard we'd mis-attribute
-        # coverage gaps to Trellis when neither side emitted anything --
-        # that's a binding-reference gap, not a Trellis-coverage gap.
-        # (PR #593 round 1 Copilot review.)
+        # from the INTERSECTION of
+        #   (a) canonical Greek names (via `is_greek_output`)
+        #   (b) declared-but-Trellis-missing outputs (`missing_trellis_outputs`)
+        #   (c) Greeks FinancePy actually emitted for this task
+        # Without (c), the reason text would list Greeks that *neither* side
+        # emitted -- those are binding-reference gaps, not Trellis-coverage
+        # gaps.  The financepy-emitted set is read from the comparison
+        # summary's `financepy_outputs` dict plus any nested `greeks`.
+        # (PR #593 round 2 Copilot review.)
         task_id = summary.get("task_id") or ""
+        financepy_outputs = (
+            comparison_summary_for_miss := latest_records_by_task.get(task_id)
+            or {}
+        )
+        if isinstance(financepy_outputs, Mapping):
+            financepy_outputs = (
+                dict(financepy_outputs.get("comparison_summary") or {}).get(
+                    "financepy_outputs"
+                )
+                or {}
+            )
+        if not isinstance(financepy_outputs, Mapping):
+            financepy_outputs = {}
+        financepy_greek_keys: set[str] = set()
+        for key, value in financepy_outputs.items():
+            if value is None:
+                continue
+            if is_greek_output(str(key)):
+                financepy_greek_keys.add(str(key))
+        nested_greeks = financepy_outputs.get("greeks")
+        if isinstance(nested_greeks, Mapping):
+            for key, value in nested_greeks.items():
+                if value is None:
+                    continue
+                if is_greek_output(str(key)):
+                    financepy_greek_keys.add(str(key))
         expected_greeks = [
             name
             for name in summary.get("missing_trellis_outputs") or ()
-            if is_greek_output(name)
+            if is_greek_output(name) and name in financepy_greek_keys
         ]
         if (
             task_id

--- a/trellis/agent/pilot_parity_scorecard.py
+++ b/trellis/agent/pilot_parity_scorecard.py
@@ -95,6 +95,7 @@ from trellis.agent.benchmark_history import (
 )
 from trellis.agent.benchmark_pilots import get_pilot_task_ids
 from trellis.agent.financepy_benchmark import DEFAULT_FINANCEPY_BENCHMARK_ROOT
+from trellis.agent.financepy_output_comparison import is_greek_output
 
 
 PILOT_SCORECARD_TASK_IDS: tuple[str, ...] = get_pilot_task_ids("financepy")
@@ -293,12 +294,15 @@ def build_pilot_parity_scorecard(
         )
 
     # Aggregate Greek coverage across the pilot.  A task is counted as
-    # having Trellis Greek coverage if its latest comparison reported at
-    # least one compared Greek.  Tasks whose binding declared Greek overlap
-    # but whose Trellis side emitted no Greek are flagged as a residual
-    # miss with category `missing_greek_coverage` -- price parity can pass
-    # while the Greek contract is silently uncovered, and the scorecard
-    # should say so.  (QUA-861 item #4/#5.)
+    # having Trellis Greek coverage when its latest comparison reports
+    # `trellis_greek_count > 0` (at least one Trellis-emitted Greek),
+    # regardless of whether the other side compared it.
+    # `tasks_with_greek_overlap` is the stricter bar: both sides emitted
+    # the same Greek.  Tasks whose binding declared Greek overlap AND
+    # whose FinancePy side emitted those Greeks AND whose Trellis side
+    # emitted none are flagged `missing_greek_coverage` -- price parity
+    # can pass while the Greek contract is silently uncovered.
+    # (QUA-861 items #4/#5; Copilot review on PR #593 round 1.)
     tasks_with_trellis_greeks = 0
     tasks_with_greek_overlap = 0
     tasks_with_greek_parity_passed = 0
@@ -307,6 +311,7 @@ def build_pilot_parity_scorecard(
     for summary in task_summaries:
         coverage = summary.get("greek_coverage") or {}
         trellis_greek_count = int(coverage.get("trellis_greek_count") or 0)
+        financepy_greek_count = int(coverage.get("financepy_greek_count") or 0)
         compared_greek_count = int(coverage.get("compared_greek_count") or 0)
         if trellis_greek_count > 0:
             tasks_with_trellis_greeks += 1
@@ -317,14 +322,19 @@ def build_pilot_parity_scorecard(
             tasks_with_greek_parity_passed += 1
         elif greek_parity == "failed":
             tasks_with_greek_parity_failed += 1
-        # Missing-Greek residual miss: declared overlap expected Greeks
-        # (the financepy side reported > 0 Greeks), but Trellis emitted
-        # none.  Avoid double-listing tasks already on the miss list.
+        # Missing-Greek residual miss: derive the expected-but-missing set
+        # from the intersection of "declared Greek overlap" (canonical Greek
+        # names in `missing_trellis_outputs`) and "FinancePy actually emitted
+        # Greeks".  Without the financepy-count guard we'd mis-attribute
+        # coverage gaps to Trellis when neither side emitted anything --
+        # that's a binding-reference gap, not a Trellis-coverage gap.
+        # (PR #593 round 1 Copilot review.)
         task_id = summary.get("task_id") or ""
         expected_greeks = [
-            name for name in summary.get("missing_trellis_outputs") or () if name != "price"
+            name
+            for name in summary.get("missing_trellis_outputs") or ()
+            if is_greek_output(name)
         ]
-        financepy_greek_count = int(coverage.get("financepy_greek_count") or 0)
         if (
             task_id
             and expected_greeks

--- a/trellis/agent/pilot_parity_scorecard.py
+++ b/trellis/agent/pilot_parity_scorecard.py
@@ -204,17 +204,21 @@ def build_pilot_parity_scorecard(
         )
         summary["fresh_generated_module"] = str(boundary.get("generated_module") or "")
         latest_snapshot = summary.get("latest") or {}
+        # Validate the comparison_summary shape once, then reuse the
+        # validated mapping everywhere below.  Building `dict(... or {})`
+        # against a non-mapping (e.g. a list or None that slipped through
+        # a bad record write) would raise.  (PR #593 round 3 Copilot review.)
+        comparison_summary = latest_record.get("comparison_summary")
+        if not isinstance(comparison_summary, Mapping):
+            comparison_summary = {}
         summary["latest_comparison_status"] = str(
-            dict(latest_record.get("comparison_summary") or {}).get("status") or ""
+            comparison_summary.get("status") or ""
         )
         summary["latest_run_id"] = str(latest_snapshot.get("run_id") or "")
         # Surface Greek coverage honestly -- the comparison summary carries
         # `missing_trellis_outputs`, `greek_parity`, and `greek_coverage` under
         # QUA-861, but the pilot scorecard used to hide all of it behind the
         # aggregate price-parity status.
-        comparison_summary = latest_record.get("comparison_summary") or {}
-        if not isinstance(comparison_summary, Mapping):
-            comparison_summary = {}
         summary["missing_trellis_outputs"] = list(
             comparison_summary.get("missing_trellis_outputs") or ()
         )

--- a/trellis/agent/pilot_parity_scorecard.py
+++ b/trellis/agent/pilot_parity_scorecard.py
@@ -207,6 +207,27 @@ def build_pilot_parity_scorecard(
             dict(latest_record.get("comparison_summary") or {}).get("status") or ""
         )
         summary["latest_run_id"] = str(latest_snapshot.get("run_id") or "")
+        # Surface Greek coverage honestly -- the comparison summary carries
+        # `missing_trellis_outputs`, `greek_parity`, and `greek_coverage` under
+        # QUA-861, but the pilot scorecard used to hide all of it behind the
+        # aggregate price-parity status.
+        comparison_summary = latest_record.get("comparison_summary") or {}
+        if not isinstance(comparison_summary, Mapping):
+            comparison_summary = {}
+        summary["missing_trellis_outputs"] = list(
+            comparison_summary.get("missing_trellis_outputs") or ()
+        )
+        summary["missing_financepy_outputs"] = list(
+            comparison_summary.get("missing_financepy_outputs") or ()
+        )
+        greek_coverage = comparison_summary.get("greek_coverage") or {}
+        if not isinstance(greek_coverage, Mapping):
+            greek_coverage = {}
+        summary["greek_coverage"] = dict(greek_coverage)
+        summary["greek_parity"] = str(
+            comparison_summary.get("greek_parity") or "not_applicable"
+        )
+        summary["greek_failures"] = list(comparison_summary.get("greek_failures") or ())
         if latest_snapshot.get("passed"):
             latest_pass += 1
         else:
@@ -271,6 +292,65 @@ def build_pilot_parity_scorecard(
             }
         )
 
+    # Aggregate Greek coverage across the pilot.  A task is counted as
+    # having Trellis Greek coverage if its latest comparison reported at
+    # least one compared Greek.  Tasks whose binding declared Greek overlap
+    # but whose Trellis side emitted no Greek are flagged as a residual
+    # miss with category `missing_greek_coverage` -- price parity can pass
+    # while the Greek contract is silently uncovered, and the scorecard
+    # should say so.  (QUA-861 item #4/#5.)
+    tasks_with_trellis_greeks = 0
+    tasks_with_greek_overlap = 0
+    tasks_with_greek_parity_passed = 0
+    tasks_with_greek_parity_failed = 0
+    already_missed_ids = {miss["task_id"] for miss in residual_misses}
+    for summary in task_summaries:
+        coverage = summary.get("greek_coverage") or {}
+        trellis_greek_count = int(coverage.get("trellis_greek_count") or 0)
+        compared_greek_count = int(coverage.get("compared_greek_count") or 0)
+        if trellis_greek_count > 0:
+            tasks_with_trellis_greeks += 1
+        if compared_greek_count > 0:
+            tasks_with_greek_overlap += 1
+        greek_parity = str(summary.get("greek_parity") or "not_applicable")
+        if greek_parity == "passed":
+            tasks_with_greek_parity_passed += 1
+        elif greek_parity == "failed":
+            tasks_with_greek_parity_failed += 1
+        # Missing-Greek residual miss: declared overlap expected Greeks
+        # (the financepy side reported > 0 Greeks), but Trellis emitted
+        # none.  Avoid double-listing tasks already on the miss list.
+        task_id = summary.get("task_id") or ""
+        expected_greeks = [
+            name for name in summary.get("missing_trellis_outputs") or () if name != "price"
+        ]
+        financepy_greek_count = int(coverage.get("financepy_greek_count") or 0)
+        if (
+            task_id
+            and expected_greeks
+            and financepy_greek_count > 0
+            and trellis_greek_count == 0
+            and task_id not in already_missed_ids
+        ):
+            latest_snapshot = summary.get("latest") or {}
+            residual_misses.append(
+                {
+                    "task_id": task_id,
+                    "category": "missing_greek_coverage",
+                    "reason": (
+                        f"Trellis emits no Greek outputs; binding expected "
+                        f"{expected_greeks}"
+                    ),
+                    "run_id": str(latest_snapshot.get("run_id") or ""),
+                    "run_started_at": str(latest_snapshot.get("run_started_at") or ""),
+                    "git_sha": str(latest_snapshot.get("git_sha") or ""),
+                    "knowledge_revision": str(
+                        latest_snapshot.get("knowledge_revision") or ""
+                    ),
+                }
+            )
+            already_missed_ids.add(task_id)
+
     pilot_summary = {
         "fresh_generated_enforced_count": enforced,
         "boundary_violation_count": violations,
@@ -278,6 +358,10 @@ def build_pilot_parity_scorecard(
         "latest_pass_count": latest_pass,
         "deviation_median_pct": median_deviation_pct,
         "deviation_outlier_count": outlier_count,
+        "tasks_with_trellis_greek_coverage": tasks_with_trellis_greeks,
+        "tasks_with_greek_overlap": tasks_with_greek_overlap,
+        "greek_parity_passed_count": tasks_with_greek_parity_passed,
+        "greek_parity_failed_count": tasks_with_greek_parity_failed,
     }
     return {
         "scorecard_name": scorecard_name,
@@ -312,6 +396,10 @@ def render_pilot_parity_scorecard(scorecard: Mapping[str, Any]) -> str:
         f"- Latest pass count: `{summary.get('latest_pass_count', 0)}`",
         f"- Deviation median: `{summary.get('deviation_median_pct', 0.0)}%`",
         f"- Deviation outliers: `{summary.get('deviation_outlier_count', 0)}`",
+        f"- Tasks with Trellis Greek coverage: `{summary.get('tasks_with_trellis_greek_coverage', 0)}`",
+        f"- Tasks with Greek overlap (both sides): `{summary.get('tasks_with_greek_overlap', 0)}`",
+        f"- Greek parity passed: `{summary.get('greek_parity_passed_count', 0)}`",
+        f"- Greek parity failed: `{summary.get('greek_parity_failed_count', 0)}`",
     ]
     if scorecard.get("notes"):
         lines.extend(["", "## Notes"])
@@ -369,8 +457,22 @@ def render_pilot_parity_scorecard(scorecard: Mapping[str, Any]) -> str:
                 f"- Max output deviation: `{task.get('max_output_deviation_pct')}%`",
                 f"- Vs pilot median: `{task.get('deviation_vs_pilot_median')}x`",
                 f"- Outlier: `{task.get('outlier_flag', False)}`",
+                f"- Greek parity: `{task.get('greek_parity', 'not_applicable')}`",
             ]
         )
+        coverage = task.get("greek_coverage") or {}
+        if coverage:
+            lines.append(
+                f"- Greek coverage: trellis=`{coverage.get('trellis_greek_count', 0)}` "
+                f"financepy=`{coverage.get('financepy_greek_count', 0)}` "
+                f"compared=`{coverage.get('compared_greek_count', 0)}`"
+            )
+        missing_trellis = task.get("missing_trellis_outputs") or ()
+        if missing_trellis:
+            lines.append(f"- Missing Trellis outputs: `{', '.join(missing_trellis)}`")
+        greek_failures = task.get("greek_failures") or ()
+        if greek_failures:
+            lines.append(f"- Greek failures: `{', '.join(greek_failures)}`")
         if task.get("fresh_generated_boundary_status") == "violated":
             reason = task.get("fresh_generated_boundary_reason") or "boundary violation"
             lines.append(f"- Boundary reason: `{reason}`")

--- a/trellis/agent/pilot_parity_scorecard.py
+++ b/trellis/agent/pilot_parity_scorecard.py
@@ -337,19 +337,22 @@ def build_pilot_parity_scorecard(
         # summary's `financepy_outputs` dict plus any nested `greeks`.
         # (PR #593 round 2 Copilot review.)
         task_id = summary.get("task_id") or ""
-        financepy_outputs = (
-            comparison_summary_for_miss := latest_records_by_task.get(task_id)
-            or {}
+        # Validate each hop: a corrupted history record could have a
+        # non-mapping at either `latest_record` or `comparison_summary`
+        # or `financepy_outputs`.  Guarding each level keeps the scorecard
+        # generator from raising on bad input.  (PR #593 round 4 Copilot.)
+        latest_record_for_miss = latest_records_by_task.get(task_id)
+        miss_comparison_summary: Mapping[str, Any] = {}
+        if isinstance(latest_record_for_miss, Mapping):
+            raw_comparison_summary = latest_record_for_miss.get("comparison_summary")
+            if isinstance(raw_comparison_summary, Mapping):
+                miss_comparison_summary = raw_comparison_summary
+        raw_financepy_outputs = miss_comparison_summary.get("financepy_outputs")
+        financepy_outputs: Mapping[str, Any] = (
+            raw_financepy_outputs
+            if isinstance(raw_financepy_outputs, Mapping)
+            else {}
         )
-        if isinstance(financepy_outputs, Mapping):
-            financepy_outputs = (
-                dict(financepy_outputs.get("comparison_summary") or {}).get(
-                    "financepy_outputs"
-                )
-                or {}
-            )
-        if not isinstance(financepy_outputs, Mapping):
-            financepy_outputs = {}
         financepy_greek_keys: set[str] = set()
         for key, value in financepy_outputs.items():
             if value is None:


### PR DESCRIPTION
## Summary

First of three slices that close [QUA-861](https://linear.app/quant-macro/issue/QUA-861) (benchmark Greek parity coverage). The FinancePy pilot passed 6/6 on prices but the comparison layer silently collapsed to whatever outputs both sides emitted — F001 declares `overlapping_outputs=[price, delta, gamma, vega, theta]` but Trellis only emits `price`, and the old `_compare_outputs` dropped the four missing Greeks with no signal. This PR fixes the honest-reporting gap before any native-Greek or bump-and-reprice code lands.

### Comparison layer changes

`scripts/run_financepy_benchmark.py:_compare_outputs` now records:
- `missing_trellis_outputs` / `missing_financepy_outputs` — declared overlaps absent from each side
- `greek_coverage` — per-side Greek counts + compared count (price excluded)
- `greek_parity` — `passed` | `failed` | `not_applicable`, evaluated separately from price
- `greek_failures` — per-Greek tolerance breaches

### Pilot scorecard changes

`trellis/agent/pilot_parity_scorecard.py`:
- per-task summaries thread `missing_trellis_outputs`, `greek_coverage`, `greek_parity`, `greek_failures`
- pilot summary aggregates `tasks_with_trellis_greek_coverage`, `tasks_with_greek_overlap`, and pass/fail Greek-parity counts
- new residual-miss category `missing_greek_coverage` fires when binding expected Greeks but Trellis side emitted none
- Markdown render surfaces all of the above

### What this PR does *not* do

- No native Greek implementation — that's QUA-862 (next slice).
- No bump-and-reprice fallback — that's QUA-863 (third slice). The primitives already exist in `trellis/analytics/measures.py`; QUA-863 glues them into `benchmark_outputs`.

The three slices are landing incrementally so each has independent value and the first scorecard emitted after this lands will immediately surface the existing Greek gaps honestly.

## Test plan

- [x] `pytest tests/test_agent/test_financepy_greek_coverage.py -q` — 6 new tests cover the comparison shape
- [x] `pytest tests/test_agent/test_pilot_parity_scorecard.py -q` — 21 passed (+3 for Greek aggregation)
- [x] `pytest tests/test_agent/ -q -m \"not integration\"` — 1854 passed, no regressions (+9 vs previous baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)