### PR TITLE
agent: exempt signed linear payoffs from check_non_negativity (QUA-851)

### DIFF
--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -24,6 +24,7 @@ ground truth until revalidated.
 | L10 | ~~Accrued interest simplified~~ | Bond accrued interest now uses the explicit coupon schedule plus the selected day-count convention instead of a flat period approximation. |
 | L5 | ~~Hull-White helper routes still default mean reversion to `0.1`~~ | Callable-bond, Bermudan-swaption, and ZCB-option helpers now resolve Hull-White parameters from explicit inputs or `MarketState.model_parameters` / `model_parameter_sets`, with legacy heuristics only as fallback. |
 | L2 | ~~`YieldCurve.bump()` only hits exact tenor matches~~ | The shared curve-shock substrate now supports off-grid bucket nodes, and `KeyRateDurations` consumes the same bucket grid so interpolation-aware KRD requests no longer collapse to exact-knot-only sensitivities. |
+| L39 | ~~Build-loop rejected legitimate signed-PV payoffs~~ | `check_non_negativity` in `trellis/agent/invariants.py` now short-circuits via `_payoff_is_signed_linear` for single-name CDS (and any future signed linear products declared through the same trait helper), so protection-buyer CDS clean PV no longer fails the invariant suite. Family-specific CDS invariants (`check_cds_spread_quote_normalization`, `check_cds_credit_curve_sensitivity`) remain in force. (QUA-851.) |
 
 ## Revalidated Open Limitations
 

--- a/tests/test_agent/test_invariants.py
+++ b/tests/test_agent/test_invariants.py
@@ -74,14 +74,24 @@ class TestNonNegativity:
         assert failure.actual == pytest.approx(-2.5)
         assert "available_capabilities" in failure.context
 
