### PR TITLE
agent: positive-filter match for analytical_black76 (QUA-909, Phase 1 P1.3)

### DIFF
--- a/tests/test_agent/test_analytical_traces.py
+++ b/tests/test_agent/test_analytical_traces.py
@@ -4,13 +4,36 @@ from types import SimpleNamespace
 
 
 def _black76_pricing_plan():
+    # QUA-909: the Black76 match clause now requires ``black_vol_surface``
+    # in the pricing plan's required market data and restricts dispatch to
+    # ``european`` / ``bermudan`` exercise styles. The trace fixtures below
+    # must therefore declare both, matching what a real analytical pricing
+    # plan would carry; otherwise Black76 is filtered out and the
+    # generation plan lands on the empty-route fallback.
     return SimpleNamespace(
         method="analytical",
         method_modules=("trellis.models.black",),
-        required_market_data=(),
+        required_market_data=("discount_curve", "black_vol_surface"),
         model_to_build="vanilla_option",
         reasoning="trace black76 analytical assembly",
         modeling_requirements=(),
+    )
+
+
+def _black76_product_ir():
+    # QUA-909: the Black76 match clause now filters on both ``payoff_family``
+    # and ``exercise``. A bare ``product_ir=None`` argument leaves both at
+    # their default values (empty string / "none"), so the positive filters
+    # reject Black76 and the generation plan falls back to no route. Supply
+    # a minimal European vanilla ``ProductIR`` so these trace fixtures
+    # actually exercise the Black76 dispatch path they claim to test.
+    from trellis.agent.knowledge.schema import ProductIR
+
+    return ProductIR(
+        instrument="european_option",
+        payoff_family="vanilla_option",
+        exercise_style="european",
+        model_family="equity_diffusion",
     )
 
 
@@ -26,7 +49,7 @@ def test_analytical_trace_round_trip_and_render(tmp_path):
         pricing_plan=_black76_pricing_plan(),
         instrument_type="vanilla_option",
         inspected_modules=("trellis.models.black",),
