### PR TITLE
QUA-896: admit FX GK benchmark outputs

### DIFF
--- a/doc/plan/active__semantic-simulation-substrate.md
+++ b/doc/plan/active__semantic-simulation-substrate.md
@@ -79,7 +79,7 @@ Status mirror last synced: `2026-04-18`
 | `QUA-734` | Done | landed the universal `EventProgramIR` / `ControlProgramIR` boundary that this plan must extend rather than duplicate |
 | `QUA-635` | Done | landed `ScenarioResultCube`, which is adjacent to but not the same as a future-value cube |
 | `QUA-594` | Backlog | later institutional consumer umbrella, not the right parent abstraction |
-| `QUA-638` | In Review | first swap-portfolio future-value consumer that should narrow onto this substrate instead of redefining it |
+| `QUA-638` | Done | first swap-portfolio future-value consumer that should narrow onto this substrate instead of redefining it |
 | `QUA-639` | Backlog | collateral-state consumer of the future-value substrate |
 | `QUA-640` | Backlog | netting-set consumer of the future-value substrate |
 | `QUA-641` | Backlog | exposure-statistics consumer of the future-value substrate |

--- a/doc/plan/done__exotic-desk-roadmap.md
+++ b/doc/plan/done__exotic-desk-roadmap.md
@@ -63,7 +63,7 @@ Rules for coding agents:
   - only then update the corresponding row in this file
 - Update this table only after the ticket is closed in Linear.
 
-Status mirror last synced: `2026-04-05`
+Status mirror last synced: `2026-04-18`
 
 ### Ordered Epic Queue
 
@@ -164,7 +164,7 @@ Status mirror last synced: `2026-04-05`
 | Ticket | Status |
 | --- | --- |
 | `QUA-620` Semantic contract: collateral and netting set representation | Backlog |
-| `QUA-638` Counterparty exposure: swap portfolio future value cube | In Review |
+| `QUA-638` Counterparty exposure: swap portfolio future value cube | Done |
 | `QUA-639` Collateral workflow: margin period and collateral state projection | Backlog |
 | `QUA-640` Netting workflow: netting-set aggregation and closeout exposure inputs | Backlog |
 | `QUA-641` Counterparty exposure: EE EPE PFE aggregation outputs | Backlog |

--- a/tests/test_agent/test_task_runtime.py
+++ b/tests/test_agent/test_task_runtime.py
@@ -220,6 +220,40 @@ def test_run_task_records_benchmark_outputs_from_payoff_snapshot():
     assert result["benchmark_outputs"]["fair_strike_variance"] == pytest.approx(0.048411342420965765)
 
 
+def test_run_task_records_native_fx_vanilla_gk_outputs_from_checked_in_adapter():
+    from trellis.agent.task_manifests import load_task_manifest
+    from trellis.agent.task_runtime import build_market_state, run_task
+    from trellis.instruments._agent.fxvanillaanalytical import FXVanillaAnalyticalPayoff
+
+    class FakeResult:
+        success = True
+        attempts = 1
+        gap_confidence = 1.0
+        knowledge_gaps = []
+        payoff_cls = FXVanillaAnalyticalPayoff
+        failures = []
+        reflection = {}
+
+    tasks = {
+        task["id"]: task
+        for task in load_task_manifest("TASKS_BENCHMARK_FINANCEPY.yaml")
+    }
+
+    result = run_task(
+        tasks["F002"],
+        market_state=build_market_state(),
+        build_fn=lambda **_kwargs: FakeResult(),
+        model="test-model",
+    )
+
+    assert result["price"] == pytest.approx(62146.380285788415, rel=1e-10)
+    assert set(result["benchmark_outputs"]) >= {"price", "delta", "gamma", "vega", "theta"}
+    assert result["benchmark_outputs"]["delta"] == pytest.approx(
+        0.5750997663426305,
+        abs=1e-6,
+    )
+
+
 def test_run_task_uses_an_explicit_simulation_seed_when_one_is_provided():
     from trellis.agent.task_runtime import run_task
 

--- a/trellis/instruments/_agent/_fresh/fxvanillaanalytical.py
+++ b/trellis/instruments/_agent/_fresh/fxvanillaanalytical.py
@@ -7,6 +7,7 @@ from datetime import date
 
 from trellis.core.market_state import MarketState
 from trellis.core.types import DayCountConvention
+from trellis.models.analytical.fx_vanilla_gk import fx_vanilla_gk_outputs
 from trellis.models.fx_vanilla import price_fx_vanilla_analytical, resolve_fx_vanilla_inputs
 
 
@@ -44,3 +45,7 @@ class FXVanillaAnalyticalPayoff:
 
     def evaluate(self, market_state: MarketState) -> float:
         return float(price_fx_vanilla_analytical(market_state, self._spec))
+
+    def benchmark_outputs(self, market_state: MarketState) -> dict[str, float]:
+        """Return native GK parity outputs for the FinancePy benchmark harness."""
+        return dict(fx_vanilla_gk_outputs(market_state, self._spec))

--- a/trellis/instruments/_agent/fxvanillaanalytical.py
+++ b/trellis/instruments/_agent/fxvanillaanalytical.py
@@ -7,6 +7,7 @@ from datetime import date
 
 from trellis.core.market_state import MarketState
 from trellis.core.types import DayCountConvention
+from trellis.models.analytical.fx_vanilla_gk import fx_vanilla_gk_outputs
 from trellis.models.fx_vanilla import price_fx_vanilla_analytical, resolve_fx_vanilla_inputs
 
 
@@ -44,3 +45,7 @@ class FXVanillaAnalyticalPayoff:
 
     def evaluate(self, market_state: MarketState) -> float:
         return float(price_fx_vanilla_analytical(market_state, self._spec))
+
+    def benchmark_outputs(self, market_state: MarketState) -> dict[str, float]:
+        """Return native GK parity outputs for the FinancePy benchmark harness."""
+        return dict(fx_vanilla_gk_outputs(market_state, self._spec))


### PR DESCRIPTION
## Summary
- expose native GK benchmark outputs from the admitted and `_fresh` FX vanilla analytical adapters
- add a task-runtime regression proving the admitted adapter persists `F002` benchmark outputs
- sync the repo-local plan mirror now that QUA-638 is merged

## Validation
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_task_runtime.py -x -q
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_models/test_fx_vanilla_gk_outputs.py -x -q
- /Users/steveyang/miniforge3/bin/python3 scripts/run_financepy_benchmark.py --execution-policy cached_existing F002 F003 F004 F005 F006 F007 F008 F009 F010 F011 F012 F013 F014 F015