### PR TITLE
[codex] Shard the PR gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-and-test:
-    name: build-and-test
+  repo-checks:
+    name: repo-checks
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -52,13 +52,92 @@ jobs:
             git diff --check "${base_sha}" "${head_sha}" --
           fi
 
-      - name: Run PR gate
-        if: github.event_name == 'pull_request'
-        run: make gate-pr PYTHON=python
+      - name: Run hygiene gate
+        run: make gate-hygiene PYTHON=python
+
+  pr-gate-shard:
+    if: github.event_name == 'pull_request'
+    name: pr-gate-shard-${{ matrix.shard }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shard: [1, 2, 3, 4]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev,agent,mcp,pipeline]"
+
+      - name: Run PR gate shard
+        run: make gate-pr-shard PYTHON=python PR_GATE_SHARD_COUNT=4 PR_GATE_SHARD_INDEX=${{ matrix.shard }}
+
+  pr-gate-tier2-contracts:
+    if: github.event_name == 'pull_request'
+    name: pr-gate-tier2-contracts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev,agent,mcp,pipeline]"
+
+      - name: Run tier2 contract gate
+        run: make gate-tier2-contracts PYTHON=python
+
+  release-gate:
+    if: github.event_name == 'push'
+    name: release-gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev,agent,mcp,pipeline]"
 
       - name: Run release gate
-        if: github.event_name == 'push'
         run: make gate-release PYTHON=python
+
+  build-and-test:
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    name: build-and-test
+    runs-on: ubuntu-latest
+    needs:
+      - repo-checks
+      - pr-gate-shard
+      - pr-gate-tier2-contracts
+    steps:
+      - name: Assert PR shard jobs passed
+        run: |
+          test "${{ needs.repo-checks.result }}" = "success"
+          test "${{ needs.pr-gate-shard.result }}" = "success"
+          test "${{ needs.pr-gate-tier2-contracts.result }}" = "success"
 
   typecheck:
     name: typecheck

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
 PYTHON ?= /Users/steveyang/miniforge3/bin/python3
 PYTEST ?= $(PYTHON) -m pytest
 CANARY_FLAGS ?=
+PR_CORE_MARKERS ?= not integration and not tier2
 PR_GATE_IGNORES ?= --ignore=tests/test_contracts --ignore=tests/test_crossval --ignore=tests/test_verification --ignore=tests/test_tasks
+PR_GATE_SHARD_COUNT ?= 4
+PR_GATE_SHARD_INDEX ?= 1
 
-.PHONY: gate-hygiene gate-tier2-contracts gate-pr gate-canary gate-release
+.PHONY: gate-hygiene gate-pr-shard gate-tier2-contracts gate-pr gate-canary gate-release
 
 gate-hygiene:
 	$(PYTHON) scripts/test_hygiene.py --fail-on-ancient-unticketed-xfail
@@ -11,9 +14,14 @@ gate-hygiene:
 gate-tier2-contracts:
 	$(PYTEST) tests/test_contracts/ -q -m "tier2 and not freshness"
 
+gate-pr-shard:
+	$(PYTHON) scripts/pr_gate_shard.py --count $(PR_GATE_SHARD_COUNT) --index $(PR_GATE_SHARD_INDEX) \
+		| tr '\n' '\0' \
+		| xargs -0 $(PYTEST) -x -q -m "$(PR_CORE_MARKERS)"
+
 gate-pr:
 	$(MAKE) gate-hygiene
-	$(PYTEST) tests/ -x -q -m "not integration and not tier2" $(PR_GATE_IGNORES)
+	$(PYTEST) tests/ -x -q -m "$(PR_CORE_MARKERS)" $(PR_GATE_IGNORES)
 	$(MAKE) gate-tier2-contracts
 
 gate-canary:

--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -81,6 +81,10 @@ and cassette freshness) and keeps those in ``make gate-release`` instead. The
 intent is to keep ordinary merge validation centered on core correctness while
 still preserving the broader numerical/reference evidence before releases.
 
+GitHub Actions now runs that same PR surface as deterministic shards generated
+by ``scripts/pr_gate_shard.py`` plus a separate tier-2 contract job, so PR wall
+clock is no longer pinned to one serial pytest command.
+
 Use ``scripts/should_run_canary.py`` before paying for the live canary subset.
 The helper reads local changed files from git status by default and recommends
 the focused ``core`` canary subset when runtime, pricing, task-manifest, or

--- a/docs/developer/test_gates.md
+++ b/docs/developer/test_gates.md
@@ -71,6 +71,23 @@ For explicit path checks, repeat `--path`:
   full-task replays plus the slower proof/reference suites and the
   drift/freshness checks.
 
+## CI Layout
+
+GitHub Actions now fans the PR gate out into independent jobs instead of one
+large serial pytest invocation:
+
+- `repo-checks`: build, whitespace diff check, and stale-marker hygiene
+- `pr-gate-shard-1` through `pr-gate-shard-4`: deterministic slices of the
+  core PR test surface produced by `scripts/pr_gate_shard.py`
+- `pr-gate-tier2-contracts`: the retained tier-2 contract tranche
+- `build-and-test`: branch-protection aggregator that goes green only after
+  the PR shard jobs succeed
+- `typecheck`: the existing non-blocking mypy pass
+
+Local `make gate-pr` stays serial and unchanged so developers still have a
+single command for full PR-ready validation. The shard helper only changes the
+remote PR workflow shape.
+
 The release gate's drift step uses `scripts/run_canary.py --check-drift`, so
 it compares against the latest available decision checkpoint for the replayed
 task. If no latest checkpoint exists yet, the runner reports that the drift