-        product_ir=None,
+        product_ir=_black76_product_ir(),
     )
 
     artifact = emit_analytical_trace_from_generation_plan(
@@ -80,7 +103,7 @@ def test_route_health_snapshot_reports_instruction_counts():
         pricing_plan=_black76_pricing_plan(),
         instrument_type="vanilla_option",
         inspected_modules=("trellis.models.black",),
-        product_ir=None,
+        product_ir=_black76_product_ir(),
     )
 
     trace = build_analytical_trace_from_generation_plan(
@@ -96,7 +119,16 @@ def test_route_health_snapshot_reports_instruction_counts():
     assert snapshot["effective_instruction_count"] >= 1
     assert snapshot["hard_constraint_count"] == 0
     assert snapshot["conflict_count"] == 0
-    assert "analytical_black76:schedule-builder" in snapshot["effective_instruction_ids"]
+    # QUA-909: the canonical European vanilla ``ProductIR`` now dispatches
+    # through Black76's ``when: vanilla_option`` clause, which emits the
+    # three call/put/digital guidance notes instead of the shared
+    # ``build_payment_timeline`` schedule-builder primitive reserved for
+    # the ``when: default`` fallback. At least one note must be present on
+    # the resulting route-health snapshot.
+    assert any(
+        iid.startswith("analytical_black76:note:")
+        for iid in snapshot["effective_instruction_ids"]
+    )
 
 
 def test_analytical_trace_route_from_dict_preserves_blank_route_name():

--- a/tests/test_agent/test_codegen_guardrails.py
+++ b/tests/test_agent/test_codegen_guardrails.py
@@ -52,6 +52,12 @@ from trellis.models.trees.control import (
 
 
 def _analytical_plan():
+    # QUA-909: Black76's positive match clause now filters on
+    # ``payoff_family`` and ``exercise``; provide a minimal swaption
+    # ``ProductIR`` so the generation-plan fixture still reaches
+    # ``analytical_black76`` under the new match-clause discipline.
+    from trellis.agent.knowledge.schema import ProductIR
+
     pricing_plan = PricingPlan(
         method="analytical",
         method_modules=["trellis.models.black"],
@@ -59,10 +65,18 @@ def _analytical_plan():
         model_to_build="swaption",
         reasoning="test",
     )
+    product_ir = ProductIR(
+        instrument="swaption",
+        payoff_family="swaption",
+        exercise_style="european",
+        model_family="interest_rate",
+        schedule_dependence=True,
+    )
     return build_generation_plan(
         pricing_plan=pricing_plan,
         instrument_type="swaption",
         inspected_modules=("trellis.instruments.cap", "trellis.models.black"),
+        product_ir=product_ir,
     )
 
 
@@ -588,9 +602,17 @@ def test_schedule_dependent_route_card_mentions_shared_schedule_builder():
     plan = _analytical_plan()
     card = render_generation_route_card(plan)
 
-    assert "build_payment_timeline" in card
-    assert "Schedule construction:" in card
-    assert "Do not hard-code observation or payment grids inside the payoff body." in card
+    # QUA-909: under the positive-filter Black76 match clause a canonical
+    # European swaption ``ProductIR`` dispatches to the ``when: swaption +
+    # exercise_style: [european]`` conditional which wires in
+    # ``trellis.models.rate_style_swaption.price_swaption_black76`` as a
+    # full ``route_helper``.  The helper handles schedule construction
+    # internally, so the card surfaces the helper binding rather than the
+    # shared ``build_payment_timeline`` schedule-builder primitive that is
+    # only exposed through the ``when: default`` fallback clause. The card
+    # still carries the instruction-precedence language the builder relies
+    # on, which is what this test actually defends.
+    assert "price_swaption_black76" in card
     assert "Instruction precedence: follow the lane obligations in this card first." in card
 
 

--- a/tests/test_agent/test_instruction_lifecycle.py
+++ b/tests/test_agent/test_instruction_lifecycle.py
@@ -9,10 +9,13 @@ from trellis.agent.knowledge.schema import InstructionRecord, ProductIR
 
 
 def _analytical_pricing_plan() -> SimpleNamespace:
+    # QUA-909: Black76 now requires ``black_vol_surface`` in
+    # ``required_market_data``; declare it so the route lifecycle test
+    # actually dispatches to ``analytical_black76`` as intended.
     return SimpleNamespace(
         method="analytical",
         method_modules=("trellis.models.black",),
-        required_market_data=(),
+        required_market_data=("discount_curve", "black_vol_surface"),
         model_to_build="swaption",
         reasoning="route lifecycle test",
         modeling_requirements=(),
@@ -20,9 +23,16 @@ def _analytical_pricing_plan() -> SimpleNamespace:
 
 
 def _swaption_product_ir() -> ProductIR:
+    # QUA-909: Black76's positive payoff-family filter uses the canonical
+    # ``swaption`` label (what ``make_rate_style_swaption_contract`` emits
+    # in ``trellis/agent/semantic_contracts.py``). Use that here so the
+    # lifecycle fixture matches production dispatch shape instead of the
+    # internal ``rate_style_swaption`` subfamily used before QUA-909.
     return ProductIR(
         instrument="swaption",
-        payoff_family="rate_style_swaption",
+        payoff_family="swaption",
+        exercise_style="european",
+        model_family="interest_rate",
         schedule_dependence=True,
     )
 
@@ -208,6 +218,16 @@ def test_generation_plan_materializes_resolved_instructions():
 
     assert plan.resolved_instructions is not None
     assert plan.resolved_instructions.route == "analytical_black76"
-    assert plan.resolved_instructions.effective_instructions[0].id == "analytical_black76:schedule-builder"
-    assert plan.resolved_instructions.effective_instructions[1].id == "analytical_black76:schedule-body"
+    # QUA-909: with a canonical ``payoff_family="swaption"`` +
+    # ``exercise_style="european"`` ProductIR the specific swaption when
+    # clause activates, routing through
+    # ``price_swaption_black76`` as a ``route_helper``. The route-helper
+    # instruction lands first because the specific-helper clause preempts
+    # the shared schedule-builder primitive that only appears on the
+    # ``when: default`` fallback clause.
+    instruction_ids = [
+        instruction.id
+        for instruction in plan.resolved_instructions.effective_instructions
+    ]
+    assert instruction_ids[0] == "analytical_black76:route-helper"
     assert plan.resolved_instructions.conflicts == ()

--- a/tests/test_agent/test_route_registry.py
+++ b/tests/test_agent/test_route_registry.py
@@ -1074,9 +1074,21 @@ class TestAnalyticalRoutes:
     )
     VANILLA_IR = ProductIR(instrument="european_option", payoff_family="vanilla_option", exercise_style="european")
     ZCB_IR = ProductIR(instrument="zcb_option", payoff_family="zcb_option", exercise_style="european")
+    # QUA-909: ``analytical_black76`` now requires ``black_vol_surface`` in the
+    # pricing-plan required market data (positive filter replacing the old
+    # ``exclude_required_market_data: [fx_rates]`` clause). Tests that exercise
+    # the Black76 match clause must pass a plan carrying that data; the bare
+    # no-plan form stays exercised below to defend the ``pricing_plan is None``
+    # branch in ``match_candidate_routes``.
+    BLACK76_PLAN = _make_plan(
+        "analytical",
+        market_data={"discount_curve", "black_vol_surface"},
+    )
 
     def test_swaption_candidate(self, registry):
-        new = _new_routes(registry, "analytical", self.SWAPTION_IR)
+        new = _new_routes(
+            registry, "analytical", self.SWAPTION_IR, pricing_plan=self.BLACK76_PLAN,
+        )
         assert new == ("analytical_black76",)
 
     def test_zcb_candidate(self, registry):
@@ -1920,3 +1932,154 @@ class TestRouteMatchParityHarness:
                 },
                 fixtures,
             )
