### PR TITLE
knowledge: analytical decomposition anchors for digital/lookback/chooser/compound (QUA-852)

### DIFF
--- a/tests/test_agent/test_knowledge_store.py
+++ b/tests/test_agent/test_knowledge_store.py
@@ -654,11 +654,11 @@ class TestKnowledgeStore:
         from trellis.agent.knowledge import get_store
         store = get_store()
 
-        for instrument in (
-            "digital_option",
-            "lookback_option",
-            "chooser_option",
-            "compound_option",
+        for instrument, helper_symbol in (
+            ("digital_option", "price_equity_digital_option_analytical"),
+            ("lookback_option", "price_equity_fixed_lookback_option_analytical"),
+            ("chooser_option", "price_equity_chooser_option_analytical"),
+            ("compound_option", "price_equity_compound_option_analytical"),
         ):
             decomp = store._decompositions.get(instrument)
             assert decomp is not None, f"missing analytical decomposition for {instrument}"
@@ -671,6 +671,15 @@ class TestKnowledgeStore:
             )
             assert "discount_curve" in decomp.required_market_data
             assert "black_vol_surface" in decomp.required_market_data
+            # QUA-852 PR #597 Codex P1: the modeling-requirement string MUST
+            # keep the helper identifier contiguous (no whitespace inside the
+            # symbol), otherwise folded YAML produces ``foo_ analytical(...)``
+            # and generated adapters reference a non-existent symbol.
+            joined_requirements = " ".join(decomp.modeling_requirements)
+            assert f"{helper_symbol}(market_state, spec)" in joined_requirements, (
+                f"{instrument} modeling requirement must contain the "
+                f"contiguous helper call {helper_symbol}(market_state, spec)"
+            )
 
     def test_retrieve_for_task_uses_runtime_cache(self):
         from trellis.agent.knowledge.schema import RetrievalSpec

--- a/tests/test_agent/test_knowledge_store.py
+++ b/tests/test_agent/test_knowledge_store.py
@@ -641,6 +641,37 @@ class TestKnowledgeStore:
         assert "callable" in d.features
         assert d.method == "rate_tree"
 
+    def test_analytical_exotic_decompositions_anchor_on_equity_exotics_module(self):
+        """QUA-852: digital/lookback/chooser/compound intent requests resolve to analytical.
+
+        Without these entries the planner's decomposition router falls through to
+        an LLM decomposition for intent-based requests (e.g. "price a digital
+        option", no ``financepy_binding_id`` set).  With them, the decomposition
+        anchor directly points at the promoted equity-exotic analytical route.
+        Benchmark tasks already resolve via ``financepy_binding_id`` so this
+        guards the non-benchmark planner path.
+        """
+        from trellis.agent.knowledge import get_store
+        store = get_store()
+
+        for instrument in (
+            "digital_option",
+            "lookback_option",
+            "chooser_option",
+            "compound_option",
+        ):
+            decomp = store._decompositions.get(instrument)
+            assert decomp is not None, f"missing analytical decomposition for {instrument}"
+            assert decomp.method == "analytical", (
+                f"{instrument} decomposition must anchor on analytical route, "
+                f"got {decomp.method!r}"
+            )
+            assert "trellis.models.analytical.equity_exotics" in decomp.method_modules, (
+                f"{instrument} must list the shared equity-exotics module"
+            )
+            assert "discount_curve" in decomp.required_market_data
+            assert "black_vol_surface" in decomp.required_market_data
+
     def test_retrieve_for_task_uses_runtime_cache(self):
         from trellis.agent.knowledge.schema import RetrievalSpec
         from trellis.agent.knowledge.store import KnowledgeStore

--- a/trellis/agent/knowledge/canonical/decompositions.yaml
+++ b/trellis/agent/knowledge/canonical/decompositions.yaml
@@ -404,10 +404,7 @@
     - trellis.models.analytical.equity_exotics
   required_market_data: [discount_curve, black_vol_surface]
   modeling_requirements:
-    - >-
-      USE THE EXACT HELPER: Call ``price_equity_digital_option_analytical
-      (market_state, spec)`` directly; do not restate the Black digital payoff
-      assembly inline.
+    - "USE THE EXACT HELPER: Call `price_equity_digital_option_analytical(market_state, spec)` directly; do not restate the Black digital payoff assembly inline."
   reasoning: "Digital cash-or-nothing and asset-or-nothing payoffs have closed-form BS expressions via the shared analytical helper."
   learned: false
 
@@ -418,10 +415,7 @@
     - trellis.models.analytical.equity_exotics
   required_market_data: [discount_curve, black_vol_surface]
   modeling_requirements:
-    - >-
-      USE THE EXACT HELPER: Call ``price_equity_fixed_lookback_option_
-      analytical(market_state, spec)`` directly; do not restate the
-      running-extreme formula inside the generated payoff.
+    - "USE THE EXACT HELPER: Call `price_equity_fixed_lookback_option_analytical(market_state, spec)` directly; do not restate the running-extreme formula inside the generated payoff."
   reasoning: "Fixed-strike lookback options have a Conze-Viswanathan closed form; use the shared analytical helper."
   learned: false
 
@@ -432,10 +426,7 @@
     - trellis.models.analytical.equity_exotics
   required_market_data: [discount_curve, black_vol_surface]
   modeling_requirements:
-    - >-
-      USE THE EXACT HELPER: Call ``price_equity_chooser_option_analytical
-      (market_state, spec)`` directly; keep the critical-spot solve inside
-      the shared analytical module.
+    - "USE THE EXACT HELPER: Call `price_equity_chooser_option_analytical(market_state, spec)` directly; keep the critical-spot solve inside the shared analytical module."
   reasoning: "Simple chooser options decompose into a call plus a put on a common underlier at the choice date — closed form via the shared helper."
   learned: false
 
