### PR TITLE
agent: retire dead route_id-fallback branches in family_lowering_ir (QUA-794 slice 1)

### DIFF
--- a/tests/test_agent/test_backend_bindings.py
+++ b/tests/test_agent/test_backend_bindings.py
@@ -24,6 +24,25 @@ def test_binding_catalog_loads_core_route_backed_bindings():
     } <= route_ids
 
 
+def test_binding_catalog_covers_retired_fallback_routes():
+    """QUA-794: bindings for these lanes must remain in the canonical catalog.
+
+    `family_lowering_ir` retired its
+    ``route_id == X and binding_spec is None`` fallbacks for these routes on
+    the basis that the catalog always resolves a binding_spec.  If a binding
+    disappears from the catalog, this test fires before the missing-binding
+    path exercises production builds.
+    """
+    catalog = load_backend_binding_catalog()
+    route_ids = {binding.route_id for binding in catalog.bindings}
+    assert {
+        "analytical_black76",
+        "transform_fft",
+        "monte_carlo_paths",
+        "local_vol_monte_carlo",
+    } <= route_ids
+
+
 def test_binding_catalog_canonical_load_is_not_derived_from_route_registry(monkeypatch):
     from trellis.agent import route_registry as route_registry_module
 

--- a/trellis/agent/family_lowering_ir.py
+++ b/trellis/agent/family_lowering_ir.py
@@ -842,7 +842,17 @@ def _binding_supports_black76_analytical(
     *,
     route_id: str,
 ) -> bool:
-    """Return whether the binding surface fits the Black76 analytical lane."""
+    """Return whether the binding surface fits the Black76 analytical lane.
+
+    QUA-794: the `analytical_black76` binding is guaranteed to be in the
+    canonical catalog (`tests/test_agent/test_backend_bindings.py::
+    test_binding_catalog_loads_core_route_backed_bindings`), so the
+    historical `route_id == "analytical_black76" and binding_spec is None`
+    fallback is now dead code and has been retired.  If a future lane reaches
+    this function with `binding_spec is None`, that is a real binding-
+    resolution failure that must be surfaced, not silently rescued.
+    """
+    del route_id  # retained for backwards-compatible call signature
     if _binding_has_all_symbols(binding_spec, "pricing_kernel", "black76_call", "black76_put"):
         return True
     if _binding_has_any_symbol(
@@ -851,7 +861,7 @@ def _binding_supports_black76_analytical(
         "price_rate_cap_floor_strip_analytical",
     ):
         return True
-    return route_id == "analytical_black76" and binding_spec is None
+    return False
 
 
 def _binding_has_all_symbols(
@@ -869,7 +879,13 @@ def _binding_supports_transform_pricing(
     *,
     route_id: str,
 ) -> bool:
-    """Return whether the binding surface fits the transform-pricing lane."""
+    """Return whether the binding surface fits the transform-pricing lane.
+
+    QUA-794: the `transform_fft` binding is in the canonical catalog; the
+    historical `route_id == "transform_fft" and binding_spec is None`
+    fallback has been retired.
+    """
+    del route_id
     if _binding_has_role(binding_spec, "transform_pricer"):
         return True
     if _binding_has_any_symbol(
@@ -879,7 +895,7 @@ def _binding_supports_transform_pricing(
         "price_basket_option_transform_proxy",
     ):
         return True
-    return route_id == "transform_fft" and binding_spec is None
+    return False
 
 
 def _binding_supports_vanilla_equity_pde(
@@ -919,7 +935,14 @@ def _binding_supports_event_aware_monte_carlo(
     *,
     route_id: str,
 ) -> bool:
-    """Return whether the binding surface fits the bounded event-aware MC lane."""
+    """Return whether the binding surface fits the bounded event-aware MC lane.
+
+    QUA-794: `monte_carlo_paths` and `local_vol_monte_carlo` bindings are in
+    the canonical catalog; the historical
+    `route_id in {"monte_carlo_paths", "local_vol_monte_carlo"} and
+    binding_spec is None` fallback has been retired.
+    """
+    del route_id
     if _binding_has_role(binding_spec, "path_simulation") and _binding_has_role(binding_spec, "state_process"):
         return True
     if _binding_has_any_symbol(
@@ -931,7 +954,7 @@ def _binding_supports_event_aware_monte_carlo(
         "price_swaption_monte_carlo",
     ):
         return True
-    return route_id in {"monte_carlo_paths", "local_vol_monte_carlo"} and binding_spec is None
+    return False
 
 
 def _binding_supports_exercise_lattice(


### PR DESCRIPTION
## Summary

Retire 3 transitional `route_id == X and binding_spec is None` fallback branches in `family_lowering_ir.py` whose underlying bindings are now permanently in the canonical catalog. Each fallback was a safe rescue for the pre-catalog era; with bindings in place they're dead code.

Retired:
- `_binding_supports_black76_analytical` — `analytical_black76`
- `_binding_supports_transform_pricing` — `transform_fft`
- `_binding_supports_event_aware_monte_carlo` — `monte_carlo_paths` / `local_vol_monte_carlo`

## Test plan

- [x] New `test_binding_catalog_covers_retired_fallback_routes` asserts the canonical catalog still resolves bindings for each of the four retired routes. Acts as a regression guard: removing a binding now fires this test before production builds hit the missing-binding path.
- [x] `pytest tests/test_agent -x -q -m "not integration"` → 1885 passed, zero regressions.

## Out of scope (follow-on)

- `_binding_supports_vanilla_equity_pde`, `_binding_supports_event_aware_pde`, and `_credit_default_swap_pricing_mode` / `_credit_default_swap_helper_symbol` interact with QUA-880's PDE + exercise-MC lane work and should retire as that work lands.

Generated with Claude Code