+
+
+# ---------------------------------------------------------------------------
+# QUA-909: analytical_black76 positive-filter rewrite parity
+# ---------------------------------------------------------------------------
+
+class TestBlack76PositiveFilterParity:
+    """Parity gate for the QUA-909 rewrite of ``analytical_black76``.
+
+    Phase 1 of QUA-887 retires instrument-keyed dispatch. The ``analytical_black76``
+    match clause previously carried a 12-entry ``exclude_instruments`` list plus
+    ``exclude_required_market_data: [fx_rates]`` so that the broad
+    ``methods: [analytical]`` matcher did not accidentally swallow exotic
+    instrument-specific analytical routes. QUA-909 replaces those exclusions
+    with positive filters:
+
+        required_market_data: [black_vol_surface]
+        payoff_family: [vanilla_option, basket_option, swaption]
+
+    Every ``(ProductIR, PricingPlan)`` fixture that dispatched to
+    ``analytical_black76`` before the rewrite must still dispatch there after
+    the rewrite with an identical ``PrimitivePlan`` tuple (route id, primitives,
+    adapters, blockers). The fixtures below cover the concrete Black76 use cases:
+
+      - European vanilla call on equity (``vanilla_option`` positive match)
+      - European vanilla put on equity (``vanilla_option`` positive match)
+      - European basket option (``basket_option`` positive match, exercises the
+        ``when: payoff_family: basket_option`` conditional)
+      - European swaption on interest rates (``swaption`` positive match)
+      - Bermudan swaption on interest rates (``swaption`` positive match, drives
+        the lower-bound helper conditional)
+
+    Every fixture carries ``black_vol_surface`` in its pricing-plan required
+    market data because the new positive filter is AND-semantics on that field;
+    a fixture lacking it would drop from Black76 under the new clause. Tests
+    elsewhere in the file still exercise the legacy no-``PricingPlan`` path on
+    the Black76 route to keep backward compatibility for internal callers that
+    rely on ``match_required_market_data`` being a no-op when ``pricing_plan``
+    is ``None``.
+    """
+
+    _ANALYTICAL_PLAN_MARKET_DATA = {"discount_curve", "black_vol_surface"}
+
+    @classmethod
+    def _analytical_plan(cls) -> PricingPlan:
+        return _make_plan(
+            "analytical",
+            market_data=set(cls._ANALYTICAL_PLAN_MARKET_DATA),
+        )
+
+    @classmethod
+    def _european_call_fixture(cls) -> tuple[ProductIR, PricingPlan]:
+        product_ir = ProductIR(
+            instrument="european_option",
+            payoff_family="vanilla_option",
+            exercise_style="european",
+            model_family="equity_diffusion",
+        )
+        return product_ir, cls._analytical_plan()
+
+    @classmethod
+    def _european_put_fixture(cls) -> tuple[ProductIR, PricingPlan]:
+        product_ir = ProductIR(
+            instrument="european_option",
+            payoff_family="vanilla_option",
+            exercise_style="european",
+            model_family="equity_diffusion",
+            payoff_traits=("put",),
+        )
+        return product_ir, cls._analytical_plan()
+
+    @classmethod
+    def _european_basket_fixture(cls) -> tuple[ProductIR, PricingPlan]:
+        product_ir = ProductIR(
+            instrument="basket_option",
+            payoff_family="basket_option",
+            exercise_style="european",
+            model_family="equity_diffusion",
+        )
+        return product_ir, cls._analytical_plan()
+
+    @classmethod
+    def _european_swaption_fixture(cls) -> tuple[ProductIR, PricingPlan]:
+        product_ir = ProductIR(
+            instrument="swaption",
+            payoff_family="swaption",
+            exercise_style="european",
+            model_family="interest_rate",
+        )
+        return product_ir, cls._analytical_plan()
+
+    @classmethod
+    def _bermudan_swaption_fixture(cls) -> tuple[ProductIR, PricingPlan]:
+        product_ir = ProductIR(
+            instrument="bermudan_swaption",
+            payoff_family="swaption",
+            exercise_style="bermudan",
+            model_family="interest_rate",
+        )
+        return product_ir, cls._analytical_plan()
+
+    @classmethod
+    def _all_fixtures(cls) -> list[tuple[ProductIR, PricingPlan]]:
+        return [
+            cls._european_call_fixture(),
+            cls._european_put_fixture(),
+            cls._european_basket_fixture(),
+            cls._european_swaption_fixture(),
+            cls._bermudan_swaption_fixture(),
+        ]
+
+    def test_fixtures_reach_black76_under_current_registry(self, registry):
+        """Precondition: every fixture must dispatch to ``analytical_black76``
+        under the current registry. Without this precondition the parity
+        harness would run on fixtures that never exercised the rewritten
+        match clause and pass trivially.
+        """
+        for idx, (product_ir, pricing_plan) in enumerate(self._all_fixtures()):
+            routes = _new_routes(
+                registry, "analytical", product_ir, pricing_plan=pricing_plan,
+            )
+            assert "analytical_black76" in routes, (
+                f"fixture[{idx}] ({product_ir.instrument!r}, "
+                f"payoff_family={product_ir.payoff_family!r}) did not dispatch "
+                f"to analytical_black76 under the current registry; "
+                f"candidate routes={routes}"
+            )
+
+    def test_positive_filter_rewrite_preserves_dispatch(self):
+        """Rewriting ``analytical_black76.match`` from an exclude-heavy clause
+        to positive filters on ``required_market_data`` + ``payoff_family``
+        must preserve the ranked ``PrimitivePlan`` tuple on every fixture.
+        """
+        from tests.test_agent.route_parity import assert_route_match_parity
+
+        new_match_clause = {
+            "methods": ("analytical",),
+            "required_market_data": ("black_vol_surface",),
+            "payoff_family": (
+                "vanilla_option",
+                "basket_option",
+                "swaption",
+            ),
+            "exercise": ("european", "bermudan"),
+            "exclude_required_market_data": ("fx_rates",),
+        }
+        assert_route_match_parity(
+            route_id="analytical_black76",
+            new_match_clause=new_match_clause,
+            fixtures=self._all_fixtures(),
+        )

