### PR TITLE
agent: retire 7 remaining route_id fallback branches (QUA-794 slice 2)

### DIFF
--- a/tests/test_agent/test_backend_bindings.py
+++ b/tests/test_agent/test_backend_bindings.py
@@ -27,19 +27,36 @@ def test_binding_catalog_loads_core_route_backed_bindings():
 def test_binding_catalog_covers_retired_fallback_routes():
     """QUA-794: bindings for these lanes must remain in the canonical catalog.
 
-    `family_lowering_ir` retired its
+    ``family_lowering_ir`` retired its
     ``route_id == X and binding_spec is None`` fallbacks for these routes on
     the basis that the catalog always resolves a binding_spec.  If a binding
     disappears from the catalog, this test fires before the missing-binding
     path exercises production builds.
+
+    Slice 1 (PR #600): ``analytical_black76``, ``transform_fft``,
+    ``monte_carlo_paths``, ``local_vol_monte_carlo``.
+
+    Slice 2 (this PR): ``vanilla_equity_theta_pde``, ``pde_theta_1d``,
+    ``exercise_lattice``, ``correlated_basket_monte_carlo``,
+    ``credit_default_swap_analytical``, ``credit_default_swap_monte_carlo``,
+    ``nth_to_default_monte_carlo``.
     """
     catalog = load_backend_binding_catalog()
     route_ids = {binding.route_id for binding in catalog.bindings}
     assert {
+        # slice 1
         "analytical_black76",
         "transform_fft",
         "monte_carlo_paths",
         "local_vol_monte_carlo",
+        # slice 2
+        "vanilla_equity_theta_pde",
+        "pde_theta_1d",
+        "exercise_lattice",
+        "correlated_basket_monte_carlo",
+        "credit_default_swap_analytical",
+        "credit_default_swap_monte_carlo",
+        "nth_to_default_monte_carlo",
     } <= route_ids
 
 

--- a/trellis/agent/family_lowering_ir.py
+++ b/trellis/agent/family_lowering_ir.py
@@ -903,10 +903,19 @@ def _binding_supports_vanilla_equity_pde(
     *,
     route_id: str,
 ) -> bool:
-    """Return whether the binding surface fits the vanilla-equity PDE lane."""
-    if _binding_has_symbol(binding_spec, "route_helper", "price_vanilla_equity_option_pde"):
-        return True
-    return route_id == "vanilla_equity_theta_pde" and binding_spec is None
+    """Return whether the binding surface fits the vanilla-equity PDE lane.
+
+    QUA-794 slice 2: ``vanilla_equity_theta_pde`` binding is in the
+    canonical catalog; the historical
+    ``route_id == "vanilla_equity_theta_pde" and binding_spec is None``
+    fallback is dead code and has been retired.
+    """
+    del route_id
+    return _binding_has_symbol(
+        binding_spec,
+        "route_helper",
+        "price_vanilla_equity_option_pde",
+    )
 
 
 def _binding_supports_event_aware_pde(
@@ -914,7 +923,15 @@ def _binding_supports_event_aware_pde(
     *,
     route_id: str,
 ) -> bool:
-    """Return whether the binding surface fits the event-aware PDE lane."""
+    """Return whether the binding surface fits the event-aware PDE lane.
+
+    QUA-794 slice 2: ``pde_theta_1d`` binding is in the canonical
+    catalog (plus QUA-880 migrated the route's constructive prose onto
+    `lane_obligations`), so the historical
+    ``route_id == "pde_theta_1d" and binding_spec is None`` fallback is
+    dead code and has been retired.
+    """
+    del route_id
     if _binding_has_all_symbols(binding_spec, "grid", "Grid") and _binding_has_role(
         binding_spec,
         "spatial_operator",
@@ -927,7 +944,7 @@ def _binding_supports_event_aware_pde(
         "price_callable_bond_pde",
     ):
         return True
-    return route_id == "pde_theta_1d" and binding_spec is None
+    return False
 
 
 def _binding_supports_event_aware_monte_carlo(
@@ -962,7 +979,13 @@ def _binding_supports_exercise_lattice(
     *,
     route_id: str,
 ) -> bool:
-    """Return whether the binding surface fits the exercise-lattice lane."""
+    """Return whether the binding surface fits the exercise-lattice lane.
+
+    QUA-794 slice 2: ``exercise_lattice`` binding is in the canonical
+    catalog; the historical ``route_id == "exercise_lattice" and
+    binding_spec is None`` fallback is dead code and has been retired.
+    """
+    del route_id
     if _binding_has_role(binding_spec, "lattice_builder") and _binding_has_role(
         binding_spec,
         "backward_induction",
@@ -976,7 +999,7 @@ def _binding_supports_exercise_lattice(
         "price_bermudan_swaption_tree",
     ):
         return True
-    return route_id == "exercise_lattice" and binding_spec is None
+    return False
 
 
 def _binding_supports_correlated_basket_monte_carlo(
@@ -984,12 +1007,19 @@ def _binding_supports_correlated_basket_monte_carlo(
     *,
     route_id: str,
 ) -> bool:
-    """Return whether the binding surface fits the ranked-basket MC lane."""
+    """Return whether the binding surface fits the ranked-basket MC lane.
+
+    QUA-794 slice 2: ``correlated_basket_monte_carlo`` binding is in the
+    canonical catalog; the historical ``route_id ==
+    "correlated_basket_monte_carlo" and binding_spec is None`` fallback
+    is dead code and has been retired.
+    """
+    del route_id
     if _binding_has_symbol(binding_spec, "market_binding", "resolve_basket_semantics"):
         return True
     if _binding_has_symbol(binding_spec, "route_helper", "price_ranked_observation_basket_monte_carlo"):
         return True
-    return route_id == "correlated_basket_monte_carlo" and binding_spec is None
+    return False
 
 
 def _binding_supports_credit_default_swap(
@@ -997,12 +1027,19 @@ def _binding_supports_credit_default_swap(
     *,
     route_id: str,
 ) -> bool:
-    """Return whether the binding surface fits the CDS lowering lane."""
+    """Return whether the binding surface fits the CDS lowering lane.
+
+    QUA-794 slice 2: ``credit_default_swap_analytical`` /
+    ``credit_default_swap_monte_carlo`` bindings are in the canonical
+    catalog; the historical ``route_id in {...} and binding_spec is None``
+    fallback is dead code and has been retired.
+    """
+    del route_id
     if _binding_has_symbol(binding_spec, "schedule_builder", "build_cds_schedule"):
         return True
     if _binding_has_any_symbol(binding_spec, "route_helper", "price_cds_analytical", "price_cds_monte_carlo"):
         return True
-    return route_id in {"credit_default_swap_analytical", "credit_default_swap_monte_carlo"} and binding_spec is None
+    return False
 
 
 def _binding_supports_nth_to_default(
@@ -1010,12 +1047,19 @@ def _binding_supports_nth_to_default(
     *,
     route_id: str,
 ) -> bool:
-    """Return whether the binding surface fits the nth-to-default copula lane."""
+    """Return whether the binding surface fits the nth-to-default copula lane.
+
+    QUA-794 slice 2: ``nth_to_default_monte_carlo`` binding is in the
+    canonical catalog; the historical ``route_id ==
+    "nth_to_default_monte_carlo" and binding_spec is None`` fallback is
+    dead code and has been retired.
+    """
+    del route_id
     if _binding_has_symbol(binding_spec, "default_time_sampler", "GaussianCopula"):
         return True
     if _binding_has_symbol(binding_spec, "route_helper", "price_nth_to_default_basket"):
         return True
-    return route_id == "nth_to_default_monte_carlo" and binding_spec is None
+    return False
 
 
 def _resolve_exercise_lattice_profile(contract, product_ir) -> ExerciseLatticeProfile | None:
@@ -1624,11 +1668,12 @@ def _mc_process_spec_for_product(
             process_family="local_vol_1d",
             simulation_scheme="euler_local_vol",
         )
-    if route_id == "local_vol_monte_carlo" and binding_spec is None:
-        return MCProcessSpec(
-            process_family="local_vol_1d",
-            simulation_scheme="euler_local_vol",
-        )
+    # QUA-794 slice 2: ``local_vol_monte_carlo`` binding is in the
+    # canonical catalog, so the historical ``route_id ==
+    # "local_vol_monte_carlo" and binding_spec is None`` process-config
+    # fallback is dead code.  The primary path (lines above) already
+    # detects the local-vol pricing_kernel binding directly.
+    del route_id  # retained for call-site compatibility; unused after catalog coverage
     model_family = str(getattr(product, "model_family", "") or "").strip().lower()
     if model_family in {"interest_rate", "short_rate"}:
         return MCProcessSpec(


### PR DESCRIPTION
## Summary

Completes QUA-794's fallback-branch retirement started in slice 1 (PR #600).  All 7 remaining `route_id == X and binding_spec is None` fallbacks in `family_lowering_ir.py` are dead code because the referenced routes have canonical entries in `backend_bindings.yaml`.  Retiring them lets real binding-resolution failures surface loudly instead of silently rescuing broken builds.

Retired: `vanilla_equity_theta_pde`, `pde_theta_1d`, `exercise_lattice`, `correlated_basket_monte_carlo`, `credit_default_swap_analytical`, `credit_default_swap_monte_carlo`, `nth_to_default_monte_carlo`, plus the `local_vol_monte_carlo` MC-process-config fallback.

## Test plan

- [x] `test_binding_catalog_covers_retired_fallback_routes` extended to cover all 11 retired routes (slice 1 + slice 2).  Regression guard: catalog integrity is pinned.
- [x] `pytest tests/test_agent -x -q -m 'not integration'` -> **1889 passed**, zero regressions.

With this slice, `family_lowering_ir.py` has no remaining `route_id == X and binding_spec is None` fallbacks.  QUA-794's original acceptance bar (family lowering no longer depends on direct route-id special cases) is now met.

Generated with Claude Code