### PR TITLE
[codex] Split PR gate from release proof suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,13 @@ jobs:
             git diff --check "${base_sha}" "${head_sha}" --
           fi
 
-      - name: Run non-integration test suite
-        run: python -m pytest tests/ -x -q -m "not integration"
+      - name: Run PR gate
+        if: github.event_name == 'pull_request'
+        run: make gate-pr PYTHON=python
+
+      - name: Run release gate
+        if: github.event_name == 'push'
+        run: make gate-release PYTHON=python
 
   typecheck:
     name: typecheck

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Trellis is an AI-augmented quantitative finance library for derivative pricing. 
 **Language:** Python 3.10+
 **Dependencies:** numpy, autograd, scipy (core); openai/anthropic (agent); pytest (test)
 **Python:** `/Users/steveyang/miniforge3/bin/python3`
-**Tests:** `pytest tests/ -x -q -m "not integration"` (~980 tests)
+**Tests:** `make gate-pr` for PR-ready validation; `make gate-release` for the broader proof/reference gate
 
 Always run Python through the conda interpreter above. Do not rely on the
 system `python3` on `PATH` for tests, replays, or task execution.
@@ -26,7 +26,7 @@ the miniforge interpreter.
 - Use `from trellis.core.differentiable import get_numpy` instead of `import numpy` for autograd compatibility
 - All value types should be frozen dataclasses
 - All market interfaces should be protocols (not base classes)
-- Run `pytest tests/ -x -q -m "not integration"` after every change
+- Run targeted tests for the touched subsystem after every change; use `make gate-pr` before merge-ready handoff, and `make gate-release` when touching cross-validation, verification, task-challenge, or cassette-freshness surfaces
 - Do NOT modify `trellis/agent/knowledge/` files — that's the Knowledge Agent's domain
 
 ### Role: Knowledge Agent

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Trellis is an AI-augmented quantitative finance library for derivative pricing. 
 **Language:** Python 3.10+
 **Dependencies:** numpy, autograd, scipy (core); openai/anthropic (agent); pytest (test)
 **Python:** `/Users/steveyang/miniforge3/bin/python3`
-**Tests:** `pytest tests/ -x -q -m "not integration"` (~980 tests)
+**Tests:** `make gate-pr` for PR-ready validation; `make gate-release` for the broader proof/reference gate
 
 Always run Python through the conda interpreter above. Do not rely on the
 system `python3` on `PATH` for tests, replays, or task execution.
@@ -26,7 +26,7 @@ the miniforge interpreter.
 - Use `from trellis.core.differentiable import get_numpy` instead of `import numpy` for autograd compatibility
 - All value types should be frozen dataclasses
 - All market interfaces should be protocols (not base classes)
-- Run `pytest tests/ -x -q -m "not integration"` after every change
+- Run targeted tests for the touched subsystem after every change; use `make gate-pr` before merge-ready handoff, and `make gate-release` when touching cross-validation, verification, task-challenge, or cassette-freshness surfaces
 - Do NOT modify `trellis/agent/knowledge/` files — that's the Knowledge Agent's domain
 
 ### Role: Knowledge Agent

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 PYTHON ?= /Users/steveyang/miniforge3/bin/python3
 PYTEST ?= $(PYTHON) -m pytest
 CANARY_FLAGS ?=
+PR_GATE_IGNORES ?= --ignore=tests/test_contracts --ignore=tests/test_crossval --ignore=tests/test_verification --ignore=tests/test_tasks
 
 .PHONY: gate-hygiene gate-tier2-contracts gate-pr gate-canary gate-release
 
@@ -8,11 +9,11 @@ gate-hygiene:
 	$(PYTHON) scripts/test_hygiene.py --fail-on-ancient-unticketed-xfail
 
 gate-tier2-contracts:
-	$(PYTEST) tests/test_contracts/ -q -m tier2
+	$(PYTEST) tests/test_contracts/ -q -m "tier2 and not freshness"
 
 gate-pr:
 	$(MAKE) gate-hygiene