--- a/trellis/agent/knowledge/canonical/routes.yaml
+++ b/trellis/agent/knowledge/canonical/routes.yaml
@@ -932,30 +932,62 @@ routes:
       non_european_penalty: -4.0
     match:
       methods: [analytical]
-      # QUA-882: every instrument listed here has its own instrument-specific
-      # analytical route (`equity_digital_analytical`, `equity_variance_swap_analytical`,
-      # etc.) and ``analytical_black76`` lacks a matching conditional-primitive
-      # ``when`` clause for them.  Without the exclusion, the broad
-      # ``methods: [analytical]`` matcher on Black76 competes with the
-      # instrument-specific matcher and can be selected instead, forcing the
-      # assembly guard to demand the ``when: default`` Black76 kernels that
-      # the instrument's helper does not use (the F015 variance-swap failure
-      # mode).  ``basket_option`` is **deliberately not excluded** because
-      # Black76 has a legitimate ``when: payoff_family: basket_option +
-      # european + equity_diffusion`` clause that delegates to
-      # ``price_basket_option_analytical``.
-      exclude_instruments:
-        - quanto_option
-        - cds
-        - nth_to_default
-        - zcb_option
-        - variance_swap
-        - digital_option
-        - lookback_option
-        - chooser_option
-        - compound_option
-        - cliquet_option
-        - barrier_option
+      # QUA-909 (Phase 1 of QUA-887): positive filters on
+      # ``required_market_data``, ``payoff_family``, and ``exercise`` replace
+      # the earlier 12-entry ``exclude_instruments`` list. Dispatch is now
+      # restricted to the three payoff families Black76 has concrete
+      # ``when`` clauses for (vanilla European options, European baskets
+      # delegating to ``price_basket_option_analytical``, and European /
+      # Bermudan swaptions delegating to ``price_swaption_black76`` or
+      # ``price_bermudan_swaption_black76_lower_bound``) and to requests
+      # whose pricing plan carries a Black vol surface. Several instrument-
+      # specific analytical routes (``equity_digital_analytical``,
+      # ``equity_variance_swap_analytical``, ``zcb_option_analytical``,
+      # ``equity_barrier_analytical``, ``equity_lookback_analytical``,
+      # ``equity_chooser_analytical``, ``equity_compound_analytical``,
+      # ``equity_cliquet_analytical``, ``credit_default_swap_analytical``,
+      # ``basket_credit_nth_to_default_analytical``) carry payoff families
+      # outside the positive set (``digital_option``, ``variance_swap``,
+      # ``zcb_option``, ``barrier_option``, ``lookback_option``,
+      # ``chooser_option``, ``compound_option``, ``cliquet_option``,
+      # ``event_triggered_two_legged_contract``, ``credit_basket``) so the
+      # new filter leaves them uncontested. Phase 1.4 will extend this
+      # positive filter when it absorbs the instrument-specific exotic
+      # routes into Black76 via conditional ``when`` clauses.
+      #
+      # The ``exercise: [european, bermudan]`` positive filter is the
+      # principled discriminant against American exercise vanilla options.
+      # ``vanilla_option`` is a shared payoff family across European and
+      # American styles; without this filter Black76's broad positive
+      # payoff-family match would admit American requests, which would then
+      # propagate ``analytical`` into the request's
+      # ``candidate_engine_families`` via
+      # ``_augment_ir_with_promoted_route_support`` and drive the product-
+      # IR pricing-method selector to pick ``analytical`` over the true
+      # Monte-Carlo / rate-tree / PDE solvers. Black76's ``when`` clauses
+      # only handle ``european`` (vanilla, basket, swaption) and
+      # ``bermudan`` (swaption via the lower-bound helper), so restricting
+      # the match clause to those two exercise styles matches the concrete
+      # capability surface.
+      #
+      # The ``exclude_required_market_data: [fx_rates]`` clause is retained
+      # as a market-data-shape discriminant (not instrument-name dispatch)
+      # against quanto and FX-vanilla requests. Those contracts currently
+      # declare ``payoff_family="vanilla_option"`` in
+      # ``trellis/agent/semantic_contracts.py`` and therefore still reach
+      # this route under the positive ``payoff_family`` filter; their
+      # pricing plans, however, emit ``fx_rates`` to drive
+      # ``quanto_adjustment_analytical`` and ``analytical_garman_kohlhagen``
+      # respectively. Black76 does not model FX coupling, so excluding
+      # plans that require ``fx_rates`` is the principled market-data-shape
+      # discriminant here (the Phase 1 pattern we are moving toward, vs.
+      # the instrument-name ``exclude_instruments`` pattern we are
+      # retiring). Once the decomposer emits a more specific
+      # ``payoff_family`` for quanto / FX-vanilla (Phase 2+ work), this
+      # exclusion becomes redundant and can be dropped.
+      required_market_data: [black_vol_surface]
+      payoff_family: [vanilla_option, basket_option, swaption]
+      exercise: [european, bermudan]
       exclude_required_market_data: [fx_rates]
     admissibility:
       control_styles: [identity, holder_max]

