### PR TITLE
[codex] normalize cds onto event-triggered family

### DIFF
--- a/CANARY_TASKS.yaml
+++ b/CANARY_TASKS.yaml
@@ -27,12 +27,11 @@ canary_set:
     complexity: complex
     core: true
     estimated_cost_usd: 0.15
-    record_cassette: true
-    rationale: Legacy replay-backed credit canary retained for the CDS survival-curve path.
+    record_cassette: false
+    rationale: Credit canary retained for the CDS survival-curve path, but cassette replay is disabled while the route surface is being retired.
     covers:
       - credit
       - cds
-      - replay
 
   - id: F001
     engine_family: analytical

--- a/doc/plan/active__contract-ir-compiler-retiring-route-registry.md
+++ b/doc/plan/active__contract-ir-compiler-retiring-route-registry.md
@@ -1,0 +1,534 @@
+# Contract IR Compiler — Structural Dispatch Execution Mirror
+
+## Status
+
+Active. Live execution mirror for `QUA-887`.
+
+Status mirror last synced: `2026-04-18`
+
+## Linked Linear
+
+- QUA-887 — Semantic contract: contract-IR compiler (replace route registry)
+- QUA-792 — Binding-first exotic assembly (active successor epic; this plan
+  completes its dispatch-replacement slice)
+- QUA-727 / QUA-778–791 — Route-registry minimization (Done; groundwork)
+- QUA-902 — Semantic dispatch: normalize CDS onto event-triggered two-legged
+  contract family
+- QUA-900 — Semantic dispatch: rate and exotic analytical routes stop matching
+  by instrument
+- QUA-901 — Semantic dispatch: residual instrument-keyed MC and PDE routes stop
+  matching by instrument
+
+## Purpose
+
+This plan is the live execution mirror for staged retirement of
+instrument-keyed route matching under `QUA-887`. The goal is to retire
+`ProductIR.instrument -> route_id` as the primary dispatch key and replace it
+with structural / pattern-based dispatch that composes with the existing
+semantic compiler, family IRs, and backend-binding surfaces.
+
+`QUA-902` is the current front-of-queue normalization slice. It freezes one
+foundational execution decision before broader route migration: single-name CDS
+must compile and route as an `event_triggered_two_legged_contract`, not as a
+product-shaped `credit_default_swap` computational family.
+
+## Framing
+
+This plan is a continuation of work already in flight, not a green-field
+proposal. The repo shows two prior pushes at this target:
+
+- `doc/plan/done__route-registry-minimization.md` — QUA-727 + QUA-778–791
+  (completed). Focus: retiring route-card prose (notes, adapter wording,
+  promoted-route synthesis authority). Outcome: route cards are now
+  metadata-first, but the dispatch key is still `ProductIR.instrument →
+  route_id`.
+- `doc/plan/active__binding-first-exotic-assembly.md` — QUA-792 (backlog).
+  Five-epic program: backend-binding architecture, lowering/assembly
+  decoupling, validation/replay migration, operator surface separation,
+  exotic composition proof. This is the live strand. It establishes the
+  substrate (binding catalogs, family IRs, DSL lowering) but does not
+  specify the replacement dispatch mechanism.
+
+What is already in the code (so the plan is not starting from zero):
+
+- `trellis/agent/dsl_algebra.py` has `ContractSignature`, `ContractAtom`,
+  `ControlStyle` — a minimal algebraic substrate, intentionally
+  structure-preserving.
+- `trellis/agent/dsl_lowering.py::SemanticDslLowering` produces typed
+  `DslTargetBinding` records with `module.symbol` primitives and typed
+  roles, plus explicit `admissibility_errors` instead of guessing.
+- `trellis/agent/semantic_contract_compiler.py::SemanticImplementationBlueprint`
+  already emits dual views: legacy route/module hints and a conservative
+  `dsl_lowering` companion. This is the natural splice point for a Contract
+  IR dispatch.
+- `routes.yaml` has 30 routes, of which 14 are instrument-dispatch
+  (`match.instruments: [X]`), 5 use `match.methods` only, and 6 use
+  `conditional_primitives` — a pattern-style when-clause dispatch that
+  already works.
+
+## Execution Decisions
+
+1. The first live structural-dispatch slice is not just "match CDS by payoff
+   family." It is `QUA-902`: normalize CDS onto a reusable
+   `event_triggered_two_legged_contract` family and route both analytical and
+   Monte Carlo helper-backed paths through that structural surface.
+2. `credit_default_swap` remains a semantic concept / wrapper surface. The
+   product name is not deleted; it is decoupled from the computational
+   `payoff_family`, `route_family`, and family-lowering IR identity.
+3. Phase 1 route rewrites should prefer reusable contract shapes over product
+   names whenever the existing semantic surface already carries typed
+   obligations, event state, and schedule structure.
+
+## Ordered Execution Queue
+
+| Ticket | Status | Scope |
+| --- | --- | --- |
+| `QUA-902` | In Progress | normalize CDS semantic/routing/lowering surfaces onto `event_triggered_two_legged_contract` and migrate both CDS helper-backed routes off product-shaped family matching |
+| `QUA-900` | Backlog | migrate the remaining low-complexity analytical instrument-keyed routes |
+| `QUA-901` | Backlog | migrate the residual MC / PDE / credit routes that still dispatch by instrument |
+
+Pickup rule:
+
+- start with the first non-`Done` ticket in the queue
+- keep each slice parity-gated and reviewable
+- do not start additive Contract IR AST work until the structural-dispatch
+  queue above is materially landed or deliberately split further
+
+## Why Prior Attempts Stalled
+
+Honest assessment based on the pattern of work in the plan docs and the
+shape of the code today. The next attempt has to account for each of
+these explicitly, or it will stall the same way.
+
+1. Boil-the-ocean scope. Prior attempts (and the instinct everyone has
+   when thinking "retire the registry") reach for a general IR that can
+   express every instrument — callable / Bermudan, PDE-style path
+   dependence, copula baskets, credit. The IR balloons into something as
+   complex as the registry it replaces and never lands.
+2. Dual-track drift. A new IR is introduced alongside the old system.
+   Both need maintenance. The new one never reaches feature parity; the
+   old one keeps growing because it is the one that actually prices.
+   QUA-727 partially avoided this by minimizing rather than replacing —
+   that is why it landed. Full replacement attempts have not.
+3. Unclear "done" signal per instrument. Without a concrete parity gate
+   per migration slice, "we have migrated variance swaps" is ambiguous,
+   so the registry never shrinks even as the new system grows.
+4. Kernel signature heterogeneity. `black76_call(F, K, σ, T)` is pure
+   scalars. `price_rate_cap_floor_strip_analytical(market_state, spec,
+   **11 kwargs)` is market-state plus spec plus eleven keyword args.
+   `price_equity_variance_swap_analytical(market_state, spec)` is
+   market-state plus untyped spec. Any pattern-matching compiler needs to
+   adapt to each kernel's native calling convention. If that adaptation
+   layer is built separately from the kernels, it accumulates special
+   cases and breaks.
+5. Implicit dependencies on `ProductIR.instrument`. Logging, tracing,
+   diagnostic text, task-runtime bookkeeping, benchmark scorecards — many
+   things read `instrument` as a string tag. "Delete the field" surfaces
+   hundreds of call sites.
+6. Registry is not a single thing. `routes.yaml` carries at least five
+   orthogonal concerns: instrument dispatch, primitive resolution,
+   admissibility envelopes, market-data access hints, and scoring
+   bonuses. Only instrument dispatch is the retirement target. Trying to
+   retire the whole file blocks on unrelated concerns.
+
+## What Is Different This Time
+
+Four principles baked into every phase:
+
+- Parity gate is non-negotiable. No migration slice lands without a
+  side-by-side test: old path and new path produce equal output within ε
+  tolerance on the full set of benchmark tasks that touch the slice. No
+  parity, no migration.
+- Additive before subtractive. Phases 1–3 add infrastructure without
+  changing existing paths. Only Phase 4 deletes. This prevents "we broke
+  everything while building the new thing."
+- Scope gate, not time gate. A phase is done when its migration checklist
+  is ticked. No date pressure. Time pressure against scope is what killed
+  prior attempts.
+- Kernel signature normalization is inside the pattern declaration, not
+  in a separate layer. Each `@solves_pattern` declaration carries its own
+  mapping from Contract IR field values to the kernel's native kwargs.
+  This collapses the combinatorial explosion of a central adapter into N
+  independent, testable, small adapters.
+
+## Phase 1 — Pattern-keyed kernel declarations inside `routes.yaml`
+
+### Why
+
+The file can shrink dramatically without introducing a new IR. 14 routes
+use `match.instruments: [X]`, but 6 already use `conditional_primitives`
+(when-clause dispatch on `payoff_family` + `exercise_style` +
+`model_family` → primitives). Extending that pattern to the remaining 14
+retires instrument-name dispatch as the matching key while keeping
+`routes.yaml` as the storage.
+
+### What we do
+
+- For each of the 14 remaining instrument-keyed routes, rewrite its match clause
+  from `instruments: [X]` to a pattern declaration on `(payoff_family,
+  exercise_style, model_family, payoff_traits)`. Example:
+  `equity_variance_swap_analytical` changes from `match.instruments:
+  [variance_swap]` to `match.payoff_family: [variance_replication],
+  match.model_family: [equity_diffusion]`.
+- For product families that already admit a reusable structural contract,
+  normalize that family first before collapsing route rows. `QUA-902` is the
+  exemplar: CDS now routes through `event_triggered_two_legged_contract`, so
+  future event-triggered products do not need one route family per product
+  name.
+- Collapse groups of instrument-keyed routes that resolve to the same
+  kernel family into one pattern-keyed route with `conditional_primitives`
+  dispatch (mirroring how `analytical_black76` already does this for
+  basket / swaption / vanilla).
+- `ProductIR.instrument` stops being consulted by the route matcher.
+  Other callers (traces, diagnostics) keep reading it until Phase 4.
+
+### Deliverables
+
+- 14 remaining route rewrites after the CDS structural normalization slice.
+- Per-rewrite parity test: `rank_primitive_routes` returns the same
+  `PrimitivePlan.route` and `PrimitivePlan.primitives` under the new
+  pattern declaration as under the old `instruments:` declaration, for
+  every `ProductIR` fixture that hits the route.
+- A handful of collapsed routes (projection: 16 narrow routes → ~7
+  pattern families).
+
+### Done criteria per rewrite
+
+- New pattern declaration landed.
+- Old `match.instruments` entry deleted.
+- `rank_primitive_routes` returns identical output for every fixture
+  that exercised the old entry (parity test in
+  `tests/test_agent/test_route_registry.py`).
+- Full agent test suite green.
+- Live benchmark task that was routed through the old entry produces
+  identical price within ε.
+
+### Failure modes to watch
+
+- Scoring bonuses tied to route id. `trellis/agent/route_scorer.py`
+  scores routes with `ScoringContext`. Some bonuses may be keyed on
+  specific route ids. Audit before rewriting.
+- Admissibility drift. Each route carries admissibility metadata
+  (`control_styles`, `event_support`, `supported_state_tags`). When two
+  routes collapse into one pattern, their admissibility envelopes must be
+  the intersection, not the union — otherwise you silently expand what
+  the route accepts.
+- Conditional_primitives resolution order. The order of `when:` clauses
+  matters (first match wins). When collapsing routes, the combined
+  ordering must be explicit and tested.
+
+### Why this will land where prior attempts did not
+
+- No new infrastructure. `conditional_primitives` is 20% of the registry
+  already — this is migration, not invention.
+- Per-route tickets with per-route parity gates. Each slice is small
+  enough to review in a single PR.
+- `routes.yaml` gets lighter each time, observably.
+
+## Phase 2 — Contract IR as an algebraic AST alongside ProductIR
+
+### Why
+
+Phase 1 moves dispatch from instrument names to structural tags on a
+flat record (`ProductIR`). Real dispatch-by-structure needs a recursive,
+compositional AST — so that `barrier_variance_swap` is
+`indicator(hit_barrier) × variance_payoff` rather than a new leaf. This
+phase introduces that AST without touching dispatch yet.
+
+### What we do
+
+- Extend `dsl_algebra.ContractAtom` into a proper sum type. Sketch:
+
+      ContractIR = Payoff(expr: PayoffExpr)
+                 | Exercise(style: ExerciseStyle, schedule: Schedule)
+                 | Observation(kind: ObservationKind, schedule: Schedule)
+                 | Underlying(process: ProcessRef)
+                 | Composite(parts: tuple[ContractIR, ...])
+
+      PayoffExpr = Max(args: tuple[PayoffExpr, ...])
+                 | Sub(lhs, rhs)
+                 | Indicator(pred: Predicate)
+                 | Constant(value: float)
+                 | Spot(underlier: str)
+                 | Strike(value: float)
+                 | Integral(integrand: PayoffExpr, over: Schedule)
+                 | ...
+
+- Define simplification rewrites: associativity / commutativity of
+  `Max`, distribution of `Indicator` over sums, collapse of `Sub(x, 0)
+  → x`. Property-based tests prove the rewrites preserve semantics.
+- Decomposer learns to emit Contract IR for a bounded set: vanilla
+  call / put, variance swap, digital (cash-or-nothing and
+  asset-or-nothing), arithmetic asian. Four instruments only. Not five.
+  Not barrier yet.
+- Contract IR is purely additive. It lives as a new field on
+  `SemanticImplementationBlueprint.contract_ir: ContractIR | None`. No
+  production code consumes it yet. No dispatch path reads it. The
+  existing `route_id → primitives` pipeline continues to work unchanged.
+
+### Deliverables
+
+- `trellis/agent/contract_ir.py` with the AST and simplification
+  rewrites.
+- Decomposer extension: `decompose_to_ir()` emits Contract IR for the
+  four target payoffs, returns `None` otherwise.
+- Property-based test suite (`tests/test_agent/test_contract_ir.py`)
+  using Hypothesis or similar to fuzz simplification invariants.
+- Fixture-level test that the decomposer produces the expected Contract
+  IR for 20+ canonical descriptions spanning the four payoffs.
+
+### Done criteria
+
+- AST types defined with frozen dataclasses.
+- Simplification rewrites pass property-based tests for associativity,
+  commutativity, idempotence.
+- Decomposer emits Contract IR for all 20+ fixtures and matches the
+  hand-written expected AST.
+- `SemanticImplementationBlueprint.contract_ir` populated end-to-end.
+- Full agent test suite green. Contract IR is purely additive, so
+  regressions are impossible if the additive discipline holds.
+
+### Failure modes to watch
+
+- Premature generalization. The temptation to "while we are here, let
+  us also do path-dependent exercise and stochastic vol" is the kill
+  shot. If barrier-under-Heston does not fit, leave it as
+  `decompose_to_ir()` returning `None` for that case. Phase 2 covers the
+  trivial ground.
+- Non-compositional design. If `Payoff` carries instrument-specific
+  fields, it is not a real AST — it is just a renamed record. Keep the
+  expression types structurally uniform.
+- Simplification divergence. If a rewrite is not confluent (different
+  simplification orders produce different canonical forms), pattern
+  matching in Phase 3 breaks. Property tests must include confluence.
+
+### Why this will land
+
+- Scope explicitly bounded to four instruments. No one is tempted to
+  expand it because the phase is done the moment those four work.
+- Additive — no existing path changes. Regression risk is zero if the
+  additive discipline holds.
+- Property-based tests validate the algebra before any compiler
+  consumes it.
+
+## Phase 3 — Kernels declare the patterns they solve
+
+### Why
+
+This is where Contract IR actually dispatches. After Phase 2 we have an
+AST. After Phase 3 kernels in `trellis/models/` declare which ASTs they
+solve, and a compiler walks incoming Contract IRs to find the satisfying
+kernel.
+
+### What we do
+
+- Introduce a `@solves_pattern(ir_pattern, adapter_fn)` decorator for
+  kernels. Example:
+
+      @solves_pattern(
+          Payoff(Max(Sub(Spot("S"), Strike(K)), Constant(0)))
+            * Exercise("european", T)
+            * Underlying("gbm"),
+          adapter=lambda ir, ms: dict(
+              F=ms.forward(ir.underlier),
+              K=ir.strike,
+              sigma=ms.vol_surface.black_vol(ir.expiry, ir.strike),
+              T=year_fraction(ms.as_of, ir.expiry, ir.day_count),
+          ),
+      )
+      def black76_call(F, K, sigma, T) -> float:
+          ...
+
+  The decorator declares both the IR pattern the kernel solves and the
+  adapter that translates Contract IR into the kernel's native
+  signature. Normalization lives per-kernel, not centrally.
+- Compiler: `compile_contract_ir(ir: ContractIR, market_state:
+  MarketState) -> KernelCall | None`. Simplifies the IR, pattern-matches
+  against the registered declarations, returns a bound `KernelCall(fn,
+  kwargs)`. Returns `None` on no match — the legacy
+  `rank_primitive_routes` path still runs as fallback.
+- Parity harness. For every benchmark task that hits one of the four
+  migrated instruments, run both the old route-based pipeline and the
+  new Contract IR compiler. Assert output equality within ε.
+- Parity tickets, one per instrument: `[vanilla, variance_swap,
+  digital, asian]`. Each is a Linear ticket with its own parity test.
+
+### Deliverables
+
+- `trellis/agent/contract_ir_compiler.py` with the decorator, registry,
+  pattern matcher, and simplifier feed.
+- `@solves_pattern` annotations on `black76_call`, `black76_put`,
+  `price_equity_variance_swap_analytical`,
+  `price_equity_digital_option_analytical`, and the asian analytical
+  helper (whichever subset of the four instruments' kernels lands
+  cleanly).
+- Parity harness in `scripts/` that runs dual-pipeline pricing on the
+  full benchmark corpus and reports any divergence above ε.
+- Per-instrument parity test in
+  `tests/test_agent/test_contract_ir_compiler.py`.
+
+### Done criteria per instrument
+
+- `@solves_pattern` declaration on the target kernel.
+- Adapter translates Contract IR to native kernel kwargs.
+- Compiler resolves this kernel for the expected IR patterns.
+- Parity harness confirms old path and new path produce equal output
+  within ε on all benchmark tasks for this instrument.
+- Live benchmark run (`scripts/run_financepy_benchmark.py`) green under
+  both pipelines.
+
+### Failure modes to watch
+
+- Pattern matching is not exact equality. `Payoff(Max(Sub(Spot("S"),
+  Strike(K)), Constant(0)))` needs to match even when the IR is
+  `Payoff(Max(Constant(0), Sub(Spot("S"), Strike(K))))` after
+  simplification. The simplifier must normalize before matching. If
+  confluence is not proven (Phase 2 output), matching fails silently.
+- Kernel signature drift. If `black76_call`'s signature changes, the
+  adapter in `@solves_pattern` must change. Keep adapters close to the
+  kernel they wrap — same file — so refactoring is local.
+- Parity harness lies. The harness must compare on the actual benchmark
+  (live FinancePy runs, not just test fixtures), otherwise it passes by
+  construction.
+- Dual-path maintenance cost. Running both pipelines on every task
+  forever is expensive. Make the dual-pipeline mode a flag that stays on
+  through migration and flips off instrument-by-instrument after parity
+  is proven.
+
+### Why this will land
+
+- Pattern matching is a well-understood technique, not novel compiler
+  research.
+- Scope bounded to four instruments. Each has its own ticket, parity
+  test, and done checklist.
+- Dual-path with parity gate makes regressions impossible — if parity
+  fails, you do not migrate.
+- Normalization lives per-kernel, so there is no central adapter that
+  accumulates special cases.
+
+## Phase 4 — Delete migrated routes and eventually retire `ProductIR.instrument`
+
+### Why
+
+Phase 4 is a consequence of Phases 1–3, not a separate effort. If the
+earlier phases landed with parity gates, Phase 4 is deletion of redundant
+code paths. This phase is intentionally boring.
+
+### What we do
+
+- For each migrated instrument (from Phase 3), delete its `routes.yaml`
+  entry (which by Phase 1 is a pattern declaration, not an
+  instrument-keyed one).
+- Flip `rank_primitive_routes` to consult `compile_contract_ir` first
+  and fall back to the legacy `match_candidate_routes` for unmigrated
+  surface.
+- Over time, as more instruments migrate through Phases 2–3, more
+  `routes.yaml` entries are deleted.
+- `ProductIR.instrument` is retired last, field-by-field. The
+  diagnostic / trace consumers of `instrument` get migrated to read from
+  Contract IR first. Only when no production code reads
+  `ProductIR.instrument` does it get deleted.
+
+### Deliverables
+
+- Deleted route entries in `routes.yaml` for each migrated instrument
+  (per-instrument tickets).
+- Rewritten `rank_primitive_routes` with Contract IR compiler as the
+  primary path and legacy registry as fallback.
+- Per-consumer ticket for each reader of `ProductIR.instrument` that
+  gets migrated to Contract IR.
+
+### Done criteria per slice
+
+- Route entry deleted.
+- Live benchmark tasks for the instrument still green.
+- No test or prod path references the deleted route.
+- Trace output still identifies the instrument (via Contract IR, not
+  via the deleted route id).
+
+### Failure modes to watch
+
+- Trace / diagnostic breakage. Traces and `LIMITATIONS.md` entries
+  reference route ids and instrument names. Deleting the route entry
+  without updating trace renderers produces broken telemetry.
+- Compatibility aliases. Routes have `compatibility_alias_policy` that
+  governs deprecated naming. Deleted routes need their aliases
+  explicitly retired or redirected.
+- `ProductIR.instrument` read sites are not all in `trellis/agent/`.
+  Benchmark scorecards, task runtime, and arbiter all read it. Audit
+  before deletion.
+
+### Why this will land
+
+- Nothing in Phase 4 is novel. It is deletion gated on passing parity
+  tests.
+- Deletion is per-instrument, so the unit of risk is one instrument at
+  a time.
+- The legacy registry persists as fallback until all instruments
+  migrate, so partial progress is safe.
+
+## Cross-cutting Principles
+
+These apply to every phase. Dropping any one of them is how prior
+attempts stalled.
+
+1. No migration without a parity test. The gate is not "the new path
+   works" — it is "the new path produces equal output within ε to the
+   old path on all fixtures and all benchmark tasks."
+2. No generalization to un-migrated surface. If Phase 2 covers
+   vanilla / variance / digital / asian, Phase 3 can only migrate those
+   four. Do not try to "cover barrier while we are here." Each
+   instrument is its own Phase 3 ticket.
+3. Per-kernel adapters. Normalization lives inside `@solves_pattern`,
+   not in a central adapter layer. This prevents the central layer from
+   becoming the new registry.
+4. The registry does not disappear in Phase 1. It becomes declarative
+   pattern metadata. It shrinks incrementally through Phase 4.
+5. Traces and diagnostics migrate last. Do not touch observability
+   until the dispatch change lands. This keeps debugging possible
+   throughout the migration.
+6. Reviewer gets a parity report per PR. Every migration PR must
+   include the parity test output (old vs. new path for all affected
+   fixtures and benchmarks) in the PR description.
+
+## Open Questions For The Reviewer
+
+These are the places where the author is least certain and where
+outside judgment would help most.
+
+1. Should Phase 1 and Phase 2 overlap? Phase 1 uses pattern-keyed
+   `conditional_primitives` inside `routes.yaml`. Phase 2 introduces a
+   proper Contract IR. Is there a path where Phase 1's patterns are
+   Contract IR patterns from the start, rather than two separate layers?
+   This could collapse Phases 1 and 2 but might overconstrain Phase 1.
+2. What is the smallest possible Phase 2? The current pick is vanilla +
+   variance + digital + asian (four). Could it be two (vanilla +
+   variance)? The fewer the scope, the more likely the phase lands, but
+   below some threshold the Contract IR does not prove its generality.
+3. Kernel normalization — decorator vs. subtyping. The proposal uses
+   `@solves_pattern(ir, adapter_fn)`. Alternative: kernels implement a
+   `Pricer[IR]` protocol with an `apply(ir, market_state) -> float`
+   method. Protocol-based is more discoverable; decorator-based is more
+   additive. Which does the codebase's conventions prefer?
+4. Relationship to QUA-792. This plan assumes Contract IR completes
+   what QUA-792 started. Is that the right framing, or should the
+   Contract IR compiler be a parallel epic that feeds into QUA-792
+   epic 5 (exotic composition proof)? The reviewer may see this
+   differently.
+5. Parity tolerance ε. FinancePy parity runs use 1–3% tolerance today.
+   For dual-path parity (old vs. new Trellis paths) ε should probably be
+   much lower — around 1e-10 relative, since both paths should produce
+   bit-identical outputs when the math is equivalent. Kernels with Monte
+   Carlo components have RNG state, so ε has to be strategy-dependent.
+   Worth deciding up front.
+
+## Next Steps
+
+- Land this document as a draft plan doc for review.
+- Collect reviewer feedback on the five open questions.
+- Promote to `active__contract-ir-compiler-retiring-route-registry.md`
+  once the framing is endorsed and the first implementation ticket is
+  queued.
+- The first implementation ticket is the smallest Phase 1 slice: one
+  instrument-keyed route converted to a pattern declaration, with its
+  parity test.

