### PR TITLE
agent: route variance swap + exotics around broad Black76 matcher (QUA-882)

### DIFF
--- a/tests/test_agent/test_build_gate.py
+++ b/tests/test_agent/test_build_gate.py
@@ -303,6 +303,32 @@ class TestPreGenerationGate:
         assert decision.decision == "block"
         assert "path_dependent_early_exercise_under_stochastic_vol" in decision.reason
 
+    def test_block_reason_truncates_many_unresolved_primitives(self):
+        """QUA-882: when the IR declares many unresolved primitives, the gate
+        reason previews the first two and appends a `+N more` suffix so the
+        log entry stays bounded (matches the pattern used by other gate
+        decisions)."""
+        gap = _StubGapReport(confidence=0.8)
+        plan = _StubGenerationPlan(
+            primitive_plan=None,
+            lane_family="analytical",
+            lane_plan_kind="constructive_synthesis",
+            lane_construction_steps=("Bind analytical inputs.",),
+            lane_unresolved_primitives=(
+                "primitive_one",
+                "primitive_two",
+                "primitive_three",
+                "primitive_four",
+                "primitive_five",
+            ),
+        )
+        decision = evaluate_pre_generation_gate(gap, plan)
+        assert decision.decision == "block"
+        assert "primitive_one" in decision.reason
+        assert "primitive_two" in decision.reason
+        assert "primitive_three" not in decision.reason
+        assert "+3 more" in decision.reason
+
     def test_none_gap_report_proceeds_when_clean(self):
         plan = _StubGenerationPlan(
             primitive_plan=_StubPrimitivePlan(),

--- a/tests/test_agent/test_build_gate.py
+++ b/tests/test_agent/test_build_gate.py
@@ -77,6 +77,7 @@ class _StubGenerationPlan:
     lane_plan_kind: str = ""
     lane_exact_binding_refs: tuple = ()
     lane_construction_steps: tuple = ()
+    lane_unresolved_primitives: tuple = ()
 
 
 def _generation_plan_for_semantic_blueprint(semantic_blueprint):
@@ -283,6 +284,24 @@ class TestPreGenerationGate:
         )
         decision = evaluate_pre_generation_gate(gap, plan)
         assert decision.decision == "proceed"