@@ -446,9 +437,6 @@
     - trellis.models.analytical.equity_exotics
   required_market_data: [discount_curve, black_vol_surface]
   modeling_requirements:
-    - >-
-      USE THE EXACT HELPER: Call ``price_equity_compound_option_analytical
-      (market_state, spec)`` directly; keep the critical-spot solve inside
-      the shared analytical module.
+    - "USE THE EXACT HELPER: Call `price_equity_compound_option_analytical(market_state, spec)` directly; keep the critical-spot solve inside the shared analytical module."
   reasoning: "Call-on-call, call-on-put, put-on-call, put-on-put compound options have a bivariate-normal closed form (Geske) via the shared helper."
   learned: false

--- a/trellis/agent/knowledge/canonical/decompositions.yaml
+++ b/trellis/agent/knowledge/canonical/decompositions.yaml
@@ -391,3 +391,64 @@
       (log(S_{t+1}/S_t))^2 — needs fine time grid for accuracy.
   reasoning: "Variance swap payoff depends on realized variance — MC simulation."
   learned: false
+
+# QUA-852: anchor intent-based requests for analytical exotic pricers on the
+# promoted equity-exotic analytical routes.  For benchmark tasks these are
+# reached via ``financepy_binding_id`` + the deterministic exact-binding body
+# path, so these entries are defensive hygiene for the non-benchmark planner
+# path (intent-based requests without an explicit binding).
+- instrument: digital_option
+  features: [terminal_markov, discounting, vol_surface_dependence]
+  method: analytical
+  method_modules:
+    - trellis.models.analytical.equity_exotics
+  required_market_data: [discount_curve, black_vol_surface]
+  modeling_requirements:
+    - >-
+      USE THE EXACT HELPER: Call ``price_equity_digital_option_analytical
+      (market_state, spec)`` directly; do not restate the Black digital payoff
+      assembly inline.
+  reasoning: "Digital cash-or-nothing and asset-or-nothing payoffs have closed-form BS expressions via the shared analytical helper."
+  learned: false
+
+- instrument: lookback_option
+  features: [path_dependent, discounting, vol_surface_dependence]
+  method: analytical
+  method_modules:
+    - trellis.models.analytical.equity_exotics
+  required_market_data: [discount_curve, black_vol_surface]
+  modeling_requirements:
+    - >-
+      USE THE EXACT HELPER: Call ``price_equity_fixed_lookback_option_
+      analytical(market_state, spec)`` directly; do not restate the
+      running-extreme formula inside the generated payoff.
+  reasoning: "Fixed-strike lookback options have a Conze-Viswanathan closed form; use the shared analytical helper."
+  learned: false
+
+- instrument: chooser_option
+  features: [terminal_markov, discounting, vol_surface_dependence]
+  method: analytical
+  method_modules:
+    - trellis.models.analytical.equity_exotics
+  required_market_data: [discount_curve, black_vol_surface]
+  modeling_requirements:
+    - >-
+      USE THE EXACT HELPER: Call ``price_equity_chooser_option_analytical
+      (market_state, spec)`` directly; keep the critical-spot solve inside
+      the shared analytical module.
+  reasoning: "Simple chooser options decompose into a call plus a put on a common underlier at the choice date — closed form via the shared helper."
+  learned: false
+
+- instrument: compound_option
+  features: [terminal_markov, discounting, vol_surface_dependence]
+  method: analytical
+  method_modules:
+    - trellis.models.analytical.equity_exotics
+  required_market_data: [discount_curve, black_vol_surface]
+  modeling_requirements:
+    - >-
+      USE THE EXACT HELPER: Call ``price_equity_compound_option_analytical
+      (market_state, spec)`` directly; keep the critical-spot solve inside
+      the shared analytical module.
+  reasoning: "Call-on-call, call-on-put, put-on-call, put-on-put compound options have a bivariate-normal closed form (Geske) via the shared helper."
+  learned: false


### PR DESCRIPTION
## Summary

- Adds four canonical decomposition entries in `trellis/agent/knowledge/canonical/decompositions.yaml` anchored on `trellis.models.analytical.equity_exotics` for `digital_option`, `lookback_option`, `chooser_option`, `compound_option`.
- Closes a gap in the non-benchmark **intent-based** planner path: a request like "price a digital option" without an explicit `financepy_binding_id` had no canonical decomposition anchor and fell through to the LLM decomposition fallback.

## Scope clarification after audit

The ticket's original framing assumed the decomposition anchor was blocking for benchmark parity. It isn't — F009 (barrier analytical) currently succeeds at 0.003% without an analytical decomposition entry, because `financepy_binding_id` + the deterministic exact-binding body path in `executor.py` are load-bearing. This PR addresses the defensive-hygiene leg; the binding/route/body stack was the real unblock and was already in place.

## Out of scope

- `barrier_option` unchanged: the existing loader (dict-keyed by instrument) only carries one decomposition per instrument. Dual-tracking MC + analytical requires a loader enhancement — separate follow-on.
- F010–F013 live parity runs deferred to the user's next `scripts/run_financepy_benchmark.py` pass; ticket will close on that evidence.

## Test plan

- [x] `pytest tests/test_agent/test_knowledge_store.py -x -q -k "decomposition"` → 2 passed (1 new)
- [x] `pytest tests/test_agent -x -q -m "not integration"` → **1881 passed** (+1 new, zero regressions)
- [ ] Live F010-F013 parity runs (deferred; handled by user at next benchmark run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)