--- a/docs/quant/contract_algebra.rst
+++ b/docs/quant/contract_algebra.rst
@@ -257,7 +257,9 @@ Shipped family IRs:
   theta-method PDE route
 - ``ExerciseLatticeIR``
 - ``CorrelatedBasketMonteCarloIR``
-- ``CreditDefaultSwapIR``
+- ``EventTriggeredTwoLeggedContractIR`` as the structural helper-backed family
+  surface for event-triggered two-legged contracts, currently proven on
+  single-name CDS
 - ``NthToDefaultIR``
 
 For transform routes, the compiler now also carries an explicit bounded family
@@ -382,7 +384,9 @@ The typed semantic boundary is proven end-to-end for:
   equity exercise and issuer-min Hull-White callable bonds
 - ``exercise_lattice`` on callable bonds and Bermudan swaptions
 - ``correlated_basket_monte_carlo`` on ranked-observation baskets
-- ``credit_default_swap_analytical`` and ``credit_default_swap_monte_carlo`` on single-name CDS
+- ``credit_default_swap_analytical`` and ``credit_default_swap_monte_carlo`` on
+  single-name CDS, both routed through the structural
+  ``event_triggered_two_legged_contract`` family
 - ``nth_to_default_monte_carlo`` on nth-to-default basket credit
 
 These routes preserve the existing helper-backed pricing math. The work in this

