### PR TITLE
agent: DSL contract-pattern schema for conditional_primitives (QUA-919, Phase 1.5.C)

### DIFF
--- a/tests/test_agent/test_route_registry_dsl_when.py
+++ b/tests/test_agent/test_route_registry_dsl_when.py
@@ -1,0 +1,506 @@
+"""DSL-form `conditional_primitives.when` schema tests (QUA-919 / Phase 1.5.C).
+
+These tests lock in the two-form ``when``-clause dispatch contract that the
+route registry exposes after QUA-919:
+
+1. **Legacy string-tag filter form** — a mapping of trait keys (``payoff_family``,
+   ``exercise_style``, ``model_family``, ``schedule_dependence``) to literal or
+   list expectations.  Dispatch goes through ``_matches_condition`` exactly as
+   before QUA-919; every existing ``routes.yaml`` clause keeps this shape.
+2. **DSL ``contract_pattern`` form** — a mapping with a single
+   ``contract_pattern`` key whose value is a structured pattern payload
+   consumable by :func:`trellis.agent.contract_pattern.parse_contract_pattern`
+   and evaluable by
+   :func:`trellis.agent.contract_pattern_eval.evaluate_pattern`.
+
+The parser must decide which form a clause uses at parse time, and dispatch
+must then route legacy clauses through ``_matches_condition`` and DSL clauses
+through ``evaluate_pattern``.  Mixed-form clauses (both ``contract_pattern``
+and legacy trait keys in the same ``when:``) are a parse error.
+
+Forward-compat: QUA-920 migrates ``analytical_black76``'s existing four
+``conditional_primitives.when`` clauses to this DSL form without changing
+behaviour.  The tests below assert that the migrated shape (``payoff + exercise
++ underlying`` patterns) dispatches identically to today's string-tag form.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from trellis.agent.codegen_guardrails import PrimitiveRef
+from trellis.agent.contract_pattern import ContractPattern, parse_contract_pattern
+from trellis.agent.knowledge.schema import ProductIR
+from trellis.agent.route_registry import (
+    ConditionalPrimitive,
+    RouteRegistry,
+    RouteSpec,
+    _parse_conditional_primitives,
+    _parse_route,
+    load_route_registry,
+    resolve_route_adapters,
+    resolve_route_notes,
+    resolve_route_primitives,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_route_spec(
+    *,
+    route_id: str,
+    conditional_primitives: tuple,
+    base_primitives: tuple = (),
+    base_adapters: tuple = (),
+    base_notes: tuple = (),
+) -> RouteSpec:
+    """Build a minimal synthetic RouteSpec around a conditional_primitives tuple."""
+    return RouteSpec(
+        id=route_id,
+        engine_family="analytical",
+        route_family="analytical",
+        status="promoted",
+        confidence=1.0,
+        match_methods=("analytical",),
+        match_instruments=None,
+        exclude_instruments=(),
+        match_exercise=None,
+        exclude_exercise=(),
+        match_payoff_family=None,
+        match_payoff_traits=None,
+        match_required_market_data=None,
+        exclude_required_market_data=None,
+        primitives=base_primitives,
+        conditional_primitives=conditional_primitives,
+        conditional_route_family=None,
+        adapters=base_adapters,
+        notes=base_notes,
+    )
+
+
+def _vanilla_ir() -> ProductIR:
+    return ProductIR(
+        instrument="vanilla_call",
+        payoff_family="vanilla_option",
+        payoff_traits=("vanilla_option",),
+        exercise_style="european",
+        state_dependence="terminal_markov",
+        schedule_dependence=False,
+        model_family="equity_diffusion",
+        candidate_engine_families=("analytical",),
+    )
+
+
+def _basket_ir() -> ProductIR:
+    return ProductIR(
+        instrument="basket_option",
+        payoff_family="basket_option",
+        payoff_traits=("basket_payoff",),
+        exercise_style="european",
+        state_dependence="terminal_markov",
+        schedule_dependence=False,
+        model_family="equity_diffusion",
+        candidate_engine_families=("analytical",),
+    )
+
+
+def _swaption_european_ir() -> ProductIR:
+    return ProductIR(
+        instrument="swaption",
+        payoff_family="swaption",
+        exercise_style="european",
+        state_dependence="terminal_markov",
+        schedule_dependence=False,
+        model_family="rate_style",
+        candidate_engine_families=("analytical",),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Round-trip parsing
+# ---------------------------------------------------------------------------
+
+
+class TestDSLWhenClauseParsing:
+    """YAML round-trip: a DSL-form clause parses into a ConditionalPrimitive
+    whose ``when`` is empty and whose ``contract_pattern`` is populated."""
+
+    def test_parses_contract_pattern_into_new_field(self):
+        raw = [
+            {
+                "when": {
+                    "contract_pattern": {
+                        "payoff": {"kind": "vanilla_payoff"},
+                    },
+                },
+                "primitives": [
+                    {
+                        "module": "trellis.models.black",
+                        "symbol": "black76_call",
+                        "role": "pricing_kernel",
+                    },
+                ],
+            },
+        ]
+        parsed = _parse_conditional_primitives(raw)
+        assert len(parsed) == 1
+        cp = parsed[0]
+        assert isinstance(cp, ConditionalPrimitive)
+        assert cp.when == {}
+        assert isinstance(cp.contract_pattern, ContractPattern)
+        assert cp.contract_pattern.payoff is not None
+        assert cp.primitives[0].symbol == "black76_call"
+
+    def test_legacy_string_tag_form_leaves_contract_pattern_none(self):
+        raw = [
+            {
+                "when": {
+                    "payoff_family": "vanilla_option",
+                    "exercise_style": ["european"],
+                },
+                "primitives": [
+                    {
+                        "module": "trellis.models.black",
+                        "symbol": "black76_call",
+                        "role": "pricing_kernel",
+                    },
+                ],
+            },
+        ]
+        parsed = _parse_conditional_primitives(raw)
+        assert len(parsed) == 1
+        cp = parsed[0]
+        assert cp.contract_pattern is None
+        assert cp.when == {
+            "payoff_family": "vanilla_option",
+            "exercise_style": ["european"],
+        }
+
+    def test_default_sentinel_leaves_contract_pattern_none(self):
+        raw = [
+            {
+                "when": "default",
+                "primitives": [],
+            },
+        ]
+        parsed = _parse_conditional_primitives(raw)
+        assert len(parsed) == 1
+        assert parsed[0].when == "default"
+        assert parsed[0].contract_pattern is None
+
+    def test_dsl_form_routes_through_parse_route_wrapper(self):
+        """A full route payload with a DSL when-clause parses end-to-end."""
+        raw_route = {
+            "id": "synthetic_dsl_route",
+            "engine_family": "analytical",
+            "match": {"methods": ["analytical"]},
+            "primitives": [],
+            "conditional_primitives": [
+                {
+                    "when": {
+                        "contract_pattern": {
+                            "payoff": {"kind": "vanilla_payoff"},
+                        },
+                    },
+                    "primitives": [
+                        {
+                            "module": "trellis.models.black",
+                            "symbol": "black76_call",
+                            "role": "pricing_kernel",
+                        },
+                    ],
+                },
+            ],
+        }
+        spec = _parse_route(raw_route)
+        assert spec.id == "synthetic_dsl_route"
+        assert len(spec.conditional_primitives) == 1
+        cp = spec.conditional_primitives[0]
+        assert cp.when == {}
+        assert isinstance(cp.contract_pattern, ContractPattern)
+
+
+# ---------------------------------------------------------------------------
+# 2. Dispatch (DSL-only route)
+# ---------------------------------------------------------------------------
+
+
+class TestDSLDispatch:
+    """``resolve_route_primitives`` routes DSL-form clauses through the
+    evaluator and returns the clause's primitives on a pattern match."""
+
+    def test_dsl_clause_matches_vanilla_ir_returns_clause_primitives(self, monkeypatch):
+        # Disable the backend-binding short-circuit so the conditional branch
+        # is actually exercised.
+        from trellis.agent import backend_bindings as backend_bindings_module
+
+        monkeypatch.setattr(
+            backend_bindings_module,
+            "resolve_backend_binding_by_route_id",
+            lambda *args, **kwargs: None,
+        )
+
+        expected_prim = PrimitiveRef(
+            module="trellis.models.black",
+            symbol="black76_call",
+            role="pricing_kernel",
+        )
+        dsl_clause = ConditionalPrimitive(
+            when={},
+            contract_pattern=parse_contract_pattern(
+                {"payoff": {"kind": "vanilla_payoff"}}
+            ),
+            primitives=(expected_prim,),
+        )
+        spec = _make_route_spec(
+            route_id="synthetic_dsl_vanilla",
+            conditional_primitives=(dsl_clause,),
+        )
+        resolved = resolve_route_primitives(spec, _vanilla_ir())
+        assert resolved == (expected_prim,)
+
+    def test_dsl_clause_does_not_match_non_vanilla_falls_through(self, monkeypatch):
+        from trellis.agent import backend_bindings as backend_bindings_module
+
+        monkeypatch.setattr(
+            backend_bindings_module,
+            "resolve_backend_binding_by_route_id",
+            lambda *args, **kwargs: None,
+        )
+
+        base_prim = PrimitiveRef(
+            module="trellis.models.black",
+            symbol="black76_call",
+            role="pricing_kernel",
+        )
+        clause_prim = PrimitiveRef(
+            module="trellis.models.black",
+            symbol="black76_basket",
+            role="pricing_kernel",
+        )
+        dsl_clause = ConditionalPrimitive(
+            when={},
+            contract_pattern=parse_contract_pattern(
+                {"payoff": {"kind": "basket_payoff"}}
+            ),
+            primitives=(clause_prim,),
+        )
+        spec = _make_route_spec(
+            route_id="synthetic_dsl_basket",
+            conditional_primitives=(dsl_clause,),
+            base_primitives=(base_prim,),
+        )
+        # A vanilla IR should NOT match the basket DSL pattern, so resolution
+        # falls through to the base primitives.
+        resolved = resolve_route_primitives(spec, _vanilla_ir())
+        assert resolved == (base_prim,)
+
+    def test_dsl_clause_adapters_and_notes_propagate(self, monkeypatch):
+        from trellis.agent import backend_bindings as backend_bindings_module
+
+        monkeypatch.setattr(
+            backend_bindings_module,
+            "resolve_backend_binding_by_route_id",
+            lambda *args, **kwargs: None,
+        )
+
+        dsl_clause = ConditionalPrimitive(
+            when={},
+            contract_pattern=parse_contract_pattern(
+                {"payoff": {"kind": "vanilla_payoff"}}
+            ),
+            primitives=(
+                PrimitiveRef(
+                    module="trellis.models.black",
+                    symbol="black76_call",
+                    role="pricing_kernel",
+                ),
+            ),
+            adapters=("vanilla_adapter",),
+            notes=("use vanilla kernel",),
+        )
+        spec = _make_route_spec(
+            route_id="synthetic_dsl_adapters",
+            conditional_primitives=(dsl_clause,),
+            base_adapters=("base_adapter",),
+            base_notes=("base note",),
+        )
+        assert resolve_route_adapters(spec, _vanilla_ir()) == ("vanilla_adapter",)
+        assert resolve_route_notes(spec, _vanilla_ir()) == ("use vanilla kernel",)
+
+
+# ---------------------------------------------------------------------------
+# 3. Mixed-mode (DSL + legacy clauses in the same route)
+# ---------------------------------------------------------------------------
+
+
+class TestMixedModeDispatch:
+    """A single route can carry both legacy and DSL clauses; each dispatches
+    correctly against its target ProductIR."""
+
+    def test_dsl_then_legacy_default_tail(self, monkeypatch):
+        from trellis.agent import backend_bindings as backend_bindings_module
+
+        monkeypatch.setattr(
+            backend_bindings_module,
+            "resolve_backend_binding_by_route_id",
+            lambda *args, **kwargs: None,
+        )
+
+        vanilla_prim = PrimitiveRef(
+            module="trellis.models.black",
+            symbol="black76_call",
+            role="pricing_kernel",
+        )
+        default_prim = PrimitiveRef(
+            module="trellis.models.black",
+            symbol="black76_default",
+            role="pricing_kernel",
+        )
+        dsl_clause = ConditionalPrimitive(
+            when={},
+            contract_pattern=parse_contract_pattern(
+                {"payoff": {"kind": "vanilla_payoff"}}
+            ),
+            primitives=(vanilla_prim,),
+        )
+        default_clause = ConditionalPrimitive(
+            when="default",
+            primitives=(default_prim,),
+        )
+        spec = _make_route_spec(
+            route_id="synthetic_mixed_dsl_default",
+            conditional_primitives=(dsl_clause, default_clause),
+        )
+
+        # DSL match on vanilla.
+        assert resolve_route_primitives(spec, _vanilla_ir()) == (vanilla_prim,)
+        # Fallthrough to default on a basket.
+        assert resolve_route_primitives(spec, _basket_ir()) == (default_prim,)
+
+    def test_legacy_then_dsl_dispatch_independently(self, monkeypatch):
+        from trellis.agent import backend_bindings as backend_bindings_module
+
+        monkeypatch.setattr(
+            backend_bindings_module,
+            "resolve_backend_binding_by_route_id",
+            lambda *args, **kwargs: None,
+        )
+
+        legacy_prim = PrimitiveRef(
+            module="trellis.models.rate_style_swaption",
+            symbol="price_swaption_black76",
+            role="route_helper",
+        )
+        dsl_prim = PrimitiveRef(
+            module="trellis.models.basket_option",
+            symbol="price_basket_option_analytical",
+            role="route_helper",
+        )
+
+        legacy_clause = ConditionalPrimitive(
+            when={
+                "payoff_family": "swaption",
+                "exercise_style": ["european"],
+            },
+            primitives=(legacy_prim,),
+        )
+        dsl_clause = ConditionalPrimitive(
+            when={},
+            contract_pattern=parse_contract_pattern(
+                {
+                    "payoff": {"kind": "basket_payoff"},
+                    "exercise": {"style": "european"},
+                    "underlying": {"kind": "equity_diffusion"},
+                }
+            ),
+            primitives=(dsl_prim,),
+        )
+        spec = _make_route_spec(
+            route_id="synthetic_legacy_then_dsl",
+            conditional_primitives=(legacy_clause, dsl_clause),
+        )
+
+        # Legacy path hits on european swaption.
+        assert resolve_route_primitives(spec, _swaption_european_ir()) == (legacy_prim,)
+        # DSL path hits on basket.
+        assert resolve_route_primitives(spec, _basket_ir()) == (dsl_prim,)
+
+
+# ---------------------------------------------------------------------------
+# 4. Error paths
+# ---------------------------------------------------------------------------
+
+
+class TestDSLWhenClauseErrors:
+    """Mixed-form clauses and malformed patterns raise clear parse errors."""
+
+    def test_mixed_contract_pattern_and_legacy_keys_raises(self):
+        raw = [
+            {
+                "when": {
+                    "contract_pattern": {
+                        "payoff": {"kind": "vanilla_payoff"},
+                    },
+                    "payoff_family": "vanilla_option",
+                },
+                "primitives": [],
+            },
+        ]
+        with pytest.raises(ValueError, match="contract_pattern"):
+            _parse_conditional_primitives(raw)
+
+    def test_invalid_contract_pattern_propagates_parse_error(self):
+        # "bogus_kind" isn't a valid payoff head tag, so parse_contract_pattern
+        # should raise ContractPatternParseError, which is a ValueError.
+        raw = [
+            {
+                "when": {
+                    "contract_pattern": {
+                        "payoff": {"kind": "bogus_kind"},
+                    },
+                },
+                "primitives": [],
+            },
+        ]
+        with pytest.raises(ValueError):
+            _parse_conditional_primitives(raw)
+
+    def test_contract_pattern_dataclass_rejects_both_populated(self):
+        """Constructing a ConditionalPrimitive with both non-empty ``when``
+        and non-None ``contract_pattern`` is explicitly disallowed."""
+        with pytest.raises(ValueError):
+            ConditionalPrimitive(
+                when={"payoff_family": "vanilla_option"},
+                contract_pattern=parse_contract_pattern(
+                    {"payoff": {"kind": "vanilla_payoff"}}
+                ),
+                primitives=(),
+            )
+
+
+# ---------------------------------------------------------------------------
+# 5. Legacy regression — the on-disk canonical registry keeps parsing cleanly
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyRegistryRegression:
+    """Every existing ``routes.yaml`` clause is legacy form; the new parser
+    must preserve that exactly."""
+
+    def test_every_existing_clause_is_legacy_form(self):
+        registry = load_route_registry()
+        for route in registry.routes:
+            for cp in route.conditional_primitives:
+                # Legacy form: contract_pattern must be None, and the
+                # `when` must be either a string sentinel or a trait dict.
+                assert cp.contract_pattern is None, (
+                    f"Route {route.id!r} has an unexpected DSL-form clause; "
+                    "routes.yaml still owns only legacy form before QUA-920."
+                )
+                assert isinstance(cp.when, (dict, str)), (
+                    f"Route {route.id!r} has a malformed when-clause: {cp.when!r}"
+                )