-	$(PYTEST) tests/ -x -q -m "not integration"
+	$(PYTEST) tests/ -x -q -m "not integration and not tier2" $(PR_GATE_IGNORES)
 	$(MAKE) gate-tier2-contracts
 
 gate-canary:
@@ -21,6 +22,7 @@ gate-canary:
 
 gate-release:
 	$(MAKE) gate-pr
-	$(PYTEST) tests/test_contracts/test_cassette_freshness.py -q -m tier2
+	$(PYTEST) tests/test_crossval tests/test_verification tests/test_tasks -x -q -m "not integration"
+	$(PYTEST) tests/test_contracts/test_cassette_freshness.py -q -m "tier2 and freshness"
 	PYTHONHASHSEED=0 $(PYTHON) scripts/run_canary.py --task T13 --replay --check-drift
 	PYTHONHASHSEED=0 $(PYTHON) scripts/run_canary.py --task T38 --replay --check-drift

--- a/docs/developer/legacy_test_audit.md
+++ b/docs/developer/legacy_test_audit.md
@@ -16,14 +16,17 @@ non-integration strata used during review:
 
 - `crossval`
 - `verification`
+- `task_challenge`
 - `global_workflow`
 - `legacy_compat`
+- `freshness`
 
 Useful selector examples:
 
 ```bash
 /Users/steveyang/miniforge3/bin/python3 -m pytest tests -x -q -m "legacy_compat and not integration"
 /Users/steveyang/miniforge3/bin/python3 -m pytest tests -x -q -m "global_workflow and not integration"
+/Users/steveyang/miniforge3/bin/python3 -m pytest tests -x -q -m "task_challenge and not integration"
 ```
 
 ## Legacy-Only Set

--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -32,8 +32,12 @@ strata:
 
 - ``crossval`` for independent-library cross-checks
 - ``verification`` for numerical or analytical reference tests
+- ``task_challenge`` for proof-style task challenge regressions under
+  ``tests/test_tasks/``
 - ``global_workflow`` for user-facing workflow tests that span modules
 - ``legacy_compat`` for deprecated or compatibility-only behavior
+- ``freshness`` for release-gate freshness contracts such as cassette age
+  validation
 
 The stale-test hygiene layer now sits alongside those strata rather than
 replacing them. Use ``scripts/test_hygiene.py`` to inventory `skip`, `xfail`,
@@ -70,6 +74,12 @@ The repo root ``Makefile`` now exposes the explicit gate entrypoints:
 - ``make gate-pr`` for PR-ready validation
 - ``make gate-canary`` for the focused live canary subset
 - ``make gate-release`` for the broader replay/drift/freshness release gate
+
+``make gate-pr`` now skips the slow proof/reference layers
+(``tests/test_crossval/``, ``tests/test_verification/``, ``tests/test_tasks/``,
+and cassette freshness) and keeps those in ``make gate-release`` instead. The
+intent is to keep ordinary merge validation centered on core correctness while
+still preserving the broader numerical/reference evidence before releases.
 
 Use ``scripts/should_run_canary.py`` before paying for the live canary subset.
 The helper reads local changed files from git status by default and recommends
@@ -538,6 +548,7 @@ Useful commands:
    /Users/steveyang/miniforge3/bin/python3 scripts/remediate.py --analyze-only
    /Users/steveyang/miniforge3/bin/python3 -m pytest tests -x -q -m "crossval and not integration"
    /Users/steveyang/miniforge3/bin/python3 -m pytest tests -x -q -m "verification and not integration"
+   /Users/steveyang/miniforge3/bin/python3 -m pytest tests -x -q -m "task_challenge and not integration"
    /Users/steveyang/miniforge3/bin/python3 -m pytest tests -x -q -m "global_workflow and not integration"
 
 Related Reading

--- a/docs/developer/test_gates.md
+++ b/docs/developer/test_gates.md
@@ -19,14 +19,18 @@ the supported interpreter even if your shell `python3` resolves elsewhere.
 
 ## Gate Selection
 