-    def test_non_negativity_surfaces_cds_spread_unit_hint(self):
+    def test_non_negativity_skips_cds_like_payoff_with_negative_pv(self):
+        """CDS-like payoffs are signed linear products; non-negativity must NOT fail them.
+
+        Protection-buyer CDS clean PV is legitimately negative when spreads
+        have tightened from issuance; the build loop's invariant suite
+        previously rejected those payoffs at build gate, which blocked the
+        FinancePy CDS parity task (F007).  Signed-linear products are
+        validated by the dedicated ``check_cds_spread_quote_normalization``
+        and ``check_cds_credit_curve_sensitivity`` invariants instead.
+        (QUA-851.)
+        """
         class CdsLikePayoff:
             def __init__(self):
                 self._spec = type(
                     "CDSSpec",
                     (),
                     {
-                        "spread": 150.0,
+                        "spread": 0.015,  # decimal quote, as the model expects
                         "recovery": 0.4,
                         "start_date": SETTLE,
                         "end_date": date(2029, 11, 15),
@@ -106,11 +116,80 @@ class TestNonNegativity:
             return_diagnostics=True,
         )
 
+        assert failures == []
+
+    def test_non_negativity_still_fails_option_like_payoffs(self):
+        """Regression: gating signed products must not weaken the option-like contract."""
+        class OptionLikePayoff:
+            @property
+            def requirements(self):
+                return {"discount_curve"}
+
+            def evaluate(self, market_state):
+                return -1.23
+
+        failures = check_non_negativity(
+            OptionLikePayoff(),
+            _ms_factory(),
+            return_diagnostics=True,
+        )
         assert len(failures) == 1
-        failure = failures[0]
-        assert "150 bp -> 0.015" in failure.message
-        assert failure.context["cds_spread_hint"] == "basis_points_to_decimal"
-        assert failure.context["reported_spread"] == pytest.approx(150.0)
+        assert failures[0].check == "check_non_negativity"
+        assert failures[0].actual == pytest.approx(-1.23)
+
+    def test_run_invariant_suite_allows_signed_cds_payoff_through_build_gate(self):
+        """Integration: ``run_invariant_suite`` must not reject a signed CDS payoff.
+
+        ``run_invariant_suite`` is the path ``arbiter.validate_payoff_with_critic``
+        invokes inside the build loop.  Before QUA-851, it unconditionally
+        called ``check_non_negativity`` and the protection-buyer CDS benchmark
+        (F007) died at the gate.  This integration test guards against a
+        regression where a parallel validation path slips past the new
+        signed-linear gate.
+        """
+        class CdsPayoff:
+            def __init__(self):
+                self._spec = type(
+                    "CDSSpec",
+                    (),
+                    {
+                        "notional": 1_000_000.0,
+                        "spread": 0.015,
+                        "recovery": 0.4,
+                        "start_date": SETTLE,
+                        "end_date": date(2029, 11, 15),
+                    },
+                )()
+
+            @property
+            def spec(self):
+                return self._spec
+
+            @property
+            def requirements(self):
+                return {"discount_curve", "credit_curve"}
+
+            def evaluate(self, market_state):
+                return -65_000.0
+
+        def payoff_factory():
+            return CdsPayoff()
+
+        def market_state_factory(**_kwargs):
+            return MarketState(
+                as_of=SETTLE,
+                settlement=SETTLE,
+                discount=YieldCurve.flat(0.05),
+                credit_curve=CreditCurve.flat(0.02),
+            )
+
+        passed, failures = run_invariant_suite(
+            payoff_factory=payoff_factory,
+            market_state_factory=market_state_factory,
+            is_option=False,
+        )
+        assert passed, f"signed CDS payoff should pass invariant suite; got: {failures}"
+        assert failures == []
 
 
 class TestPriceSanity:

--- a/tests/test_agent/test_invariants.py
+++ b/tests/test_agent/test_invariants.py
@@ -137,6 +137,53 @@ class TestNonNegativity:
         assert failures[0].check == "check_non_negativity"
         assert failures[0].actual == pytest.approx(-1.23)
 
+    def test_non_negativity_still_surfaces_pricing_exceptions_for_signed_products(self):
+        """Signed-product exemption must NOT also skip pricing-exception detection.
+
+        ``check_non_negativity`` is the only always-run check in the
+        ``is_option=False`` branch of ``run_invariant_suite``.  If the
+        signed-linear gate short-circuits *before* invoking pricing, a CDS
+        whose ``evaluate`` raises (e.g. missing credit curve) would pass the
+        invariant suite silently instead of being rejected at build gate.
+        (PR #596 Codex P1 round 1.)
+        """
+        class BrokenCdsPayoff:
+            def __init__(self):
+                self._spec = type(
+                    "CDSSpec",
+                    (),
+                    {
+                        "spread": 0.015,
+                        "recovery": 0.4,
+                        "start_date": SETTLE,
+                        "end_date": date(2029, 11, 15),
+                    },
+                )()
+
+            @property
+            def requirements(self):
+                return {"discount_curve", "credit_curve"}
+
+            def evaluate(self, market_state):
+                raise RuntimeError("credit_curve missing from market_state")
+
+        failures = check_non_negativity(
+            BrokenCdsPayoff(),
+            MarketState(
+                as_of=SETTLE,
+                settlement=SETTLE,
+                discount=YieldCurve.flat(0.05),
+                credit_curve=CreditCurve.flat(0.02),
+            ),
+            return_diagnostics=True,
+        )
+        assert len(failures) == 1
+        failure = failures[0]
+        assert failure.check == "check_non_negativity"
+        assert "Pricing failed" in failure.message
+        assert failure.exception_type == "RuntimeError"
+        assert failure.exception_message == "credit_curve missing from market_state"
+
     def test_run_invariant_suite_allows_signed_cds_payoff_through_build_gate(self):
         """Integration: ``run_invariant_suite`` must not reject a signed CDS payoff.
 

--- a/trellis/agent/invariants.py
+++ b/trellis/agent/invariants.py
@@ -299,14 +299,41 @@ def check_price_sanity(
     return _emit_failures(failures, return_diagnostics=return_diagnostics)
 
 
+def _payoff_is_signed_linear(payoff: Payoff) -> bool:
+    """Return whether the payoff is a signed linear product, not a non-negative option.
+
+    Signed linear products (currently: single-name CDS clean PV from either
+    protection side) do NOT satisfy the non-negativity contract -- the PV is
+    allowed to be negative.  They are validated through their own
+    family-specific invariants (``check_cds_spread_quote_normalization``,
+    ``check_cds_credit_curve_sensitivity``) rather than the generic
+    non-negativity guard.  Callers should skip ``check_non_negativity`` when
+    this returns ``True``.
+
+    Kept as a dedicated helper so future signed products (e.g. fee-only
+    swap legs) can be added here without touching ``check_non_negativity``
+    directly.  (QUA-851.)
+    """
+    spec = _extract_spec(payoff)
+    return _is_cds_like(payoff, spec)
+
+
 def check_non_negativity(
     payoff: Payoff,
     market_state: MarketState,
     *,
     return_diagnostics: bool = False,
 ) -> list[InvariantFailure] | list[str]:
-    """Price must be non-negative for option-like payoffs."""
+    """Price must be non-negative for option-like payoffs.
+
+    Signed linear products (see :func:`_payoff_is_signed_linear`) are
+    exempt: their PV is legitimately negative from at least one side of
+    the trade.  Running the guard on them would kill benchmark parity for
+    protection-buyer CDS and other signed linear products.  (QUA-851.)
+    """
     failures: list[InvariantFailure] = []
+    if _payoff_is_signed_linear(payoff):
+        return _emit_failures(failures, return_diagnostics=return_diagnostics)
     try:
         pv = price_payoff(payoff, market_state)
         spread_hint, spread_context = _cds_spread_unit_hint(payoff)

--- a/trellis/agent/invariants.py
+++ b/trellis/agent/invariants.py
@@ -327,17 +327,20 @@ def check_non_negativity(
     """Price must be non-negative for option-like payoffs.
 
     Signed linear products (see :func:`_payoff_is_signed_linear`) are
-    exempt: their PV is legitimately negative from at least one side of
-    the trade.  Running the guard on them would kill benchmark parity for
-    protection-buyer CDS and other signed linear products.  (QUA-851.)
+    exempt from the ``pv >= 0`` assertion: their PV is legitimately
+    negative from at least one side of the trade.  We still invoke
+    ``price_payoff`` for those products so pricing-time exceptions (e.g.
+    a broken CDS implementation missing the credit curve) are surfaced --
+    in ``run_invariant_suite`` with ``is_option=False`` this is often the
+    only always-run check, so it must stay capable of catching a broken
+    build.  (QUA-851; PR #596 Codex P1 round 1.)
     """
     failures: list[InvariantFailure] = []
-    if _payoff_is_signed_linear(payoff):
-        return _emit_failures(failures, return_diagnostics=return_diagnostics)
+    is_signed = _payoff_is_signed_linear(payoff)
     try:
         pv = price_payoff(payoff, market_state)
         spread_hint, spread_context = _cds_spread_unit_hint(payoff)
-        if pv < -1e-6:
+        if not is_signed and pv < -1e-6:
             failures.append(
                 InvariantFailure(
                     check="check_non_negativity",


### PR DESCRIPTION
## Summary

- Signed linear payoffs (currently: single-name CDS clean PV) are exempt from the build-loop `check_non_negativity` invariant. Unblocks the FinancePy CDS parity task F007, which was dying at build gate because protection-buyer PV can legitimately be negative.
- Family-specific CDS invariants (`check_cds_spread_quote_normalization`, `check_cds_credit_curve_sensitivity`) continue to enforce correctness via `validation_bundles.py`.

## Why this shape

`execute_validation_bundle` already excluded non-negativity from the CDS bundle, but `run_invariant_suite` — invoked by `arbiter.validate_payoff_with_critic` — was a parallel unconditional path. The new `_payoff_is_signed_linear` helper gates the check at the `check_non_negativity` function itself, so both paths respect the same contract. The helper is a deliberate extension point for future signed products (fee-only swap legs etc.).

## Test plan

- [x] `pytest tests/test_agent/test_invariants.py::TestNonNegativity -x -q` → 5 passed (1 rewritten, 2 new)
- [x] `pytest tests/test_agent -x -q -m "not integration"` → 1879 passed (+4 new, zero regressions)
- [x] `LIMITATIONS.md` L39 added to Resolved
- [ ] F007 live rerun deferred to a one-shot validation after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)