### PR TITLE
agent: ContractPattern AST + YAML parser (QUA-917, Phase 1.5.A)

### DIFF
--- a/tests/test_agent/test_contract_pattern.py
+++ b/tests/test_agent/test_contract_pattern.py
@@ -1,0 +1,503 @@
+"""Tests for the ContractPattern AST and parser (QUA-917 / Phase 1.5.A).
+
+The pattern substrate is pure types + parsing in this slice.  No evaluator
+runs against ProductIR here (QUA-918) and no route schema reads it yet
+(QUA-919).  These tests therefore focus on:
+
+- canonical AST construction for the four existing ``analytical_black76``
+  when-clauses, confirming the AST is expressive enough to encode them,
+- round-trip parse -> serialize -> parse fidelity,
+- wildcard semantics (anonymous vs named capture),
+- AST-level composition via ``AndPattern`` / ``OrPattern`` / ``NotPattern``,
+- clear error behaviour on malformed input (not a silently wrong AST).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from trellis.agent.contract_pattern import (
+    AndPattern,
+    AtomPattern,
+    ConstantPattern,
+    ContractPattern,
+    ContractPatternParseError,
+    ExercisePattern,
+    NotPattern,
+    ObservationPattern,
+    OrPattern,
+    PayoffPattern,
+    SchedulePattern,
+    SpotPattern,
+    StrikePattern,
+    UnderlyingPattern,
+    Wildcard,
+    dump_contract_pattern,
+    parse_contract_pattern,
+    parse_payoff_pattern,
+)
+
+
+# ---------------------------------------------------------------------------
+# Structural smoke tests
+# ---------------------------------------------------------------------------
+
+
+class TestPatternConstruction:
+    def test_wildcard_anonymous_carries_no_binding(self):
+        node = Wildcard()
+        assert node.name is None
+
+    def test_wildcard_named_captures_binding_name(self):
+        node = Wildcard(name="K")
+        assert node.name == "K"
+
+    def test_contract_pattern_missing_fields_default_to_none(self):
+        pattern = ContractPattern()
+        assert pattern.payoff is None
+        assert pattern.exercise is None
+        assert pattern.observation is None
+        assert pattern.underlying is None
+
+    def test_payoff_pattern_children_are_immutable_tuples(self):
+        payoff = PayoffPattern(
+            kind="max",
+            args=(
+                PayoffPattern(
+                    kind="sub",
+                    args=(SpotPattern(), StrikePattern()),
+                ),
+                ConstantPattern(value=0.0),
+            ),
+        )
+        # Frozen dataclasses forbid reassignment.
+        with pytest.raises(Exception):
+            payoff.kind = "min"  # type: ignore[misc]
+        with pytest.raises(Exception):
+            payoff.args = ()  # type: ignore[misc]
+
+
+class TestAtomPatternHelpers:
+    def test_spot_pattern_underlier_defaults_to_wildcard(self):
+        spot = SpotPattern()
+        assert isinstance(spot.underlier, Wildcard)
+
+    def test_strike_pattern_value_defaults_to_wildcard(self):
+        strike = StrikePattern()
+        assert isinstance(strike.value, Wildcard)
+
+    def test_constant_pattern_carries_literal(self):
+        node = ConstantPattern(value=0.0)
+        assert node.value == 0.0
+
+    def test_constant_pattern_accepts_wildcard_literal(self):
+        node = ConstantPattern(value=Wildcard(name="zero"))
+        assert isinstance(node.value, Wildcard)
+        assert node.value.name == "zero"
+
+
+# ---------------------------------------------------------------------------
+# analytical_black76 canonical when-clauses (fixture parity)
+# ---------------------------------------------------------------------------
+
+
+class TestBlack76CanonicalPatterns:
+    def test_vanilla_option_payoff_encoded_as_max_sub_spot_strike(self):
+        payload = {
+            "payoff": {
+                "kind": "max",
+                "args": [
+                    {
+                        "kind": "sub",
+                        "args": [
+                            {"kind": "spot", "underlier": "_"},
+                            {"kind": "strike", "value": "_"},
+                        ],
+                    },
+                    {"kind": "constant", "value": 0},
+                ],
+            },
+            "exercise": {"style": "european"},
+        }
+        pattern = parse_contract_pattern(payload)
+
+        assert isinstance(pattern, ContractPattern)
+        assert pattern.exercise is not None
+        assert pattern.exercise.style == "european"
+
+        assert isinstance(pattern.payoff, PayoffPattern)
+        assert pattern.payoff.kind == "max"
+        outer_args = pattern.payoff.args
+        assert len(outer_args) == 2
+        sub_node, zero_node = outer_args
+        assert isinstance(sub_node, PayoffPattern) and sub_node.kind == "sub"
+        assert isinstance(zero_node, ConstantPattern) and zero_node.value == 0.0
+
+        lhs, rhs = sub_node.args
+        assert isinstance(lhs, SpotPattern)
+        assert isinstance(lhs.underlier, Wildcard) and lhs.underlier.name is None
+        assert isinstance(rhs, StrikePattern)
+        assert isinstance(rhs.value, Wildcard) and rhs.value.name is None
+
+    def test_basket_european_equity_diffusion(self):
+        payload = {
+            "payoff": {"kind": "basket_payoff"},
+            "exercise": {"style": "european"},
+            "underlying": {"kind": "linear_basket", "dynamics": "equity_diffusion"},
+        }
+        pattern = parse_contract_pattern(payload)
+
+        assert pattern.payoff is not None and pattern.payoff.kind == "basket_payoff"
+        assert pattern.exercise is not None and pattern.exercise.style == "european"
+        assert pattern.underlying is not None
+        assert pattern.underlying.kind == "linear_basket"
+        assert pattern.underlying.dynamics == "equity_diffusion"
+
+    def test_swaption_bermudan(self):
+        payload = {
+            "payoff": {"kind": "swaption_payoff"},
+            "exercise": {"style": "bermudan"},
+        }
+        pattern = parse_contract_pattern(payload)
+
+        assert pattern.payoff is not None and pattern.payoff.kind == "swaption_payoff"
+        assert pattern.exercise is not None and pattern.exercise.style == "bermudan"
+
+    def test_swaption_european(self):
+        payload = {
+            "payoff": {"kind": "swaption_payoff"},
+            "exercise": {"style": "european"},
+        }
+        pattern = parse_contract_pattern(payload)
+
+        assert pattern.payoff is not None and pattern.payoff.kind == "swaption_payoff"
+        assert pattern.exercise is not None and pattern.exercise.style == "european"
+
+
+# ---------------------------------------------------------------------------
+# Wildcard parsing semantics
+# ---------------------------------------------------------------------------
+
+
+class TestWildcardParsing:
+    def test_bare_underscore_parses_as_anonymous_wildcard(self):
+        payload = {
+            "payoff": {"kind": "spot", "underlier": "_"},
+        }
+        pattern = parse_contract_pattern(payload)
+        assert isinstance(pattern.payoff, SpotPattern)
+        assert isinstance(pattern.payoff.underlier, Wildcard)
+        assert pattern.payoff.underlier.name is None
+
+    def test_underscore_prefixed_identifier_is_named_capture(self):
+        payload = {
+            "payoff": {"kind": "strike", "value": "_K"},
+        }
+        pattern = parse_contract_pattern(payload)
+        assert isinstance(pattern.payoff, StrikePattern)
+        assert isinstance(pattern.payoff.value, Wildcard)
+        assert pattern.payoff.value.name == "K"
+
+    def test_named_wildcard_via_dict_form(self):
+        payload = {
+            "payoff": {
+                "kind": "strike",
+                "value": {"kind": "wildcard", "name": "strike_binding"},
+            },
+        }
+        pattern = parse_contract_pattern(payload)
+        assert isinstance(pattern.payoff, StrikePattern)
+        assert isinstance(pattern.payoff.value, Wildcard)
+        assert pattern.payoff.value.name == "strike_binding"
+
+    def test_wildcard_with_explicit_null_name_is_anonymous(self):
+        payload = {
+            "payoff": {
+                "kind": "spot",
+                "underlier": {"kind": "wildcard"},
+            },
+        }
+        pattern = parse_contract_pattern(payload)
+        assert isinstance(pattern.payoff, SpotPattern)
+        assert isinstance(pattern.payoff.underlier, Wildcard)
+        assert pattern.payoff.underlier.name is None
+
+
+# ---------------------------------------------------------------------------
+# AND / OR / NOT composition (AST-level; no evaluation yet)
+# ---------------------------------------------------------------------------
+
+
+class TestCompositionPatterns:
+    def test_and_pattern_parses_with_multiple_children(self):
+        payload = {
+            "payoff": {
+                "kind": "and",
+                "patterns": [
+                    {"kind": "spot", "underlier": "_"},
+                    {"kind": "strike", "value": "_"},
+                ],
+            },
+        }
+        pattern = parse_contract_pattern(payload)
+        assert isinstance(pattern.payoff, AndPattern)
+        assert len(pattern.payoff.patterns) == 2
+        assert isinstance(pattern.payoff.patterns[0], SpotPattern)
+        assert isinstance(pattern.payoff.patterns[1], StrikePattern)
+
+    def test_or_pattern_parses_with_multiple_children(self):
+        payload = {
+            "exercise": {
+                "style": {
+                    "kind": "or",
+                    "patterns": [
+                        {"kind": "literal", "value": "european"},
+                        {"kind": "literal", "value": "bermudan"},
+                    ],
+                },
+            },
+        }
+        pattern = parse_contract_pattern(payload)
+        assert isinstance(pattern.exercise, ExercisePattern)
+        assert isinstance(pattern.exercise.style, OrPattern)
+        assert len(pattern.exercise.style.patterns) == 2
+
+    def test_not_pattern_parses_with_single_child(self):
+        payload = {
+            "exercise": {
+                "style": {
+                    "kind": "not",
+                    "pattern": {"kind": "literal", "value": "american"},
+                },
+            },
+        }
+        pattern = parse_contract_pattern(payload)
+        assert isinstance(pattern.exercise, ExercisePattern)
+        assert isinstance(pattern.exercise.style, NotPattern)
+
+    def test_and_pattern_requires_at_least_one_child(self):
+        with pytest.raises(ContractPatternParseError):
+            parse_contract_pattern(
+                {"payoff": {"kind": "and", "patterns": []}}
+            )
+
+    def test_or_pattern_requires_at_least_one_child(self):
+        with pytest.raises(ContractPatternParseError):
+            parse_contract_pattern(
+                {"payoff": {"kind": "or", "patterns": []}}
+            )
+
+    def test_not_pattern_requires_a_child(self):
+        with pytest.raises(ContractPatternParseError):
+            parse_contract_pattern({"payoff": {"kind": "not"}})
+
+
+# ---------------------------------------------------------------------------
+# Round-trip (parse -> dump -> parse)
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTrip:
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            # 1. simple contract pattern with only an exercise
+            {"exercise": {"style": "european"}},
+            # 2. canonical vanilla option payoff
+            {
+                "payoff": {
+                    "kind": "max",
+                    "args": [
+                        {
+                            "kind": "sub",
+                            "args": [
+                                {"kind": "spot", "underlier": "_"},
+                                {"kind": "strike", "value": "_K"},
+                            ],
+                        },
+                        {"kind": "constant", "value": 0},
+                    ],
+                },
+                "exercise": {"style": "european"},
+            },
+            # 3. basket option clause
+            {
+                "payoff": {"kind": "basket_payoff"},
+                "exercise": {"style": "european"},
+                "underlying": {
+                    "kind": "linear_basket",
+                    "dynamics": "equity_diffusion",
+                },
+            },
+            # 4. OR-composed exercise style
+            {
+                "exercise": {
+                    "style": {
+                        "kind": "or",
+                        "patterns": [
+                            {"kind": "literal", "value": "european"},
+                            {"kind": "literal", "value": "bermudan"},
+                        ],
+                    },
+                },
+            },
+            # 5. NOT-composed exercise style
+            {
+                "exercise": {
+                    "style": {
+                        "kind": "not",
+                        "pattern": {"kind": "literal", "value": "american"},
+                    },
+                },
+            },
+            # 6. observation pattern
+            {"observation": {"kind": "terminal"}},
+            # 7. nested AND on the payoff (expressive stress)
+            {
+                "payoff": {
+                    "kind": "and",
+                    "patterns": [
+                        {"kind": "spot", "underlier": "_"},
+                        {"kind": "strike", "value": "_"},
+                    ],
+                },
+            },
+        ],
+    )
+    def test_parse_dump_parse_idempotent(self, payload):
+        first = parse_contract_pattern(payload)
+        dumped = dump_contract_pattern(first)
+        second = parse_contract_pattern(dumped)
+        assert first == second
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+class TestErrorPaths:
+    def test_payload_must_be_mapping(self):
+        with pytest.raises(ContractPatternParseError):
+            parse_contract_pattern([])  # type: ignore[arg-type]
+
+    def test_unknown_payoff_kind_raises_with_clear_message(self):
+        with pytest.raises(ContractPatternParseError) as excinfo:
+            parse_contract_pattern({"payoff": {"kind": "__bogus__"}})
+        assert "__bogus__" in str(excinfo.value)
+
+    def test_payoff_must_be_mapping_or_composite(self):
+        with pytest.raises(ContractPatternParseError):
+            parse_contract_pattern({"payoff": 42})  # type: ignore[dict-item]
+
+    def test_exercise_must_be_mapping(self):
+        with pytest.raises(ContractPatternParseError):
+            parse_contract_pattern({"exercise": "european"})  # type: ignore[dict-item]
+
+    def test_unknown_top_level_field_raises(self):
+        with pytest.raises(ContractPatternParseError) as excinfo:
+            parse_contract_pattern({"payoff": {"kind": "max", "args": []}, "wat": 1})
+        assert "wat" in str(excinfo.value)
+
+    def test_max_payoff_requires_args(self):
+        with pytest.raises(ContractPatternParseError):
+            parse_contract_pattern({"payoff": {"kind": "max"}})
+
+    def test_sub_payoff_requires_two_args(self):
+        with pytest.raises(ContractPatternParseError):
+            parse_contract_pattern(
+                {
+                    "payoff": {
+                        "kind": "sub",
+                        "args": [{"kind": "spot", "underlier": "_"}],
+                    }
+                }
+            )
+
+    def test_constant_requires_value_key(self):
+        with pytest.raises(ContractPatternParseError):
+            parse_contract_pattern({"payoff": {"kind": "constant"}})
+
+    def test_wildcard_name_must_be_string(self):
+        with pytest.raises(ContractPatternParseError):
+            parse_contract_pattern(
+                {"payoff": {"kind": "spot", "underlier": {"kind": "wildcard", "name": 5}}}
+            )
+
+
+class TestSchedulePattern:
+    def test_schedule_pattern_parses_frequency_only(self):
+        payload = {
+            "exercise": {
+                "style": "bermudan",
+                "schedule": {"frequency": "annual"},
+            },
+        }
+        pattern = parse_contract_pattern(payload)
+        assert pattern.exercise is not None
+        assert isinstance(pattern.exercise.schedule, SchedulePattern)
+        assert pattern.exercise.schedule.frequency == "annual"
+
+    def test_schedule_pattern_accepts_wildcard_frequency(self):
+        payload = {
+            "exercise": {
+                "style": "bermudan",
+                "schedule": {"frequency": "_"},
+            },
+        }
+        pattern = parse_contract_pattern(payload)
+        assert pattern.exercise is not None
+        assert isinstance(pattern.exercise.schedule, SchedulePattern)
+        assert isinstance(pattern.exercise.schedule.frequency, Wildcard)
+
+
+class TestTopLevelParser:
+    def test_parser_accepts_nested_under_contract_pattern_key(self):
+        payload = {
+            "contract_pattern": {
+                "exercise": {"style": "european"},
+            }
+        }
+        pattern = parse_contract_pattern(payload)
+        assert pattern.exercise is not None
+        assert pattern.exercise.style == "european"
+
+    def test_parse_payoff_pattern_shortcut(self):
+        pattern = parse_payoff_pattern(
+            {
+                "kind": "max",
+                "args": [
+                    {
+                        "kind": "sub",
+                        "args": [
+                            {"kind": "spot", "underlier": "_"},
+                            {"kind": "strike", "value": "_"},
+                        ],
+                    },
+                    {"kind": "constant", "value": 0},
+                ],
+            }
+        )
+        assert isinstance(pattern, PayoffPattern)
+        assert pattern.kind == "max"
+        assert len(pattern.args) == 2
+
+    def test_atom_pattern_literal(self):
+        # Underlying kind supplied as a plain literal string.
+        payload = {"underlying": {"kind": "equity_spot"}}
+        pattern = parse_contract_pattern(payload)
+        assert pattern.underlying is not None
+        assert pattern.underlying.kind == "equity_spot"
+
+    def test_atom_pattern_wrapped_atompattern(self):
+        # Atoms can also be written out via the {"kind": "atom", "value": ...}
+        # dict form for uniformity with the composite vocabulary.
+        payload = {
+            "underlying": {
+                "kind": {"kind": "literal", "value": "equity_spot"},
+            },
+        }
+        pattern = parse_contract_pattern(payload)
+        assert pattern.underlying is not None
+        assert isinstance(pattern.underlying.kind, AtomPattern)
+        assert pattern.underlying.kind.value == "equity_spot"

--- a/trellis/agent/contract_pattern.py
+++ b/trellis/agent/contract_pattern.py
@@ -1,0 +1,876 @@
+"""Contract pattern AST and parser (QUA-917 / Phase 1.5.A).
+
+This module introduces a pure pattern-matching substrate that mirrors the
+concrete contract vocabulary from :mod:`trellis.agent.dsl_algebra` one
+level up: it represents *patterns* over concrete contract terms rather
+than the concrete terms themselves.  A ``ContractPattern`` is therefore a
+shape that can match many different :class:`ProductIR` / contract
+instances, with explicit anonymous or named wildcards where structural
+freedom is desired.
+
+The slice is intentionally narrow:
+
+- types + frozen-dataclass AST only, so Phase 1 registry dispatch and
+  Phase 3 ``@solves_pattern`` decorators can share the vocabulary,
+- structured YAML parser (the form routes.yaml will eventually write),
+- round-trippable ``dump_contract_pattern`` so parse/serialize parity can
+  be tested today,
+- clear :class:`ContractPatternParseError` on malformed inputs rather than
+  silently building a wrong AST.
+
+Not in scope for QUA-917 (tracked separately):
+
+- evaluator against ``ProductIR`` — QUA-918,
+- conditional_primitives YAML schema integration — QUA-919,
+- string-expression parser (e.g. ``Payoff(Max(Sub(Spot(_), Strike(_))...``);
+  the structured YAML form is the priority surface because it is the form
+  ``routes.yaml`` will actually use.  Adding a string-form parser on top
+  of this AST is a follow-up.
+
+The AST reuses naming from :mod:`dsl_algebra` where that vocabulary
+already exists (``Spot``, ``Strike``, ``Max``, ``Sub`` etc.) rather than
+inventing parallel types.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence, Union
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class ContractPatternParseError(ValueError):
+    """Raised when a pattern payload does not describe a valid pattern.
+
+    The parser always surfaces a structural failure instead of producing a
+    silently-wrong AST.  Callers can catch this to report clean user-facing
+    diagnostics.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Leaf patterns
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Wildcard:
+    """Anonymous or named wildcard leaf.
+
+    ``name=None`` matches anything without capturing it.  A non-empty
+    ``name`` captures the matched sub-term under that binding identifier
+    when an evaluator runs (QUA-918).  At the AST level this slice only
+    stores the identifier.
+    """
+
+    name: str | None = None
+
+
+@dataclass(frozen=True)
+class AtomPattern:
+    """Match one concrete literal value.
+
+    Used for string tags (e.g. an exercise style of ``"european"``) and
+    numeric literals (e.g. a constant strike at ``0.0``) when the pattern
+    author wants to pin down a specific value rather than wildcard it.
+    """
+
+    value: Any
+
+
+# A field-level pattern is any of: a concrete literal atom, a wildcard, or
+# an AST-level composition that eventually resolves to one of those.
+FieldPattern = Union["Wildcard", "AtomPattern", "AndPattern", "OrPattern", "NotPattern"]
+
+
+# ---------------------------------------------------------------------------
+# Payoff-level patterns
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PayoffPattern:
+    """Shape of a payoff expression.
+
+    ``kind`` is the head tag (``max``, ``sub``, ``mul``, ``indicator``,
+    ``scaled``, ``basket_payoff``, ``swaption_payoff`` etc.) mirroring the
+    vocabulary of :mod:`dsl_algebra` and the pricing stack; ``args`` is the
+    tuple of sub-patterns to recurse into.  Leaf payoff shapes use
+    :class:`SpotPattern`, :class:`StrikePattern`, or :class:`ConstantPattern`.
+    """
+
+    kind: str
+    args: tuple["Pattern", ...] = ()
+
+
+@dataclass(frozen=True)
+class SpotPattern:
+    """Payoff leaf ``Spot(underlier)``."""
+
+    underlier: FieldPattern = Wildcard()
+
+
+@dataclass(frozen=True)
+class StrikePattern:
+    """Payoff leaf ``Strike(value)``."""
+
+    value: FieldPattern = Wildcard()
+
+
+@dataclass(frozen=True)
+class ConstantPattern:
+    """Payoff leaf ``Constant(value)``.
+
+    ``value`` may be a concrete numeric literal or a :class:`Wildcard` when
+    the pattern author wants to allow any constant.
+    """
+
+    value: Any
+
+
+# ---------------------------------------------------------------------------
+# Field-level helper patterns
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SchedulePattern:
+    """Shape of a schedule the exercise / observation references."""
+
+    frequency: FieldPattern | None = None
+
+
+@dataclass(frozen=True)
+class ExercisePattern:
+    """Match the exercise style (and optionally the exercise schedule)."""
+
+    style: FieldPattern
+    schedule: SchedulePattern | None = None
+
+
+@dataclass(frozen=True)
+class UnderlyingPattern:
+    """Match the underlying kind (and optionally its dynamics / process)."""
+
+    kind: FieldPattern
+    dynamics: FieldPattern | None = None
+
+
+@dataclass(frozen=True)
+class ObservationPattern:
+    """Match the observation kind (terminal / schedule / path-dependent)."""
+
+    kind: FieldPattern
+
+
+# ---------------------------------------------------------------------------
+# Composite patterns (AND / OR / NOT)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AndPattern:
+    """Conjunction — all sub-patterns must match."""
+
+    patterns: tuple["Pattern", ...]
+
+
+@dataclass(frozen=True)
+class OrPattern:
+    """Disjunction — any sub-pattern may match."""
+
+    patterns: tuple["Pattern", ...]
+
+
+@dataclass(frozen=True)
+class NotPattern:
+    """Negation — the sub-pattern must not match."""
+
+    pattern: "Pattern"
+
+
+# ---------------------------------------------------------------------------
+# Top-level contract pattern
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ContractPattern:
+    """Full pattern over a contract / ProductIR.
+
+    Each field is optional.  A missing field means "don't care about this
+    aspect," mirroring how ``ProductIR`` fields default in the knowledge
+    schema.  This lets a pattern say "payoff must be max(sub(spot, strike),
+    0) and I don't care about the exercise schedule" without having to
+    enumerate the whole space.
+    """
+
+    payoff: "PatternPayoffLike | None" = None
+    exercise: ExercisePattern | None = None
+    observation: ObservationPattern | None = None
+    underlying: UnderlyingPattern | None = None
+
+
+# Alias for the payoff-slot union to keep the top-level dataclass readable.
+PatternPayoffLike = Union[
+    PayoffPattern,
+    SpotPattern,
+    StrikePattern,
+    ConstantPattern,
+    AndPattern,
+    OrPattern,
+    NotPattern,
+]
+
+
+# Broadest alias used by composite traversal.
+Pattern = Union[
+    PayoffPattern,
+    SpotPattern,
+    StrikePattern,
+    ConstantPattern,
+    ExercisePattern,
+    UnderlyingPattern,
+    ObservationPattern,
+    SchedulePattern,
+    AndPattern,
+    OrPattern,
+    NotPattern,
+    Wildcard,
+    AtomPattern,
+    ContractPattern,
+]
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+
+_TOP_LEVEL_FIELDS = ("payoff", "exercise", "observation", "underlying")
+
+_PAYOFF_COMPOSITE_KINDS = {"and", "or", "not"}
+
+# Known payoff head tags.  The parser is strict: an unknown kind is an
+# error rather than being quietly preserved, because this slice is
+# explicitly about expressiveness parity with routes.yaml when-clauses.
+_PAYOFF_KINDS = {
+    "max",
+    "min",
+    "sum",
+    "sub",
+    "mul",
+    "scaled",
+    "indicator",
+    "constant",
+    "spot",
+    "strike",
+    "wildcard",
+    "literal",
+    "and",
+    "or",
+    "not",
+    # Instrument-level payoff head tags used by routes.yaml when-clauses.
+    # These are treated as opaque identifiers on a PayoffPattern with no
+    # args; the AST stays expressive enough to encode the existing
+    # analytical_black76 `payoff_family: swaption / basket_option` clauses.
+    "swaption_payoff",
+    "basket_payoff",
+    "variance_payoff",
+    "digital_payoff",
+    "barrier_payoff",
+    "vanilla_payoff",
+    "rate_payoff",
+    "lookback_payoff",
+    "asian_payoff",
+    "cliquet_payoff",
+    "chooser_payoff",
+    "compound_payoff",
+}
+
+
+def parse_contract_pattern(payload: Any) -> ContractPattern:
+    """Parse a structured YAML-style payload into a :class:`ContractPattern`.
+
+    The expected top-level shape is::
+
+        {
+          "payoff": <payoff pattern>,
+          "exercise": {"style": <field>, "schedule": {...}?},
+          "observation": {"kind": <field>},
+          "underlying": {"kind": <field>, "dynamics": <field>?},
+        }
+
+    For ergonomic embedding inside larger documents, a top-level
+    ``{"contract_pattern": {...}}`` wrapper is also accepted.
+
+    Raises :class:`ContractPatternParseError` on any structural problem.
+    """
+    if not isinstance(payload, Mapping):
+        raise ContractPatternParseError(
+            f"contract pattern payload must be a mapping, got {type(payload).__name__}"
+        )
+
+    # Accept the wrapped form routes.yaml will likely use.
+    if set(payload.keys()) == {"contract_pattern"}:
+        return parse_contract_pattern(payload["contract_pattern"])
+
+    unknown = [key for key in payload.keys() if key not in _TOP_LEVEL_FIELDS]
+    if unknown:
+        raise ContractPatternParseError(
+            "unknown contract pattern field(s): "
+            + ", ".join(repr(key) for key in unknown)
+        )
+
+    payoff = _parse_payoff_slot(payload.get("payoff"))
+    exercise = _parse_exercise(payload.get("exercise"))
+    observation = _parse_observation(payload.get("observation"))
+    underlying = _parse_underlying(payload.get("underlying"))
+
+    return ContractPattern(
+        payoff=payoff,
+        exercise=exercise,
+        observation=observation,
+        underlying=underlying,
+    )
+
+
+def parse_payoff_pattern(payload: Any) -> Pattern:
+    """Shortcut: parse a single payoff expression in isolation."""
+    if payload is None:
+        raise ContractPatternParseError("payoff payload must not be None")
+    return _parse_payoff_node(payload)
+
+
+# ---------------------------------------------------------------------------
+# Per-slot parsers
+# ---------------------------------------------------------------------------
+
+
+def _parse_payoff_slot(node: Any) -> PatternPayoffLike | None:
+    if node is None:
+        return None
+    if not isinstance(node, Mapping):
+        raise ContractPatternParseError(
+            f"'payoff' must be a mapping, got {type(node).__name__}"
+        )
+    result = _parse_payoff_node(node)
+    if isinstance(
+        result,
+        (PayoffPattern, SpotPattern, StrikePattern, ConstantPattern, AndPattern, OrPattern, NotPattern),
+    ):
+        return result
+    raise ContractPatternParseError(
+        "'payoff' must resolve to a payoff pattern, not a leaf wildcard/literal"
+    )
+
+
+def _parse_exercise(node: Any) -> ExercisePattern | None:
+    if node is None:
+        return None
+    if not isinstance(node, Mapping):
+        raise ContractPatternParseError(
+            f"'exercise' must be a mapping, got {type(node).__name__}"
+        )
+    unknown = [key for key in node.keys() if key not in {"style", "schedule"}]
+    if unknown:
+        raise ContractPatternParseError(
+            "unknown 'exercise' field(s): " + ", ".join(repr(k) for k in unknown)
+        )
+    if "style" not in node:
+        raise ContractPatternParseError("'exercise' requires a 'style' field")
+    style = _parse_field_pattern(node["style"])
+    schedule_payload = node.get("schedule")
+    schedule = _parse_schedule(schedule_payload) if schedule_payload is not None else None
+    return ExercisePattern(style=style, schedule=schedule)
+
+
+def _parse_observation(node: Any) -> ObservationPattern | None:
+    if node is None:
+        return None
+    if not isinstance(node, Mapping):
+        raise ContractPatternParseError(
+            f"'observation' must be a mapping, got {type(node).__name__}"
+        )
+    unknown = [key for key in node.keys() if key not in {"kind"}]
+    if unknown:
+        raise ContractPatternParseError(
+            "unknown 'observation' field(s): " + ", ".join(repr(k) for k in unknown)
+        )
+    if "kind" not in node:
+        raise ContractPatternParseError("'observation' requires a 'kind' field")
+    return ObservationPattern(kind=_parse_field_pattern(node["kind"]))
+
+
+def _parse_underlying(node: Any) -> UnderlyingPattern | None:
+    if node is None:
+        return None
+    if not isinstance(node, Mapping):
+        raise ContractPatternParseError(
+            f"'underlying' must be a mapping, got {type(node).__name__}"
+        )
+    unknown = [key for key in node.keys() if key not in {"kind", "dynamics"}]
+    if unknown:
+        raise ContractPatternParseError(
+            "unknown 'underlying' field(s): " + ", ".join(repr(k) for k in unknown)
+        )
+    if "kind" not in node:
+        raise ContractPatternParseError("'underlying' requires a 'kind' field")
+    kind = _parse_field_pattern(node["kind"])
+    dynamics_payload = node.get("dynamics")
+    dynamics = _parse_field_pattern(dynamics_payload) if dynamics_payload is not None else None
+    return UnderlyingPattern(kind=kind, dynamics=dynamics)
+
+
+def _parse_schedule(node: Any) -> SchedulePattern:
+    if not isinstance(node, Mapping):
+        raise ContractPatternParseError(
+            f"'schedule' must be a mapping, got {type(node).__name__}"
+        )
+    unknown = [key for key in node.keys() if key not in {"frequency"}]
+    if unknown:
+        raise ContractPatternParseError(
+            "unknown 'schedule' field(s): " + ", ".join(repr(k) for k in unknown)
+        )
+    frequency = None
+    if "frequency" in node:
+        frequency = _parse_field_pattern(node["frequency"])
+    return SchedulePattern(frequency=frequency)
+
+
+# ---------------------------------------------------------------------------
+# Field-level parsing (atoms, wildcards, composites)
+# ---------------------------------------------------------------------------
+
+
+def _parse_field_pattern(payload: Any) -> FieldPattern:
+    """Parse a field-level pattern (atom, wildcard, or composite)."""
+    if isinstance(payload, Wildcard):
+        return payload
+    if isinstance(payload, AtomPattern):
+        return payload
+    if isinstance(payload, (AndPattern, OrPattern, NotPattern)):
+        return payload
+
+    if isinstance(payload, str):
+        return _parse_string_shorthand(payload, atom_factory=lambda v: v)
+    if isinstance(payload, (int, float, bool)) or payload is None:
+        return AtomPattern(value=payload)
+
+    if isinstance(payload, Mapping):
+        return _parse_mapping_as_field(payload)
+
+    raise ContractPatternParseError(
+        f"field pattern must be str/number/mapping, got {type(payload).__name__}"
+    )
+
+
+def _parse_string_shorthand(raw: str, *, atom_factory) -> FieldPattern:
+    """Interpret a bare string: wildcard shorthand vs literal atom."""
+    if raw == "_":
+        return Wildcard()
+    if raw.startswith("_") and len(raw) > 1:
+        name = raw[1:]
+        return Wildcard(name=name)
+    # Plain literal — wrap as atom so evaluator can distinguish from
+    # wildcard when comparing.  The atom_factory lets callers decide
+    # whether to unwrap on the top-level fast path (e.g. exercise.style
+    # stored as a raw string for ergonomic comparisons).
+    return atom_factory(raw) if callable(atom_factory) else AtomPattern(value=raw)
+
+
+def _parse_mapping_as_field(payload: Mapping[str, Any]) -> FieldPattern:
+    """Parse a mapping payload into a field-level pattern."""
+    if "kind" not in payload:
+        raise ContractPatternParseError(
+            "field pattern mapping is missing required 'kind' key"
+        )
+    kind = payload["kind"]
+    if not isinstance(kind, str):
+        raise ContractPatternParseError(
+            f"field pattern 'kind' must be a string, got {type(kind).__name__}"
+        )
+
+    if kind == "wildcard":
+        return _parse_wildcard_mapping(payload)
+    if kind == "literal":
+        if "value" not in payload:
+            raise ContractPatternParseError("'literal' requires a 'value' field")
+        return AtomPattern(value=payload["value"])
+    if kind == "and":
+        return AndPattern(
+            patterns=_parse_composite_children(
+                payload, multi_key="patterns", kind_label="and", min_children=1
+            )
+        )
+    if kind == "or":
+        return OrPattern(
+            patterns=_parse_composite_children(
+                payload, multi_key="patterns", kind_label="or", min_children=1
+            )
+        )
+    if kind == "not":
+        if "pattern" not in payload:
+            raise ContractPatternParseError("'not' requires a 'pattern' field")
+        child = _parse_field_pattern(payload["pattern"])
+        return NotPattern(pattern=child)
+
+    raise ContractPatternParseError(
+        f"unknown field pattern kind {kind!r}"
+    )
+
+
+def _parse_wildcard_mapping(payload: Mapping[str, Any]) -> Wildcard:
+    unknown = [key for key in payload.keys() if key not in {"kind", "name"}]
+    if unknown:
+        raise ContractPatternParseError(
+            "unknown 'wildcard' field(s): " + ", ".join(repr(k) for k in unknown)
+        )
+    name = payload.get("name")
+    if name is None:
+        return Wildcard()
+    if not isinstance(name, str):
+        raise ContractPatternParseError(
+            f"wildcard 'name' must be a string, got {type(name).__name__}"
+        )
+    return Wildcard(name=name)
+
+
+def _parse_composite_children(
+    payload: Mapping[str, Any],
+    *,
+    multi_key: str,
+    kind_label: str,
+    min_children: int,
+) -> tuple[Pattern, ...]:
+    if multi_key not in payload:
+        raise ContractPatternParseError(
+            f"{kind_label!r} requires a {multi_key!r} field"
+        )
+    raw_children = payload[multi_key]
+    if not isinstance(raw_children, Sequence) or isinstance(raw_children, (str, bytes)):
+        raise ContractPatternParseError(
+            f"{kind_label!r} {multi_key!r} must be a sequence"
+        )
+    if len(raw_children) < min_children:
+        raise ContractPatternParseError(
+            f"{kind_label!r} requires at least {min_children} child pattern(s)"
+        )
+    children = tuple(_parse_payoff_node(child) for child in raw_children)
+    return children
+
+
+# ---------------------------------------------------------------------------
+# Payoff-node parsing
+# ---------------------------------------------------------------------------
+
+
+def _parse_payoff_node(payload: Any) -> Pattern:
+    """Parse a payoff-context node.
+
+    This is the workhorse used for the ``payoff`` slot, for ``args`` of
+    head-tagged payoffs, and for the children of ``and`` / ``or`` / ``not``
+    composites.
+    """
+    if isinstance(payload, (PayoffPattern, SpotPattern, StrikePattern, ConstantPattern)):
+        return payload
+    if isinstance(payload, (AndPattern, OrPattern, NotPattern)):
+        return payload
+    if isinstance(payload, (Wildcard, AtomPattern)):
+        return payload
+
+    if isinstance(payload, str):
+        # In payoff contexts a bare string is either an underscore-wildcard
+        # or an opaque literal atom.  Literals show up mainly as observation
+        # tags or exercise-style leaves reused inside OR/NOT composites.
+        if payload == "_":
+            return Wildcard()
+        if payload.startswith("_") and len(payload) > 1:
+            return Wildcard(name=payload[1:])
+        return AtomPattern(value=payload)
+
+    if isinstance(payload, (int, float, bool)) or payload is None:
+        return AtomPattern(value=payload)
+
+    if not isinstance(payload, Mapping):
+        raise ContractPatternParseError(
+            f"payoff node must be str/number/mapping, got {type(payload).__name__}"
+        )
+    if "kind" not in payload:
+        raise ContractPatternParseError(
+            "payoff node mapping is missing required 'kind' key"
+        )
+
+    kind = payload["kind"]
+    if not isinstance(kind, str):
+        raise ContractPatternParseError(
+            f"payoff node 'kind' must be a string, got {type(kind).__name__}"
+        )
+
+    if kind == "wildcard":
+        return _parse_wildcard_mapping(payload)
+    if kind == "literal":
+        if "value" not in payload:
+            raise ContractPatternParseError("'literal' requires a 'value' field")
+        return AtomPattern(value=payload["value"])
+    if kind == "and":
+        return AndPattern(
+            patterns=_parse_composite_children(
+                payload, multi_key="patterns", kind_label="and", min_children=1
+            )
+        )
+    if kind == "or":
+        return OrPattern(
+            patterns=_parse_composite_children(
+                payload, multi_key="patterns", kind_label="or", min_children=1
+            )
+        )
+    if kind == "not":
+        if "pattern" not in payload:
+            raise ContractPatternParseError("'not' requires a 'pattern' field")
+        return NotPattern(pattern=_parse_payoff_node(payload["pattern"]))
+    if kind == "spot":
+        underlier_payload = payload.get("underlier", "_")
+        return SpotPattern(underlier=_parse_field_pattern(underlier_payload))
+    if kind == "strike":
+        value_payload = payload.get("value", "_")
+        return StrikePattern(value=_parse_field_pattern(value_payload))
+    if kind == "constant":
+        if "value" not in payload:
+            raise ContractPatternParseError("'constant' requires a 'value' field")
+        value = payload["value"]
+        if isinstance(value, Mapping) or (isinstance(value, str) and value.startswith("_")):
+            wrapped = _parse_field_pattern(value)
+            return ConstantPattern(value=wrapped)
+        if isinstance(value, (int, float)):
+            return ConstantPattern(value=float(value))
+        if isinstance(value, str):
+            return ConstantPattern(value=value)
+        raise ContractPatternParseError(
+            f"'constant' value must be a number, string, or wildcard mapping, "
+            f"got {type(value).__name__}"
+        )
+
+    if kind in _PAYOFF_KINDS:
+        # A head-tagged PayoffPattern.  ``args`` is required for head tags
+        # with known arity (``max``, ``min``, ``sum``, ``sub``, ``mul``,
+        # ``scaled``, ``indicator``); instrument-level payoff family tags
+        # (``basket_payoff`` etc.) may legitimately omit ``args``.
+        args_payload = payload.get("args")
+        if args_payload is None:
+            _require_args_optional(kind)
+            return PayoffPattern(kind=kind, args=())
+        if not isinstance(args_payload, Sequence) or isinstance(args_payload, (str, bytes)):
+            raise ContractPatternParseError(
+                f"payoff node 'args' must be a sequence for kind {kind!r}"
+            )
+        args = tuple(_parse_payoff_node(child) for child in args_payload)
+        _validate_arity(kind, args)
+        return PayoffPattern(kind=kind, args=args)
+
+    raise ContractPatternParseError(f"unknown payoff node kind {kind!r}")
+
+
+_ARITY_TABLE: dict[str, int | None] = {
+    # Arity-exact head tags.
+    "sub": 2,
+    "mul": 2,
+    "scaled": 2,
+    "indicator": 1,
+    # Variadic (>=1) head tags — we accept any non-zero arity.
+    "max": None,
+    "min": None,
+    "sum": None,
+    # Instrument-level payoff tags have no structural sub-args requirement.
+    "swaption_payoff": 0,
+    "basket_payoff": 0,
+    "variance_payoff": 0,
+    "digital_payoff": 0,
+    "barrier_payoff": 0,
+    "vanilla_payoff": 0,
+    "rate_payoff": 0,
+    "lookback_payoff": 0,
+    "asian_payoff": 0,
+    "cliquet_payoff": 0,
+    "chooser_payoff": 0,
+    "compound_payoff": 0,
+}
+
+
+def _validate_arity(kind: str, args: tuple[Pattern, ...]) -> None:
+    expected = _ARITY_TABLE.get(kind)
+    if expected is None:
+        # Variadic — require at least one child.
+        if kind in {"max", "min", "sum"} and len(args) < 1:
+            raise ContractPatternParseError(
+                f"payoff node {kind!r} requires at least one 'args' entry"
+            )
+        return
+    if expected == 0:
+        # Instrument-level tags accept either zero args or none; nothing to check.
+        return
+    if len(args) != expected:
+        raise ContractPatternParseError(
+            f"payoff node {kind!r} requires exactly {expected} 'args' entries, got {len(args)}"
+        )
+
+
+def _require_args_optional(kind: str) -> None:
+    """Ensure missing ``args`` is only legal for instrument-level head tags."""
+    expected = _ARITY_TABLE.get(kind)
+    if expected is None:
+        raise ContractPatternParseError(
+            f"payoff node {kind!r} requires an 'args' list"
+        )
+    if expected == 0:
+        return
+    raise ContractPatternParseError(
+        f"payoff node {kind!r} requires an 'args' list"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Serializer (dump)
+# ---------------------------------------------------------------------------
+
+
+def dump_contract_pattern(pattern: ContractPattern) -> dict[str, Any]:
+    """Serialize a :class:`ContractPattern` back to a YAML-friendly mapping.
+
+    The result round-trips through :func:`parse_contract_pattern` — this is
+    how QUA-917's parse/dump parity is tested.
+    """
+    if not isinstance(pattern, ContractPattern):
+        raise TypeError(
+            f"dump_contract_pattern expects ContractPattern, got {type(pattern).__name__}"
+        )
+    out: dict[str, Any] = {}
+    if pattern.payoff is not None:
+        out["payoff"] = _dump_pattern(pattern.payoff)
+    if pattern.exercise is not None:
+        out["exercise"] = _dump_exercise(pattern.exercise)
+    if pattern.observation is not None:
+        out["observation"] = _dump_observation(pattern.observation)
+    if pattern.underlying is not None:
+        out["underlying"] = _dump_underlying(pattern.underlying)
+    return out
+
+
+def _dump_exercise(node: ExercisePattern) -> dict[str, Any]:
+    out: dict[str, Any] = {"style": _dump_field(node.style)}
+    if node.schedule is not None:
+        out["schedule"] = _dump_schedule(node.schedule)
+    return out
+
+
+def _dump_observation(node: ObservationPattern) -> dict[str, Any]:
+    return {"kind": _dump_field(node.kind)}
+
+
+def _dump_underlying(node: UnderlyingPattern) -> dict[str, Any]:
+    out: dict[str, Any] = {"kind": _dump_field(node.kind)}
+    if node.dynamics is not None:
+        out["dynamics"] = _dump_field(node.dynamics)
+    return out
+
+
+def _dump_schedule(node: SchedulePattern) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    if node.frequency is not None:
+        out["frequency"] = _dump_field(node.frequency)
+    return out
+
+
+def _dump_field(node: Any) -> Any:
+    """Serialize a field-level pattern back to its YAML-friendly form."""
+    if isinstance(node, Wildcard):
+        return {"kind": "wildcard", "name": node.name} if node.name else "_"
+    if isinstance(node, AtomPattern):
+        # Always serialize explicit atoms via the {"kind": "literal", ...}
+        # form so the parser does not re-interpret a bare underscore-prefixed
+        # string as wildcard shorthand on reparse.
+        return {"kind": "literal", "value": node.value}
+    if isinstance(node, AndPattern):
+        return {
+            "kind": "and",
+            "patterns": [_dump_pattern(child) for child in node.patterns],
+        }
+    if isinstance(node, OrPattern):
+        return {
+            "kind": "or",
+            "patterns": [_dump_pattern(child) for child in node.patterns],
+        }
+    if isinstance(node, NotPattern):
+        return {"kind": "not", "pattern": _dump_pattern(node.pattern)}
+    if isinstance(node, str):
+        # A field sometimes carries a bare string (e.g. exercise style)
+        # when the caller constructed it directly with a literal rather than
+        # an AtomPattern.  Serialize it as-is so downstream ergonomic
+        # comparisons (``pattern.exercise.style == "european"``) continue to
+        # work, and so that underscore-prefixed strings round-trip back
+        # through the wildcard shorthand.
+        return node
+    if isinstance(node, (int, float, bool)) or node is None:
+        return {"kind": "literal", "value": node}
+    raise TypeError(
+        f"cannot serialize field-level pattern of type {type(node).__name__}"
+    )
+
+
+def _dump_pattern(node: Any) -> Any:
+    """Serialize a payoff-context pattern."""
+    if isinstance(node, PayoffPattern):
+        out: dict[str, Any] = {"kind": node.kind}
+        if node.args:
+            out["args"] = [_dump_pattern(child) for child in node.args]
+        return out
+    if isinstance(node, SpotPattern):
+        return {"kind": "spot", "underlier": _dump_field(node.underlier)}
+    if isinstance(node, StrikePattern):
+        return {"kind": "strike", "value": _dump_field(node.value)}
+    if isinstance(node, ConstantPattern):
+        value = node.value
+        if isinstance(value, Wildcard):
+            return {"kind": "constant", "value": _dump_field(value)}
+        return {"kind": "constant", "value": value}
+    if isinstance(node, (AndPattern, OrPattern, NotPattern)):
+        return _dump_field(node)
+    if isinstance(node, (Wildcard, AtomPattern)):
+        return _dump_field(node)
+    raise TypeError(
+        f"cannot serialize payoff-context pattern of type {type(node).__name__}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public re-exports
+# ---------------------------------------------------------------------------
+
+
+__all__ = [
+    "AndPattern",
+    "AtomPattern",
+    "ConstantPattern",
+    "ContractPattern",
+    "ContractPatternParseError",
+    "ExercisePattern",
+    "FieldPattern",
+    "NotPattern",
+    "ObservationPattern",
+    "OrPattern",
+    "Pattern",
+    "PatternPayoffLike",
+    "PayoffPattern",
+    "SchedulePattern",
+    "SpotPattern",
+    "StrikePattern",
+    "UnderlyingPattern",
+    "Wildcard",
+    "dump_contract_pattern",
+    "parse_contract_pattern",
+    "parse_payoff_pattern",
+]


### PR DESCRIPTION
## Summary

Phase 1.5.A of QUA-887 — Contract IR compiler retiring the route registry.

Lands the foundation types for DSL-pattern expressions that will replace string-tag filters in `conditional_primitives.when`. Phase 1 route rewrites (QUA-910+) and Phase 3 `@solves_pattern` decorators will share this AST.

## What this ships

- **New module** `trellis/agent/contract_pattern.py` (876 lines) — `ContractPattern` sum type, parser, serializer, `ContractPatternParseError`.
- **Tests** `tests/test_agent/test_contract_pattern.py` (503 lines) — 44 tests covering round-trip, wildcards, composition, canonical `analytical_black76` patterns (vanilla / basket / swaption-bermudan / swaption-european), error paths.

## What this is NOT

- Not a pattern evaluator — that's QUA-918 (P1.5.B), blocked on this.
- Not wired into `conditional_primitives.when` — that's QUA-919 (P1.5.C).
- Not migrating existing when-clauses — that's QUA-920 (P1.5.D).

## Key design decisions

1. **Prioritized structured YAML form.** `routes.yaml` is the primary consumer, so the YAML-dict form is fully supported. String-expression form (`Payoff(Max(Sub(Spot(_), Strike(_)), Constant(0)))`) is deferred as a follow-up — the AST is shaped so a string parser can be added without schema changes.

2. **Reused `dsl_algebra` vocabulary.** `Spot`, `Strike`, `Max`, `Sub`, `Constant` are preserved as head-tag names rather than inventing parallel types.

3. **Top-level shape** — `ContractPattern(payoff, exercise, observation, underlying)` with each field optional (missing = don't care). Composition (`AndPattern` / `OrPattern` / `NotPattern`) is valid at both payoff and field level.

4. **Wildcard ergonomics** — bare `\"_\"` → anonymous `Wildcard()`, `\"_K\"` → named `Wildcard(name=\"K\")`, and the verbose `{\"kind\": \"wildcard\", \"name\": \"K\"}` is also accepted.

5. **Strict validation** — unknown top-level keys, unknown `kind` tags, missing required fields, and wrong types all raise `ContractPatternParseError`. No silent wrong ASTs.

6. **Round-trippable serializer** — `dump_contract_pattern()` writes back to a canonical YAML-friendly dict that re-parses to an equal AST.

## Forward-compat notes for downstream tickets

- `UnderlyingPattern.kind` / `ExercisePattern.style` accept both bare strings (`\"european\"`) and `AtomPattern` wrappers. **QUA-918's evaluator will need to handle both** when matching. **QUA-920 should prefer the bare-string form** in `routes.yaml` for readability.
- `ExercisePattern.schedule: SchedulePattern | None` carries only a `frequency` field today. Extend with dates/tenor constraints when real schedule-dependent patterns appear.
- Instrument-level payoff tags (`basket_payoff`, `swaption_payoff`, `variance_payoff`) are accepted as zero-arity `PayoffPattern(kind=...)` values. **QUA-918's evaluator will need a mapping from `ProductIR.payoff_family` to these tags**, or QUA-920 can write the structural payoff AST directly (the AST already supports it).
- `Indicator`, `Scaled`, `Mul` are registered in the arity table for downstream use but no fixture exercises them yet. QUA-918 may want to add fixtures.

## Test plan

- [x] `pytest tests/test_agent/test_contract_pattern.py -q` → 44/44 passed
- [x] `pytest tests/test_agent -q` → 1941 passed, 5 deselected (full agent suite green)

## Closes

Closes QUA-917.

🤖 Generated with [Claude Code](https://claude.com/claude-code)