+
+    def test_block_when_lane_unresolved_primitives_and_no_primitive_plan(self):
+        """QUA-882: when no primitive route matches but the ProductIR declared
+        unresolved primitives, the fallback lane plan must surface them and
+        the gate must block rather than proceed to code generation."""
+        gap = _StubGapReport(confidence=0.8)
+        plan = _StubGenerationPlan(
+            primitive_plan=None,
+            lane_family="analytical",
+            lane_plan_kind="constructive_synthesis",
+            lane_construction_steps=("Bind analytical inputs.",),
+            lane_unresolved_primitives=(
+                "path_dependent_early_exercise_under_stochastic_vol",
+            ),
+        )
+        decision = evaluate_pre_generation_gate(gap, plan)
+        assert decision.decision == "block"
+        assert "path_dependent_early_exercise_under_stochastic_vol" in decision.reason
 
     def test_none_gap_report_proceeds_when_clean(self):
         plan = _StubGenerationPlan(

--- a/trellis/agent/build_gate.py
+++ b/trellis/agent/build_gate.py
@@ -149,11 +149,14 @@ def _lane_obligation_gate_decision(
         getattr(generation_plan, "lane_unresolved_primitives", ()) or ()
     )
     if lane_unresolved and primitive_plan is None:
+        preview = ", ".join(lane_unresolved[:2])
+        if len(lane_unresolved) > 2:
+            preview += f", +{len(lane_unresolved) - 2} more"
         return BuildGateDecision(
             decision="block",
             reason=(
                 "Product IR declares unresolved primitives with no matching "
-                f"primitive route: {', '.join(lane_unresolved)}."
+                f"primitive route: {preview}."
             ),
             gap_confidence=gap_confidence,
             gate_source=gate_source,

--- a/trellis/agent/build_gate.py
+++ b/trellis/agent/build_gate.py
@@ -140,6 +140,24 @@ def _lane_obligation_gate_decision(
         generation_plan,
         semantic_blueprint=semantic_blueprint,
     )
+    # QUA-882: when the lane plan surfaces unresolved primitives from the
+    # product IR (e.g. path-dependent early exercise under stochastic vol),
+    # block even if the primitive planner or constructive lane would
+    # otherwise let generation proceed.  The IR has already declared the
+    # product unsupported; generation would just guess a helper.
+    lane_unresolved = tuple(
+        getattr(generation_plan, "lane_unresolved_primitives", ()) or ()
+    )
+    if lane_unresolved and primitive_plan is None:
+        return BuildGateDecision(
+            decision="block",
+            reason=(
+                "Product IR declares unresolved primitives with no matching "
+                f"primitive route: {', '.join(lane_unresolved)}."
+            ),
+            gap_confidence=gap_confidence,
+            gate_source=gate_source,
+        )
     if primitive_plan is not None:
         return None
     if exact_refs or steps:

--- a/trellis/agent/knowledge/canonical/routes.yaml
+++ b/trellis/agent/knowledge/canonical/routes.yaml
@@ -932,7 +932,30 @@ routes:
       non_european_penalty: -4.0
     match:
       methods: [analytical]
-      exclude_instruments: [quanto_option, cds, nth_to_default, zcb_option]
+      # QUA-882: every instrument listed here has its own instrument-specific
+      # analytical route (`equity_digital_analytical`, `equity_variance_swap_analytical`,
+      # etc.) and ``analytical_black76`` lacks a matching conditional-primitive
+      # ``when`` clause for them.  Without the exclusion, the broad
+      # ``methods: [analytical]`` matcher on Black76 competes with the
+      # instrument-specific matcher and can be selected instead, forcing the
+      # assembly guard to demand the ``when: default`` Black76 kernels that
+      # the instrument's helper does not use (the F015 variance-swap failure
+      # mode).  ``basket_option`` is **deliberately not excluded** because
+      # Black76 has a legitimate ``when: payoff_family: basket_option +
+      # european + equity_diffusion`` clause that delegates to
+      # ``price_basket_option_analytical``.
+      exclude_instruments:
+        - quanto_option
+        - cds
+        - nth_to_default
+        - zcb_option
+        - variance_swap
+        - digital_option
+        - lookback_option
+        - chooser_option
+        - compound_option
+        - cliquet_option
+        - barrier_option
       exclude_required_market_data: [fx_rates]
     admissibility:
       control_styles: [identity, holder_max]

--- a/trellis/agent/lane_obligations.py
+++ b/trellis/agent/lane_obligations.py
@@ -180,7 +180,20 @@ def compile_fallback_lane_construction_plan(
         required_market_data=required_market,
         primitive_plan=primitive_plan,
     )
-    unresolved_primitives = tuple(getattr(primitive_plan, "blockers", ()) or ())
+    # QUA-882: fall back to ``product_ir.unresolved_primitives`` when no
+    # primitive plan was produced.  When the IR itself declares the product
+    # unsupported (e.g. path-dependent early exercise under stochastic vol),
+    # the route registry may legitimately match no analytical helper and
+    # ``primitive_plan`` will be ``None``.  Carrying the IR's blocker forward
+    # here lets the pre-generation gate surface the blocker instead of
+    # silently proceeding to code generation.
+    blockers_from_plan = tuple(getattr(primitive_plan, "blockers", ()) or ())
+    blockers_from_ir = tuple(
+        getattr(product_ir, "unresolved_primitives", ()) or ()
+    )
+    unresolved_primitives = _tuple_unique(
+        list(blockers_from_plan) + list(blockers_from_ir)
+    )
     plan_kind = (
         "exact_target_binding"
         if exact_target_refs

--- a/trellis/agent/lane_obligations.py
+++ b/trellis/agent/lane_obligations.py
@@ -180,20 +180,23 @@ def compile_fallback_lane_construction_plan(
         required_market_data=required_market,
         primitive_plan=primitive_plan,
     )
-    # QUA-882: fall back to ``product_ir.unresolved_primitives`` when no
+    # QUA-882: fall back to ``product_ir.unresolved_primitives`` only when no
     # primitive plan was produced.  When the IR itself declares the product
     # unsupported (e.g. path-dependent early exercise under stochastic vol),
     # the route registry may legitimately match no analytical helper and
-    # ``primitive_plan`` will be ``None``.  Carrying the IR's blocker forward
-    # here lets the pre-generation gate surface the blocker instead of
-    # silently proceeding to code generation.
-    blockers_from_plan = tuple(getattr(primitive_plan, "blockers", ()) or ())
-    blockers_from_ir = tuple(
-        getattr(product_ir, "unresolved_primitives", ()) or ()
-    )
-    unresolved_primitives = _tuple_unique(
-        list(blockers_from_plan) + list(blockers_from_ir)
-    )
+    # ``primitive_plan`` will be ``None``.  Carrying the IR's blockers forward
+    # here lets the pre-generation gate surface them instead of silently
+    # proceeding to code generation.  When a primitive plan is present its
+    # ``blockers`` already include ``product_ir.unresolved_primitives`` (via
+    # ``rank_primitive_routes``), so no further merge is needed.
+    if primitive_plan is not None:
+        unresolved_primitives = tuple(
+            getattr(primitive_plan, "blockers", ()) or ()
+        )
+    else:
+        unresolved_primitives = tuple(
+            getattr(product_ir, "unresolved_primitives", ()) or ()
+        )
     plan_kind = (
         "exact_target_binding"
         if exact_target_refs


### PR DESCRIPTION
## Summary
- Excluded `variance_swap`, `digital_option`, `lookback_option`, `chooser_option`, `compound_option`, `cliquet_option`, and `barrier_option` from `analytical_black76`'s broad `methods: [analytical]` matcher so instrument-specific analytical routes win (fixes F015 assembly-guard failure).
- Kept `basket_option` OFF the exclusion list because Black76 has a legitimate `when: basket_option + european + equity_diffusion` clause that delegates to `price_basket_option_analytical`.
- Added a pre-generation build-gate fallback: when no primitive route matches but the product IR declares `unresolved_primitives`, the fallback lane plan carries those forward and the gate blocks with a clear reason instead of guessing a helper.

## Why
F015 was failing with `assembly.required_primitive_missing: Generated code did not use the required primitives... black76_call, black76_put` because the broad Black76 matcher was beating the instrument-specific `equity_variance_swap_analytical` matcher. After narrowing Black76, a regression (`test_build_aborts_when_primitive_plan_has_blockers`) started failing because the `American Asian barrier under Heston` composite no longer matched any analytical route and the gate silently proceeded; the gate fallback closes that hole.

## Test plan
- [x] `pytest tests/test_agent` (1889 passed)
- [x] `pytest tests/test_agent/test_build_gate.py` with new `test_block_when_lane_unresolved_primitives_and_no_primitive_plan`
- [x] `pytest tests/test_agent/test_build_loop.py::TestBuildLoop::test_build_aborts_when_primitive_plan_has_blockers` (regression restored)
- [x] `pytest tests/test_agent/test_platform_requests.py::test_compile_build_request_bootstraps_title_only_rainbow_task_into_exact_basket_bindings` (basket route still resolves)
- [x] F015 cached adapter: Trellis 800.11 vs FinancePy 800.13 (0.002% deviation)
- [x] F011 cached adapter: Trellis 20.923 vs FinancePy 20.922 (0.004% deviation) - route flipped from analytical_black76 to equity_lookback_analytical

## Follow-ons
- QUA-887 filed for long-term Contract IR compiler.
- QUA-888 filed for cross-cutting fresh-gen LLM-reliability concern.

Closes QUA-882. Resolves QUA-883, QUA-884, QUA-885 on the cached-adapter surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)