--- a/trellis/agent/route_registry.py
+++ b/trellis/agent/route_registry.py
@@ -29,6 +29,12 @@ from trellis.agent.binding_operator_metadata import (
     resolve_binding_operator_metadata,
 )
 from trellis.agent.codegen_guardrails import PrimitiveRef
+from trellis.agent.contract_pattern import (
+    ContractPattern,
+    ContractPatternParseError,
+    parse_contract_pattern,
+)
+from trellis.agent.contract_pattern_eval import evaluate_pattern
 from trellis.agent.family_lowering_ir import (
     AnalyticalBlack76IR,
     EventAwareMonteCarloIR,
@@ -76,12 +82,47 @@ class ConditionalRouteFamily:
 
 @dataclass(frozen=True)
 class ConditionalPrimitive:
-    """A conditional block of primitives/adapters/notes applied when traits match."""
+    """A conditional block of primitives/adapters/notes applied when a clause matches.
 
-    when: dict[str, Any] | str  # dict of trait conditions, or "default"
+    A clause is expressed in exactly one of two forms:
+
+    * **Legacy string-tag filter** (``when`` is either a trait mapping or the
+      string sentinel ``"default"``).  Dispatch goes through
+      :func:`_matches_condition`.
+    * **DSL contract pattern** (``contract_pattern`` is non-``None``).
+      Dispatch goes through
+      :func:`trellis.agent.contract_pattern_eval.evaluate_pattern`.  The
+      accompanying ``when`` field is an empty dict so legacy tag-key lookups
+      still work without special-casing.
+
+    Declaring both a non-empty ``when`` mapping and a non-``None``
+    ``contract_pattern`` is disallowed — the YAML parser and this
+    ``__post_init__`` both reject it so the dispatch fork stays unambiguous.
+    """
+
+    when: dict[str, Any] | str  # trait mapping, "default" sentinel, or empty dict when DSL form
     primitives: tuple[PrimitiveRef, ...] = ()
     adapters: tuple[str, ...] | None = None
     notes: tuple[str, ...] | None = None
+    contract_pattern: ContractPattern | None = None
+
+    def __post_init__(self) -> None:
+        if self.contract_pattern is None:
+            return
+        # DSL form must have an empty-dict ``when`` placeholder so the
+        # legacy dispatch short-circuits and the evaluator takes over.
+        if isinstance(self.when, str):
+            raise ValueError(
+                "ConditionalPrimitive cannot combine a string 'when' sentinel "
+                f"({self.when!r}) with a contract_pattern; DSL clauses must "
+                "use an empty-dict 'when' placeholder."
+            )
+        if isinstance(self.when, dict) and self.when:
+            raise ValueError(
+                "ConditionalPrimitive cannot populate both 'when' trait keys "
+                f"({sorted(self.when.keys())}) and a 'contract_pattern'; "
+                "choose one form."
+            )
 
 
 @dataclass(frozen=True)
@@ -289,21 +330,84 @@ def _parse_conditional_route_family(raw: list | None) -> tuple[ConditionalRouteF
 
 
 def _parse_conditional_primitives(raw: list | None) -> tuple[ConditionalPrimitive, ...]:
+    """Parse a ``conditional_primitives`` list into structured dataclass entries.
+
+    Each entry's ``when:`` block is inspected up-front to decide which form it
+    uses:
+
+    * A mapping containing the ``contract_pattern`` key is DSL form; the
+      accompanying payload is parsed via
+      :func:`trellis.agent.contract_pattern.parse_contract_pattern` and stored
+      on :attr:`ConditionalPrimitive.contract_pattern`.  The dispatch-time
+      ``when`` field is left as an empty dict so legacy trait-key scans treat
+      the clause as "no legacy conditions" and hand off to the evaluator.
+    * Any other mapping is legacy trait-filter form and stored verbatim on
+      ``when``.
+    * The string sentinel ``"default"`` is preserved as-is for the catch-all
+      branch.
+
+    Mixing ``contract_pattern`` with legacy trait keys in the same ``when:``
+    block is rejected to keep the dispatch fork unambiguous.
+    """
     if not raw:
         return ()
     result = []
     for entry in raw:
-        when = entry.get("when", "default")
+        raw_when = entry.get("when", "default")
         primitives = tuple(_parse_primitive(p) for p in entry.get("primitives", ()))
         adapters = None if "adapters" not in entry else tuple(entry.get("adapters", ()))
         notes = None if "notes" not in entry else tuple(entry.get("notes", ()))
+
+        when_value, contract_pattern = _parse_when_clause(raw_when)
         result.append(ConditionalPrimitive(
-            when=when,
+            when=when_value,
             primitives=primitives,
             adapters=adapters,
             notes=notes,
+            contract_pattern=contract_pattern,
         ))
     return tuple(result)
+
+
+def _parse_when_clause(
+    raw_when: Any,
+) -> tuple[dict[str, Any] | str, ContractPattern | None]:
+    """Classify a raw ``when`` payload as legacy trait-filter or DSL form.
+
+    Returns ``(when_value, contract_pattern)``.  For legacy form
+    ``contract_pattern`` is ``None`` and ``when_value`` is the original
+    mapping / sentinel string.  For DSL form ``contract_pattern`` is a
+    parsed :class:`ContractPattern` and ``when_value`` is an empty dict.
+    """
+    if isinstance(raw_when, str):
+        # ``"default"`` sentinel or any other raw string is legacy form.
+        return raw_when, None
+    if not isinstance(raw_when, dict):
+        # Preserve historical tolerance: anything non-dict, non-string falls
+        # through to the legacy path unchanged so downstream dispatch decides.
+        return raw_when, None
+
+    if "contract_pattern" not in raw_when:
+        return raw_when, None
+
+    # DSL form.  Reject mixed clauses before delegating to the pattern parser
+    # so the diagnostic points at the schema mismatch, not at an AST failure.
+    extra_keys = sorted(key for key in raw_when.keys() if key != "contract_pattern")
+    if extra_keys:
+        raise ValueError(
+            "when-clause cannot mix 'contract_pattern' with legacy trait keys "
+            f"{extra_keys}; use either a contract_pattern or legacy tag filters "
+            "in a single clause, not both."
+        )
+
+    try:
+        pattern = parse_contract_pattern(raw_when["contract_pattern"])
+    except ContractPatternParseError as exc:
+        raise ValueError(
+            f"invalid contract_pattern in when-clause: {exc}"
+        ) from exc
+
+    return {}, pattern
 
 
 def _parse_dynamic_notes(raw: list | None) -> tuple[DynamicNote, ...]:
@@ -873,9 +977,8 @@ def resolve_route_primitives(
         if isinstance(cond.when, str) and cond.when == "default":
             # Default branch — use if no prior branch matched
             return cond.primitives if cond.primitives else spec.primitives
-        if isinstance(cond.when, dict):
-            if _matches_condition(cond.when, payoff_family, exercise, model_family, product_ir):
-                return cond.primitives if cond.primitives else spec.primitives
+        if _conditional_primitive_matches(cond, payoff_family, exercise, model_family, product_ir):
+            return cond.primitives if cond.primitives else spec.primitives
 
     # No conditional matched — use base primitives
     return spec.primitives
@@ -900,13 +1003,12 @@ def resolve_route_adapters(
             if not cond.primitives and not cond.adapters:
                 return spec.adapters
             return cond.adapters
-        if isinstance(cond.when, dict):
-            if _matches_condition(cond.when, payoff_family, exercise, model_family, product_ir):
-                if cond.adapters is None:
-                    return spec.adapters
-                if not cond.primitives and not cond.adapters:
-                    return spec.adapters
-                return cond.adapters
+        if _conditional_primitive_matches(cond, payoff_family, exercise, model_family, product_ir):
+            if cond.adapters is None:
+                return spec.adapters
+            if not cond.primitives and not cond.adapters:
+                return spec.adapters
+            return cond.adapters
 
     return spec.adapters
 
@@ -927,8 +1029,10 @@ def resolve_route_notes(
             matched = False
             if isinstance(cond.when, str) and cond.when == "default":
                 matched = True
-            elif isinstance(cond.when, dict):
-                matched = _matches_condition(cond.when, payoff_family, exercise, model_family, product_ir)
+            else:
+                matched = _conditional_primitive_matches(
+                    cond, payoff_family, exercise, model_family, product_ir
+                )
             if matched:
                 if cond.notes is None:
                     base_notes = list(spec.notes)
@@ -1727,8 +1831,40 @@ def _requires_reporting_currency_conversion(product, market_binding_spec, valuat
 
 
 # ---------------------------------------------------------------------------
-# Condition matching helper
+# Condition matching helpers
 # ---------------------------------------------------------------------------
+
+
+def _conditional_primitive_matches(
+    cond: ConditionalPrimitive,
+    payoff_family: str,
+    exercise_style: str,
+    model_family: str,
+    product_ir: ProductIR | None,
+) -> bool:
+    """Dispatch a single :class:`ConditionalPrimitive` against a ProductIR.
+
+    Routes the decision through the DSL pattern evaluator when the clause
+    carries a :class:`ContractPattern`, or through the legacy string-tag
+    filter :func:`_matches_condition` otherwise.  The ``"default"`` sentinel
+    is handled by the callers (since they need to distinguish catch-all
+    fall-through from a conditional match miss) and never reaches this
+    helper.
+    """
+    if cond.contract_pattern is not None:
+        # DSL path: only meaningful when we actually have a ProductIR.  The
+        # legacy path is also a no-match on ``None`` product_ir via its own
+        # defaults, so the two forms stay symmetric.
+        if product_ir is None:
+            return False
+        return evaluate_pattern(cond.contract_pattern, product_ir).ok
+
+    if isinstance(cond.when, dict):
+        return _matches_condition(
+            cond.when, payoff_family, exercise_style, model_family, product_ir
+        )
+    return False
+
 
 def _matches_condition(
     when: dict[str, Any],
@@ -1737,7 +1873,7 @@ def _matches_condition(
     model_family: str,
     product_ir: ProductIR | None,
 ) -> bool:
-    """Check whether a ProductIR matches a conditional 'when' clause."""
+    """Check whether a ProductIR matches a legacy string-tag 'when' clause."""
     payoff_families = _expanded_payoff_families(payoff_family, product_ir)
     for key, expected in when.items():
         if key == "payoff_family":


### PR DESCRIPTION
## Summary

Phase 1.5.C of QUA-887. Extends `conditional_primitives.when` schema in `routes.yaml` to accept DSL-pattern expressions alongside the legacy string-tag filter form. Wires QUA-918's evaluator into the route registry's primitive-resolution path.

Dual-mode: both forms work. Legacy string-tag clauses dispatch unchanged; new DSL clauses evaluate via `contract_pattern_eval.evaluate_pattern`.

## What this ships

- **`ConditionalPrimitive` dataclass** (`trellis/agent/route_registry.py`) — new optional `contract_pattern: ContractPattern | None` field. `__post_init__` invariant: when `contract_pattern` is set, `when` must be `{}` — enforced at object construction.
- **`_parse_when_clause` helper** isolates DSL-vs-legacy detection. Mixed form (both `contract_pattern` AND trait keys in same when-block) raises `ValueError` at parse time with a clear diagnostic.
- **`_conditional_primitive_matches` dispatcher** routes on `cond.contract_pattern is not None` → `evaluate_pattern`; else falls through to legacy `_matches_condition`. All three consumer resolvers (`resolve_route_primitives`, `resolve_route_adapters`, `resolve_route_notes`) call through this, so dispatch is uniform.
- **Tests** `tests/test_agent/test_route_registry_dsl_when.py` (+506 lines) — 13 new tests covering round-trip, dispatch, mixed-mode, error paths, and a `TestLegacyRegistryRegression` class that iterates every route in live `routes.yaml` and asserts `cp.contract_pattern is None` (i.e. no silent reclassification).

## Legacy compat confirmation

`TestLegacyRegistryRegression` iterates every route in canonical `routes.yaml` and asserts `cp.contract_pattern is None` for every `conditional_primitive`. Every legacy when-clause still parses as legacy form; no silent reclassification.

## Test plan

- [x] `pytest tests/test_agent/test_route_registry.py tests/test_agent/test_route_registry_dsl_when.py tests/test_agent/test_contract_pattern*.py -q` → 239 passed
- [x] `pytest tests/test_agent -q` → 2024 passed, 5 deselected (+13 new DSL tests, zero regressions vs 2011 baseline)
- [x] All 119 legacy `test_route_registry.py` tests pass unchanged

## Key design decisions

1. **Dispatch fork in a new helper** (`_conditional_primitive_matches`). Legacy path preserved verbatim; helper wraps it. Three consumer resolvers call through the helper for uniform dispatch. `default` sentinel stays with callers (they need to distinguish catch-all from non-match).
2. **YAML detection in `_parse_when_clause`**: DSL form detected by presence of `contract_pattern` key inside `when:` mapping. Mixed form raises before delegating to pattern parser.
3. **`__post_init__` invariant** guards the `contract_pattern ⇒ when == {}` rule at construction time, independently of the YAML parser path. `dataclasses.replace` re-calls `__init__` so the guard propagates.
4. **DSL clauses with `product_ir=None`** return `False` — mirrors legacy `_matches_condition(None)` behavior. Preserves `resolve_route_primitives(spec, None)` call-site semantics.

## Forward-compat notes for QUA-920

QUA-920 migrates `analytical_black76`'s 4 existing when-clauses to DSL form. Mapping table:

| # | Legacy | DSL |
|---|---|---|
| 1 | `{payoff_family: vanilla_option}` | `contract_pattern: {payoff: {kind: vanilla_payoff}}` |
| 2 | `{payoff_family: basket_option, exercise_style: [european], model_family: [equity_diffusion]}` | `contract_pattern: {payoff: {kind: basket_payoff}, exercise: {style: european}, underlying: {kind: equity_diffusion}}` |
| 3 | `{payoff_family: swaption, exercise_style: [bermudan]}` | `contract_pattern: {payoff: {kind: swaption_payoff}, exercise: {style: bermudan}}` |
| 4 | `{payoff_family: swaption, exercise_style: [european]}` | `contract_pattern: {payoff: {kind: swaption_payoff}, exercise: {style: european}}` |

QUA-918's `TestAnalyticalBlack76Parity::test_full_parity_matrix` locks expected semantics for all 4 clauses. Migration is mechanical: swap YAML bodies and relax the new `TestLegacyRegistryRegression` to tolerate DSL form for the 4 migrated clauses.

`conditional_route_family` (different dataclass) still uses `_matches_condition` directly — per QUA-919's non-goals, top-level `match` stays string-tag.

## Closes

Closes QUA-919. Unblocks QUA-920 (P1.5.D migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)