--- a/trellis/agent/knowledge/decompose.py
+++ b/trellis/agent/knowledge/decompose.py
@@ -833,12 +833,29 @@ def _augment_ir_with_promoted_route_support(ir: ProductIR) -> ProductIR:
 
     route_families = list(ir.route_families)
     candidate_engine_families = list(ir.candidate_engine_families)
+    exercise_style = str(getattr(ir, "exercise_style", "") or "").strip().lower()
 
     for route in load_route_registry().routes:
         if route.status != "promoted":
             continue
         if not _route_matches_product_ir(route, ir):
             continue
+        # QUA-909: a route whose scorer declares ``non_european_penalty`` is
+        # signaling that it is a lower-bound / fallback approximation for
+        # non-European exercise styles and must not be advertised as a
+        # first-class candidate engine family against rate-tree / PDE /
+        # Monte-Carlo routes that are the true method for those products
+        # (e.g. Bermudan swaption selects rate_tree, not the Black76
+        # lower-bound helper). Skip the augmentation contribution for such
+        # routes; their direct ``match_candidate_routes`` dispatch via the
+        # scorer still works.
+        if exercise_style and exercise_style != "european":
+            score_hints = getattr(route, "score_hints", None) or {}
+            non_european_penalty = float(
+                score_hints.get("non_european_penalty", 0.0) or 0.0
+            )
+            if non_european_penalty < 0:
+                continue
 
         route_family = str(getattr(route, "route_family", "") or "").strip()
         if (

--- a/trellis/agent/knowledge/gap_check.py
+++ b/trellis/agent/knowledge/gap_check.py
@@ -188,9 +188,19 @@ def _check_route_gap(decomposition: ProductDecomposition) -> RouteGap | None:
         )
         registry = load_route_registry()
 
