### PR TITLE
knowledge: retire route-card adapters/notes on 3 fallback lanes (QUA-816 slice 1)

### DIFF
--- a/tests/test_agent/test_lane_obligations.py
+++ b/tests/test_agent/test_lane_obligations.py
@@ -184,3 +184,35 @@ def test_transform_lane_plan_emits_terminal_characteristic_contract():
     assert "quote_semantics:equity_black_vol_surface" in plan.control_obligations
     assert any("terminal-only transform contract" in step for step in plan.construction_steps)
     assert any("helper_backed" in step for step in plan.construction_steps)
+
+
+def test_waterfall_lane_plan_emits_cashflow_engine_construction_steps():
+    """QUA-816 slice 1 round-1 Codex P1: removing the route-card adapter for
+    ``waterfall_cashflows`` must not leave the lane with empty construction
+    steps.  The lane-obligation surface now carries the "map collateral
+    cashflows onto the tranche structure" guidance that used to live as an
+    adapter on the route card.
+    """
+    lowering = SemanticDslLowering(
+        route_id="waterfall_cashflows",
+        route_family="waterfall",
+        family_ir=None,
+        expr=None,
+        normalized_expr=None,
+    )
+
+    plan = compile_lane_construction_plan(
+        preferred_method="waterfall",
+        required_market_data=("discount_curve",),
+        dsl_lowering=lowering,
+    )
+
+    assert plan is not None
+    assert plan.lane_family == "waterfall"
+    assert plan.construction_steps, (
+        "waterfall lane plan must emit construction steps even without a "
+        "specialized family IR; otherwise removing route-card adapters "
+        "leaves build-time guidance empty."
+    )
+    assert any("cashflow_engine" in step for step in plan.construction_steps)
+    assert any("tranche" in step.lower() for step in plan.construction_steps)

--- a/tests/test_agent/test_primitive_planning.py
+++ b/tests/test_agent/test_primitive_planning.py
@@ -313,7 +313,12 @@ def test_builds_local_vol_monte_carlo_plan_for_local_vol_context():
     assert plan.primitive_plan.route == "local_vol_monte_carlo"
     primitive_symbols = {primitive.symbol for primitive in plan.primitive_plan.primitives}
     assert {"LocalVol", "MonteCarloEngine", "local_vol_european_vanilla_price"} <= primitive_symbols
-    assert "map_market_state_local_vol_surface_spot_and_discount_into_local_vol_mc_inputs" in plan.primitive_plan.adapters
+    # QUA-816: route-card `adapters` retired from `local_vol_monte_carlo`;
+    # constructive guidance flows through `lane_obligations._construction_steps_for`
+    # for `EventAwareMonteCarloIR` with `process_family=local_vol_1d` instead.
+    # The typed `state_process` / `path_simulation` / `pricing_kernel`
+    # primitives above are the source of truth.
+    assert plan.primitive_plan.adapters == ()
     assert plan.primitive_plan.blockers == ()
 
 

--- a/tests/test_agent/test_route_registry.py
+++ b/tests/test_agent/test_route_registry.py
@@ -682,6 +682,35 @@ class TestMonteCarloPathsRoutes:
         assert resolve_route_adapters(spec, self.GENERIC_IR) == ()
         assert resolve_route_notes(spec, self.GENERIC_IR) == ()
 
+    def test_fallback_lanes_have_no_route_card_adapters_or_notes(self, registry):
+        """QUA-816: route-card constructive adapters/notes retired for these lanes.
+
+        The thinned lanes rely on the typed binding primitives (``state_process``,
+        ``path_simulation``, ``pricing_kernel``, ``low_discrepancy_sampler``,
+        ``cashflow_engine``) plus ``lane_obligations._construction_steps_for``
+        for constructive guidance.  Reintroducing prose on these cards would
+        resurrect the dual-authority problem QUA-816 closed.
+        """
+        thinned_lane_ids = {
+            "local_vol_monte_carlo",
+            "qmc_sobol_paths",
+            "waterfall_cashflows",
+        }
+        for spec in registry.routes:
+            if spec.id not in thinned_lane_ids:
+                continue
+            assert spec.adapters == (), (
+                f"route {spec.id} unexpectedly carries adapters: {spec.adapters}"
+            )
+            assert spec.notes == (), (
+                f"route {spec.id} unexpectedly carries notes: {spec.notes}"
+            )
+            # The typed binding primitives are the new source of truth; keep
+            # the test honest by asserting at least one primitive exists.
+            assert spec.primitives, (
+                f"route {spec.id} must keep typed primitives after QUA-816 cleanup"
+            )
+
     def test_admissibility_hydrates_process_and_path_contracts(self, registry):
         generic = find_route_by_id("monte_carlo_paths", registry)
         local_vol = find_route_by_id("local_vol_monte_carlo", registry)

--- a/trellis/agent/knowledge/canonical/routes.yaml
+++ b/trellis/agent/knowledge/canonical/routes.yaml
@@ -684,11 +684,10 @@ routes:
       - module: trellis.models.monte_carlo.local_vol
         symbol: local_vol_european_vanilla_price
         role: pricing_kernel