--- a/docs/quant/pricing_stack.rst
+++ b/docs/quant/pricing_stack.rst
@@ -103,7 +103,9 @@ The shipped family IRs are:
 - ``VanillaEquityPDEIR``
 - ``ExerciseLatticeIR``
 - ``CorrelatedBasketMonteCarloIR``
-- ``CreditDefaultSwapIR``
+- ``EventTriggeredTwoLeggedContractIR`` as the structural helper-backed family
+  surface for event-triggered two-legged contracts, currently proven on
+  single-name CDS
 - ``NthToDefaultIR``
 
 This is intentionally not a flat universal IR. The current stack uses
@@ -278,7 +280,9 @@ The end-to-end typed boundary is currently proven for:
 - ``bermudan_swaption_tree_v1`` on the first supported Bermudan swaption desk slice
 - ``correlated_basket_monte_carlo`` on ranked-observation baskets
 - ``range_accrual_discounted_cashflow_v1`` on the first single-index range-accrual note slice
-- ``credit_default_swap_analytical`` and ``credit_default_swap_monte_carlo`` on single-name CDS
+- ``credit_default_swap_analytical`` and ``credit_default_swap_monte_carlo`` on
+  single-name CDS, both routed through the structural
+  ``event_triggered_two_legged_contract`` family
 - ``nth_to_default_monte_carlo`` on nth-to-default basket credit
 - ``copula_loss_distribution`` on tranche-style basket-credit comparison tasks
   through the semantic-facing basket-credit helper surface

--- a/tests/test_agent/test_backend_bindings.py
+++ b/tests/test_agent/test_backend_bindings.py
@@ -126,7 +126,7 @@ def test_resolve_backend_binding_spec_captures_helper_schedule_and_cashflow_role
         cds,
         product_ir=ProductIR(
             instrument="cds",
-            payoff_family="credit_default_swap",
+            payoff_family="event_triggered_two_legged_contract",
             schedule_dependence=True,
             state_dependence="pathwise_only",
         ),

--- a/tests/test_agent/test_canary_runner.py
+++ b/tests/test_agent/test_canary_runner.py
@@ -410,6 +410,56 @@ class TestRunCanaries:
         output = capsys.readouterr().out
         assert "CANARY RESULTS: 1/1 passed, 1 skipped" in output
 
+    def test_run_canaries_skips_replay_unsupported_tasks_even_when_cassette_exists(
+        self, monkeypatch, tmp_path
+    ):
+        seen: dict[str, int] = {"run_task_calls": 0}
+
+        def fake_build_market_state():
+            return object()
+
+        def fake_load_tasks(*, status="pending", path=None):
+            return [{"id": "T38", "title": "CDS pricing canary"}]
+
+        def fake_run_task(task, market_state, **kwargs):
+            seen["run_task_calls"] += 1
+            return {"task_id": task["id"], "success": True}
+
+        (tmp_path / "T38.yaml").write_text("meta: {}\ncalls: []\n", encoding="utf-8")
+
+        monkeypatch.setattr(
+            "trellis.agent.task_runtime.build_market_state",
+            fake_build_market_state,
+        )
+        monkeypatch.setattr(
+            "trellis.agent.task_runtime.load_tasks",
+            fake_load_tasks,
+        )
+        monkeypatch.setattr(
+            "trellis.agent.task_runtime.run_task",
+            fake_run_task,
+        )
+
+        results = run_canaries(
+            [
+                {
+                    "id": "T38",
+                    "engine_family": "credit",
+                    "complexity": "complex",
+                    "record_cassette": False,
+                }
+            ],
+            {"total_budget_usd": 1.0},
+            replay=True,
+            cassette_dir=tmp_path,
+        )
+
+        assert seen["run_task_calls"] == 0
+        assert results[0]["canary_id"] == "T38"
+        assert results[0]["success"] is False
+        assert results[0]["skipped"] is True
+        assert results[0]["reason"] == "replay_unsupported"
+
     def test_run_canaries_replay_mode_uses_full_task_cassette(self, monkeypatch, tmp_path):
         from trellis.agent.cassette import _prompt_hash
 
@@ -631,7 +681,7 @@ class TestCanaryFileValidity:
         for c in canaries:
             assert c["id"] in task_lookup, f"Canary {c['id']} not found in active task manifests"
 
-    def test_real_canary_file_keeps_replay_backed_legacy_tasks(self):
+    def test_real_canary_file_marks_t38_as_live_only_during_route_refactor(self):
         real_path = ROOT / "CANARY_TASKS.yaml"
         if not real_path.exists():
             pytest.skip("CANARY_TASKS.yaml not found in repo root")
@@ -642,11 +692,13 @@ class TestCanaryFileValidity:
         assert expected_ids <= set(canary_lookup)
 
         assert canary_lookup["T13"]["canary_kind"] == "legacy_replay"
-        assert canary_lookup["T38"]["canary_kind"] == "legacy_replay"
+        assert canary_lookup["T13"].get("record_cassette", True) is True
+        assert canary_lookup["T38"].get("record_cassette", True) is False
         assert canary_lookup["F001"]["canary_kind"] == "parity"
         assert canary_lookup["P003"]["canary_kind"] == "extension"
         assert canary_lookup["N001"]["canary_kind"] == "negative"
         assert "financepy_parity" in canary_lookup["F002"]["covers"]