-- `make gate-pr`: default PR-ready gate. Runs stale-test hygiene, the full
-  non-integration suite, and the explicit tier-2 contract-test tranche.
+- `make gate-pr`: default PR-ready gate. Runs stale-test hygiene, the core
+  non-integration suite, and the tier-2 contract tranche, but skips the
+  cross-validation, verification, task-challenge, and cassette-freshness proof
+  layers so ordinary merges are not blocked on the slowest numerical evidence
+  slices.
 - `make gate-canary`: focused core canary gate for agent/runtime/pricing-core
   changes. This calls `scripts/should_run_canary.py` first so the current path
   diff is visible before the live canary subset runs.
 - `make gate-release`: broader release-facing gate. Runs `gate-pr`, then the
-  cassette freshness contract and replay-backed canary drift checks for the
-  committed full-task cassettes.
+  cross-validation, verification, task-challenge, and cassette-freshness proof
+  layers, followed by the replay-backed canary drift checks for the committed
+  full-task cassettes.
 
 ## Canary Trigger Helper
 
@@ -59,11 +63,13 @@ For explicit path checks, repeat `--path`:
 ## Cost Notes
 
 - `gate-pr` is the normal correctness gate and does not require live model
-  tokens.
+  tokens. It intentionally avoids the slower proof/reference strata so the
+  merge path stays closer to the core runtime contract.
 - `gate-canary` is live by default and intentionally narrower than the full
   canary surface.
 - `gate-release` stays deterministic and zero-token by using committed
-  full-task replays plus drift/freshness checks.
+  full-task replays plus the slower proof/reference suites and the
+  drift/freshness checks.
 
 The release gate's drift step uses `scripts/run_canary.py --check-drift`, so
 it compares against the latest available decision checkpoint for the replayed

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,8 +38,10 @@ def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line("markers", "integration: Full integration tests requiring live LLM")
     config.addinivalue_line("markers", "crossval: Cross-validation tests against independent libraries or engines")
     config.addinivalue_line("markers", "verification: Numerical or analytical verification tests against trusted references")
+    config.addinivalue_line("markers", "task_challenge: Proof-style task challenge tests that defend benchmark/task workflows")
     config.addinivalue_line("markers", "global_workflow: End-to-end or user-facing workflow tests spanning multiple modules")
     config.addinivalue_line("markers", "legacy_compat: Compatibility tests that defend deprecated or legacy-only behavior")
+    config.addinivalue_line("markers", "freshness: Release-gate tests that validate cassette freshness or similar age-based contracts")
 
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
@@ -54,6 +56,8 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
             item.add_marker(pytest.mark.crossval)
         if rel_path.startswith("tests/test_verification/"):
             item.add_marker(pytest.mark.verification)
+        if rel_path.startswith("tests/test_tasks/"):
+            item.add_marker(pytest.mark.task_challenge)
         if rel_path in _GLOBAL_WORKFLOW_TEST_PATHS:
             item.add_marker(pytest.mark.global_workflow)
 

--- a/tests/test_agent/test_financepy_benchmark.py
+++ b/tests/test_agent/test_financepy_benchmark.py
@@ -18,7 +18,9 @@ from trellis.agent.financepy_reference import price_financepy_reference
 
 ROOT = Path(__file__).resolve().parents[2]
 
-pytest.importorskip("financepy")
+
+def _require_financepy() -> None:
+    pytest.importorskip("financepy")
 
 
 def test_select_financepy_benchmark_tasks_filters_requested_ids():
@@ -45,6 +47,7 @@ def test_persist_financepy_benchmark_record_writes_history_and_latest(tmp_path):
 
 
 def test_price_financepy_reference_supports_equity_vanilla_and_fx():
+    _require_financepy()
     tasks = {task["id"]: task for task in load_financepy_benchmark_tasks(root=ROOT)}
     equity = price_financepy_reference(tasks["F001"], root=ROOT)
     fx = price_financepy_reference(tasks["F002"], root=ROOT)
@@ -72,6 +75,7 @@ def test_financepy_benchmark_manifest_includes_tranche_two_families():
     ],
 )
 def test_price_financepy_reference_supports_tranche_two_families(task_id, expected_outputs):