--- a/scripts/pr_gate_shard.py
+++ b/scripts/pr_gate_shard.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import ast
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Final
+
+RELEASE_ONLY_DIRS: Final[tuple[str, ...]] = (
+    "tests/test_contracts",
+    "tests/test_crossval",
+    "tests/test_tasks",
+    "tests/test_verification",
+)
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _is_release_only(relpath: str) -> bool:
+    return any(
+        relpath == excluded or relpath.startswith(f"{excluded}/")
+        for excluded in RELEASE_ONLY_DIRS
+    )
+
+
+def iter_pr_gate_files(root: Path) -> list[Path]:
+    tests_root = root / "tests"
+    return [
+        path
+        for path in sorted(tests_root.rglob("test_*.py"))
+        if not _is_release_only(path.relative_to(root).as_posix())
+    ]
+
+
+def test_weight(path: Path) -> int:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    count = sum(
+        1
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name.startswith("test_")
+    )
+    return max(1, count)
+
+
+@dataclass
+class Shard:
+    index: int
+    total_weight: int = 0
+    file_count: int = 0
+    paths: list[Path] = field(default_factory=list)
+
+
+def build_shards(paths: list[Path], count: int) -> list[Shard]:
+    shards = [Shard(index=index) for index in range(count)]
+    weighted_paths = sorted(
+        ((test_weight(path), path) for path in paths),
+        key=lambda item: (-item[0], item[1].as_posix()),
+    )
+    for weight, path in weighted_paths:
+        shard = min(shards, key=lambda item: (item.total_weight, item.file_count, item.index))
+        shard.paths.append(path)
+        shard.total_weight += weight
+        shard.file_count += 1
+    for shard in shards:
+        shard.paths.sort(key=lambda path: path.as_posix())
+    return shards
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Print the deterministic pytest file list for one PR-gate shard."
+    )
+    parser.add_argument("--count", type=int, required=True, help="Total shard count.")
+    parser.add_argument(
+        "--index",
+        type=int,
+        required=True,
+        help="1-based shard index to print.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.count <= 0:
+        raise SystemExit("--count must be positive")
+    if args.index <= 0 or args.index > args.count:
+        raise SystemExit("--index must be between 1 and --count")
+
+    root = repo_root()
+    shards = build_shards(iter_pr_gate_files(root), args.count)
+    for path in shards[args.index - 1].paths:
+        print(path.relative_to(root).as_posix())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cli/test_pr_gate_shard.py
+++ b/tests/test_cli/test_pr_gate_shard.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "pr_gate_shard.py"
+RELEASE_ONLY_DIRS = (
+    "tests/test_contracts",
+    "tests/test_crossval",
+    "tests/test_tasks",
+    "tests/test_verification",
+)
+
+
+def _run_shard(index: int, count: int) -> set[str]:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--count", str(count), "--index", str(index)],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return {line for line in result.stdout.splitlines() if line}
+
+
+def _eligible_pr_gate_files() -> set[str]:
+    files: set[str] = set()
+    for path in (REPO_ROOT / "tests").rglob("test_*.py"):
+        relpath = path.relative_to(REPO_ROOT).as_posix()
+        if any(
+            relpath == excluded or relpath.startswith(f"{excluded}/")
+            for excluded in RELEASE_ONLY_DIRS
+        ):
+            continue
+        files.add(relpath)
+    return files
+
+
+def test_pr_gate_shards_cover_each_core_test_exactly_once() -> None:
+    shard_count = 4
+    seen: set[str] = set()
+
+    for index in range(1, shard_count + 1):
+        shard_paths = _run_shard(index=index, count=shard_count)
+        assert shard_paths
+        assert seen.isdisjoint(shard_paths)
+        seen.update(shard_paths)
+
+    assert seen == _eligible_pr_gate_files()
+
+
+def test_pr_gate_shards_skip_release_only_suites() -> None:
+    shard_count = 4
+
+    for index in range(1, shard_count + 1):
+        for relpath in _run_shard(index=index, count=shard_count):
+            assert not any(
+                relpath == excluded or relpath.startswith(f"{excluded}/")
+                for excluded in RELEASE_ONLY_DIRS
+            )


### PR DESCRIPTION
## Summary
- split the PR gate into deterministic shard jobs plus a separate tier2 contract job so branch protection no longer waits on one serial pytest invocation
- keep local `make gate-pr` unchanged while adding `make gate-pr-shard` and `scripts/pr_gate_shard.py` for remote CI fan-out
- preserve the existing required `build-and-test` check name with an aggregator job so branch protection keeps working after the split

## Validation
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_cli/test_pr_gate_shard.py -q -m "not integration"`
- `make gate-pr-shard PYTHON=/Users/steveyang/miniforge3/bin/python3 PYTEST="/Users/steveyang/miniforge3/bin/python3 -m pytest --collect-only" PR_GATE_SHARD_COUNT=4 PR_GATE_SHARD_INDEX=1`
- workflow YAML parsed locally