### PR TITLE
agent: native Black-Scholes Greek outputs for equity vanilla parity (QUA-862)

### DIFF
--- a/tests/test_agent/test_executor.py
+++ b/tests/test_agent/test_executor.py
@@ -688,6 +688,134 @@ def test_deterministic_exact_binding_module_materializes_black_scholes_comparato
     assert "market_state.vol_surface.black_vol(max(T, 1e-6), strike)" in generated.code
     assert "terminal_vanilla_from_basis(" not in generated.code
     assert EVALUATE_SENTINEL not in generated.code
+    # QUA-862: the Black-Scholes deterministic route now also emits a native
+    # ``benchmark_outputs`` method backed by ``equity_vanilla_bs_outputs`` so
+    # scorecards can record price + Greeks without a post-hoc bump-and-reprice.
+    assert "def benchmark_outputs(self, market_state: MarketState) -> dict[str, float]:" in generated.code
+    assert "equity_vanilla_bs_outputs(market_state, self._spec)" in generated.code
+    assert (
+        "from trellis.models.analytical.equity_vanilla_bs import equity_vanilla_bs_outputs"
+        in generated.code
+    )
+
+
+def test_deterministic_exact_binding_module_non_black_scholes_route_omits_benchmark_outputs_method():
+    """Only the Black-Scholes comparison target injects the native-greeks method (QUA-862)."""
+    from trellis.agent.executor import (
+        _generate_skeleton,
+        _materialize_deterministic_exact_binding_module,
+    )
+    from trellis.agent.planner import STATIC_SPECS
+
+    generation_plan = SimpleNamespace(
+        lane_exact_binding_refs=(
+            "trellis.models.analytical.barrier.barrier_option_price",
+        ),
+        primitive_plan=None,
+        method="analytical",
+        instrument_type="barrier_option",
+    )
+    skeleton = _generate_skeleton(
+        STATIC_SPECS["barrier_option"],
+        "Barrier option analytical",
+        generation_plan=generation_plan,
+    )
+    generated = _materialize_deterministic_exact_binding_module(
+        skeleton,
+        generation_plan,
+        comparison_target=None,
+    )
+    assert generated is not None
+    assert "def benchmark_outputs" not in generated.code
+    assert "equity_vanilla_bs_outputs" not in generated.code
+
+
+def test_deterministic_exact_binding_module_black_scholes_benchmark_outputs_runs_end_to_end():
+    """The injected method executes and returns the canonical Greek dict (QUA-862)."""
+    from datetime import date as _date
+
+    import numpy as _np
+
+    from trellis.agent.executor import (
+        _generate_skeleton,
+        _materialize_deterministic_exact_binding_module,
+    )
+    from trellis.agent.planner import SPECIALIZED_SPECS
+    from trellis.core.market_state import MarketState
+
+    class _FlatDiscount:
+        def __init__(self, rate: float):
+            self._rate = float(rate)
+
+        def zero_rate(self, t: float) -> float:
+            return self._rate
+
+        def discount(self, t: float) -> float:
+            return float(_np.exp(-self._rate * float(t)))
+
+    class _FlatBlackVol:
+        def __init__(self, vol: float):
+            self._vol = float(vol)
+
+        def black_vol(self, t: float, k: float) -> float:
+            return self._vol
+
+    generation_plan = SimpleNamespace(
+        lane_exact_binding_refs=(
+            "trellis.models.black.black76_call",
+            "trellis.models.black.black76_put",
+        ),
+        primitive_plan=None,
+        method="analytical",
+        instrument_type="european_option",
+    )
+    skeleton = _generate_skeleton(
+        SPECIALIZED_SPECS["european_option_analytical"],
+        "European option analytical comparator",
+        generation_plan=generation_plan,
+    )
+    generated = _materialize_deterministic_exact_binding_module(
+        skeleton,
+        generation_plan,
+        comparison_target="black_scholes",
+    )
+    assert generated is not None
+
+    namespace: dict = {}
+    exec(compile(generated.code, "<qua_862>", "exec"), namespace)  # noqa: S102 -- test harness
+    payoff_cls = next(
+        obj
+        for name, obj in namespace.items()
+        if name.endswith("Payoff") and isinstance(obj, type)
+    )
+    spec_cls = next(
+        obj
+        for name, obj in namespace.items()
+        if name.endswith("Spec") and isinstance(obj, type)
+    )
+    payoff = payoff_cls(
+        spec_cls(
+            notional=1.0,
+            spot=100.0,
+            strike=100.0,
+            expiry_date=_date(2025, 11, 15),
+            option_type="call",
+        )
+    )
+    market = MarketState(
+        as_of=_date(2024, 11, 15),
+        settlement=_date(2024, 11, 15),
+        discount=_FlatDiscount(0.05),
+        vol_surface=_FlatBlackVol(0.25),
+    )
+
+    outputs = payoff.benchmark_outputs(market)
+    assert set(outputs) == {"price", "delta", "gamma", "vega", "theta"}
+    # evaluate() and benchmark_outputs() must agree on the price.
+    assert outputs["price"] == pytest.approx(float(payoff.evaluate(market)), rel=1e-10)
+    # ATM call spot-check against classical BS numerics at r=5%, σ=25%, T=1.
+    assert outputs["delta"] == pytest.approx(0.6274, abs=1e-3)
+    assert outputs["vega"] == pytest.approx(37.842, abs=1e-2)
 
 
 def test_deterministic_exact_binding_module_materializes_barrier_helper_with_time_import():

