### PR TITLE
agent: collapse nth-to-default route family (QUA-914, Phase 1)

### DIFF
--- a/tests/test_agent/test_backend_bindings.py
+++ b/tests/test_agent/test_backend_bindings.py
@@ -21,6 +21,7 @@ def test_binding_catalog_loads_core_route_backed_bindings():
         "zcb_option_rate_tree",
         "analytical_black76",
         "credit_default_swap",
+        "credit_basket_nth_to_default",
         "analytical_garman_kohlhagen",
         "waterfall_cashflows",
     } <= route_ids
@@ -41,7 +42,7 @@ def test_binding_catalog_covers_retired_fallback_routes():
     Slice 2 (this PR): ``vanilla_equity_theta_pde``, ``pde_theta_1d``,
     ``exercise_lattice``, ``correlated_basket_monte_carlo``,
     ``credit_default_swap``,
-    ``nth_to_default_monte_carlo``.
+    ``credit_basket_nth_to_default``.
     """
     catalog = load_backend_binding_catalog()
     route_ids = {binding.route_id for binding in catalog.bindings}
@@ -57,7 +58,7 @@ def test_binding_catalog_covers_retired_fallback_routes():
         "exercise_lattice",
         "correlated_basket_monte_carlo",
         "credit_default_swap",
-        "nth_to_default_monte_carlo",
+        "credit_basket_nth_to_default",
     } <= route_ids
 
 
@@ -446,11 +447,14 @@ def test_nth_to_default_bindings_have_no_schedule_builder_surface():
         state_dependence="schedule_state",
     )
 
-    for route_id in ("nth_to_default_analytical", "nth_to_default_monte_carlo"):
-        binding = find_backend_binding_by_route_id(route_id, catalog)
-        assert binding is not None
-
-        resolved = resolve_backend_binding_spec(binding, product_ir=product_ir)
+    binding = find_backend_binding_by_route_id("credit_basket_nth_to_default", catalog)
+    assert binding is not None
+    for method in ("analytical", "monte_carlo"):
+        resolved = resolve_backend_binding_spec(
+            binding,
+            product_ir=product_ir,
+            method=method,
+        )
 
         assert resolved.binding_id == "trellis.instruments.nth_to_default.price_nth_to_default_basket"
         assert resolved.helper_refs == ("trellis.instruments.nth_to_default.price_nth_to_default_basket",)

--- a/tests/test_agent/test_codegen_guardrails.py
+++ b/tests/test_agent/test_codegen_guardrails.py
@@ -922,7 +922,7 @@ def test_nth_to_default_monte_carlo_route_uses_copula_assembly():
     card = render_generation_route_card(plan)
 
     assert plan.primitive_plan is not None
-    assert plan.primitive_plan.route == "nth_to_default_monte_carlo"
+    assert plan.primitive_plan.route == "credit_basket_nth_to_default"
     assert plan.primitive_plan.route_family == "nth_to_default"
     primitive_symbols = {primitive.symbol for primitive in plan.primitive_plan.primitives}
     assert "GaussianCopula" in primitive_symbols

--- a/tests/test_agent/test_dsl_lowering.py
+++ b/tests/test_agent/test_dsl_lowering.py
@@ -649,7 +649,7 @@ def test_nth_to_default_lowers_to_helper_backed_credit_basket_route():
 
     lowering = blueprint.dsl_lowering
     assert lowering is not None
-    assert lowering.route_id == "nth_to_default_monte_carlo"
+    assert lowering.route_id == "credit_basket_nth_to_default"
     assert lowering.route_family == "nth_to_default"
     assert lowering.admissibility_errors == ()
     assert isinstance(lowering.family_ir, NthToDefaultIR)

--- a/tests/test_agent/test_family_lowering_ir.py
+++ b/tests/test_agent/test_family_lowering_ir.py
@@ -843,7 +843,7 @@ def test_nth_to_default_compiles_to_family_ir():
 
     family_ir = blueprint.dsl_lowering.family_ir
     assert isinstance(family_ir, NthToDefaultIR)
-    assert family_ir.route_id == "nth_to_default_monte_carlo"
+    assert family_ir.route_id == "credit_basket_nth_to_default"
     assert family_ir.route_family == "nth_to_default"
     assert family_ir.product_instrument == "nth_to_default"
     assert family_ir.payoff_family == "nth_to_default"

--- a/tests/test_agent/test_platform_requests.py
+++ b/tests/test_agent/test_platform_requests.py
@@ -984,7 +984,7 @@ def test_compile_build_request_treats_generic_basket_wrapper_as_nth_to_default_w
     assert compiled.pricing_plan.method == "monte_carlo"
     assert compiled.generation_plan is not None
     assert compiled.generation_plan.primitive_plan is not None
-    assert compiled.generation_plan.primitive_plan.route == "nth_to_default_monte_carlo"
+    assert compiled.generation_plan.primitive_plan.route == "credit_basket_nth_to_default"
 
 
 @pytest.mark.parametrize(
@@ -1400,8 +1400,8 @@ def test_compile_build_request_uses_nth_to_default_semantic_contract_blueprint()
     assert compiled.pricing_plan is not None
     assert compiled.pricing_plan.method == "copula"
     assert compiled.semantic_blueprint.route_modules == _expected_route_modules(compiled)
-    assert compiled.semantic_blueprint.primitive_routes == ("nth_to_default_monte_carlo",)
-    assert compiled.request.metadata["semantic_blueprint"]["dsl_route"] == "nth_to_default_monte_carlo"
+    assert compiled.semantic_blueprint.primitive_routes == ("credit_basket_nth_to_default",)
+    assert compiled.request.metadata["semantic_blueprint"]["dsl_route"] == "credit_basket_nth_to_default"
     assert compiled.request.metadata["semantic_blueprint"]["dsl_family_ir_type"] == "NthToDefaultIR"
     assert compiled.request.metadata["semantic_blueprint"]["dsl_expr_kind"] == "ContractAtom"
     assert (

--- a/tests/test_agent/test_route_registry.py
+++ b/tests/test_agent/test_route_registry.py
@@ -502,12 +502,56 @@ class TestCreditRoutes:
         assert new == ("credit_default_swap",)
 
     def test_nth_to_default_analytical(self, registry):
-        new = _new_routes(registry, "analytical", self.NTD_IR)
-        assert new == ("nth_to_default_analytical",)
+        plan = _make_plan("analytical", market_data={"discount_curve", "credit_curve"})
+        new = _new_routes(registry, "analytical", self.NTD_IR, pricing_plan=plan)
+        assert new == ("credit_basket_nth_to_default",)
 
     def test_nth_to_default_monte_carlo(self, registry):
-        new = _new_routes(registry, "monte_carlo", self.NTD_IR)
-        assert new == ("nth_to_default_monte_carlo",)
+        plan = _make_plan("monte_carlo", market_data={"discount_curve", "credit_curve"})
+        new = _new_routes(registry, "monte_carlo", self.NTD_IR, pricing_plan=plan)
+        assert new == ("credit_basket_nth_to_default",)
+
+    _PRE_COLLAPSE_ANALYTICAL_PRIMITIVES = frozenset({
+        ("trellis.core.date_utils", "year_fraction", "time_measure"),
+        ("trellis.instruments.nth_to_default", "price_nth_to_default_basket", "route_helper"),
+    })
+
+    _PRE_COLLAPSE_MC_PRIMITIVES = frozenset({
+        ("trellis.core.date_utils", "year_fraction", "time_measure"),
+        ("trellis.core.differentiable", "get_numpy", "array_backend"),
+        ("trellis.models.copulas.gaussian", "GaussianCopula", "default_time_sampler"),
+        ("trellis.instruments.nth_to_default", "price_nth_to_default_basket", "route_helper"),
+        ("trellis.models.monte_carlo.engine", "MonteCarloEngine", "path_simulation"),
+    })
+
+    def test_nth_to_default_collapsed_route_preserves_analytical_primitive_surface(self, registry):
+        spec = find_route_by_id("credit_basket_nth_to_default", registry)
+        assert spec is not None
+        primitives = resolve_route_primitives(spec, self.NTD_IR, method="analytical")
+        assert _prim_set(primitives) == self._PRE_COLLAPSE_ANALYTICAL_PRIMITIVES
+
+    def test_nth_to_default_collapsed_route_preserves_mc_primitive_surface(self, registry):
+        spec = find_route_by_id("credit_basket_nth_to_default", registry)
+        assert spec is not None
+        primitives = resolve_route_primitives(spec, self.NTD_IR, method="monte_carlo")
+        assert _prim_set(primitives) == self._PRE_COLLAPSE_MC_PRIMITIVES
+
+    def test_nth_to_default_collapsed_route_qmc_copula_methods_share_mc_surface(self, registry):
+        spec = find_route_by_id("credit_basket_nth_to_default", registry)
+        assert spec is not None
+        mc = _prim_set(resolve_route_primitives(spec, self.NTD_IR, method="monte_carlo"))
+        qmc = _prim_set(resolve_route_primitives(spec, self.NTD_IR, method="qmc"))
+        copula = _prim_set(resolve_route_primitives(spec, self.NTD_IR, method="copula"))
+        assert mc == qmc == copula == self._PRE_COLLAPSE_MC_PRIMITIVES
+
+    def test_nth_to_default_collapsed_route_admissibility_envelope_is_union(self, registry):
+        spec = find_route_by_id("credit_basket_nth_to_default", registry)
+        assert spec is not None
+        tags = set(spec.admissibility.supported_state_tags)
+        assert {"pathwise_only", "remaining_pool", "schedule_state"}.issubset(tags)
+        assert spec.admissibility.supported_control_styles == ("identity",)
+        assert spec.admissibility.event_support == "automatic"
+        assert spec.admissibility.supports_sensitivity_outputs is True
 
     def test_route_family(self, registry):
         spec = [r for r in registry.routes if r.id == "credit_default_swap"][0]
@@ -1922,8 +1966,7 @@ class TestFallbackRoutes:
     def test_credit_and_copula_routes_are_thin_backend_bindings(self, registry):
         for route_id in (
             "credit_default_swap",
-            "nth_to_default_analytical",
-            "nth_to_default_monte_carlo",
+            "credit_basket_nth_to_default",
             "copula_loss_distribution",
         ):
             spec = find_route_by_id(route_id, registry)
@@ -1953,8 +1996,7 @@ class TestEngineFamilyCoverage:
     EXPECTED = {
         "equity_quanto": "analytical",
         "credit_default_swap": "analytical",
-        "nth_to_default_analytical": "analytical",
-        "nth_to_default_monte_carlo": "monte_carlo",
+        "credit_basket_nth_to_default": "analytical",
         "correlated_basket_monte_carlo": "monte_carlo",
         "exercise_monte_carlo": "exercise",
         "monte_carlo_paths": "monte_carlo",

--- a/tests/test_agent/test_route_scorer.py
+++ b/tests/test_agent/test_route_scorer.py
@@ -120,7 +120,14 @@ class TestFeatureExtraction:
         assert features["capability_failure:schedule_dependence_unsupported"] == 1.0
 
     def test_credit_copula_features_record_default_time_sampler_support(self, registry):
-        spec = [r for r in registry.routes if r.id == "nth_to_default_monte_carlo"][0]
+        # QUA-914: the collapsed ``credit_basket_nth_to_default`` route
+        # dispatches its copula kernel surface via method-keyed
+        # ``conditional_primitives``. Thread a ``monte_carlo`` pricing plan
+        # so the scorer resolves the MC leg (which declares
+        # ``GaussianCopula`` as the default_time_sampler).
+        from trellis.agent.quant import PricingPlan
+
+        spec = [r for r in registry.routes if r.id == "credit_basket_nth_to_default"][0]
         ir = ProductIR(
             instrument="nth_to_default",
             payoff_family="credit_basket",
@@ -129,10 +136,17 @@ class TestFeatureExtraction:
             candidate_engine_families=("copula", "monte_carlo"),
             route_families=("nth_to_default",),
         )
+        pricing_plan = PricingPlan(
+            method="monte_carlo",
+            method_modules=["trellis.models.copulas.gaussian"],
+            required_market_data={"discount_curve", "credit_curve"},
+            model_to_build="nth_to_default",
+            reasoning="test",
+        )
         ctx = ScoringContext(
             product_ir=ir,
             route_spec=spec,
-            pricing_plan=None,
+            pricing_plan=pricing_plan,
             blockers=[],
         )
 

--- a/tests/test_agent/test_route_scoring.py
+++ b/tests/test_agent/test_route_scoring.py
@@ -221,7 +221,7 @@ def test_nth_to_default_uses_dedicated_credit_basket_route():
     )
 
     assert ranked
-    assert ranked[0].route == "nth_to_default_monte_carlo"
+    assert ranked[0].route == "credit_basket_nth_to_default"
     assert ranked[0].route_family == "nth_to_default"
     assert ranked[0].score > 0.0
 
@@ -248,7 +248,7 @@ def test_nth_to_default_copula_prefers_default_time_sampler_route():
     )
 
     assert ranked
-    assert ranked[0].route == "nth_to_default_monte_carlo"
+    assert ranked[0].route == "credit_basket_nth_to_default"
     assert ranked[0].score > ranked[1].score
 
 

--- a/tests/test_agent/test_semantic_contracts.py
+++ b/tests/test_agent/test_semantic_contracts.py
@@ -1450,9 +1450,9 @@ def test_nth_to_default_contract_validates_and_compiles():
     assert compiled.pricing_plan.method == "copula"
     assert compiled.target_modules == ("trellis.instruments.nth_to_default",)
     assert compiled.route_modules == _expected_route_modules(compiled)
-    assert compiled.primitive_routes == ("nth_to_default_monte_carlo",)
+    assert compiled.primitive_routes == ("credit_basket_nth_to_default",)
     assert compiled.dsl_lowering is not None
-    assert compiled.dsl_lowering.route_id == "nth_to_default_monte_carlo"
+    assert compiled.dsl_lowering.route_id == "credit_basket_nth_to_default"
 
 
 def test_nth_to_default_summary_is_stable_and_route_specific():
@@ -1472,7 +1472,7 @@ def test_nth_to_default_summary_is_stable_and_route_specific():
     assert summary["product"]["payoff_family"] == "nth_to_default"
     assert summary["typed_semantics"]["controller_protocol"]["controller_style"] == "identity"
     assert summary["market_data"]["required_inputs"] == ["discount_curve", "credit_curve"]
-    assert summary["blueprint"]["primitive_families"] == ["nth_to_default_monte_carlo"]
+    assert summary["blueprint"]["primitive_families"] == ["credit_basket_nth_to_default"]
 
 
 def test_cdo_tranche_contract_validates_and_compiles():

--- a/tests/test_agent/test_semantic_validators.py
+++ b/tests/test_agent/test_semantic_validators.py
@@ -691,7 +691,7 @@ def evaluate(self, market_state):
         assert any(f.category == "route_helper_signature_mismatch" for f in findings)
 
     def test_flags_nth_to_default_helper_signature_mismatch(self, registry):
-        spec = [r for r in registry.routes if r.id == "nth_to_default_monte_carlo"][0]
+        spec = [r for r in registry.routes if r.id == "credit_basket_nth_to_default"][0]
         source = '''
 from trellis.instruments.nth_to_default import price_nth_to_default_basket
 
@@ -708,11 +708,11 @@ def evaluate(self, market_state):
     )
 '''
         validator = AlgorithmContractValidator()
-        findings = validator.validate(source, _make_plan("nth_to_default_monte_carlo", "monte_carlo"), spec)
+        findings = validator.validate(source, _make_plan("credit_basket_nth_to_default", "monte_carlo"), spec)
         assert any(f.category == "route_helper_signature_mismatch" for f in findings)
 
     def test_accepts_nth_to_default_helper_surface(self, registry):
-        spec = [r for r in registry.routes if r.id == "nth_to_default_monte_carlo"][0]
+        spec = [r for r in registry.routes if r.id == "credit_basket_nth_to_default"][0]
         source = '''
 from trellis.instruments.nth_to_default import price_nth_to_default_basket
 
@@ -729,11 +729,11 @@ def evaluate(self, market_state):
     )
 '''
         validator = AlgorithmContractValidator()
-        findings = validator.validate(source, _make_plan("nth_to_default_monte_carlo", "monte_carlo"), spec)
+        findings = validator.validate(source, _make_plan("credit_basket_nth_to_default", "monte_carlo"), spec)
         assert not any(f.category == "route_helper_signature_mismatch" for f in findings)
 
     def test_rejects_nth_to_default_positional_calls(self, registry):
-        spec = [r for r in registry.routes if r.id == "nth_to_default_monte_carlo"][0]
+        spec = [r for r in registry.routes if r.id == "credit_basket_nth_to_default"][0]
         source = '''
 from trellis.instruments.nth_to_default import price_nth_to_default_basket
 
@@ -750,7 +750,7 @@ def evaluate(self, market_state):
     )
 '''
         validator = AlgorithmContractValidator()
-        findings = validator.validate(source, _make_plan("nth_to_default_monte_carlo", "monte_carlo"), spec)
+        findings = validator.validate(source, _make_plan("credit_basket_nth_to_default", "monte_carlo"), spec)
         assert any(f.category == "route_helper_signature_mismatch" for f in findings)
 
     def test_flags_credit_basket_tranche_helper_signature_mismatch(self, registry):

--- a/tests/test_agent/test_skill_index.py
+++ b/tests/test_agent/test_skill_index.py
@@ -103,7 +103,11 @@ def test_skill_lineage_query_surfaces_children_and_same_source_records():
 
 
 def test_nth_to_default_no_longer_projects_schedule_builder_route_hint():
+    # QUA-914: ``nth_to_default_monte_carlo`` and ``nth_to_default_analytical``
+    # collapsed into ``credit_basket_nth_to_default``. Neither legacy id
+    # nor the collapsed id should emit the schedule-builder route hint.
     assert get_skill_record("route_hint:nth_to_default_monte_carlo:schedule-builder") is None
+    assert get_skill_record("route_hint:credit_basket_nth_to_default:schedule-builder") is None
 
 
 def test_route_notes_are_not_projected_as_live_route_hints():

--- a/tests/test_agent/test_validation_contract.py
+++ b/tests/test_agent/test_validation_contract.py
@@ -248,7 +248,7 @@ def test_route_less_semantic_request_keeps_validation_contract_truthful():
             "First-to-default basket on ACME, BRAVO, CHARLIE, DELTA, ECHO maturing 2029-11-15",
             "nth_to_default",
             "nth_to_default",
-            "nth_to_default_monte_carlo",
+            "credit_basket_nth_to_default",
             "copula:nth_to_default",
             {"discount_curve", "credit_curve"},
             (),

--- a/trellis/agent/codegen_guardrails.py
+++ b/trellis/agent/codegen_guardrails.py
@@ -1778,9 +1778,13 @@ def _route_score(
     if not route_family:
         route_family = spec.route_family if spec is not None else ""
 
+    scoring_method = normalize_method(getattr(pricing_plan, "method", None) or "") or None
+
     score = 0.0
     if product_ir is not None and spec is not None:
-        resolved_primitives = tuple(resolve_route_primitives(spec, product_ir))
+        resolved_primitives = tuple(
+            resolve_route_primitives(spec, product_ir, method=scoring_method)
+        )
         resolved_roles = {primitive.role for primitive in resolved_primitives}
         exact_surface_roles = {"route_helper", "pricing_kernel", "cashflow_engine"}
         if engine_family in product_ir.candidate_engine_families:

--- a/trellis/agent/family_lowering_ir.py
+++ b/trellis/agent/family_lowering_ir.py
@@ -1171,10 +1171,9 @@ def _binding_supports_nth_to_default(
 ) -> bool:
     """Return whether the binding surface fits the nth-to-default copula lane.
 