+    _require_financepy()
     tasks = {task["id"]: task for task in load_financepy_benchmark_tasks(root=ROOT)}
     result = price_financepy_reference(tasks[task_id], root=ROOT)
 

--- a/tests/test_contracts/test_cassette_freshness.py
+++ b/tests/test_contracts/test_cassette_freshness.py
@@ -15,6 +15,7 @@ from tests.test_contracts.conftest import (
 )
 
 
+@pytest.mark.freshness
 @pytest.mark.tier2
 def test_cassettes_are_fresh():
     """All committed cassettes should be less than CASSETTE_MAX_AGE_DAYS old."""
@@ -40,6 +41,7 @@ def test_cassettes_are_fresh():
         pytest.fail(msg)
 
 
+@pytest.mark.freshness
 @pytest.mark.tier2
 def test_cassette_files_are_valid_yaml():
     """All cassette files must be parseable YAML with meta and calls sections."""

--- a/tests/test_crossval/test_xv_bonds.py
+++ b/tests/test_crossval/test_xv_bonds.py
@@ -8,9 +8,6 @@ from datetime import date
 import numpy as np
 import pytest
 
-pytest.importorskip("QuantLib")
-pytest.importorskip("financepy")
-
 # --- Trellis ---
 from trellis.core.market_state import MarketState
 from trellis.core.payoff import DeterministicCashflowPayoff
@@ -27,6 +24,14 @@ FACE = 100.0
 RATE = 0.05
 
 
+def _require_quantlib():
+    pytest.importorskip("QuantLib")
+
+
+def _require_financepy():
+    pytest.importorskip("financepy")
+
+
 def trellis_bond_price(rate=RATE, settle=SETTLE):
     bond = Bond(face=FACE, coupon=COUPON, maturity_date=MATURITY,
                 maturity=10, frequency=2)
@@ -39,6 +44,7 @@ def trellis_bond_price(rate=RATE, settle=SETTLE):
 # ---------------------------------------------------------------------------
 
 def quantlib_bond_price(rate=RATE, settle=SETTLE):
+    _require_quantlib()
     import QuantLib as ql
 
     settle_ql = ql.Date(settle.day, settle.month, settle.year)
@@ -71,6 +77,7 @@ def quantlib_bond_price(rate=RATE, settle=SETTLE):
 # ---------------------------------------------------------------------------
 
 def financepy_bond_price(rate=RATE):
+    _require_financepy()
     from financepy.products.bonds.bond import Bond as FPBond
     from financepy.utils.date import Date as FPDate
     from financepy.utils.frequency import FrequencyTypes

--- a/tests/test_crossval/test_xv_caps.py
+++ b/tests/test_crossval/test_xv_caps.py
@@ -5,8 +5,6 @@ from datetime import date
 import numpy as raw_np
 import pytest
 
-pytest.importorskip("QuantLib")
-
 # --- Trellis ---
 from trellis.core.market_state import MarketState
 from trellis.core.types import DayCountConvention, Frequency
@@ -16,6 +14,10 @@ from trellis.instruments.cap import CapFloorSpec, CapPayoff, FloorPayoff
 from trellis.models.vol_surface import FlatVol
 
 SETTLE = date(2024, 11, 15)
+
+
+def _require_quantlib():
+    pytest.importorskip("QuantLib")
 
 
 def trellis_cap_price(rate=0.05, vol=0.20, strike=0.05, years=5):
@@ -31,6 +33,7 @@ def trellis_cap_price(rate=0.05, vol=0.20, strike=0.05, years=5):
 
 
 def quantlib_cap_price(rate=0.05, vol=0.20, strike=0.05, years=5):
+    _require_quantlib()
     import QuantLib as ql
 
     today = ql.Date(15, 11, 2024)

--- a/tests/test_crossval/test_xv_credit.py
+++ b/tests/test_crossval/test_xv_credit.py
@@ -5,13 +5,15 @@ from datetime import date
 import numpy as raw_np
 import pytest
 
-pytest.importorskip("QuantLib")
-
 # --- Trellis ---
 from trellis.curves.credit_curve import CreditCurve
 from trellis.curves.yield_curve import YieldCurve
 
 SETTLE = date(2024, 11, 15)
