### PR TITLE
agent: binding-driven bump-and-reprice Greek fallback (QUA-863)

### DIFF
--- a/FINANCEPY_BINDINGS.yaml
+++ b/FINANCEPY_BINDINGS.yaml
@@ -14,6 +14,12 @@ bindings:
     comparison_modes:
     - price_parity
     - warm_runtime
+    # Fill any declared Greek the payoff did not emit natively via
+    # trellis.analytics.measures finite-difference bumping.  Binding-driven
+    # policy so adding a new Greek to overlapping_outputs above enables the
+    # fallback without touching task or runner code (QUA-863).
+    greek_fallback:
+      kind: bump_and_reprice
   financepy.fx.vanilla.garman_kohlhagen:
     instrument_family: fx_vanilla
     method_family: analytical
@@ -29,6 +35,8 @@ bindings:
       price:
         source: financepy
         scale_by_contract_field: notional
+    greek_fallback:
+      kind: bump_and_reprice
   financepy.rates.cap_floor.black:
     instrument_family: cap_floor
     method_family: analytical

--- a/scripts/run_financepy_benchmark.py
+++ b/scripts/run_financepy_benchmark.py
@@ -186,6 +186,17 @@ def _execute_single_benchmark_task(
         raise_on_violation=False,
     )
 
+    # Resolve the binding before the warm probe so we can drive the
+    # bump-and-reprice Greek fallback (QUA-863).  The binding is also used
+    # below for the FinancePy output comparison; computing it once keeps the
+    # runner deterministic.
+    binding = financepy_binding_for_task(task, root=ROOT)
+    # The cold agent's native outputs -- what the payoff produced without any
+    # warm-probe augmentation -- provide the "already emitted" set for the
+    # fallback.  Declared Greeks already present here are skipped; only the
+    # missing ones are filled by bump-and-reprice.
+    cold_native_outputs = extract_trellis_benchmark_outputs(cold_result, None)
+
     if cold_result.get("success"):
         status = "priced"
         try:
@@ -202,6 +213,8 @@ def _execute_single_benchmark_task(
                     repeats=args.repeats,
                     warmups=args.warmups,
                     spec_overrides=benchmark_spec_overrides(task),
+                    binding=binding,
+                    native_outputs=cold_native_outputs,
                 )
             else:
                 warm_result = benchmark_existing_task(
@@ -211,6 +224,8 @@ def _execute_single_benchmark_task(
                     warmups=args.warmups,
                     model=args.model,
                     spec_overrides=benchmark_spec_overrides(task),
+                    binding=binding,
+                    native_outputs=cold_native_outputs,
                 )
         except Exception as exc:
             warm_result = {"error": str(exc)}
@@ -220,7 +235,6 @@ def _execute_single_benchmark_task(
         except Exception as exc:
             financepy_result = {"error": str(exc)}
 
-    binding = financepy_binding_for_task(task, root=ROOT)
     trellis_outputs = extract_trellis_benchmark_outputs(cold_result, warm_result)
     trellis_outputs_normalized = normalize_benchmark_outputs(
         task,

--- a/tests/test_agent/test_benchmark_greek_fallback.py
+++ b/tests/test_agent/test_benchmark_greek_fallback.py
@@ -152,6 +152,54 @@ def test_fallback_rejects_invalid_override_shape_without_blowing_up():
     assert "measure constructor rejected" in report.skipped["vega"]
 
 
+def test_fallback_treats_nested_native_greeks_as_already_emitted():
+    """Native Greeks preserved under ``greeks[...]`` must skip the warm bump.
+
+    ``extract_trellis_benchmark_outputs`` carries cold-run native Greeks
+    inside a nested ``greeks`` mapping for sources that report them that
+    way (``summary.greeks``, ``comparison.greeks``, ``result.greeks``).
+    Treating those as missing would let the bump fallback overwrite
+    native values when its output gets merged as a top-level key.  (PR
+    #594 Codex P2 round 1.)
+    """
+    report = compute_bump_and_reprice_greeks(
+        payoff=object(),
+        market_state=object(),
+        binding=_binding("price", "delta", "vega"),
+        already_emitted={
+            "price": 10.45,
+            "greeks": {"delta": 0.60, "vega": 0.41},
+        },
+        measure_factories={
+            "delta": _StubDelta,
+            "vega": _StubVega,
+        },
+    )
+    assert report.greeks == {}
+    assert report.skipped == {}
+
+
+def test_fallback_nested_mapping_with_non_mapping_greeks_is_robust():
+    """A non-Mapping value under ``greeks`` must not blow up the fallback.
+
+    Defensive shape check so a malformed cold-run payload degrades to
+    "top-level keys only" detection rather than raising, keeping the
+    fallback available for any other correctly-typed declared Greeks.
+    """
+    report = compute_bump_and_reprice_greeks(
+        payoff=object(),
+        market_state=object(),
+        binding=_binding("price", "delta"),
+        already_emitted={
+            "price": 10.45,
+            "greeks": "not-a-mapping",
+        },
+        measure_factories={"delta": _StubDelta},
+    )
+    assert report.greeks == {"delta": 0.55}
+    assert report.skipped == {}
+
+
 def test_fallback_report_serializes_to_record():
     report = GreekFallbackReport(
         greeks={"delta": 0.55, "vega": 0.4},

--- a/tests/test_agent/test_benchmark_greek_fallback.py
+++ b/tests/test_agent/test_benchmark_greek_fallback.py
@@ -1,0 +1,166 @@
+"""Tests for the benchmark Greek bump-and-reprice fallback (QUA-863)."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from trellis.agent.benchmark_greek_fallback import (
+    GreekFallbackReport,
+    compute_bump_and_reprice_greeks,
+)
+
+
+class _StubDelta:
+    def __init__(self, value: float = 0.55):
+        self._value = value
+
+    def compute(self, payoff, ms):
+        return self._value
+
+
+class _StubVega:
+    def __init__(self, value: float = 0.40, **_kwargs):
+        self._value = value
+
+    def compute(self, payoff, ms):
+        return self._value
+
+
+class _RaisingGamma:
+    def compute(self, payoff, ms):
+        raise RuntimeError("no spot binding available")
+
+
+def _binding(*outputs, policy_kind: str | None = "bump_and_reprice"):
+    binding: dict = {"overlapping_outputs": list(outputs)}
+    if policy_kind:
+        binding["greek_fallback"] = {"kind": policy_kind}
+    return binding
+
+
+def test_fallback_returns_empty_when_policy_is_not_bump_and_reprice():
+    report = compute_bump_and_reprice_greeks(
+        payoff=object(),
+        market_state=object(),
+        binding=_binding("price", "delta", policy_kind=None),
+        measure_factories={"delta": _StubDelta},
+    )
+    assert report.greeks == {}
+    assert report.skipped == {}
+    assert report.policy == "none"
+
+
+def test_fallback_fills_greek_declared_in_overlap_and_not_already_emitted():
+    report = compute_bump_and_reprice_greeks(
+        payoff=object(),
+        market_state=object(),
+        binding=_binding("price", "delta"),
+        already_emitted={"price": 10.45},
+        measure_factories={"delta": _StubDelta},
+    )
+    assert report.greeks == {"delta": 0.55}
+    assert report.skipped == {}
+    assert report.policy == "bump_and_reprice"
+
+
+def test_fallback_skips_greeks_already_emitted_natively():
+    report = compute_bump_and_reprice_greeks(
+        payoff=object(),
+        market_state=object(),
+        binding=_binding("price", "delta"),
+        already_emitted={"price": 10.45, "delta": 0.60},
+        measure_factories={"delta": _StubDelta},
+    )
+    assert report.greeks == {}
+    assert report.skipped == {}
+
+
+def test_fallback_skips_greeks_without_a_registered_measure():
+    report = compute_bump_and_reprice_greeks(
+        payoff=object(),
+        market_state=object(),
+        binding=_binding("price", "rho"),
+        measure_factories={"delta": _StubDelta},  # no `rho`
+    )
+    assert report.greeks == {}
+    assert "rho" in report.skipped
+    assert "no bump-and-reprice measure" in report.skipped["rho"]
+
+
+def test_fallback_records_measure_exception_without_raising():
+    report = compute_bump_and_reprice_greeks(
+        payoff=object(),
+        market_state=object(),
+        binding=_binding("price", "gamma"),
+        measure_factories={"gamma": _RaisingGamma},
+    )
+    assert report.greeks == {}
+    assert "gamma" in report.skipped
+    assert "no spot binding available" in report.skipped["gamma"]
+
+
+def test_fallback_passes_binding_measure_overrides_to_constructor():
+    captured: dict = {}
+
+    class _CapturingVega(_StubVega):
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            super().__init__(**kwargs)
+
+    binding = {
+        "overlapping_outputs": ["price", "vega"],
+        "greek_fallback": {
+            "kind": "bump_and_reprice",
+            "measures": {"vega": {"bump_pct": 0.25}},
+        },
+    }
+    report = compute_bump_and_reprice_greeks(
+        payoff=object(),
+        market_state=object(),
+        binding=binding,
+        measure_factories={"vega": _CapturingVega},
+    )
+    assert report.greeks == {"vega": 0.40}
+    assert captured == {"bump_pct": 0.25}
+
+
+def test_fallback_rejects_invalid_override_shape_without_blowing_up():
+    class _BumpOnlyVega:
+        def __init__(self, bump_pct: float = 1.0):
+            self.bump_pct = bump_pct
+
+        def compute(self, payoff, ms):
+            return 0.41
+
+    binding = {
+        "overlapping_outputs": ["price", "vega"],
+        "greek_fallback": {
+            "kind": "bump_and_reprice",
+            "measures": {"vega": {"unknown_kwarg": 42}},
+        },
+    }
+    report = compute_bump_and_reprice_greeks(
+        payoff=object(),
+        market_state=object(),
+        binding=binding,
+        measure_factories={"vega": _BumpOnlyVega},
+    )
+    assert report.greeks == {}
+    assert "vega" in report.skipped
+    assert "measure constructor rejected" in report.skipped["vega"]
+
+
+def test_fallback_report_serializes_to_record():
+    report = GreekFallbackReport(
+        greeks={"delta": 0.55, "vega": 0.4},
+        skipped={"gamma": "raised"},
+        policy="bump_and_reprice",
+    )
+    record = report.as_record()
+    assert record == {
+        "greeks": {"delta": 0.55, "vega": 0.4},
+        "skipped": {"gamma": "raised"},
+        "policy": "bump_and_reprice",
+    }

--- a/tests/test_agent/test_financepy_benchmark.py
+++ b/tests/test_agent/test_financepy_benchmark.py
@@ -154,6 +154,31 @@ def test_extract_trellis_benchmark_outputs_merges_benchmark_outputs_payload():
     assert outputs["fair_strike_variance"] == 0.048
 
 
+def test_extract_trellis_benchmark_outputs_merges_benchmark_greeks_as_top_level_keys():
+    """QUA-863 bump-and-reprice greeks surface as comparable top-level outputs."""
+    outputs = extract_trellis_benchmark_outputs(
+        {"benchmark_outputs": {"price": 1.23}},
+        {
+            "benchmark_greeks": {"delta": 0.55, "vega": 0.40},
+            "benchmark_greek_policy": "bump_and_reprice",
+        },
+    )
+
+    assert outputs["price"] == 1.23
+    assert outputs["delta"] == 0.55
+    assert outputs["vega"] == 0.40
+
+
+def test_extract_trellis_benchmark_outputs_cold_native_greeks_win_over_warm_fallback():
+    """Cold-run native greeks must outrank the warm bump-and-reprice fill."""
+    outputs = extract_trellis_benchmark_outputs(
+        {"benchmark_outputs": {"price": 1.23, "delta": 0.52}},
+        {"benchmark_greeks": {"delta": 0.99}},
+    )
+
+    assert outputs["delta"] == 0.52
+
+
 def test_extract_trellis_benchmark_outputs_reads_nested_result_comparison_prices():
     outputs = extract_trellis_benchmark_outputs(
         {

--- a/tests/test_agent/test_task_runtime.py
+++ b/tests/test_agent/test_task_runtime.py
@@ -2965,6 +2965,153 @@ def test_benchmark_existing_task_prefers_runtime_schema_over_stale_static_schema
     assert result["last_price"] == pytest.approx(1.0873716740767274, rel=5e-5)
 
 
+def _stub_benchmark_existing_prepared(monkeypatch):
+    """Shared stub for the QUA-863 benchmark-fallback wiring tests below."""
+    from trellis.agent.task_runtime import PreparedTask
+
+    FakePayoff = type("StubPayoff", (), {})
+    prepared = PreparedTask(
+        task_id="F001",
+        title="FinancePy parity: equity vanilla",
+        description="stubbed",
+        instrument_type="equity_vanilla",
+        requirements=set(),
+        payoff_cls=FakePayoff,
+        spec_schema=object(),
+    )
+    monkeypatch.setattr(
+        "trellis.agent.task_runtime.prepare_existing_task",
+        lambda task, model="gpt-5.4-mini": prepared,
+    )
+    monkeypatch.setattr(
+        "trellis.agent.task_runtime._make_test_payoff",
+        lambda payoff_cls, spec_schema, settle, **_kwargs: "payoff-instance",
+    )
+    return FakePayoff
+
+
+def test_benchmark_existing_task_without_binding_does_not_invoke_greek_fallback(monkeypatch):
+    """No binding means no fallback call and no ``benchmark_greeks`` on the result."""
+    from trellis.agent.task_runtime import benchmark_existing_task
+
+    _stub_benchmark_existing_prepared(monkeypatch)
+
+    def exploding_compute(*_args, **_kwargs):
+        raise AssertionError(
+            "compute_bump_and_reprice_greeks must not be invoked when no binding is supplied"
+        )
+
+    monkeypatch.setattr(
+        "trellis.agent.task_runtime.compute_bump_and_reprice_greeks",
+        exploding_compute,
+    )
+
+    result = benchmark_existing_task(
+        {"id": "F001", "title": "FinancePy parity: equity vanilla"},
+        market_state=object(),
+        repeats=1,
+        warmups=0,
+        price_fn=lambda payoff, ms: 1.23,
+    )
+
+    assert "benchmark_greeks" not in result
+    assert "benchmark_greek_skipped" not in result
+    assert "benchmark_greek_policy" not in result
+
+
+def test_benchmark_existing_task_records_fallback_greeks_when_binding_declares_policy(monkeypatch):
+    """A binding with ``greek_fallback`` fills ``benchmark_greeks`` / ``benchmark_greek_policy``."""
+    from trellis.agent.benchmark_greek_fallback import GreekFallbackReport
+    from trellis.agent.task_runtime import benchmark_existing_task
+
+    _stub_benchmark_existing_prepared(monkeypatch)
+
+    captured: dict = {}
+
+    def fake_compute(payoff, market_state, *, binding, already_emitted):
+        captured["payoff"] = payoff
+        captured["market_state"] = market_state
+        captured["binding"] = dict(binding)
+        captured["already_emitted"] = dict(already_emitted)
+        return GreekFallbackReport(
+            greeks={"delta": 0.55, "vega": 0.40},
+            skipped={"gamma": "RuntimeError: no spot binding"},
+            policy="bump_and_reprice",
+        )
+
+    monkeypatch.setattr(
+        "trellis.agent.task_runtime.compute_bump_and_reprice_greeks",
+        fake_compute,
+    )
+
+    binding = {
+        "overlapping_outputs": ["price", "delta", "gamma", "vega"],
+        "greek_fallback": {"kind": "bump_and_reprice"},
+    }
+    result = benchmark_existing_task(
+        {"id": "F001", "title": "FinancePy parity: equity vanilla"},
+        market_state="stub-market",
+        repeats=1,
+        warmups=0,
+        price_fn=lambda payoff, ms: 1.23,
+        binding=binding,
+        native_outputs={"price": 1.23},
+    )
+
+    assert captured["payoff"] == "payoff-instance"
+    assert captured["market_state"] == "stub-market"
+    assert captured["binding"] == binding
+    assert captured["already_emitted"] == {"price": 1.23}
+    assert result["benchmark_greek_policy"] == "bump_and_reprice"
+    assert result["benchmark_greeks"] == {"delta": 0.55, "vega": 0.40}
+    assert result["benchmark_greek_skipped"] == {"gamma": "RuntimeError: no spot binding"}
+
+
+def test_benchmark_generated_artifact_applies_fallback(monkeypatch, tmp_path):
+    """``benchmark_generated_artifact`` must honor the same ``binding`` contract."""
+    from trellis.agent.benchmark_greek_fallback import GreekFallbackReport
+    from trellis.agent.task_runtime import benchmark_generated_artifact
+
+    class StubPayoff:
+        pass
+
+    monkeypatch.setattr(
+        "trellis.agent.task_runtime._load_generated_artifact_payoff",
+        lambda artifact: (StubPayoff, object()),
+    )
+    monkeypatch.setattr(
+        "trellis.agent.task_runtime._make_test_payoff",
+        lambda payoff_cls, spec_schema, settle, **_kwargs: "payoff-instance",
+    )
+
+    def fake_compute(payoff, market_state, *, binding, already_emitted):
+        return GreekFallbackReport(
+            greeks={"delta": 0.11},
+            skipped={},
+            policy="bump_and_reprice",
+        )
+
+    monkeypatch.setattr(
+        "trellis.agent.task_runtime.compute_bump_and_reprice_greeks",
+        fake_compute,
+    )
+
+    result = benchmark_generated_artifact(
+        {"id": "F001", "title": "FinancePy parity: equity vanilla"},
+        generated_artifact={"module_name": "m", "module_path": "p", "file_path": "f", "code_hash": "h", "is_fresh_build": True},
+        market_state="stub-market",
+        repeats=1,
+        warmups=0,
+        price_fn=lambda payoff, ms: 9.99,
+        binding={"overlapping_outputs": ["price", "delta"], "greek_fallback": {"kind": "bump_and_reprice"}},
+        native_outputs={"price": 9.99},
+    )
+
+    assert result["benchmark_greeks"] == {"delta": 0.11}
+    assert result["benchmark_greek_policy"] == "bump_and_reprice"
+    assert "benchmark_greek_skipped" not in result
+
+
 def test_build_result_payload_includes_generated_artifact_provenance(monkeypatch, tmp_path):
     from trellis.agent.task_runtime import _build_result_payload
 

--- a/trellis/agent/benchmark_greek_fallback.py
+++ b/trellis/agent/benchmark_greek_fallback.py
@@ -70,6 +70,38 @@ def _binding_fallback_policy(binding: Mapping[str, Any]) -> dict[str, Any]:
     return dict(raw)
 
 
+def _already_emitted_names(already_emitted: Mapping[str, Any] | None) -> set[str]:
+    """Collect native output names from top-level keys AND nested ``greeks``.
+
+    ``extract_trellis_benchmark_outputs`` preserves cold-run native Greeks
+    either at the top level (when the payoff's ``benchmark_outputs``
+    returns ``{"delta": ..., "gamma": ...}``) or under a ``greeks`` key
+    (when they come from ``summary.greeks`` / ``comparison.greeks`` /
+    ``result.greeks``).  We treat both shapes as authoritative so the
+    warm bump-and-reprice never silently overrides a native Greek just
+    because it happened to live in the nested dict.  (PR #594 Codex P2
+    round 1.)
+    """
+    if not already_emitted:
+        return set()
+    names: set[str] = set()
+    for key, value in already_emitted.items():
+        name = str(key).strip()
+        if not name:
+            continue
+        if name == "greeks":
+            if isinstance(value, Mapping):
+                for nested_key in value.keys():
+                    nested_name = str(nested_key).strip()
+                    if nested_name:
+                        names.add(nested_name)
+            # Non-mapping ``greeks`` is treated as a malformed payload:
+            # ignore silently and keep only the other top-level keys.
+            continue
+        names.add(name)
+    return names
+
+
 def _requested_greeks(
     binding: Mapping[str, Any],
     already_emitted: set[str],
@@ -127,7 +159,7 @@ def compute_bump_and_reprice_greeks(
         return GreekFallbackReport(greeks={}, skipped={}, policy=policy_kind or "none")
 
     factories = dict(measure_factories or _default_measure_factories())
-    already = {str(k).strip() for k in (already_emitted or {}) if str(k).strip()}
+    already = _already_emitted_names(already_emitted)
     requested = _requested_greeks(binding, already)
 
     policy_overrides = policy.get("measures") or {}

--- a/trellis/agent/benchmark_greek_fallback.py
+++ b/trellis/agent/benchmark_greek_fallback.py
@@ -1,0 +1,168 @@
+"""Bump-and-reprice Greek fallback for benchmark parity (QUA-863).
+
+When a benchmark binding declares Greeks in ``overlapping_outputs`` but the
+Trellis payoff doesn't expose them natively, this fallback invokes the
+analytical measures in :mod:`trellis.analytics.measures` to compute them by
+finite-difference repricing on a cloned market state.
+
+The fallback is policy-driven from the binding metadata; no per-task or
+per-instrument code lives here.  Each Greek measure declares its requirements
+(e.g. spot bindings, vol surface) and any unsupported bump is skipped with an
+explicit reason recorded in the returned record instead of raising.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class GreekFallbackReport:
+    """Result of one bump-and-reprice fallback pass.
+
+    ``greeks`` maps Greek name → float for values we successfully computed.
+    ``skipped`` maps Greek name → reason string for Greeks we declined to
+    compute (e.g. requirement unmet, unsupported binding, exception raised).
+    ``policy`` echoes the binding-level ``greek_fallback`` configuration so
+    scorecards can record which policy generated which values.
+    """
+
+    greeks: dict[str, float]
+    skipped: dict[str, str]
+    policy: str
+
+    def as_record(self) -> dict[str, Any]:
+        return {
+            "greeks": dict(self.greeks),
+            "skipped": dict(self.skipped),
+            "policy": self.policy,
+        }
+
+
+# Canonical Greek measure factories.  Each entry's value is a zero-arg
+# callable returning a configured measure instance.  Kept here rather than in
+# `measures.py` so adding a new fallback Greek doesn't require touching the
+# analytics package.
+def _default_measure_factories():
+    from trellis.analytics.measures import Delta, Gamma, Theta, Vega
+
+    return {
+        "delta": Delta,
+        "gamma": Gamma,
+        "vega": Vega,
+        "theta": Theta,
+    }
+
+
+def _binding_fallback_policy(binding: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the binding's ``greek_fallback`` policy block, or an empty dict."""
+    if not isinstance(binding, Mapping):
+        return {}
+    raw = binding.get("greek_fallback")
+    if not isinstance(raw, Mapping):
+        return {}
+    return dict(raw)
+
+
+def _requested_greeks(
+    binding: Mapping[str, Any],
+    already_emitted: set[str],
+) -> list[str]:
+    """Return the declared Greeks the Trellis side did NOT already emit.
+
+    The intersection of ``overlapping_outputs`` (minus ``price``) and the
+    absent set is what the fallback should try to fill in.
+    """
+    overlapping = [
+        str(name).strip()
+        for name in (binding.get("overlapping_outputs") or ())
+        if str(name).strip()
+    ]
+    return [
+        name
+        for name in overlapping
+        if name != "price" and name not in already_emitted
+    ]
+
+
+def compute_bump_and_reprice_greeks(
+    payoff,
+    market_state,
+    *,
+    binding: Mapping[str, Any],
+    already_emitted: Mapping[str, Any] | None = None,
+    measure_factories: Mapping[str, Any] | None = None,
+) -> GreekFallbackReport:
+    """Invoke finite-difference Greek measures for any declared Greek the
+    Trellis side didn't already emit.
+
+    Parameters
+    ----------
+    payoff
+        The built payoff with an ``evaluate(market_state)`` method.
+    market_state
+        The (benchmark-aligned) market state to price against.
+    binding
+        The binding metadata dict.  Controls which Greeks are declared
+        (via ``overlapping_outputs``) and which policy applies
+        (via ``greek_fallback``).
+    already_emitted
+        Outputs the payoff already produced natively.  Those Greeks are
+        not recomputed; the fallback only fills gaps.
+    measure_factories
+        Optional override mapping Greek name → zero-arg factory.  Tests
+        use this to inject stubs; production callers can leave it unset
+        to pick up the canonical Delta/Gamma/Vega/Theta from
+        ``trellis.analytics.measures``.
+    """
+    policy = _binding_fallback_policy(binding)
+    policy_kind = str(policy.get("kind") or "").strip().lower()
+    if policy_kind != "bump_and_reprice":
+        return GreekFallbackReport(greeks={}, skipped={}, policy=policy_kind or "none")
+
+    factories = dict(measure_factories or _default_measure_factories())
+    already = {str(k).strip() for k in (already_emitted or {}) if str(k).strip()}
+    requested = _requested_greeks(binding, already)
+
+    policy_overrides = policy.get("measures") or {}
+    if not isinstance(policy_overrides, Mapping):
+        policy_overrides = {}
+
+    greeks: dict[str, float] = {}
+    skipped: dict[str, str] = {}
+    for name in requested:
+        factory = factories.get(name)
+        if factory is None:
+            skipped[name] = f"no bump-and-reprice measure registered for {name!r}"
+            continue
+        overrides = policy_overrides.get(name) or {}
+        if not isinstance(overrides, Mapping):
+            overrides = {}
+        try:
+            measure = factory(**overrides) if overrides else factory()
+        except TypeError as exc:
+            skipped[name] = f"measure constructor rejected policy overrides: {exc}"
+            continue
+        try:
+            value = measure.compute(payoff, market_state)
+        except Exception as exc:  # noqa: BLE001 -- want any bump failure surfaced
+            skipped[name] = f"{type(exc).__name__}: {exc}"
+            continue
+        try:
+            greeks[name] = float(value)
+        except (TypeError, ValueError) as exc:
+            skipped[name] = f"non-scalar measure result: {exc}"
+
+    return GreekFallbackReport(greeks=greeks, skipped=skipped, policy=policy_kind)
+
+
+__all__ = (
+    "GreekFallbackReport",
+    "compute_bump_and_reprice_greeks",
+)

--- a/trellis/agent/financepy_benchmark.py
+++ b/trellis/agent/financepy_benchmark.py
@@ -128,6 +128,13 @@ def _merge_benchmark_output_candidate(
     for key, value in benchmark_outputs.items():
         outputs.setdefault(key, value)
 
+    # Bump-and-reprice Greeks from the warm probe (QUA-863).  They are merged
+    # top-level via ``setdefault`` so native cold-run emissions always win and
+    # the fallback only fills declared Greeks the payoff didn't produce.
+    benchmark_greeks = dict(payload.get("benchmark_greeks") or {})
+    for key, value in benchmark_greeks.items():
+        outputs.setdefault(key, value)
+
     greeks = dict(payload.get("greeks") or {})
     if greeks:
         outputs.setdefault("greeks", greeks)

--- a/trellis/agent/task_runtime.py
+++ b/trellis/agent/task_runtime.py
@@ -33,6 +33,7 @@ from trellis.agent.benchmark_contracts import (
     benchmark_spec_overrides as benchmark_contract_spec_overrides,
     canonical_benchmark_instrument_type,
 )
+from trellis.agent.benchmark_greek_fallback import compute_bump_and_reprice_greeks
 from trellis.agent.financepy_parity import align_market_state_for_financepy_parity
 from trellis.agent.instrument_identity import (
     InstrumentIdentityResolution,
@@ -2598,6 +2599,38 @@ def _capture_task_pricing_snapshot(
     }
 
 
+def _apply_benchmark_greek_fallback(
+    result: dict[str, Any],
+    *,
+    payoff: Any,
+    market_state: Any,
+    binding: Mapping[str, Any] | None,
+    native_outputs: Mapping[str, Any] | None,
+) -> None:
+    """Populate bump-and-reprice Greek fields on *result* when declared.
+
+    If ``binding`` carries a ``greek_fallback`` policy, invoke
+    :func:`compute_bump_and_reprice_greeks` and merge the resulting Greeks,
+    skipped reasons, and policy name onto ``result``.  A no-op when no
+    binding is supplied or the policy is absent/unrecognized so callers
+    outside the FinancePy parity benchmark remain unchanged (QUA-863).
+    """
+    if not isinstance(binding, Mapping):
+        return
+    report = compute_bump_and_reprice_greeks(
+        payoff,
+        market_state,
+        binding=binding,
+        already_emitted=native_outputs or {},
+    )
+    if report.policy and report.policy != "none":
+        result["benchmark_greek_policy"] = report.policy
+    if report.greeks:
+        result["benchmark_greeks"] = dict(report.greeks)
+    if report.skipped:
+        result["benchmark_greek_skipped"] = dict(report.skipped)
+
+
 def benchmark_existing_task(
     task: dict,
     *,
@@ -2608,8 +2641,17 @@ def benchmark_existing_task(
     timer: Callable[[], float] = perf_counter,
     price_fn: Callable[[Any, Any], float] | None = None,
     spec_overrides: Mapping[str, Any] | None = None,
+    binding: Mapping[str, Any] | None = None,
+    native_outputs: Mapping[str, Any] | None = None,
 ) -> dict:
-    """Benchmark pricing runtime for an existing generated payoff class."""
+    """Benchmark pricing runtime for an existing generated payoff class.
+
+    When ``binding`` is supplied and declares a
+    ``greek_fallback: bump_and_reprice`` policy, any declared Greek the
+    payoff did not emit natively (per ``native_outputs``) is computed via
+    the measures in :mod:`trellis.analytics.measures` and returned under
+    ``benchmark_greeks`` / ``benchmark_greek_skipped``.  (QUA-863.)
+    """
     from trellis.engine.payoff_pricer import price_payoff
 
     if repeats < 1:
@@ -2645,7 +2687,7 @@ def benchmark_existing_task(
         last_price = price_fn(payoff, market_state)
         durations.append(timer() - start)
 
-    return {
+    result = {
         "task_id": prepared.task_id,
         "title": prepared.title,
         "instrument_type": prepared.instrument_type,
@@ -2658,6 +2700,14 @@ def benchmark_existing_task(
         "max_seconds": round(max(durations), 6),
         "last_price": last_price,
     }
+    _apply_benchmark_greek_fallback(
+        result,
+        payoff=payoff,
+        market_state=market_state,
+        binding=binding,
+        native_outputs=native_outputs,
+    )
+    return result
 
 
 def benchmark_generated_artifact(
@@ -2670,8 +2720,16 @@ def benchmark_generated_artifact(
     timer: Callable[[], float] = perf_counter,
     price_fn: Callable[[Any, Any], float] | None = None,
     spec_overrides: Mapping[str, Any] | None = None,
+    binding: Mapping[str, Any] | None = None,
+    native_outputs: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Benchmark an already-built generated artifact without falling back to cached adapters."""
+    """Benchmark an already-built generated artifact without falling back to cached adapters.
+
+    Accepts the same ``binding`` / ``native_outputs`` kwargs as
+    :func:`benchmark_existing_task` so the FinancePy parity harness can feed
+    the bump-and-reprice Greek fallback (QUA-863) into fresh-generated
+    artifacts as well.
+    """
     from trellis.engine.payoff_pricer import price_payoff
 
     if repeats < 1:
@@ -2703,7 +2761,7 @@ def benchmark_generated_artifact(
         last_price = price_fn(payoff, market_state)
         durations.append(timer() - start)
 
-    return {
+    result: dict[str, Any] = {
         "task_id": str(task.get("id") or ""),
         "title": str(task.get("title") or ""),
         "instrument_type": canonical_benchmark_instrument_type(task) or str(task.get("instrument_type") or ""),
@@ -2721,6 +2779,14 @@ def benchmark_generated_artifact(
         "execution_code_hash": str(generated_artifact.get("code_hash") or ""),
         "execution_is_fresh_build": bool(generated_artifact.get("is_fresh_build")),
     }
+    _apply_benchmark_greek_fallback(
+        result,
+        payoff=payoff,
+        market_state=market_state,
+        binding=binding,
+        native_outputs=native_outputs,
+    )
+    return result
 
 
 def _load_fallback_cached_agent(


### PR DESCRIPTION
## Summary

- Fills in any FinancePy-declared Greek the Trellis payoff did not emit natively via finite-difference bumping on a cloned market state.
- Binding-driven policy (`greek_fallback: {kind: bump_and_reprice}`) so a new Greek is enabled by editing the binding's `overlapping_outputs`, not by touching task or runner code.
- Cold-run native emissions always win; the warm probe only backfills gaps.

## Key surfaces

- New `trellis/agent/benchmark_greek_fallback.py` + `GreekFallbackReport` with a canonical Delta/Gamma/Vega/Theta factory map.
- `benchmark_existing_task` / `benchmark_generated_artifact` accept `binding` + `native_outputs` and call the helper before return.
- `extract_trellis_benchmark_outputs` merges `benchmark_greeks` as top-level keys.
- `scripts/run_financepy_benchmark.py` resolves the binding once, passes it and cold-run native outputs into both warm calls.
- `FINANCEPY_BINDINGS.yaml` enables the policy for `financepy.equity.vanilla.black_scholes` and `financepy.fx.vanilla.garman_kohlhagen`.

## Test plan

- [x] `pytest tests/test_agent -x -q -m \"not integration\"` → 1873 passed
- [x] 8 new unit tests for the library (policy gating, skip reasons, constructor overrides, report serialization)
- [x] 3 new `test_task_runtime` integration tests (no-binding no-op, recorded fallback, generated-artifact parity)
- [x] 2 new `test_financepy_benchmark` tests (warm `benchmark_greeks` surface top-level, cold native outrank)

🤖 Generated with [Claude Code](https://claude.com/claude-code)