-        # Check for promoted routes
+        # Check for promoted routes.  ``_check_route_gap`` is a pre-flight
+        # audit — it runs before the pricing plan is synthesized, so it
+        # cannot test market-data-shape filters (``required_market_data`` /
+        # ``exclude_required_market_data``).  ``skip_market_data_filters=True``
+        # restricts the gap check to method + instrument + payoff-family +
+        # exercise-style dispatch, which is the right admissibility scope
+        # for the "is there any route for this product?" question.
         promoted = match_candidate_routes(
-            registry, decomposition.method, minimal_ir, promoted_only=True,
+            registry,
+            decomposition.method,
+            minimal_ir,
+            promoted_only=True,
+            skip_market_data_filters=True,
         )
         if promoted:
             return None
@@ -198,7 +208,11 @@ def _check_route_gap(decomposition: ProductDecomposition) -> RouteGap | None:
         # Check for candidate/validated routes
         analysis_registry = load_route_registry(include_discovered=True)
         all_matches = match_candidate_routes(
-            analysis_registry, decomposition.method, minimal_ir, promoted_only=False,
+            analysis_registry,
+            decomposition.method,
+            minimal_ir,
+            promoted_only=False,
+            skip_market_data_filters=True,
         )
         candidates = [r for r in all_matches if r.status in ("candidate", "validated")]
         if candidates:

--- a/trellis/agent/knowledge/reflect.py
+++ b/trellis/agent/knowledge/reflect.py
@@ -284,9 +284,17 @@ def _attribute_route_success(decomposition: ProductDecomposition) -> int:
                 instrument=decomposition.instrument,
             ),
         )
-        # Only boost discovered routes (not canonical)
+        # Only boost discovered routes (not canonical).  Like
+        # ``gap_check._check_route_gap``, this path operates off a
+        # ``ProductDecomposition`` without a synthesized pricing plan, so
+        # skip market-data-shape filters; dispatch reduces to
+        # method + instrument + payoff-family matching.
         all_matches = match_candidate_routes(
-            registry, decomposition.method, minimal_ir, promoted_only=False,
+            registry,
+            decomposition.method,
+            minimal_ir,
+            promoted_only=False,
+            skip_market_data_filters=True,
         )
         count = 0
         for route in all_matches:

--- a/trellis/agent/route_registry.py
+++ b/trellis/agent/route_registry.py
@@ -759,11 +759,22 @@ def match_candidate_routes(
     *,
     pricing_plan=None,
     promoted_only: bool = True,
+    skip_market_data_filters: bool = False,
 ) -> tuple[RouteSpec, ...]:
     """Filter routes by match conditions.
 
     When ``promoted_only`` is True (default for live builds), only routes with
     ``status == "promoted"`` are returned.  Set to False for gap analysis.
+
+    When ``skip_market_data_filters`` is True, the route's
+    ``match_required_market_data`` and ``exclude_required_market_data``
+    clauses are bypassed.  This is the pre-flight-audit mode used by
+    ``gap_check._check_route_gap`` and the discovery-route booster in
+    ``reflect.py``: those call sites only have a ``ProductDecomposition`` +
+    minimal ``ProductIR`` and have not yet synthesized a pricing plan, so
+    the market-data-shape filters cannot be evaluated meaningfully.  Live
+    build and scoring callers must leave this flag at its default so that
+    the market-data filters remain enforced.
     """
     method = normalize_method(method) if method else ""
     instrument = getattr(product_ir, "instrument", None) if product_ir is not None else None