+
+
+def _require_quantlib():
+    pytest.importorskip("QuantLib")
 
 
 def trellis_survival(hazard_rate, t):
@@ -20,6 +22,7 @@ def trellis_survival(hazard_rate, t):
 
 
 def quantlib_survival(hazard_rate, t):
+    _require_quantlib()
     import QuantLib as ql
     today = ql.Date(15, 11, 2024)
     ql.Settings.instance().evaluationDate = today

--- a/tests/test_crossval/test_xv_curves.py
+++ b/tests/test_crossval/test_xv_curves.py
@@ -5,14 +5,16 @@ from datetime import date
 import numpy as raw_np
 import pytest
 
-pytest.importorskip("QuantLib")
-
 # --- Trellis ---
 from trellis.curves.yield_curve import YieldCurve
 from trellis.curves.forward_curve import ForwardCurve
 
 SETTLE = date(2024, 11, 15)
 RATE = 0.05
+
+
+def _require_quantlib():
+    pytest.importorskip("QuantLib")
 
 
 def trellis_discount(rate, t):
@@ -25,6 +27,7 @@ def trellis_forward(rate, t1, t2):
 
 
 def quantlib_discount(rate, t):
+    _require_quantlib()
     import QuantLib as ql
     today = ql.Date(15, 11, 2024)
     ql.Settings.instance().evaluationDate = today
@@ -33,6 +36,7 @@ def quantlib_discount(rate, t):
 
 
 def quantlib_forward(rate, t1, t2):
+    _require_quantlib()
     import QuantLib as ql
     today = ql.Date(15, 11, 2024)
     ql.Settings.instance().evaluationDate = today

--- a/tests/test_crossval/test_xv_options.py
+++ b/tests/test_crossval/test_xv_options.py
@@ -5,9 +5,6 @@ from datetime import date
 import numpy as raw_np
 import pytest
 
-pytest.importorskip("QuantLib")
-pytest.importorskip("financepy")
-
 # --- Trellis ---
 from trellis.models.black import black76_call, black76_put
 from trellis.models.trees.binomial import BinomialTree
@@ -17,11 +14,20 @@ from trellis.models.calibration.implied_vol import implied_vol, _bs_price
 S0, K, r, sigma, T = 100.0, 100.0, 0.05, 0.20, 1.0
 
 
+def _require_quantlib():
+    pytest.importorskip("QuantLib")
+
+
+def _require_financepy():
+    pytest.importorskip("financepy")
+
+
 # ---------------------------------------------------------------------------
 # QuantLib references
 # ---------------------------------------------------------------------------
 
 def ql_european_call():
+    _require_quantlib()
     import QuantLib as ql
     today = ql.Date(15, 11, 2024)
     ql.Settings.instance().evaluationDate = today
@@ -47,6 +53,7 @@ def ql_european_call():
 
 
 def ql_american_put():
+    _require_quantlib()
     import QuantLib as ql
     today = ql.Date(15, 11, 2024)
     ql.Settings.instance().evaluationDate = today
@@ -76,6 +83,7 @@ def ql_american_put():
 # ---------------------------------------------------------------------------
 
 def fp_european_call():
+    _require_financepy()
     from financepy.products.equity.equity_vanilla_option import EquityVanillaOption
     from financepy.utils.date import Date as FPDate
     from financepy.utils.global_types import OptionTypes

--- a/tests/test_crossval/test_xv_tff.py
+++ b/tests/test_crossval/test_xv_tff.py
@@ -14,12 +14,6 @@ import pytest
 # Set protobuf workaround before any TFF import
 os.environ.setdefault("PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION", "python")
 
-try:
-    import tf_quant_finance as tff
-    HAS_TFF = True
-except (ImportError, TypeError):
-    HAS_TFF = False
-
 # --- Trellis ---
 from trellis.models.calibration.implied_vol import _bs_price
 from trellis.models.black import black76_call