+        assert "replay" not in canary_lookup["T38"]["covers"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_agent/test_codegen_guardrails.py
+++ b/tests/test_agent/test_codegen_guardrails.py
@@ -772,7 +772,7 @@ def test_cds_monte_carlo_route_uses_single_name_credit_default_swap_assembly():
 
     assert plan.primitive_plan is not None
     assert plan.primitive_plan.route == "credit_default_swap_monte_carlo"
-    assert plan.primitive_plan.route_family == "credit_default_swap"
+    assert plan.primitive_plan.route_family == "event_triggered_two_legged_contract"
     primitive_symbols = {primitive.symbol for primitive in plan.primitive_plan.primitives}
     assert {
         "build_cds_schedule",
@@ -786,6 +786,8 @@ def test_cds_monte_carlo_route_uses_single_name_credit_default_swap_assembly():
     assert "price_cds_monte_carlo" in card
     assert "spread_quote" in card
     assert "n_paths" in card
+    assert "Route family: `credit_default_swap`" in card
+    assert "Route family: `event_triggered_two_legged_contract`" not in card
     assert "survival_probability" not in card
     assert "Required adapters:" not in card
     assert "use_credit_curve_hazard_rate_or_survival_probability" not in card

--- a/tests/test_agent/test_dsl_lowering.py
+++ b/tests/test_agent/test_dsl_lowering.py
@@ -9,7 +9,7 @@ from trellis.agent.dsl_algebra import ChoiceExpr, ContractAtom, ThenExpr, Contro
 from trellis.agent.family_lowering_ir import (
     AnalyticalBlack76IR,
     CorrelatedBasketMonteCarloIR,
-    CreditDefaultSwapIR,
+    EventTriggeredTwoLeggedContractIR,
     EventAwareMonteCarloIR,
     EventAwarePDEIR,
     ExerciseLatticeIR,
@@ -544,10 +544,10 @@ def test_credit_default_swap_analytical_lowers_to_schedule_then_helper():
     lowering = blueprint.dsl_lowering
     assert lowering is not None
     assert lowering.route_id == "credit_default_swap_analytical"
-    assert lowering.route_family == "credit_default_swap"
+    assert lowering.route_family == "event_triggered_two_legged_contract"
     assert lowering.admissibility_errors == ()
     assert lowering.binding_id == "trellis.models.credit_default_swap.price_cds_analytical"
-    assert isinstance(lowering.family_ir, CreditDefaultSwapIR)
+    assert isinstance(lowering.family_ir, EventTriggeredTwoLeggedContractIR)
     assert lowering.family_ir.pricing_mode == "analytical"
     assert isinstance(lowering.normalized_expr, ThenExpr)
     schedule_builder, helper = lowering.normalized_expr.terms
@@ -577,10 +577,10 @@ def test_credit_default_swap_monte_carlo_lowers_to_schedule_then_helper():
     lowering = blueprint.dsl_lowering
     assert lowering is not None
     assert lowering.route_id == "credit_default_swap_monte_carlo"
-    assert lowering.route_family == "credit_default_swap"
+    assert lowering.route_family == "event_triggered_two_legged_contract"
     assert lowering.admissibility_errors == ()
     assert lowering.binding_id == "trellis.models.credit_default_swap.price_cds_monte_carlo"
-    assert isinstance(lowering.family_ir, CreditDefaultSwapIR)
+    assert isinstance(lowering.family_ir, EventTriggeredTwoLeggedContractIR)
     assert lowering.family_ir.pricing_mode == "monte_carlo"
     assert isinstance(lowering.normalized_expr, ThenExpr)
     schedule_builder, helper = lowering.normalized_expr.terms
@@ -598,7 +598,7 @@ def test_credit_default_swap_missing_schedule_builder_reports_binding_first_erro
         return backend_bindings_module.ResolvedBackendBindingSpec(
             route_id="credit_default_swap_analytical",
             engine_family="analytical",
-            route_family="credit_default_swap",
+            route_family="event_triggered_two_legged_contract",
             binding_id="trellis.models.credit_default_swap.price_cds_analytical",
             primitives=(
                 PrimitiveRef(

--- a/tests/test_agent/test_family_lowering_ir.py
+++ b/tests/test_agent/test_family_lowering_ir.py
@@ -10,7 +10,7 @@ from trellis.agent.family_lowering_ir import (
     AnalyticalBlack76IR,
     ConditionalValuationSpec,
     CorrelatedBasketMonteCarloIR,
-    CreditDefaultSwapIR,
+    EventTriggeredTwoLeggedContractIR,
     EventAwarePDEIR,
     EventAwareMonteCarloIR,
     ExerciseLatticeIR,
@@ -792,11 +792,11 @@ def test_credit_default_swap_compiles_to_analytical_family_ir():
     blueprint = compile_semantic_contract(contract, requested_outputs=["price", "scenario_pnl"])
 
     family_ir = blueprint.dsl_lowering.family_ir
-    assert isinstance(family_ir, CreditDefaultSwapIR)
+    assert isinstance(family_ir, EventTriggeredTwoLeggedContractIR)
     assert family_ir.route_id == "credit_default_swap_analytical"
-    assert family_ir.route_family == "credit_default_swap"
+    assert family_ir.route_family == "event_triggered_two_legged_contract"
     assert family_ir.product_instrument == "cds"
-    assert family_ir.payoff_family == "credit_default_swap"
+    assert family_ir.payoff_family == "event_triggered_two_legged_contract"
     assert family_ir.pricing_mode == "analytical"
     assert family_ir.schedule_builder_symbol == "build_cds_schedule"
     assert family_ir.helper_symbol == "price_cds_analytical"
@@ -822,7 +822,7 @@ def test_credit_default_swap_compiles_to_monte_carlo_family_ir():
     )
 
     family_ir = blueprint.dsl_lowering.family_ir
-    assert isinstance(family_ir, CreditDefaultSwapIR)
+    assert isinstance(family_ir, EventTriggeredTwoLeggedContractIR)
     assert family_ir.route_id == "credit_default_swap_monte_carlo"
     assert family_ir.pricing_mode == "monte_carlo"
     assert family_ir.helper_symbol == "price_cds_monte_carlo"
@@ -1084,7 +1084,7 @@ def test_credit_default_swap_dispatches_from_binding_surface_not_route_id(monkey
                 "array_backend",
             ),
             route_id=synthetic_route_id,
-            route_family="credit_default_swap",
+            route_family="event_triggered_two_legged_contract",
             engine_family="monte_carlo",
         ),
     )
@@ -1096,9 +1096,9 @@ def test_credit_default_swap_dispatches_from_binding_surface_not_route_id(monkey
         product_ir=blueprint.product_ir,
     )
 
-    assert isinstance(family_ir, CreditDefaultSwapIR)
+    assert isinstance(family_ir, EventTriggeredTwoLeggedContractIR)
     assert family_ir.route_id == synthetic_route_id
-    assert family_ir.route_family == "credit_default_swap"
+    assert family_ir.route_family == "event_triggered_two_legged_contract"
     assert family_ir.pricing_mode == "monte_carlo"
     assert family_ir.helper_symbol == "price_cds_monte_carlo"
 

--- a/tests/test_agent/test_knowledge_store.py
+++ b/tests/test_agent/test_knowledge_store.py
@@ -76,6 +76,16 @@ class TestKnowledgeStore:
         assert "callable" in matches[0].shared_features
         assert matches[0].promoted_routes
 
+    def test_promoted_routes_for_cds_uses_structural_payoff_family(self):
+        from trellis.agent.knowledge.store import KnowledgeStore
+
+        promoted = KnowledgeStore._promoted_routes_for(
+            instrument="cds",
+            method="analytical",
+        )
+
+        assert "credit_default_swap_analytical" in promoted
+
     def test_retrieve_callable_bond(self):
         from trellis.agent.knowledge import retrieve_for_task
         k = retrieve_for_task(

--- a/tests/test_agent/test_platform_requests.py
+++ b/tests/test_agent/test_platform_requests.py
@@ -1337,13 +1337,16 @@ def test_compile_build_request_uses_credit_default_swap_semantic_contract_bluepr
     assert compiled.request.metadata["semantic_contract"]["semantic_id"] == "credit_default_swap"
     assert compiled.product_ir is not None
     assert compiled.product_ir.instrument == "cds"
-    assert compiled.product_ir.payoff_family == "credit_default_swap"
+    assert compiled.product_ir.payoff_family == "event_triggered_two_legged_contract"
     assert compiled.pricing_plan is not None
     assert compiled.pricing_plan.method == preferred_method
     assert compiled.semantic_blueprint.route_modules == _expected_route_modules(compiled)
     assert compiled.semantic_blueprint.primitive_routes == (expected_route,)
     assert compiled.request.metadata["semantic_blueprint"]["dsl_route"] == expected_route
-    assert compiled.request.metadata["semantic_blueprint"]["dsl_family_ir_type"] == "CreditDefaultSwapIR"
+    assert (
+        compiled.request.metadata["semantic_blueprint"]["dsl_family_ir_type"]
+        == "EventTriggeredTwoLeggedContractIR"
+    )
     assert compiled.request.metadata["semantic_blueprint"]["dsl_expr_kind"] == expected_expr_kind
     assert (
         compiled.request.metadata["semantic_blueprint"]["dsl_family_ir"]["schedule_builder_symbol"]

--- a/tests/test_agent/test_platform_traces.py
+++ b/tests/test_agent/test_platform_traces.py
@@ -304,7 +304,7 @@ def test_platform_trace_persists_dsl_family_ir_summary(tmp_path):
     )
     raw = Path(trace_path).read_text()
 
-    assert "dsl_family_ir_type: CreditDefaultSwapIR" in raw
+    assert "dsl_family_ir_type: EventTriggeredTwoLeggedContractIR" in raw
     assert "schedule_builder_symbol: build_cds_schedule" in raw
 
 

--- a/tests/test_agent/test_prompts.py
+++ b/tests/test_agent/test_prompts.py
@@ -1165,11 +1165,35 @@ def test_evaluate_prompt_cds_surface_mentions_credit_curve_contract():
     assert "explicit payment/default schedule" in prompt
     assert "build_cds_schedule" in prompt
     assert "price_cds_analytical" in prompt
+    assert "Route family: `credit_default_swap`" in prompt
+    assert "Route family: `event_triggered_two_legged_contract`" not in prompt
     assert "market_state.discount.discount(t)" in prompt
     assert "spec.start_date` as the time origin" in prompt
     assert "accrued-on-default premium adjustment" in prompt
     assert "Do not average adjacent discount factors" in prompt
     assert "price_cds_analytical" in prompt
+
+
+def test_distilled_builder_memory_keeps_legacy_cds_labels_and_omits_nearest_products():
+    from trellis.agent.knowledge.retrieval import format_distilled_knowledge_for_prompt
+    from trellis.agent.knowledge.schema import ProductIR, SimilarProductMatch
+
+    text = format_distilled_knowledge_for_prompt(
+        {
+            "product_ir": ProductIR(
+                instrument="cds",
+                payoff_family="event_triggered_two_legged_contract",
+            ),
+            "similar_products": [
+                SimilarProductMatch(instrument="bond", method="analytical", score=0.6),
+                SimilarProductMatch(instrument="autocallable", method="monte_carlo", score=0.53),
+            ],
+        },
+        audience="builder",
+    )
+
+    assert "- Product: `cds` / `cds` / `none`" in text
+    assert "Nearest known products" not in text
 
 
 def test_evaluate_prompt_cds_monte_carlo_surface_mentions_get_numpy_and_schedule_loop():

--- a/tests/test_agent/test_route_registry.py
+++ b/tests/test_agent/test_route_registry.py
@@ -139,7 +139,7 @@ class TestRegistryValidation:
         spec = RouteSpec(
             id="synthetic_credit_mc",
             engine_family="monte_carlo",
-            route_family="credit_default_swap",
+            route_family="event_triggered_two_legged_contract",
             status="promoted",
             confidence=1.0,
             match_methods=("monte_carlo",),
@@ -163,11 +163,11 @@ class TestRegistryValidation:
         )
         ir = ProductIR(
             instrument="cds",
-            payoff_family="credit_default_swap",
+            payoff_family="event_triggered_two_legged_contract",
             schedule_dependence=True,
             state_dependence="pathwise_only",
             candidate_engine_families=("monte_carlo",),
-            route_families=("credit_default_swap",),
+            route_families=("event_triggered_two_legged_contract",),
         )
 
         decision = evaluate_route_capability_match(spec, ir)
@@ -207,7 +207,7 @@ class TestRegistryValidation:
                 RouteSpec(
                     id="family_mc",
                     engine_family="monte_carlo",
-                    route_family="credit_default_swap",
+                    route_family="event_triggered_two_legged_contract",
                     status="promoted",
                     confidence=1.0,
                     match_methods=("monte_carlo",),
@@ -234,11 +234,11 @@ class TestRegistryValidation:
         )
         ir = ProductIR(
             instrument="cds",
-            payoff_family="credit_default_swap",
+            payoff_family="event_triggered_two_legged_contract",
             schedule_dependence=True,
             state_dependence="pathwise_only",
             candidate_engine_families=("monte_carlo",),
-            route_families=("credit_default_swap",),
+            route_families=("event_triggered_two_legged_contract",),
         )
 
         matches = match_candidate_routes(registry, "monte_carlo", ir)
@@ -443,7 +443,11 @@ class TestQuantoRoutes:
 # ---------------------------------------------------------------------------
 
 class TestCreditRoutes:
-    CDS_IR = ProductIR(instrument="cds", payoff_family="credit_default_swap")
+    CDS_IR = ProductIR(
+        instrument="cds",
+        payoff_family="event_triggered_two_legged_contract",
+        route_families=("event_triggered_two_legged_contract",),
+    )
     NTD_IR = ProductIR(instrument="nth_to_default", payoff_family="nth_to_default")
 
     def test_cds_analytical(self, registry):
@@ -465,7 +469,20 @@ class TestCreditRoutes:
     def test_route_family(self, registry):
         spec = [r for r in registry.routes if r.id == "credit_default_swap_analytical"][0]
         new = resolve_route_family(spec, self.CDS_IR)
-        assert new == "credit_default_swap"
+        assert new == "event_triggered_two_legged_contract"
+
+    def test_cds_analytical_does_not_require_instrument_key(self, registry):
+        structural_only_ir = ProductIR(
+            instrument="synthetic_event_wrapper",
+            payoff_family="event_triggered_two_legged_contract",
+            route_families=("event_triggered_two_legged_contract",),
+            schedule_dependence=True,
+            state_dependence="schedule_state",
+        )
+
+        new = _new_routes(registry, "analytical", structural_only_ir)
+
+        assert new == ("credit_default_swap_analytical",)
 
     def test_cds_analytical_admissibility_uses_credit_family_state_tags(self, registry):
         from trellis.agent.semantic_contract_compiler import compile_semantic_contract

--- a/tests/test_agent/test_route_scorer.py
+++ b/tests/test_agent/test_route_scorer.py
@@ -100,11 +100,11 @@ class TestFeatureExtraction:
         )
         ir = ProductIR(
             instrument="cds",
-            payoff_family="credit_default_swap",
+            payoff_family="event_triggered_two_legged_contract",
             schedule_dependence=True,
             state_dependence="pathwise_only",
             candidate_engine_families=("monte_carlo",),
-            route_families=("credit_default_swap",),
+            route_families=("event_triggered_two_legged_contract",),
         )
         ctx = ScoringContext(
             product_ir=ir,
@@ -224,7 +224,7 @@ class TestScoring:
         matching = RouteSpec(
             id="family_mc",
             engine_family="monte_carlo",
-            route_family="credit_default_swap",
+            route_family="event_triggered_two_legged_contract",
             status="promoted",
             confidence=1.0,
             match_methods=("monte_carlo",),
@@ -271,11 +271,11 @@ class TestScoring:
         )
         ir = ProductIR(
             instrument="cds",
-            payoff_family="credit_default_swap",
+            payoff_family="event_triggered_two_legged_contract",
             schedule_dependence=True,
             state_dependence="pathwise_only",
             candidate_engine_families=("monte_carlo",),
-            route_families=("credit_default_swap",),
+            route_families=("event_triggered_two_legged_contract",),
         )
 
         matching_score = scorer.score_route(

--- a/tests/test_agent/test_route_scoring.py
+++ b/tests/test_agent/test_route_scoring.py
@@ -143,7 +143,7 @@ def test_cds_ranks_credit_default_swap_route_above_generic_analytical():
 
     assert ranked
     assert ranked[0].route == "credit_default_swap_analytical"
-    assert ranked[0].route_family == "credit_default_swap"
+    assert ranked[0].route_family == "event_triggered_two_legged_contract"
     assert ranked[0].score > 0.0
 
 

--- a/tests/test_agent/test_semantic_contracts.py
+++ b/tests/test_agent/test_semantic_contracts.py
@@ -1256,7 +1256,7 @@ class TestCreditConceptResolution:
 
         cds = get_semantic_concept_definition("credit_default_swap")
         ntd = get_semantic_concept_definition("nth_to_default")
-        assert cds.route_family == "credit_default_swap"
+        assert cds.route_family == "event_triggered_two_legged_contract"
         assert ntd.route_family == "nth_to_default"
 
 
@@ -1397,7 +1397,7 @@ def test_credit_default_swap_contract_validates_and_compiles():
     assert compiled.semantic_id == "credit_default_swap"
     assert compiled.product_ir is not None
     assert compiled.product_ir.instrument == "cds"
-    assert compiled.product_ir.payoff_family == "credit_default_swap"
+    assert compiled.product_ir.payoff_family == "event_triggered_two_legged_contract"
     assert compiled.product_ir.schedule_dependence is True
     assert compiled.pricing_plan.method == "analytical"
     assert compiled.target_modules == ("trellis.models.credit_default_swap",)
@@ -1419,7 +1419,7 @@ def test_credit_default_swap_summary_is_stable_and_route_specific():
     assert summary == semantic_contract_summary(contract)
     assert summary["semantic_id"] == "credit_default_swap"
     assert summary["product"]["instrument_class"] == "cds"
-    assert summary["product"]["payoff_family"] == "credit_default_swap"
+    assert summary["product"]["payoff_family"] == "event_triggered_two_legged_contract"
     assert summary["typed_semantics"]["controller_protocol"]["controller_style"] == "identity"
     assert summary["market_data"]["required_inputs"] == ["discount_curve", "credit_curve"]
     assert summary["blueprint"]["primitive_families"] == ["credit_default_swap_analytical"]

--- a/tests/test_agent/test_skill_index.py
+++ b/tests/test_agent/test_skill_index.py
@@ -67,8 +67,7 @@ def test_route_hint_projection_includes_instruction_lifecycle_records():
     route_skills = query_skill_records(
         kind="route_hint",
         method_family="monte_carlo",
-        instrument_type="cds",
-        route_family="credit_default_swap",
+        route_family="event_triggered_two_legged_contract",
     )
     skill_ids = {record.skill_id for record in route_skills}
     summaries = [record.summary for record in route_skills]

--- a/tests/test_contracts/conftest.py
+++ b/tests/test_contracts/conftest.py
@@ -1,16 +1,19 @@
 """Tier 2 contract test fixtures (QUA-427).
 
 Provides cassette-aware fixtures and helpers for canary contract tests.
-All contract tests run with cassette replay (zero tokens) by default.
+Replay-backed contract tests run with cassette replay (zero tokens) by
+default, while tasks marked ``record_cassette=false`` opt out of replay.
 """
 
 from __future__ import annotations
 
 import os
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
+import yaml
 
 from trellis.agent.task_manifests import load_canary_manifest, load_pricing_tasks
 
@@ -63,9 +66,27 @@ def cassette_path_for(task_id: str) -> Path:
     return CASSETTES_DIR / f"{task_id}.yaml"
 
 
+def cassette_recording_supported(task_id: str) -> bool:
+    """Return whether *task_id* currently participates in cassette replay."""
+    canary = CANARY_META.get(task_id)
+    return canary is None or canary.get("record_cassette", True)
+
+
+def cassette_skip_reason(task_id: str) -> str:
+    """Explain why a cassette-backed contract test should skip for *task_id*."""
+    if not cassette_recording_supported(task_id):
+        return (
+            f"Cassette replay disabled for {task_id}; the route surface is being refactored."
+        )
+    return (
+        f"Cassette not recorded for {task_id}. "
+        "Run with TRELLIS_CASSETTE_RECORD=1 to record."
+    )
+
+
 def cassette_available(task_id: str) -> bool:
     """Check whether a cassette file exists for *task_id*."""
-    return cassette_path_for(task_id).exists()
+    return cassette_recording_supported(task_id) and cassette_path_for(task_id).exists()
 
 
 def full_task_cassette_path_for(task_id: str) -> Path:
@@ -73,16 +94,32 @@ def full_task_cassette_path_for(task_id: str) -> Path:
     return FULL_TASK_CASSETTES_DIR / f"{task_id}.yaml"
 
 
+def full_task_cassette_skip_reason(task_id: str) -> str:
+    """Explain why a full-task replay contract test should skip for *task_id*."""
+    if not cassette_recording_supported(task_id):
+        return (
+            f"Full-task cassette replay disabled for {task_id}; "
+            "the route surface is being refactored."
+        )
+    return (
+        f"Full-task cassette not recorded for {task_id}. "
+        f"Run: PYTHONHASHSEED=0 {sys.executable} scripts/record_cassettes.py --task {task_id}"
+    )
+
+
 def full_task_cassette_available(task_id: str) -> bool:
     """Check whether a full-task cassette exists for *task_id*."""
-    return full_task_cassette_path_for(task_id).exists()
+    return (
+        cassette_recording_supported(task_id)
+        and full_task_cassette_path_for(task_id).exists()
+    )
 
 
 def requires_cassette(task_id: str):
     """Pytest skip decorator for tests that require a recorded cassette."""
     return pytest.mark.skipif(
         not cassette_available(task_id),
-        reason=f"Cassette not recorded for {task_id}. Run with TRELLIS_CASSETTE_RECORD=1 to record.",
+        reason=cassette_skip_reason(task_id),
     )
 
 

--- a/tests/test_contracts/test_canary_replay_contracts.py
+++ b/tests/test_contracts/test_canary_replay_contracts.py
@@ -20,6 +20,7 @@ from tests.test_contracts.conftest import (
     CANARY_META,
     FULL_TASK_CASSETTES_DIR,
     full_task_cassette_available,
+    full_task_cassette_skip_reason,
 )
 
 ROOT = Path(__file__).resolve().parent.parent.parent
@@ -30,10 +31,7 @@ def _full_task_replay_test(task_id: str):
     @pytest.mark.tier2
     @pytest.mark.skipif(
         not full_task_cassette_available(task_id),
-        reason=(
-            f"Full-task cassette not recorded for {task_id}. "
-            f"Run: PYTHONHASHSEED=0 {sys.executable} scripts/record_cassettes.py --task {task_id}"
-        ),
+        reason=full_task_cassette_skip_reason(task_id),
     )
     class _ReplayTest:
         def test_canary_replay_runs_zero_token_with_diagnosis_artifacts(self, tmp_path):

--- a/tests/test_contracts/test_cassette_contract_helpers.py
+++ b/tests/test_contracts/test_cassette_contract_helpers.py
@@ -1,0 +1,65 @@
+"""Contract tests for cassette-availability helpers."""
+
+from __future__ import annotations
+
+from tests.test_contracts import conftest as contract_conftest
+
+
+class TestCassetteAvailabilityHelpers:
+    def test_cassette_available_respects_record_cassette_false(self, monkeypatch, tmp_path):
+        cassette_path = tmp_path / "T38.yaml"
+        cassette_path.write_text("meta: {}\n", encoding="utf-8")
+
+        monkeypatch.setitem(
+            contract_conftest.CANARY_META,
+            "T38",
+            {"id": "T38", "record_cassette": False},
+        )
+        monkeypatch.setattr(contract_conftest, "cassette_path_for", lambda task_id: cassette_path)
+
+        assert contract_conftest.cassette_available("T38") is False
+
+    def test_cassette_available_falls_back_to_file_existence_without_canary_metadata(
+        self, monkeypatch, tmp_path
+    ):
+        cassette_path = tmp_path / "T01.yaml"
+        cassette_path.write_text("meta: {}\n", encoding="utf-8")
+
+        monkeypatch.delitem(contract_conftest.CANARY_META, "T01", raising=False)
+        monkeypatch.setattr(contract_conftest, "cassette_path_for", lambda task_id: cassette_path)
+
+        assert contract_conftest.cassette_available("T01") is True
+
+    def test_full_task_cassette_available_respects_record_cassette_false(
+        self, monkeypatch, tmp_path
+    ):
+        cassette_path = tmp_path / "T38.yaml"
+        cassette_path.write_text("meta: {}\n", encoding="utf-8")
+
+        monkeypatch.setitem(
+            contract_conftest.CANARY_META,
+            "T38",
+            {"id": "T38", "record_cassette": False},
+        )
+        monkeypatch.setattr(
+            contract_conftest,
+            "full_task_cassette_path_for",
+            lambda task_id: cassette_path,
+        )
+
+        assert contract_conftest.full_task_cassette_available("T38") is False
+
+    def test_full_task_cassette_available_falls_back_to_file_existence_without_metadata(
+        self, monkeypatch, tmp_path
+    ):
+        cassette_path = tmp_path / "T13.yaml"
+        cassette_path.write_text("meta: {}\n", encoding="utf-8")
+
+        monkeypatch.delitem(contract_conftest.CANARY_META, "T13", raising=False)
+        monkeypatch.setattr(
+            contract_conftest,
+            "full_task_cassette_path_for",
+            lambda task_id: cassette_path,
+        )
+
+        assert contract_conftest.full_task_cassette_available("T13") is True

--- a/tests/test_contracts/test_pipeline_contracts.py
+++ b/tests/test_contracts/test_pipeline_contracts.py
@@ -15,6 +15,7 @@ from tests.test_contracts.conftest import (
     CANARY_META,
     TASK_ENTRIES,
     cassette_available,
+    cassette_skip_reason,
     cassette_path_for,
 )
 
@@ -37,7 +38,7 @@ def _pipeline_test(task_id: str, instrument_type: str | None = None):
     @pytest.mark.tier2
     @pytest.mark.skipif(
         not cassette_available(task_id),
-        reason=f"Cassette not recorded for {task_id}. Run: python scripts/record_cassettes.py --task {task_id}",
+        reason=cassette_skip_reason(task_id),
     )
     class _PipelineTest:
         @pytest.mark.parametrize("llm_cassette", [task_id], indirect=True)

--- a/trellis/agent/codegen_guardrails.py
+++ b/trellis/agent/codegen_guardrails.py
@@ -37,6 +37,10 @@ from trellis.agent.knowledge.import_registry import (
     suggest_tests_for_symbol,
 )
 from trellis.agent.knowledge.methods import normalize_method
+from trellis.agent.semantic_tokens import (
+    prompt_display_payoff_family,
+    prompt_display_route_family,
+)
 
 
 COMMON_APPROVED_MODULES = (
@@ -588,8 +592,12 @@ def _render_backend_binding_lines(plan: GenerationPlan, *, compact: bool) -> lis
     lines = ["- Backend binding:"]
     lines.append(f"  - Route: `{plan.primitive_plan.route}`")
     lines.append(f"  - Engine family: `{plan.primitive_plan.engine_family}`")
-    if plan.primitive_plan.route_family:
-        lines.append(f"  - Route family: `{plan.primitive_plan.route_family}`")
+    display_route_family = prompt_display_route_family(
+        instrument=plan.instrument_type,
+        route_family=plan.primitive_plan.route_family,
+    )
+    if display_route_family:
+        lines.append(f"  - Route family: `{display_route_family}`")
     if not compact:
         lines.append(f"  - Route score: `{plan.primitive_plan.score:.2f}`")
     if plan.primitive_plan.primitives:
@@ -961,8 +969,12 @@ def render_semantic_repair_card(plan: GenerationPlan) -> str:
     if plan.primitive_plan is not None:
         lines.append(f"- Route: `{plan.primitive_plan.route}`")
         lines.append(f"- Engine family: `{plan.primitive_plan.engine_family}`")
-        if plan.primitive_plan.route_family:
-            lines.append(f"- Route family: `{plan.primitive_plan.route_family}`")
+        display_route_family = prompt_display_route_family(
+            instrument=plan.instrument_type,
+            route_family=plan.primitive_plan.route_family,
+        )
+        if display_route_family:
+            lines.append(f"- Route family: `{display_route_family}`")
         if plan.primitive_plan.primitives:
             lines.append("- Required primitives:")
             lines.extend(
@@ -1186,7 +1198,14 @@ def _render_compiled_boundary_lines(plan: GenerationPlan, *, compact: bool) -> l
         if plan.semantic_instrument_class:
             semantic_bits.append(f"instrument=`{plan.semantic_instrument_class}`")
         if plan.semantic_payoff_family:
-            semantic_bits.append(f"payoff=`{plan.semantic_payoff_family}`")
+            semantic_bits.append(
+                "payoff=`"
+                + prompt_display_payoff_family(
+                    instrument=plan.instrument_type,
+                    payoff_family=plan.semantic_payoff_family,
+                )
+                + "`"
+            )
         if plan.semantic_underlier_structure:
             semantic_bits.append(f"structure=`{plan.semantic_underlier_structure}`")
         lines.append(f"- Semantic contract: {', '.join(semantic_bits)}")

--- a/trellis/agent/dsl_lowering.py
+++ b/trellis/agent/dsl_lowering.py
@@ -28,7 +28,7 @@ from trellis.agent.dsl_algebra import (
 from trellis.agent.family_lowering_ir import (
     AnalyticalBlack76IR,
     CorrelatedBasketMonteCarloIR,
-    CreditDefaultSwapIR,
+    EventTriggeredTwoLeggedContractIR,
     EventAwareMonteCarloIR,
     EventAwarePDEIR,
     ExerciseLatticeIR,
@@ -382,8 +382,8 @@ def _build_expr_for_family_ir(
             family_ir=family_ir,
             bindings=bindings,
         )
-    if isinstance(family_ir, CreditDefaultSwapIR):
-        return _build_credit_default_swap_expr_from_family_ir(
+    if isinstance(family_ir, EventTriggeredTwoLeggedContractIR):
+        return _build_event_triggered_two_legged_expr_from_family_ir(
             route_id=route_id,
             binding_id=binding_id,
             family_ir=family_ir,
@@ -1080,14 +1080,14 @@ def _build_correlated_basket_mc_expr_from_family_ir(
     return ThenExpr(terms=(binding_atom, helper_atom)), ()
 
 
-def _build_credit_default_swap_expr_from_family_ir(
+def _build_event_triggered_two_legged_expr_from_family_ir(
     *,
     route_id: str,
     binding_id: str,
-    family_ir: CreditDefaultSwapIR,
+    family_ir: EventTriggeredTwoLeggedContractIR,
     bindings: tuple[DslTargetBinding, ...],
 ) -> tuple[ContractExpr | None, tuple[str, ...]]:
-    """Build a typed CDS schedule-builder and helper lowering."""
+    """Build a typed event-triggered two-legged schedule-builder and helper lowering."""
     schedule_builder = next(
         (
             binding

--- a/trellis/agent/family_lowering_ir.py
+++ b/trellis/agent/family_lowering_ir.py
@@ -6,6 +6,9 @@ from dataclasses import dataclass, field
 import re
 from typing import TYPE_CHECKING
 
+from trellis.agent.semantic_tokens import (
+    EVENT_TRIGGERED_TWO_LEGGED_CONTRACT_FAMILY,
+)
 from trellis.core.types import TimelineRole
 
 if TYPE_CHECKING:
@@ -611,20 +614,24 @@ class CorrelatedBasketMonteCarloIR(BaseFamilyLoweringIR):
 
 
 @dataclass(frozen=True)
-class CreditDefaultSwapIR(BaseFamilyLoweringIR):
-    """Typed lowering payload for single-name CDS helper-backed routes."""
+class EventTriggeredTwoLeggedContractIR(BaseFamilyLoweringIR):
+    """Typed lowering payload for helper-backed event-triggered two-legged routes."""
 
     pricing_mode: str = "analytical"
     schedule_builder_symbol: str = "build_cds_schedule"
     helper_symbol: str = "price_cds_analytical"
     market_mapping: str = "discount_curve_credit_curve_to_cds_legs"
     schedule_role: str = "payment_dates"
-    leg_semantics: tuple[str, ...] = ("premium_leg", "protection_leg")
+    leg_semantics: tuple[str, ...] = ("scheduled_leg", "trigger_leg")
     payment_dates: tuple[str, ...] = ()
     observable_ids: tuple[str, ...] = ()
     observable_types: tuple[str, ...] = ()
     state_field_names: tuple[str, ...] = ()
     state_tags: tuple[str, ...] = ()
+
+
+# Compatibility alias while the semantic surface migrates away from the product name.
+CreditDefaultSwapIR = EventTriggeredTwoLeggedContractIR
 
 
 @dataclass(frozen=True)
@@ -652,7 +659,7 @@ FamilyLoweringIR = (
     | VanillaEquityPDEIR
     | ExerciseLatticeIR
     | CorrelatedBasketMonteCarloIR
-    | CreditDefaultSwapIR
+    | EventTriggeredTwoLeggedContractIR
     | NthToDefaultIR
 )
 
@@ -708,9 +715,9 @@ _FAMILY_IR_MATCH_PROFILES = {
     "credit_default_swap": FamilyIRMatchProfile(
         semantic_id="credit_default_swap",
         allowed_instruments=("cds",),
-        allowed_payoff_families=("credit_default_swap",),
+        allowed_payoff_families=(EVENT_TRIGGERED_TWO_LEGGED_CONTRACT_FAMILY,),
         allowed_product_instruments=("cds",),
-        allowed_product_payoff_families=("credit_default_swap",),
+        allowed_product_payoff_families=(EVENT_TRIGGERED_TWO_LEGGED_CONTRACT_FAMILY,),
     ),
     "nth_to_default": FamilyIRMatchProfile(
         semantic_id="nth_to_default",
@@ -2436,8 +2443,8 @@ def _build_credit_default_swap_ir(
     timeline_roles: frozenset[TimelineRole],
     requested_outputs: tuple[str, ...],
     reporting_currency: str,
-) -> CreditDefaultSwapIR | None:
-    """Build the typed CDS family IR for helper-backed analytical and MC routes."""
+) -> EventTriggeredTwoLeggedContractIR | None:
+    """Build the structural two-legged event-contract IR for CDS helper-backed routes."""
     if not _is_credit_default_swap_contract(contract, product_ir):
         return None
 
@@ -2466,7 +2473,7 @@ def _build_credit_default_swap_ir(
         else ("terminal_markov", "schedule_state")
     )
 
-    return CreditDefaultSwapIR(
+    return EventTriggeredTwoLeggedContractIR(
         route_id=route_id,
         route_family=route_family,
         product_instrument=product_instrument,

--- a/trellis/agent/knowledge/canonical/backend_bindings.yaml
+++ b/trellis/agent/knowledge/canonical/backend_bindings.yaml
@@ -18,7 +18,7 @@ bindings:
 
   - route_id: credit_default_swap_analytical
     engine_family: analytical
-    route_family: credit_default_swap
+    route_family: event_triggered_two_legged_contract
     primitives:
       - module: trellis.models.credit_default_swap
         symbol: build_cds_schedule
@@ -30,7 +30,7 @@ bindings:
 
   - route_id: credit_default_swap_monte_carlo
     engine_family: monte_carlo
-    route_family: credit_default_swap
+    route_family: event_triggered_two_legged_contract
     primitives:
       - module: trellis.models.credit_default_swap
         symbol: build_cds_schedule

--- a/trellis/agent/knowledge/canonical/routes.yaml
+++ b/trellis/agent/knowledge/canonical/routes.yaml
@@ -76,12 +76,12 @@ routes:
 
   - id: credit_default_swap_analytical
     engine_family: analytical
-    route_family: credit_default_swap
+    route_family: event_triggered_two_legged_contract
     status: promoted
     confidence: 1.0
     match:
       methods: [analytical]
-      instruments: [cds]
+      payoff_family: [event_triggered_two_legged_contract]
     admissibility:
       control_styles: [identity]
       event_support: automatic
@@ -108,12 +108,12 @@ routes:
 
   - id: credit_default_swap_monte_carlo
     engine_family: monte_carlo
-    route_family: credit_default_swap
+    route_family: event_triggered_two_legged_contract
     status: promoted
     confidence: 1.0
     match:
       methods: [monte_carlo, qmc]
-      instruments: [cds]
+      payoff_family: [event_triggered_two_legged_contract]
     admissibility:
       control_styles: [identity]
       event_support: automatic

--- a/trellis/agent/knowledge/decompose.py
+++ b/trellis/agent/knowledge/decompose.py
@@ -14,6 +14,9 @@ from typing import TYPE_CHECKING
 
 from trellis.agent.knowledge.methods import normalize_method
 from trellis.agent.knowledge.schema import ProductDecomposition, ProductIR, RetrievalSpec
+from trellis.agent.semantic_tokens import (
+    EVENT_TRIGGERED_TWO_LEGGED_CONTRACT_FAMILY,
+)
 from trellis.core.capabilities import normalize_market_data_requirements
 
 if TYPE_CHECKING:
@@ -659,6 +662,8 @@ def _payoff_family_for(
         return "composite_option"
     if instrument in {"swaption", "bermudan_swaption"}:
         return "swaption"
+    if instrument == "cds":
+        return EVENT_TRIGGERED_TWO_LEGGED_CONTRACT_FAMILY
     if instrument == "zcb_option":
         return "zcb_option"
     if instrument == "callable_bond":
@@ -941,6 +946,8 @@ def _route_families_for(
 ) -> tuple[str, ...]:
     """Return the exact route-family labels that remain semantically valid."""
     families: list[str] = []
+    if payoff_family == EVENT_TRIGGERED_TWO_LEGGED_CONTRACT_FAMILY:
+        families.append(EVENT_TRIGGERED_TWO_LEGGED_CONTRACT_FAMILY)
     if instrument == "nth_to_default":
         families.append("nth_to_default")
     if (

--- a/trellis/agent/knowledge/gap_check.py
+++ b/trellis/agent/knowledge/gap_check.py
@@ -178,10 +178,13 @@ def _check_route_gap(decomposition: ProductDecomposition) -> RouteGap | None:
             load_route_registry,
             match_candidate_routes,
         )
+        from trellis.agent.semantic_tokens import internal_payoff_family_for_surface
 
         minimal_ir = ProductIR(
             instrument=decomposition.instrument,
-            payoff_family=decomposition.instrument,
+            payoff_family=internal_payoff_family_for_surface(
+                instrument=decomposition.instrument,
+            ),
         )
         registry = load_route_registry()
 

--- a/trellis/agent/knowledge/reflect.py
+++ b/trellis/agent/knowledge/reflect.py
@@ -275,11 +275,14 @@ def _attribute_route_success(decomposition: ProductDecomposition) -> int:
             match_candidate_routes,
         )
         from trellis.agent.knowledge.schema import ProductIR
+        from trellis.agent.semantic_tokens import internal_payoff_family_for_surface
 
         registry = load_route_registry(include_discovered=True)
         minimal_ir = ProductIR(
             instrument=decomposition.instrument,
-            payoff_family=decomposition.instrument,
+            payoff_family=internal_payoff_family_for_surface(
+                instrument=decomposition.instrument,
+            ),
         )
         # Only boost discovered routes (not canonical)
         all_matches = match_candidate_routes(

--- a/trellis/agent/knowledge/retrieval.py
+++ b/trellis/agent/knowledge/retrieval.py
@@ -17,6 +17,10 @@ from trellis.agent.knowledge.schema import (
     ProductIR,
     SimilarProductMatch,
 )
+from trellis.agent.semantic_tokens import (
+    prompt_display_payoff_family,
+    prompt_display_route_families,
+)
 from trellis.agent.knowledge.promotion import (
     detect_adapter_lifecycle_records,
     format_adapter_lifecycle_warnings,
@@ -208,10 +212,12 @@ def format_knowledge_for_prompt(knowledge: dict[str, Any], *, compact: bool = Fa
     # 3b. Product semantics from ProductIR
     product_ir: ProductIR | None = knowledge.get("product_ir")
     if product_ir is not None:
+        display_payoff_family = _prompt_display_payoff_family(product_ir)
+        display_route_families = _prompt_display_route_families(product_ir)
         lines = [
             "## Product Semantics\n",
             f"- Instrument: `{product_ir.instrument}`",
-            f"- Payoff family: `{product_ir.payoff_family}`",
+            f"- Payoff family: `{display_payoff_family}`",
             f"- Exercise style: `{product_ir.exercise_style}`",
             f"- State dependence: `{product_ir.state_dependence}`",
             f"- Schedule dependence: `{product_ir.schedule_dependence}`",
@@ -227,10 +233,10 @@ def format_knowledge_for_prompt(knowledge: dict[str, Any], *, compact: bool = Fa
                 "- Candidate engine families: "
                 + ", ".join(f"`{family}`" for family in product_ir.candidate_engine_families)
             )
-        if getattr(product_ir, "route_families", ()):
+        if display_route_families:
             lines.append(
                 "- Exact route families: "
-                + ", ".join(f"`{family}`" for family in product_ir.route_families)
+                + ", ".join(f"`{family}`" for family in display_route_families)
             )
         sections.append("\n".join(lines))
 
@@ -668,12 +674,18 @@ def format_distilled_knowledge_for_prompt(
         limits = _DISTILLED_LIMITS["builder"]
         lines = []
         api_map = format_api_map_for_prompt(compact=True)
+        instrument_label = (
+            str(getattr(product_ir, "instrument", "") or "").strip().lower()
+            if product_ir is not None
+            else ""
+        )
         if api_map:
             lines.append(api_map)
         lines.append("## Distilled Build Memory\n")
         if product_ir is not None:
+            display_payoff_family = _prompt_display_payoff_family(product_ir)
             lines.append(
-                f"- Product: `{product_ir.instrument}` / `{product_ir.payoff_family}` / "
+                f"- Product: `{product_ir.instrument}` / `{display_payoff_family}` / "
                 f"`{product_ir.exercise_style}`"
             )
         if cookbook is not None:
@@ -693,7 +705,7 @@ def format_distilled_knowledge_for_prompt(
             lines.append("- Repeated fixes to reuse:")
             for lesson in _take_limited(lessons, limits["lessons"]):
                 lines.append(f"  - `{lesson.title}` -> {lesson.fix.strip()}")
-        if similar_products:
+        if similar_products and instrument_label not in {"cds", "credit_default_swap"}:
             lines.append("- Nearest known products:")
             for match in _take_limited(similar_products, 2):
                 lines.append(f"  - `{match.instrument}` ({match.score:.0%})")
@@ -752,15 +764,16 @@ def format_distilled_knowledge_for_prompt(
             lines.append(api_map)
         lines.append("## Distilled Routing Memory\n")
         if product_ir is not None:
+            display_route_families = _prompt_display_route_families(product_ir)
             lines.append(
                 "- Route cues: "
                 f"`{product_ir.instrument}`, `{product_ir.model_family}`, "
                 + ", ".join(f"`{family}`" for family in product_ir.candidate_engine_families[:4])
             )
-            if getattr(product_ir, "route_families", ()):
+            if display_route_families:
                 lines.append(
                     "- Exact route families: "
-                    + ", ".join(f"`{family}`" for family in product_ir.route_families[:4])
+                    + ", ".join(f"`{family}`" for family in display_route_families[:4])
                 )
         if principles:
             lines.append("- Routing principles:")
@@ -1015,6 +1028,22 @@ def _omission_notice(label: str, total: int, shown: int) -> str:
     if omitted <= 0:
         return ""
     return f"- [omitted {omitted} additional {label}]"
+
+
+def _prompt_display_payoff_family(product_ir: ProductIR) -> str:
+    """Return the stable payoff-family label used in LLM-facing prompt views."""
+    return prompt_display_payoff_family(
+        instrument=getattr(product_ir, "instrument", ""),
+        payoff_family=getattr(product_ir, "payoff_family", ""),
+    )
+
+
+def _prompt_display_route_families(product_ir: ProductIR) -> tuple[str, ...]:
+    """Return stable route-family labels used in LLM-facing prompt views."""
+    return prompt_display_route_families(
+        instrument=getattr(product_ir, "instrument", ""),
+        route_families=tuple(getattr(product_ir, "route_families", ()) or ()),
+    )
 
 
 def _truncate_text(text: str, max_chars: int, *, label: str) -> str:

--- a/trellis/agent/knowledge/store.py
+++ b/trellis/agent/knowledge/store.py
@@ -37,6 +37,7 @@ from trellis.agent.knowledge.schema import (
     Severity,
     SimilarProductMatch,
 )
+from trellis.agent.semantic_tokens import internal_payoff_family_for_surface
 
 
 _KNOWLEDGE_DIR = Path(__file__).parent
@@ -627,7 +628,12 @@ class KnowledgeStore:
             promoted = match_candidate_routes(
                 registry,
                 method,
-                ProductIR(instrument=instrument, payoff_family=instrument),
+                ProductIR(
+                    instrument=instrument,
+                    payoff_family=internal_payoff_family_for_surface(
+                        instrument=instrument,
+                    ),
+                ),
                 promoted_only=True,
             )
             return tuple(route.id for route in promoted)

--- a/trellis/agent/route_registry.py
+++ b/trellis/agent/route_registry.py
@@ -1458,7 +1458,8 @@ def _route_canary_task_ids(
     aliases = {
         "callable_bond": "callable",
         "puttable_bond": "puttable",
-        "credit_default_swap": "credit_default_swap",
+        "credit_default_swap": "event_triggered_two_legged_contract",
+        "event_triggered_two_legged_contract": "event_triggered_two_legged_contract",
         "quanto_option": "quanto_option",
         "swaption": "swaption",
         "basket_option": "basket_option",

--- a/trellis/agent/semantic_concepts.py
+++ b/trellis/agent/semantic_concepts.py
@@ -7,6 +7,10 @@ from functools import lru_cache
 import re
 from typing import Any
 
+from trellis.agent.semantic_tokens import (
+    EVENT_TRIGGERED_TWO_LEGGED_CONTRACT_FAMILY,
+)
+
 
 @dataclass(frozen=True)
 class SemanticConceptDefinition:
@@ -748,9 +752,9 @@ SEMANTIC_CONCEPT_REGISTRY: tuple[SemanticConceptDefinition, ...] = (
         semantic_version="c1.0",
         scope="single-name CDS: protection buyer/seller on one reference entity",
         description=(
-            "Credit default swap on a single reference entity. Priced via "
-            "survival-probability discounting (analytical) or hazard-rate "
-            "simulation (Monte Carlo)."
+            "Single-name CDS as a single-reference-entity specialization of an "
+            "event-triggered two-legged contract. Priced via survival-probability "
+            "discounting (analytical) or hazard-rate simulation (Monte Carlo)."
         ),
         concept_role="product_contract",
         aliases=(
@@ -772,7 +776,7 @@ SEMANTIC_CONCEPT_REGISTRY: tuple[SemanticConceptDefinition, ...] = (
             "discount_curve",
             "credit_curve",
         ),
-        route_family="credit_default_swap",
+        route_family=EVENT_TRIGGERED_TWO_LEGGED_CONTRACT_FAMILY,
         example_requests=(
             "Price a 5-year CDS on Company X",
             "CDS pricing: hazard rate MC vs survival prob analytical",

--- a/trellis/agent/semantic_contract_validation.py
+++ b/trellis/agent/semantic_contract_validation.py
@@ -20,6 +20,13 @@ from trellis.agent.semantic_contracts import (
     SemanticContract,
     parse_semantic_contract,
 )
+from trellis.agent.semantic_tokens import (
+    EVENT_TRIGGERED_TWO_LEGGED_CONTRACT_FAMILY,
+    SCHEDULED_LEG_OBLIGATION_ID,
+    SCHEDULED_LEG_PLUS_TRIGGER_LEG_RULE,
+    SCHEDULED_PAYMENTS_AND_TRIGGER_SETTLEMENT_RULE,
+    TRIGGER_LEG_OBLIGATION_ID,
+)
 
 
 _KNOWN_CAPABILITIES = frozenset(cap.name for cap in capability_registry.MARKET_DATA)
@@ -2037,10 +2044,10 @@ def _validate_credit_default_swap_shape(
         contract,
         errors,
         expected_instrument_class="cds",
-        expected_payoff_family="credit_default_swap",
+        expected_payoff_family=EVENT_TRIGGERED_TWO_LEGGED_CONTRACT_FAMILY,
         expected_underlier_structure="single_reference_entity",
-        expected_payoff_rule="single_name_cds_legs",
-        expected_settlement_rule="premium_schedule_and_default_settlement",
+        expected_payoff_rule=SCHEDULED_LEG_PLUS_TRIGGER_LEG_RULE,
+        expected_settlement_rule=SCHEDULED_PAYMENTS_AND_TRIGGER_SETTLEMENT_RULE,
         expected_exercise_style="none",
         expected_multi_asset=False,
         require_schedule=True,
@@ -2061,10 +2068,10 @@ def _validate_credit_default_swap_shape(
     if "cashflow_schedule" not in observable_types:
         errors.append("Credit-default-swap semantics require a typed cashflow_schedule observable.")
     obligation_ids = {item.obligation_id for item in product.obligations}
-    if "premium_leg_cashflow" not in obligation_ids:
-        errors.append("Credit-default-swap semantics require a typed premium-leg obligation.")
-    if "protection_leg_cashflow" not in obligation_ids:
-        errors.append("Credit-default-swap semantics require a typed protection-leg obligation.")
+    if SCHEDULED_LEG_OBLIGATION_ID not in obligation_ids:
+        errors.append("Credit-default-swap semantics require a typed scheduled-leg obligation.")
+    if TRIGGER_LEG_OBLIGATION_ID not in obligation_ids:
+        errors.append("Credit-default-swap semantics require a typed trigger-leg obligation.")
     if product.controller_protocol.controller_style != "identity":
         errors.append("Credit-default-swap semantics cannot declare a strategic controller.")
     if not contract.blueprint.primitive_families:

--- a/trellis/agent/semantic_contracts.py
+++ b/trellis/agent/semantic_contracts.py
@@ -16,6 +16,13 @@ from trellis.agent.semantic_concepts import (
     get_semantic_concept_definition,
     semantic_concept_summary,
 )
+from trellis.agent.semantic_tokens import (
+    EVENT_TRIGGERED_TWO_LEGGED_CONTRACT_FAMILY,
+    SCHEDULED_LEG_OBLIGATION_ID,
+    SCHEDULED_LEG_PLUS_TRIGGER_LEG_RULE,
+    SCHEDULED_PAYMENTS_AND_TRIGGER_SETTLEMENT_RULE,
+    TRIGGER_LEG_OBLIGATION_ID,
+)
 from trellis.core.capabilities import normalize_capability_name
 
 
@@ -464,9 +471,9 @@ def _build_semantic_family_registry() -> MappingProxyType:
                     target_modules=("trellis.models.credit_default_swap",),
                     primitive_families=("credit_default_swap_analytical",),
                     adapter_obligations=(
-                        "resolve_credit_curve_and_discount_curve",
-                        "build_cds_payment_schedule",
-                        "delegate_cds_leg_pricing_to_checked_helpers",
+                        "resolve_event_trigger_and_discount_inputs",
+                        "build_scheduled_leg_payment_schedule",
+                        "delegate_two_legged_event_contract_to_checked_helpers",
                     ),
                     spec_schema_hints=("credit_default_swap",),
                 ),
@@ -475,9 +482,9 @@ def _build_semantic_family_registry() -> MappingProxyType:
                     target_modules=("trellis.models.credit_default_swap",),
                     primitive_families=("credit_default_swap_monte_carlo",),
                     adapter_obligations=(
-                        "resolve_credit_curve_and_discount_curve",
-                        "build_cds_payment_schedule",
-                        "delegate_cds_leg_pricing_to_checked_helpers",
+                        "resolve_event_trigger_and_discount_inputs",
+                        "build_scheduled_leg_payment_schedule",
+                        "delegate_two_legged_event_contract_to_checked_helpers",
                     ),
                     spec_schema_hints=("credit_default_swap",),
                 ),
@@ -2845,29 +2852,34 @@ def make_credit_default_swap_contract(
         semantic_version="c2.1",
         instrument_class="cds",
         instrument_aliases=("cds", "credit_default_swap", "single_name_cds"),
-        payoff_family="credit_default_swap",
+        payoff_family=EVENT_TRIGGERED_TWO_LEGGED_CONTRACT_FAMILY,
         timeline=_default_semantic_timeline(
             schedule,
             settlement_dates=schedule,
             state_update_dates=schedule,
         ),
         underlier_structure="single_reference_entity",
-        payoff_rule="single_name_cds_legs",
-        settlement_rule="premium_schedule_and_default_settlement",
-        payoff_traits=("credit_spread_dependence", "default_contingent", "premium_leg"),
+        payoff_rule=SCHEDULED_LEG_PLUS_TRIGGER_LEG_RULE,
+        settlement_rule=SCHEDULED_PAYMENTS_AND_TRIGGER_SETTLEMENT_RULE,
+        payoff_traits=(
+            "credit_spread_dependence",
+            "default_contingent",
+            "scheduled_leg",
+            "trigger_leg",
+        ),
         observables=(
             ObservableSpec(
-                observable_id="reference_entity_survival",
+                observable_id="event_trigger_process",
                 observable_type="credit_curve",
-                description="Survival term structure for the single reference entity.",
+                description="Event-trigger term structure for the single reference entity.",
                 source="credit_curve",
                 schedule_role="observation_dates",
                 availability_phase="observation",
             ),
             ObservableSpec(
-                observable_id="premium_payment_schedule",
+                observable_id="scheduled_leg_payment_schedule",
                 observable_type="cashflow_schedule",
-                description="Premium-leg payment schedule used for accrual and settlement.",
+                description="Scheduled-leg payment schedule used for accrual and settlement.",
                 source="contract_terms",
                 schedule_role="observation_dates",
                 availability_phase="determination",
@@ -2875,42 +2887,46 @@ def make_credit_default_swap_contract(
         ),
         state_fields=(
             StateField(
-                field_name="survival_state",
+                field_name="event_trigger_state",
                 kind="event_state",
-                description="Reference-entity survival state used to price CDS premium and protection legs.",
-                source_observables=("reference_entity_survival",),
+                description=(
+                    "Event-trigger state used to price the scheduled and trigger legs."
+                ),
+                source_observables=("event_trigger_process",),
                 tags=("terminal_markov", "schedule_state"),
             ),
             StateField(
-                field_name="premium_leg_schedule",
+                field_name="scheduled_leg_schedule",
                 kind="contract_memory",
-                description="Premium payment schedule shared by analytical and Monte Carlo CDS routes.",
-                source_observables=("premium_payment_schedule",),
+                description=(
+                    "Scheduled payment schedule shared by analytical and Monte Carlo routes."
+                ),
+                source_observables=("scheduled_leg_payment_schedule",),
                 tags=("schedule_state", "recombining_safe"),
             ),
             StateField(
-                field_name="default_indicator",
+                field_name="trigger_indicator",
                 kind="contract_memory",
-                description="Pathwise default state used by Monte Carlo CDS routes.",
-                source_observables=("reference_entity_survival",),
+                description="Pathwise event indicator used by Monte Carlo trigger sampling.",
+                source_observables=("event_trigger_process",),
                 tags=("pathwise_only", "schedule_state"),
             ),
         ),
         obligations=(
             ObligationSpec(
-                obligation_id="premium_leg_cashflow",
-                settle_date_rule="premium_schedule_and_default_settlement",
-                amount_expression="running_spread_coupon_leg",
+                obligation_id=SCHEDULED_LEG_OBLIGATION_ID,
+                settle_date_rule=SCHEDULED_PAYMENTS_AND_TRIGGER_SETTLEMENT_RULE,
+                amount_expression="scheduled_leg_coupon_stream",
                 settlement_kind="cash",
                 trigger="survive_to_payment",
                 provenance="semantic_contract",
             ),
             ObligationSpec(
-                obligation_id="protection_leg_cashflow",
-                settle_date_rule="premium_schedule_and_default_settlement",
-                amount_expression="loss_given_default_payment",
+                obligation_id=TRIGGER_LEG_OBLIGATION_ID,
+                settle_date_rule=SCHEDULED_PAYMENTS_AND_TRIGGER_SETTLEMENT_RULE,
+                amount_expression="trigger_leg_loss_payment",
                 settlement_kind="cash",
-                trigger="default_before_maturity",
+                trigger="event_before_maturity",
                 provenance="semantic_contract",
             ),
         ),
@@ -2940,13 +2956,24 @@ def make_credit_default_swap_contract(
         selection_count=0,
         lock_rule="",
         aggregation_rule="",
-        maturity_settlement_rule="premium_schedule_and_default_settlement",
+        maturity_settlement_rule=SCHEDULED_PAYMENTS_AND_TRIGGER_SETTLEMENT_RULE,
         constituents=reference_names,
-        state_variables=("survival_state", "premium_leg_schedule", "default_indicator"),
-        event_transitions=("observe_credit_state", "accrue_premium_leg", "settle_on_default_or_maturity"),
+        state_variables=("event_trigger_state", "scheduled_leg_schedule", "trigger_indicator"),
+        event_transitions=(
+            "observe_trigger_state",
+            "accrue_scheduled_leg",
+            "settle_on_trigger_or_maturity",
+        ),
         event_machine=_derive_event_machine(
-            ("observe_credit_state", "accrue_premium_leg", "settle_on_default_or_maturity"),
+            ("observe_trigger_state", "accrue_scheduled_leg", "settle_on_trigger_or_maturity"),
             state_dependence="schedule_dependent",
+        ),
+        term_fields=MappingProxyType(
+            {
+                "trigger_kind": "credit_event",
+                "event_contract_shape": EVENT_TRIGGERED_TWO_LEGGED_CONTRACT_FAMILY,
+                "event_measure": "single_reference_entity_default",
+            }
         ),
     )
 
@@ -2978,11 +3005,11 @@ def make_credit_default_swap_contract(
         universal_checks=(
             "single_reference_entity_present",
             "premium_or_maturity_schedule_present",
-            "premium_and_protection_legs_present",
+            "scheduled_and_trigger_legs_present",
         ),
         semantic_checks=(
-            "premium_leg_accrues_on_schedule",
-            "protection_leg_triggers_on_default",
+            "scheduled_leg_accrues_on_schedule",
+            "trigger_leg_settles_on_event",
         ),
         comparison_targets=(normalized_method,),
         reduction_cases=("single_name_credit_default_swap",),

--- a/trellis/agent/semantic_tokens.py
+++ b/trellis/agent/semantic_tokens.py
@@ -33,6 +33,30 @@ def _is_credit_default_swap_surface(instrument: object) -> bool:
     return _normalize_semantic_label(instrument) in _CREDIT_DEFAULT_SWAP_INSTRUMENTS
 
 
+def internal_payoff_family_for_surface(
+    *,
+    instrument: object,
+    payoff_family: object | None = None,
+) -> str:
+    """Return the canonical internal payoff family for matching and routing.
+
+    Prompt-facing CDS surfaces still use legacy labels like ``cds`` for
+    backward-compatible builder guidance. Internally those surfaces normalize
+    onto the structural ``event_triggered_two_legged_contract`` family so
+    registry lookups and capability checks can match the promoted structural
+    routes.
+    """
+    normalized_payoff_family = _normalize_semantic_label(payoff_family)
+    if normalized_payoff_family in _CREDIT_DEFAULT_SWAP_INSTRUMENTS:
+        return EVENT_TRIGGERED_TWO_LEGGED_CONTRACT_FAMILY
+    if normalized_payoff_family:
+        return normalized_payoff_family
+
+    if _is_credit_default_swap_surface(instrument):
+        return EVENT_TRIGGERED_TWO_LEGGED_CONTRACT_FAMILY
+    return _normalize_semantic_label(instrument)
+
+
 def prompt_display_payoff_family(*, instrument: object, payoff_family: object) -> str:
     """Return a stable prompt-facing payoff-family label."""
     normalized = str(payoff_family or "").strip()

--- a/trellis/agent/semantic_tokens.py
+++ b/trellis/agent/semantic_tokens.py
@@ -1,0 +1,70 @@
+"""Shared structural semantic-family tokens.
+
+These constants let product-specific semantic concepts compile onto a smaller
+set of reusable computational abstractions without scattering raw strings
+through the compiler, validator, and route registry.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+
+EVENT_TRIGGERED_TWO_LEGGED_CONTRACT_FAMILY = "event_triggered_two_legged_contract"
+SCHEDULED_LEG_PLUS_TRIGGER_LEG_RULE = "scheduled_leg_plus_trigger_leg"
+SCHEDULED_PAYMENTS_AND_TRIGGER_SETTLEMENT_RULE = (
+    "scheduled_payments_and_trigger_settlement"
+)
+SCHEDULED_LEG_OBLIGATION_ID = "scheduled_leg_cashflow"
+TRIGGER_LEG_OBLIGATION_ID = "trigger_leg_cashflow"
+
+_CREDIT_DEFAULT_SWAP_COMPAT_LABEL = "credit_default_swap"
+_CREDIT_DEFAULT_SWAP_PRODUCT_LABEL = "cds"
+_CREDIT_DEFAULT_SWAP_INSTRUMENTS = frozenset({"cds", "credit_default_swap"})
+
+
+def _normalize_semantic_label(value: object) -> str:
+    """Normalize semantic labels before applying compatibility display rules."""
+    return str(value or "").strip().lower().replace(" ", "_")
+
+
+def _is_credit_default_swap_surface(instrument: object) -> bool:
+    """Return whether prompt-facing display should use the CDS compatibility label."""
+    return _normalize_semantic_label(instrument) in _CREDIT_DEFAULT_SWAP_INSTRUMENTS
+
+
+def prompt_display_payoff_family(*, instrument: object, payoff_family: object) -> str:
+    """Return a stable prompt-facing payoff-family label."""
+    normalized = str(payoff_family or "").strip()
+    if (
+        _is_credit_default_swap_surface(instrument)
+        and normalized == EVENT_TRIGGERED_TWO_LEGGED_CONTRACT_FAMILY
+    ):
+        return _CREDIT_DEFAULT_SWAP_PRODUCT_LABEL
+    return normalized
+
+
+def prompt_display_route_family(*, instrument: object, route_family: object) -> str:
+    """Return a stable prompt-facing route-family label."""
+    normalized = str(route_family or "").strip()
+    if (
+        _is_credit_default_swap_surface(instrument)
+        and normalized == EVENT_TRIGGERED_TWO_LEGGED_CONTRACT_FAMILY
+    ):
+        return _CREDIT_DEFAULT_SWAP_COMPAT_LABEL
+    return normalized
+
+
+def prompt_display_route_families(
+    *,
+    instrument: object,
+    route_families: Iterable[object],
+) -> tuple[str, ...]:
+    """Return stable prompt-facing route-family labels."""
+    return tuple(
+        prompt_display_route_family(
+            instrument=instrument,
+            route_family=family,
+        )
+        for family in route_families
+    )


### PR DESCRIPTION
## What changed
- normalize CDS semantic routing onto the structural `event_triggered_two_legged_contract` family
- keep prompt-facing CDS compatibility labels so existing builder/prompt surfaces still speak in legacy CDS terms
- replace the special-purpose CDS family-lowering surface with `EventTriggeredTwoLeggedContractIR` plus a compatibility alias
- update route and backend-binding metadata to match structurally on payoff family instead of a CDS-only route family
- disable cassette replay support for `T38` at the canary manifest layer and harden replay helper tests against stale cassette files
- promote the contract-IR compiler plan mirror onto the active doc surface and update quant docs to describe the structural family

## Why
This removes a product-specific semantic route that should be representable as a general two-legged contingent contract. It also closes a replay-policy hole where `record_cassette: false` could still appear replay-capable if a cassette file was present.

## Impact
- internal routing and validation now reason about scheduled-leg plus trigger-leg structure rather than a CDS-specific family
- external prompt surfaces remain CDS-compatible for now, so this is a semantic/compiler cleanup rather than a user-facing rename
- `T38` is no longer treated as replay-supported
- the repo-local contract-IR compiler plan now lives on the active QUA-887 surface

## Validation
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/ -x -q -m 'not integration'`
  - `3463 passed, 17 skipped, 5 deselected`