@@ -831,13 +842,17 @@ def match_candidate_routes(
         if route.exclude_exercise and exercise in route.exclude_exercise:
             continue
 
-        # Required market data match
-        if route.match_required_market_data is not None:
-            if not all(md in required_market_data for md in route.match_required_market_data):
-                continue
-        if route.exclude_required_market_data is not None:
-            if any(md in required_market_data for md in route.exclude_required_market_data):
-                continue
+        # Required market data match.  Skipped in gap-audit mode because
+        # those callers do not yet have a pricing plan and applying the
+        # positive AND-filter against an empty set would reject every
+        # route that declares ``required_market_data``.
+        if not skip_market_data_filters:
+            if route.match_required_market_data is not None:
+                if not all(md in required_market_data for md in route.match_required_market_data):
+                    continue
+            if route.exclude_required_market_data is not None:
+                if any(md in required_market_data for md in route.exclude_required_market_data):
+                    continue
 
         matches.append(route)
 


### PR DESCRIPTION
## Summary

Phase 1 (P1.3) of QUA-887. Tightens `analytical_black76`'s top-level match clause from the 12-entry `exclude_instruments` list (which grew through QUA-882) to positive filters on `payoff_family` + `required_market_data` + `exercise`. Drops `exclude_instruments`.

## Final match shape

```yaml
match:
  methods: [analytical]
  required_market_data: [black_vol_surface]
  exclude_required_market_data: [fx_rates]
  payoff_family: [vanilla_option, basket_option, swaption]
  exercise: [european, bermudan]
```

**Why each filter**:
- `required_market_data: [black_vol_surface]` — Black76 requires Black vol surface inputs; discriminates vs. credit / local-vol / SABR routes.
- `exclude_required_market_data: [fx_rates]` — Black76 doesn't do FX coupling; this is **market-data-shape dispatch** (the principled alternative to the instrument-name `exclude_instruments` we're retiring). Discriminates vs. quanto / FX-vanilla requests that emit the same `payoff_family` as plain equity vanilla.
- `payoff_family: [vanilla_option, basket_option, swaption]` — positive scope. Will grow when QUA-910/911 absorb equity exotics.
- `exercise: [european, bermudan]` — Black76's when-clauses cover european + bermudan (swaption); discriminates vs. American products that share the `vanilla_option` payoff family.

## What else this ships

Beyond the YAML edit, the iteration surfaced and fixed 3 downstream concerns:

1. **`skip_market_data_filters` kwarg on `match_candidate_routes`** — Option C for the gap-check path. `gap_check._check_route_gap` and `reflect._attribute_route_success` call without a `PricingPlan` (pre-flight audit); those call sites pass `skip_market_data_filters=True`. Live-build callers keep the filter enforced.
2. **`_augment_ir_with_promoted_route_support` guard** — Without the guard, Black76's new positive `payoff_family` filter caused the IR augmenter to add `analytical` to `candidate_engine_families` for American/Bermudan products, which shifted the pricing-method selector from MC/tree to analytical. Added a guard: skip contributing a route's engine family when the route declares `score_hints.non_european_penalty < 0` and the product is non-European.
3. **Three test-expectation updates** (`test_analytical_traces.py`, `test_instruction_lifecycle.py`, `test_codegen_guardrails.py`) — these tests previously asserted `build_payment_timeline` + `when: default` fallback behavior; under the new canonical `swaption + european` ProductIR, the specific `when: swaption + european` clause activates and wires `price_swaption_black76` directly. Updated the assertions to match the helper-first dispatch.

## Test plan

- [x] `pytest tests/test_agent -q` → **2026 passed, 5 deselected, 0 failures**
- [x] Parity harness: every fixture that hit `analytical_black76` under the pre-QUA-909 match still hits it after, with identical `PrimitivePlan` output.

## Follow-on unblocks

This PR unblocks QUA-910 (P1.4 absorb 5 exotics) + QUA-911 (P1.5 absorb chooser + compound). Both extend the positive `payoff_family` filter to include the absorbed exotics.

## Closes

Closes QUA-909.

🤖 Generated with [Claude Code](https://claude.com/claude-code)