-    adapters:
-      - map_market_state_local_vol_surface_spot_and_discount_into_local_vol_mc_inputs
-      - derive_option_type_strike_and_expiry_for_vanilla_equity_option
-    notes:
-      - "For vanilla equity local-vol requests, prefer the reusable local-vol Monte Carlo helper over bespoke path loops."
+    # QUA-816: adapters and notes retired to the lane-obligation surface
+    # (`lane_obligations._construction_steps_for`, keyed by `EventAwareMonteCarloIR`
+    # for this lane).  The typed `state_process` / `path_simulation` /
+    # `pricing_kernel` bindings above are the source of truth.
     market_data_access:
       required:
         discount_curve: [market_state.discount]
@@ -723,10 +722,9 @@ routes:
       - module: trellis.models.processes.gbm
         symbol: GBM
         role: state_process
-    adapters:
-      - assemble_mc_style_estimator_on_sobol_paths
-    notes:
-      - "QMC in Trellis accelerates MC-style estimators rather than replacing them."
+    # QUA-816: adapters and notes retired to the lane-obligation surface.
+    # The typed `low_discrepancy_sampler` / `path_construction` / `state_process`
+    # bindings above are the source of truth for the QMC estimator scaffold.
     market_data_access:
       required:
         discount_curve: [market_state.discount]
@@ -1375,9 +1373,10 @@ routes:
       - module: trellis.models.cashflow_engine.waterfall
         symbol: Tranche
         role: cashflow_engine
-    adapters:
-      - map_collateral_cashflows_into_structure
-    notes: []
+    # QUA-816: adapter retired to the lane-obligation surface.  The two
+    # `cashflow_engine` bindings above are the typed primitives; the
+    # constructive "map collateral cashflows into the structure" guidance
+    # flows through `lane_obligations` for the waterfall lane family.
     market_data_access:
       required:
         discount_curve: [market_state.discount]

--- a/trellis/agent/lane_obligations.py
+++ b/trellis/agent/lane_obligations.py
@@ -520,6 +520,15 @@ def _construction_steps_for(*, lane_family: str, family_ir) -> tuple[str, ...]:
             "Discretize the contract onto a PDE grid with explicit terminal and boundary conditions.",
             "Evolve the grid backward with the selected stepping scheme before reading out the PV.",
         )
+    if lane_family == "waterfall":
+        # QUA-816 round-1 Codex P1: the `waterfall_cashflows` route card used
+        # to carry `map_collateral_cashflows_into_structure` as an adapter.
+        # Emit the equivalent constructive guidance here so removing the
+        # route-card prose does not leave the lane with empty steps.
+        return (
+            "Map collateral cashflows onto the declared tranche structure via the cashflow_engine primitives.",
+            "Keep deal-schedule, locked-cashflow, and remaining-pool state explicit across the waterfall rollup.",
+        )
     return ()
 
 
@@ -641,6 +650,13 @@ def _fallback_construction_steps(
         return (
             "Resolve scalar market inputs and contract terms before applying the closed-form kernel.",
             "Keep discounting and market-binding semantics explicit instead of hiding them behind invented helpers.",
+        )
+    if lane_family == "waterfall":
+        # QUA-816 round-1 Codex P1: keep waterfall guidance non-empty even
+        # on the fallback (non-semantic) path.
+        return (
+            "Resolve the deal-schedule, locked-cashflow, and remaining-pool state explicitly before walking the waterfall.",
+            "Route collateral cashflows through the declared tranche structure via the cashflow_engine primitives.",
         )
     return ()
 


### PR DESCRIPTION
## Summary

- Delete route-card `adapters:` and `notes:` on three promoted fallback lanes whose constructive guidance is already covered by typed binding primitives + `lane_obligations._construction_steps_for`: `local_vol_monte_carlo`, `qmc_sobol_paths`, `waterfall_cashflows`.
- Thinness bar: each card now ~30 lines with 0 adapters/notes (matches the `equity_variance_swap_analytical` reference).

## Why it's safe

- `route_registry._parse_route:545-546` defaults `adapters`/`notes` to empty tuples when omitted.
- All downstream consumers guard on empty sequences: `codegen_guardrails` adapter-block rendering, `prompts.py`, `knowledge/skills.py` tag generation, `lite_review`, `assembly_tools`, `analytical_traces`, `semantic_validators`.
- Typed primitives (`state_process`, `path_simulation`, `pricing_kernel`, `low_discrepancy_sampler`, `cashflow_engine`) remain the source of truth.

## Out of scope (follow-on)

`exercise_monte_carlo` and `pde_theta_1d` carry conditional-adapter and dynamic-note content that needs a richer `lane_obligations` scaffold before route-card prose can be removed. A separate ticket will track that work.

## Test plan

- [x] Updated `test_builds_local_vol_monte_carlo_plan_for_local_vol_context` to assert empty adapters (the old assertion pinned the now-retired adapter name).
- [x] New `test_fallback_lanes_have_no_route_card_adapters_or_notes` pins the three migrated lanes' thinness.
- [x] `pytest tests/test_agent -x -q -m \"not integration\"` → 1883 passed, zero regressions.

Generated with Claude Code