--- a/tests/test_models/test_equity_vanilla_bs_outputs.py
+++ b/tests/test_models/test_equity_vanilla_bs_outputs.py
@@ -138,23 +138,107 @@ def test_expired_option_returns_intrinsic_and_zero_greeks():
     assert out["theta"] == 0.0
 
 
-def test_zero_vol_returns_intrinsic_and_zero_greeks():
-    ms = _make_market(rate=0.05, vol=0.0)
-    spec = _VanillaSpec(
-        notional=1.0,
-        spot=100.0,
-        strike=120.0,
-        expiry_date=date(2025, 11, 15),
-        option_type="put",
+def test_zero_vol_nonzero_T_uses_discounted_forward_intrinsic():
+    """Zero-vol, T > 0 must match the Black-Scholes zero-vol limit.
+
+    The BS zero-vol limit for a call is ``df * max(F - K, 0)``, equivalently
+    ``max(S - K*df, 0)``.  Using spot-vs-strike intrinsic here would
+    silently make ``benchmark_outputs['price']`` diverge from ``evaluate()``
+    in non-zero-rate markets.  (PR #595 Codex P1 round 1.)
+    """
+    rate = 0.05
+    T = 1.0
+    df = float(np.exp(-rate * T))
+    ms = _make_market(rate=rate, vol=0.0)
+
+    call = equity_vanilla_bs_outputs(
+        ms,
+        _VanillaSpec(
+            notional=1.0,
+            spot=100.0,
+            strike=95.0,
+            expiry_date=date(2025, 11, 15),
+            option_type="call",
+        ),
     )
-    out = equity_vanilla_bs_outputs(ms, spec)
-    # Zero vol ⇒ deterministic payoff; helper reports intrinsic on the zero
-    # time branch so scorecards don't divide-by-zero in the d1 expression.
-    assert out["price"] == pytest.approx(20.0, abs=1e-9)
-    assert out["delta"] == 0.0
-    assert out["gamma"] == 0.0
-    assert out["vega"] == 0.0
-    assert out["theta"] == 0.0
+    # Call at zero vol: df * max(spot/df - strike, 0) = max(spot - strike*df, 0)
+    assert call["price"] == pytest.approx(max(100.0 - 95.0 * df, 0.0), abs=1e-9)
+    assert call["delta"] == 0.0
+    assert call["gamma"] == 0.0
+    assert call["vega"] == 0.0
+    assert call["theta"] == 0.0
+
+    put = equity_vanilla_bs_outputs(
+        ms,
+        _VanillaSpec(
+            notional=1.0,
+            spot=100.0,
+            strike=120.0,
+            expiry_date=date(2025, 11, 15),
+            option_type="put",
+        ),
+    )
+    # Put at zero vol: max(strike*df - spot, 0).  With r=5%, T=1, K=120:
+    # df = exp(-0.05) ≈ 0.9512; K*df ≈ 114.15; so payoff ≈ 14.15.
+    assert put["price"] == pytest.approx(max(120.0 * df - 100.0, 0.0), abs=1e-9)
+    assert put["delta"] == 0.0
+    assert put["gamma"] == 0.0
+    assert put["vega"] == 0.0
+    assert put["theta"] == 0.0
+
+
+def test_zero_vol_benchmark_outputs_price_agrees_with_evaluate():
+    """The native outputs helper and the deterministic evaluate path must agree.
+
+    This mirrors the test in ``test_executor`` that compiles+executes the
+    generated module; here we exercise only the helper for a sharper failure
+    mode if the zero-vol branch misprices.  (PR #595 Codex P1 round 1.)
+    """
+    from trellis.models.black import black76_call, black76_put
+
+    rate = 0.03
+    T = 1.5
+    df = float(np.exp(-rate * T))
+    ms = _make_market(rate=rate, vol=0.0)
+
+    for option_type in ("call", "put"):
+        spec = _VanillaSpec(
+            notional=1.0,
+            spot=105.0,
+            strike=100.0,
+            expiry_date=date(
+                2024 + int(T) + 1 if T != int(T) else 2024 + int(T),
+                5 if T != int(T) else 11,
+                15,
+            ),
+            option_type=option_type,
+        )
+        # Align T exactly to 1.5 years by setting expiry manually; our fixture
+        # approximates with a calendar date so reuse black76_* directly.
+        forward = spec.spot / df
+        undiscounted = (
+            black76_call(forward, spec.strike, 0.0, T)
+            if option_type == "call"
+            else black76_put(forward, spec.strike, 0.0, T)
+        )
+        evaluate_like_price = float(spec.notional) * df * float(undiscounted)
+        native = equity_vanilla_bs_outputs(
+            ms,
+            _VanillaSpec(
+                notional=spec.notional,
+                spot=spec.spot,
+                strike=spec.strike,
+                expiry_date=date(2026, 5, 15),  # ≈ 1.5 years from 2024-11-15
+                option_type=option_type,
+            ),
+        )
+        # Year fraction from 2024-11-15 → 2026-05-15 under ACT/365 isn't
+        # exactly 1.5, so only require agreement to within the date-grid
+        # rounding scale.
+        assert native["price"] == pytest.approx(
+            evaluate_like_price,
+            rel=5e-3,
+        ), option_type
 
 
 def test_raises_when_required_market_data_is_missing():

--- a/tests/test_models/test_equity_vanilla_bs_outputs.py
+++ b/tests/test_models/test_equity_vanilla_bs_outputs.py
@@ -1,0 +1,196 @@
+"""Tests for the Black-Scholes equity vanilla native outputs helper (QUA-862)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+
+import numpy as np
+import pytest
+
+from trellis.core.market_state import MarketState
+from trellis.core.types import DayCountConvention
+from trellis.models.analytical import equity_vanilla_bs_outputs
+
+
+class _FlatDiscount:
+    def __init__(self, rate: float):
+        self._rate = float(rate)
+
+    def zero_rate(self, t: float) -> float:
+        return self._rate
+
+    def discount(self, t: float) -> float:
+        return float(np.exp(-self._rate * float(t)))
+
+
+class _FlatBlackVol:
+    def __init__(self, vol: float):
+        self._vol = float(vol)
+
+    def black_vol(self, t: float, k: float) -> float:
+        return self._vol
+
+
+@dataclass(frozen=True)
+class _VanillaSpec:
+    notional: float
+    spot: float
+    strike: float
+    expiry_date: date
+    option_type: str = "call"
+    day_count: DayCountConvention = DayCountConvention.ACT_365
+
+
+def _make_market(rate: float, vol: float) -> MarketState:
+    return MarketState(
+        as_of=date(2024, 11, 15),
+        settlement=date(2024, 11, 15),
+        discount=_FlatDiscount(rate),
+        vol_surface=_FlatBlackVol(vol),
+    )
+
+
+def test_atm_call_matches_closed_form_and_returns_expected_keys():
+    ms = _make_market(rate=0.05, vol=0.25)
+    spec = _VanillaSpec(
+        notional=1.0,
+        spot=100.0,
+        strike=100.0,
+        expiry_date=date(2025, 11, 15),
+        option_type="call",
+    )
+    out = equity_vanilla_bs_outputs(ms, spec)
+    assert set(out) == {"price", "delta", "gamma", "vega", "theta"}
+    # ATM call under q=0, r=0.05, σ=0.25, T=1.0 → classic BS reference values.
+    assert out["price"] == pytest.approx(12.336, abs=1e-3)
+    assert out["delta"] == pytest.approx(0.6274, abs=1e-3)
+    assert out["gamma"] == pytest.approx(0.01514, abs=1e-4)
+    assert out["vega"] == pytest.approx(37.842, abs=1e-2)
+    assert out["theta"] == pytest.approx(-7.250, abs=1e-2)
+
+
+def test_put_call_parity_holds_on_delta_and_price():
+    ms = _make_market(rate=0.05, vol=0.25)
+    call = equity_vanilla_bs_outputs(
+        ms,
+        _VanillaSpec(
+            notional=1.0,
+            spot=100.0,
+            strike=100.0,
+            expiry_date=date(2025, 11, 15),
+            option_type="call",
+        ),
+    )
+    put = equity_vanilla_bs_outputs(
+        ms,
+        _VanillaSpec(
+            notional=1.0,
+            spot=100.0,
+            strike=100.0,
+            expiry_date=date(2025, 11, 15),
+            option_type="put",
+        ),
+    )
+    # Put-call parity: C - P = S - K*df
+    df = float(np.exp(-0.05 * 1.0))
+    assert (call["price"] - put["price"]) == pytest.approx(100.0 - 100.0 * df, abs=1e-6)
+    # Delta parity: call_delta - put_delta = 1 (under q=0)
+    assert (call["delta"] - put["delta"]) == pytest.approx(1.0, abs=1e-8)
+    # Gamma/vega identical for call and put
+    assert call["gamma"] == pytest.approx(put["gamma"], abs=1e-12)
+    assert call["vega"] == pytest.approx(put["vega"], abs=1e-12)
+
+
+def test_notional_scales_price_only():
+    ms = _make_market(rate=0.05, vol=0.25)
+    expiry = date(2025, 11, 15)
+    unit = equity_vanilla_bs_outputs(
+        ms,
+        _VanillaSpec(notional=1.0, spot=100.0, strike=100.0, expiry_date=expiry),
+    )
+    scaled = equity_vanilla_bs_outputs(
+        ms,
+        _VanillaSpec(notional=10.0, spot=100.0, strike=100.0, expiry_date=expiry),
+    )
+    # FinancePy's EquityVanillaOption scales value() by num_options but
+    # returns single-unit Greeks from delta/gamma/vega/theta.  Match that
+    # convention so scorecards compare apples to apples.
+    assert scaled["price"] == pytest.approx(10.0 * unit["price"], abs=1e-10)
+    for greek in ("delta", "gamma", "vega", "theta"):
+        assert scaled[greek] == pytest.approx(unit[greek], abs=1e-12)
+
+
+def test_expired_option_returns_intrinsic_and_zero_greeks():
+    ms = _make_market(rate=0.05, vol=0.25)
+    expired_spec = _VanillaSpec(
+        notional=1.0,
+        spot=120.0,
+        strike=100.0,
+        expiry_date=date(2024, 11, 15),  # same day as settlement => T == 0
+        option_type="call",
+    )
+    out = equity_vanilla_bs_outputs(ms, expired_spec)
+    assert out["price"] == pytest.approx(20.0, abs=1e-9)
+    assert out["delta"] == 0.0
+    assert out["gamma"] == 0.0
+    assert out["vega"] == 0.0
+    assert out["theta"] == 0.0
+
+
+def test_zero_vol_returns_intrinsic_and_zero_greeks():
+    ms = _make_market(rate=0.05, vol=0.0)
+    spec = _VanillaSpec(
+        notional=1.0,
+        spot=100.0,
+        strike=120.0,
+        expiry_date=date(2025, 11, 15),
+        option_type="put",
+    )
+    out = equity_vanilla_bs_outputs(ms, spec)
+    # Zero vol ⇒ deterministic payoff; helper reports intrinsic on the zero
+    # time branch so scorecards don't divide-by-zero in the d1 expression.
+    assert out["price"] == pytest.approx(20.0, abs=1e-9)
+    assert out["delta"] == 0.0
+    assert out["gamma"] == 0.0
+    assert out["vega"] == 0.0
+    assert out["theta"] == 0.0
+
+
+def test_raises_when_required_market_data_is_missing():
+    spec = _VanillaSpec(
+        notional=1.0,
+        spot=100.0,
+        strike=100.0,
+        expiry_date=date(2025, 11, 15),
+    )
+    ms_no_discount = MarketState(
+        as_of=date(2024, 11, 15),
+        settlement=date(2024, 11, 15),
+        discount=None,
+        vol_surface=_FlatBlackVol(0.25),
+    )
+    with pytest.raises(ValueError, match="discount"):
+        equity_vanilla_bs_outputs(ms_no_discount, spec)
+
+    ms_no_vol = MarketState(
+        as_of=date(2024, 11, 15),
+        settlement=date(2024, 11, 15),
+        discount=_FlatDiscount(0.05),
+        vol_surface=None,
+    )
+    with pytest.raises(ValueError, match="vol_surface"):
+        equity_vanilla_bs_outputs(ms_no_vol, spec)
+
+
+def test_unknown_option_type_raises():
+    ms = _make_market(rate=0.05, vol=0.25)
+    spec = _VanillaSpec(
+        notional=1.0,
+        spot=100.0,
+        strike=100.0,
+        expiry_date=date(2025, 11, 15),
+        option_type="digital",
+    )
+    with pytest.raises(ValueError, match="Unsupported option_type"):
+        equity_vanilla_bs_outputs(ms, spec)

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -3447,6 +3447,32 @@ def _deterministic_exact_binding_evaluate_body(
     return None
 
 
+def _deterministic_exact_binding_benchmark_outputs_block(
+    generation_plan,
+    *,
+    comparison_target: str | None = None,
+) -> str | None:
+    """Return a complete ``benchmark_outputs`` method for supported routes.
+
+    Returned text is un-indented; the caller must indent it to class scope
+    (four spaces) before appending.  Returns ``None`` when the deterministic
+    route does not have a native Greek helper available (QUA-862).
+    """
+    refs = set(_exact_binding_refs(generation_plan))
+    if (
+        comparison_target == "black_scholes"
+        and "trellis.models.black.black76_call" in refs
+        and "trellis.models.black.black76_put" in refs
+    ):
+        return textwrap.dedent(
+            """\
+            def benchmark_outputs(self, market_state: MarketState) -> dict[str, float]:
+                return dict(equity_vanilla_bs_outputs(market_state, self._spec))
+            """
+        )
+    return None
+
+
 def _materialize_deterministic_exact_binding_module(
     skeleton: str,
     generation_plan,
@@ -3462,14 +3488,29 @@ def _materialize_deterministic_exact_binding_module(
     )
     if body is None:
         return None
-    skeleton = _inject_top_level_imports(
-        skeleton,
-        list(_deterministic_exact_binding_import_lines(body)),
+    benchmark_outputs_block = _deterministic_exact_binding_benchmark_outputs_block(
+        generation_plan,
+        comparison_target=comparison_target,
     )
+    import_lines = list(_deterministic_exact_binding_import_lines(body))
+    if benchmark_outputs_block is not None:
+        import_lines.extend(
+            _deterministic_exact_binding_benchmark_outputs_import_lines(
+                benchmark_outputs_block
+            )
+        )
+    skeleton = _inject_top_level_imports(skeleton, import_lines)
     rendered = skeleton.replace(
         EVALUATE_SENTINEL,
         textwrap.indent(body, "        "),
     )
+    if benchmark_outputs_block is not None:
+        rendered = (
+            rendered.rstrip("\n")
+            + "\n\n"
+            + textwrap.indent(benchmark_outputs_block, "    ")
+            + "\n"
+        )
     source_report = sanitize_generated_source(rendered)
     return GeneratedModuleResult(
         raw_code=rendered,
@@ -3490,6 +3531,16 @@ def _deterministic_exact_binding_import_lines(body: str) -> tuple[str, ...]:
     imports: list[str] = []
     if "year_fraction(" in body:
         imports.append("from trellis.core.date_utils import year_fraction")
+    return tuple(imports)
+
+
+def _deterministic_exact_binding_benchmark_outputs_import_lines(block: str) -> tuple[str, ...]:
+    """Return imports required by the injected ``benchmark_outputs`` block (QUA-862)."""
+    imports: list[str] = []
+    if "equity_vanilla_bs_outputs(" in block:
+        imports.append(
+            "from trellis.models.analytical.equity_vanilla_bs import equity_vanilla_bs_outputs"
+        )
     return tuple(imports)
 
 

--- a/trellis/models/analytical/__init__.py
+++ b/trellis/models/analytical/__init__.py
@@ -49,6 +49,9 @@ from trellis.models.analytical.equity_exotics import (
     price_equity_fixed_lookback_option_analytical,
     price_equity_variance_swap_analytical,
 )
+from trellis.models.analytical.equity_vanilla_bs import (
+    equity_vanilla_bs_outputs,
+)
 __all__ = [
     "zcb_option_hw",
     "barrier_option_price",
@@ -62,6 +65,7 @@ __all__ = [
     "ResolvedBarrierInputs",
     "ResolvedEquityAnalyticalInputs",
     "equity_variance_swap_outputs_analytical",
+    "equity_vanilla_bs_outputs",
     "price_equity_cliquet_option_analytical",
     "vanilla_call_raw",
     "price_equity_chooser_option_analytical",

--- a/trellis/models/analytical/equity_vanilla_bs.py
+++ b/trellis/models/analytical/equity_vanilla_bs.py
@@ -1,0 +1,117 @@
+"""Native benchmark outputs for Black-Scholes equity vanilla options (QUA-862).
+
+Returns the canonical ``{price, delta, gamma, vega, theta}`` dict directly
+from closed-form Black-Scholes formulae so the FinancePy parity harness can
+report Greeks without post-hoc bump-and-reprice (see QUA-863 for the
+fallback path that this replaces for exact-binding analytical routes).
+
+Assumes the same contract the deterministic Black-Scholes ``evaluate`` body
+assumes: continuous dividend yield ``q == 0``.  The effective rate ``r`` is
+recovered from ``market_state.discount``; ``sigma`` is queried from the
+Black vol surface at ``(T, K)``.  Notional scales ``price`` only; per-unit
+Greeks are returned to match FinancePy's ``EquityVanillaOption.delta``
+etc., which themselves do not multiply by ``num_options``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from autograd.scipy.stats import norm
+
+from trellis.core.date_utils import year_fraction
+from trellis.core.differentiable import get_numpy
+from trellis.core.market_state import MarketState
+from trellis.core.types import DayCountConvention
+
+np = get_numpy()
+
+
+def _zero_time_outputs(
+    spot: float,
+    strike: float,
+    option_type: str,
+    notional: float,
+) -> dict[str, float]:
+    """Return outputs at or past expiry: intrinsic price, zero Greeks."""
+    intrinsic = (
+        max(spot - strike, 0.0) if option_type == "call" else max(strike - spot, 0.0)
+    )
+    return {
+        "price": notional * intrinsic,
+        "delta": 0.0,
+        "gamma": 0.0,
+        "vega": 0.0,
+        "theta": 0.0,
+    }
+
+
+def equity_vanilla_bs_outputs(
+    market_state: MarketState,
+    spec: Any,
+) -> dict[str, float]:
+    """Return ``{price, delta, gamma, vega, theta}`` for a BS equity vanilla."""
+    if market_state.discount is None:
+        raise ValueError("market_state.discount is required for Black-Scholes outputs")
+    if market_state.vol_surface is None:
+        raise ValueError("market_state.vol_surface is required for Black-Scholes outputs")
+
+    day_count = getattr(spec, "day_count", DayCountConvention.ACT_365)
+    T = max(
+        float(year_fraction(market_state.settlement, spec.expiry_date, day_count)),
+        0.0,
+    )
+    spot = float(spec.spot)
+    strike = float(spec.strike)
+    option_type = str(spec.option_type or "call").strip().lower()
+    if option_type not in {"call", "put"}:
+        raise ValueError(f"Unsupported option_type {spec.option_type!r}; expected 'call' or 'put'")
+    notional = float(spec.notional)
+
+    if T <= 0.0:
+        return _zero_time_outputs(spot, strike, option_type, notional)
+
+    df = float(market_state.discount.discount(T))
+    sigma = float(market_state.vol_surface.black_vol(max(T, 1e-6), strike))
+    sqrt_T = float(np.sqrt(T))
+    sigma_sqrt_T = sigma * sqrt_T
+    if sigma_sqrt_T <= 0.0:
+        return _zero_time_outputs(spot, strike, option_type, notional)
+
+    df_safe = max(df, 1e-12)
+    forward = spot / df_safe
+    # Continuous-compounding rate implied by ``df``; consistent with the
+    # deterministic Black-Scholes evaluate body in executor._deterministic
+    # _exact_binding_evaluate_body that uses ``forward = spot / df``.
+    r = -float(np.log(df_safe)) / max(T, 1e-12)
+
+    d1 = (float(np.log(forward / strike)) + 0.5 * sigma * sigma * T) / sigma_sqrt_T
+    d2 = d1 - sigma_sqrt_T
+    nd1 = float(norm.cdf(d1))
+    nd2 = float(norm.cdf(d2))
+    nd1_neg = float(norm.cdf(-d1))
+    nd2_neg = float(norm.cdf(-d2))
+    pdf_d1 = float(norm.pdf(d1))
+
+    if option_type == "call":
+        price_per_unit = df * (forward * nd1 - strike * nd2)
+        delta = nd1
+        theta = -(spot * pdf_d1 * sigma) / (2.0 * sqrt_T) - r * strike * df * nd2
+    else:
+        price_per_unit = df * (strike * nd2_neg - forward * nd1_neg)
+        delta = nd1 - 1.0
+        theta = -(spot * pdf_d1 * sigma) / (2.0 * sqrt_T) + r * strike * df * nd2_neg
+
+    gamma = pdf_d1 / (spot * sigma_sqrt_T)
+    vega = spot * pdf_d1 * sqrt_T
+
+    return {
+        "price": notional * price_per_unit,
+        "delta": delta,
+        "gamma": gamma,
+        "vega": vega,
+        "theta": theta,
+    }
+
+
+__all__ = ("equity_vanilla_bs_outputs",)

--- a/trellis/models/analytical/equity_vanilla_bs.py
+++ b/trellis/models/analytical/equity_vanilla_bs.py
@@ -46,6 +46,39 @@ def _zero_time_outputs(
     }
 
 
+def _zero_vol_outputs(
+    spot: float,
+    strike: float,
+    df: float,
+    option_type: str,
+    notional: float,
+) -> dict[str, float]:
+    """Return the zero-vol, T > 0 Black-Scholes limit.
+
+    The forward equals ``spot / df`` deterministically at σ == 0, so the
+    payoff reduces to ``df * max(F - K, 0)`` (call) / ``df * max(K - F, 0)``
+    (put), i.e. ``max(S - K*df, 0)`` / ``max(K*df - S, 0)``.  Using plain
+    ``max(S - K, 0)`` here would silently misprice parity in any non-zero
+    rate market and diverge from the deterministic ``evaluate`` body --
+    ``black76_call``/``black76_put`` also collapse to the discounted
+    forward intrinsic at σ == 0.  (PR #595 Codex P1 round 1.)
+    """
+    df_safe = max(df, 1e-12)
+    forward = spot / df_safe
+    forward_intrinsic = (
+        max(forward - strike, 0.0)
+        if option_type == "call"
+        else max(strike - forward, 0.0)
+    )
+    return {
+        "price": notional * df * forward_intrinsic,
+        "delta": 0.0,
+        "gamma": 0.0,
+        "vega": 0.0,
+        "theta": 0.0,
+    }
+
+
 def equity_vanilla_bs_outputs(
     market_state: MarketState,
     spec: Any,
@@ -76,7 +109,7 @@ def equity_vanilla_bs_outputs(
     sqrt_T = float(np.sqrt(T))
     sigma_sqrt_T = sigma * sqrt_T
     if sigma_sqrt_T <= 0.0:
-        return _zero_time_outputs(spot, strike, option_type, notional)
+        return _zero_vol_outputs(spot, strike, df, option_type, notional)
 
     df_safe = max(df, 1e-12)
     forward = spot / df_safe


### PR DESCRIPTION
## Summary

- New `trellis/models/analytical/equity_vanilla_bs.py` returns `{price, delta, gamma, vega, theta}` directly from closed-form BS formulae.
- The deterministic exact-binding Black-Scholes route now also injects a native `benchmark_outputs` method into the generated payoff class that delegates to the helper, so cold-run FinancePy parity records real native Greeks without any post-hoc bump-and-reprice.
- Notional scales `price` only. Per-unit Greeks match FinancePy's `EquityVanillaOption.delta/gamma/vega/theta`.

## Details

- Helper assumes the same contract as the existing deterministic Black-Scholes `evaluate` body: q == 0, rate recovered from `market_state.discount`, σ from the Black vol surface at (T, K).
- Zero-time and zero-vol branches return intrinsic price + zero Greeks, avoiding a div-by-zero in d1.
- The executor appends the method to the class after the sentinel replacement, and adds the import line via a new `_deterministic_exact_binding_benchmark_outputs_import_lines` helper.

## Test plan

- [x] 7 new helper unit tests (ATM numerics, put-call parity on price + delta, notional scales only price, zero-time + zero-vol branches, missing-data raises, unknown option_type raises)
- [x] 3 executor integration tests: (a) BS comparator rendered code asserts the method + import are injected, (b) non-BS barrier route does NOT inject, (c) end-to-end compile+exec of the generated module confirms `evaluate()` and `benchmark_outputs()` agree on price and numerics match classical BS
- [x] `pytest tests/test_agent -x -q -m "not integration"` → 1875 passed
- [x] `pytest tests/test_models -x -q -m "not integration"` → 536 passed

## Relation to QUA-863

QUA-863 (PR #594) landed the binding-driven bump-and-reprice fallback. Once this lands, the Black-Scholes equity vanilla binding no longer needs the fallback: the cold-run payoff emits native Greeks that win over any warm-probe bump result. Garman-Kohlhagen (F002) continues to rely on the bump fallback until a native outputs helper is added in a follow-on slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)