-    QUA-794 slice 2: ``nth_to_default_monte_carlo`` binding is in the
-    canonical catalog; the historical ``route_id ==
-    "nth_to_default_monte_carlo" and binding_spec is None`` fallback is
-    dead code and has been retired.
+    QUA-794 slice 2: the collapsed ``credit_basket_nth_to_default`` binding
+    is in the canonical catalog; the historical ``nth_to_default_monte_carlo``
+    missing-binding fallback is dead code and has been retired.
     """
     del route_id
     if _binding_has_symbol(binding_spec, "default_time_sampler", "GaussianCopula"):

--- a/trellis/agent/knowledge/canonical/backend_bindings.yaml
+++ b/trellis/agent/knowledge/canonical/backend_bindings.yaml
@@ -64,38 +64,39 @@ bindings:
             symbol: price_cds_analytical
             role: route_helper
 
-  - route_id: nth_to_default_analytical
+  - route_id: credit_basket_nth_to_default
     engine_family: analytical
     route_family: nth_to_default
-    primitives:
-      - module: trellis.core.date_utils
-        symbol: year_fraction
-        role: time_measure
-      - module: trellis.instruments.nth_to_default
-        symbol: price_nth_to_default_basket
-        role: route_helper
-
-  - route_id: nth_to_default_monte_carlo
-    engine_family: monte_carlo
-    route_family: nth_to_default
-    primitives:
-      - module: trellis.core.date_utils
-        symbol: year_fraction
-        role: time_measure
-      - module: trellis.core.differentiable
-        symbol: get_numpy
-        role: array_backend
-      - module: trellis.models.copulas.gaussian
-        symbol: GaussianCopula
-        role: default_time_sampler
-      - module: trellis.instruments.nth_to_default
-        symbol: price_nth_to_default_basket
-        role: route_helper
-      - module: trellis.models.monte_carlo.engine
-        symbol: MonteCarloEngine
-        role: path_simulation
-        required: false
-        excluded: true
+    conditional_primitives:
+      - when:
+          methods: [analytical]
+        primitives:
+          - module: trellis.core.date_utils
+            symbol: year_fraction
+            role: time_measure
+          - module: trellis.instruments.nth_to_default
+            symbol: price_nth_to_default_basket
+            role: route_helper
+      - when:
+          methods: [monte_carlo, qmc, copula]
+        primitives:
+          - module: trellis.core.date_utils
+            symbol: year_fraction
+            role: time_measure
+          - module: trellis.core.differentiable
+            symbol: get_numpy
+            role: array_backend
+          - module: trellis.models.copulas.gaussian
+            symbol: GaussianCopula
+            role: default_time_sampler
+          - module: trellis.instruments.nth_to_default
+            symbol: price_nth_to_default_basket
+            role: route_helper
+          - module: trellis.models.monte_carlo.engine
+            symbol: MonteCarloEngine
+            role: path_simulation
+            required: false
+            excluded: true
 
   - route_id: correlated_basket_monte_carlo
     engine_family: monte_carlo

--- a/trellis/agent/knowledge/canonical/routes.yaml
+++ b/trellis/agent/knowledge/canonical/routes.yaml
@@ -134,7 +134,7 @@ routes:
         discount_curve: [market_state.discount]
         credit_curve: [market_state.credit_curve]
 
-  - id: nth_to_default_analytical
+  - id: credit_basket_nth_to_default
     engine_family: analytical
     route_family: nth_to_default
     status: promoted
@@ -142,41 +142,44 @@ routes:
     score_hints:
       payoff_family_bonus: {nth_to_default: 2.0}
     match:
-      methods: [analytical, copula]
+      methods: [analytical, monte_carlo, qmc, copula]
       instruments: [nth_to_default]
-    admissibility:
-      control_styles: [identity]
-      event_support: automatic
-      phase_sensitivity: default_phase_order_only
-      multicurrency_support: single_currency_only
-      supported_outputs: [price, scenario_pnl]
-      supports_sensitivity_outputs: true
-      supported_state_tags: [remaining_pool, schedule_state]
-      supports_calibration: false
-    primitives:
-      - module: trellis.core.date_utils
-        symbol: year_fraction
-        role: time_measure
-      - module: trellis.instruments.nth_to_default
-        symbol: price_nth_to_default_basket
-        role: route_helper
-    adapters: []
-    notes: []
-    market_data_access:
-      required:
-        discount_curve: [market_state.discount]
-        credit_curve: [market_state.credit_curve]
-
-  - id: nth_to_default_monte_carlo
-    engine_family: monte_carlo
-    route_family: nth_to_default
-    status: promoted
-    confidence: 1.0
-    score_hints:
-      payoff_family_bonus: {nth_to_default: 2.0}
-    match:
-      methods: [monte_carlo, qmc, copula]
-      instruments: [nth_to_default]
+      required_market_data: [credit_curve]
+      payoff_family: [nth_to_default]
+    conditional_primitives:
+      - when:
+          methods: [analytical]
+        primitives:
+          - module: trellis.core.date_utils
+            symbol: year_fraction
+            role: time_measure
+          - module: trellis.instruments.nth_to_default
+            symbol: price_nth_to_default_basket
+            role: route_helper
+        adapters: []
+        notes: []
+      - when:
+          methods: [monte_carlo, qmc, copula]
+        primitives:
+          - module: trellis.core.date_utils
+            symbol: year_fraction
+            role: time_measure
+          - module: trellis.core.differentiable
+            symbol: get_numpy
+            role: array_backend
+          - module: trellis.models.copulas.gaussian
+            symbol: GaussianCopula
+            role: default_time_sampler
+          - module: trellis.instruments.nth_to_default
+            symbol: price_nth_to_default_basket
+            role: route_helper
+          - module: trellis.models.monte_carlo.engine
+            symbol: MonteCarloEngine
+            role: path_simulation
+            required: false
+            excluded: true
+        adapters: []
+        notes: []
     admissibility:
       control_styles: [identity]
       event_support: automatic
@@ -190,20 +193,9 @@ routes:
       - module: trellis.core.date_utils
         symbol: year_fraction
         role: time_measure
-      - module: trellis.core.differentiable
-        symbol: get_numpy
-        role: array_backend
-      - module: trellis.models.copulas.gaussian
-        symbol: GaussianCopula
-        role: default_time_sampler
       - module: trellis.instruments.nth_to_default
         symbol: price_nth_to_default_basket
         role: route_helper
-      - module: trellis.models.monte_carlo.engine
-        symbol: MonteCarloEngine
-        role: path_simulation
-        required: false
-        excluded: true
     adapters: []
     notes: []
     market_data_access:

--- a/trellis/agent/route_scorer.py
+++ b/trellis/agent/route_scorer.py
@@ -138,7 +138,8 @@ def extract_scoring_features(ctx: ScoringContext) -> dict[str, float]:
         "route_confidence": spec.confidence,
         "successful_builds": float(min(spec.successful_builds, 20)),
     }
-    resolved_primitives = tuple(resolve_route_primitives(spec, ir))
+    scoring_method = str(getattr(ctx.pricing_plan, "method", "") or "").strip() or None
+    resolved_primitives = tuple(resolve_route_primitives(spec, ir, method=scoring_method))
     resolved_roles = {primitive.role for primitive in resolved_primitives}
     exact_surface_roles = {"route_helper", "pricing_kernel", "cashflow_engine"}
 

--- a/trellis/agent/semantic_contracts.py
+++ b/trellis/agent/semantic_contracts.py
@@ -499,7 +499,10 @@ def _build_semantic_family_registry() -> MappingProxyType:
                 _method_surface_definition(
                     "copula",
                     target_modules=("trellis.instruments.nth_to_default",),
-                    primitive_families=("nth_to_default_monte_carlo",),
+                    # QUA-914: NtD analytical + monte_carlo routes collapsed
+                    # into ``credit_basket_nth_to_default``.  The copula
+                    # method surface binds that single pattern-keyed route.
+                    primitive_families=("credit_basket_nth_to_default",),
                     adapter_obligations=(
                         "resolve_basket_credit_curve_and_discount_curve",
                         "preserve_reference_entities_and_trigger_rank",


### PR DESCRIPTION
## Summary

Phase 1 of QUA-887. Collapse nth-to-default route family (2 → 1). `nth_to_default_analytical` + `nth_to_default_monte_carlo` become a single pattern-keyed route `credit_basket_nth_to_default` with method-keyed `conditional_primitives` dispatch.

## What changed

- One commit: `52d515a1` — replaces the two instrument-keyed NtD routes with a single pattern-keyed route.
- Uses the `methods:` predicate in `conditional_primitives.when` that QUA-913's foundation landed.

## Per design discussion

NtD stays distinct from CDS (which collapsed in QUA-913) because NtD uses a Gaussian copula over K correlated default times, while CDS uses a single survival curve. Different primitive roles (`default_time_sampler` vs `event_probability`), different state tags (`remaining_pool` vs `terminal_markov`).

## Test plan

- [x] QUA-914 focused agent suite: 496 passed (per handoff notes)
- P006 (NtD extension) blocked by missing OPENAI_API_KEY — not a regression

## Closes

Closes QUA-914. QUA-915 (ZCB collapse) rebases onto this merged base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)