@@ -31,13 +25,16 @@ from trellis.models.transforms.fft_pricer import fft_price
 
 S0, K, r, sigma, T = 100.0, 100.0, 0.05, 0.20, 1.0
 
-pytestmark = pytest.mark.skipif(not HAS_TFF, reason="tf-quant-finance not installed")
+
+def _tff():
+    return pytest.importorskip("tf_quant_finance", reason="tf-quant-finance not installed")
 
 
 class TestBSCrossValTFF:
 
     def test_european_call(self):
         """Trellis BS call matches TFF."""
+        tff = _tff()
         trellis_call = _bs_price(S0, K, T, r, sigma, "call")
 
         tff_call = float(tff.black_scholes.option_price(
@@ -54,6 +51,7 @@ class TestBSCrossValTFF:
         )
 
     def test_european_put(self):
+        tff = _tff()
         trellis_put = _bs_price(S0, K, T, r, sigma, "put")
 
         tff_put = float(tff.black_scholes.option_price(
@@ -68,6 +66,7 @@ class TestBSCrossValTFF:
         assert trellis_put == pytest.approx(tff_put, rel=1e-4)
 
     def test_otm_call(self):
+        tff = _tff()
         K_otm = 120.0
         trellis_call = _bs_price(S0, K_otm, T, r, sigma, "call")
 
@@ -84,6 +83,7 @@ class TestBSCrossValTFF:
 
     def test_multiple_strikes(self):
         """Vectorized: multiple strikes at once."""
+        tff = _tff()
         strikes = [80.0, 90.0, 100.0, 110.0, 120.0]
         tff_prices = tff.black_scholes.option_price(
             volatilities=raw_np.array([sigma] * len(strikes)),
@@ -104,6 +104,7 @@ class TestHestonCrossValTFF:
 
     def test_heston_call(self):
         """Trellis Heston FFT matches TFF Heston."""
+        tff = _tff()
         from trellis.models.processes.heston import Heston
 
         # Heston parameters
@@ -143,6 +144,7 @@ class TestAmericanCrossValTFF:
 
     def test_american_put_tree_vs_tff(self):
         """Trellis CRR tree American put vs TFF approximation."""
+        tff = _tff()
         # Trellis tree
         tree = BinomialTree.crr(S0, T, 500, r, sigma)
         def put_payoff(step, node):

--- a/tests/test_models/test_equity_exotics_analytical.py
+++ b/tests/test_models/test_equity_exotics_analytical.py
@@ -12,10 +12,12 @@ from trellis.models.analytical import price_equity_cliquet_option_analytical
 from trellis.models.vol_surface import FlatVol
 
 
-pytest.importorskip("financepy")
+def _require_financepy() -> None:
+    pytest.importorskip("financepy")
 
 
 def test_cliquet_analytical_matches_financepy_reset_schedule_reference():
+    _require_financepy()
     from financepy.market.curves.discount_curve_flat import DiscountCurveFlat
     from financepy.models.black_scholes import BlackScholes
     from financepy.products.equity.equity_cliquet_option import EquityCliquetOption

--- a/tests/test_tasks/test_suite_markers.py
+++ b/tests/test_tasks/test_suite_markers.py
@@ -1,0 +1,5 @@
+"""Architecture checks for the task-challenge suite."""
+
+
+def test_task_suite_is_marked_task_challenge(request):
+    assert request.node.get_closest_marker("task_challenge") is not None


### PR DESCRIPTION
## Summary
- split the PR gate from heavier release-only proof suites so pull requests stop re-running the expensive crossval, verification, task, and freshness slices
- route GitHub Actions PR runs through `make gate-pr` and push-to-main runs through `make gate-release`
- reduce test collection overhead by lazy-importing optional heavy dependencies and codifying suite markers/documentation for the new gate layout

## Validation
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_crossval/test_suite_markers.py tests/test_verification/test_suite_markers.py tests/test_tasks/test_suite_markers.py tests/test_contracts/test_cassette_freshness.py tests/test_agent/test_financepy_benchmark.py tests/test_models/test_equity_exotics_analytical.py -q -m "not integration"`
- collection checks for the split gate layout and lazy-import cleanup were run locally during development