### PR TITLE
agent: collapse ZCB-option family + DSL cleanup (QUA-915, Phase 1)

### DIFF
--- a/docs/developer/dsl_system_design_review.md
+++ b/docs/developer/dsl_system_design_review.md
@@ -206,14 +206,16 @@ projection are no longer carried as route-card instructions once the checked
 helpers already own that surface.
 
 The rate-tree cohort now follows the same discipline. ``exercise_lattice``,
-``rate_tree_backward_induction``, ``zcb_option_rate_tree``, and
-``zcb_option_analytical`` still expose the backend binding and the validation
-surface, but they no longer supply prompt-level lattice or short-rate
-construction guidance when the checked helper already owns that assembly. The
-semantic drafting boundary is also stricter here: an explicit ``instrument_type``
-such as ``zcb_option`` now blocks fallback drafting into a generic
-``vanilla_option`` contract when the prose only happens to contain generic
-``option`` language.
+``rate_tree_backward_induction``, and the QUA-915 collapsed
+``short_rate_bond_option`` (which replaces the instrument-keyed
+``zcb_option_rate_tree`` / ``zcb_option_analytical`` pair) still expose
+the backend binding and the validation surface, but they no longer
+supply prompt-level lattice or short-rate construction guidance when the
+checked helper already owns that assembly. The semantic drafting
+boundary is also stricter here: an explicit ``instrument_type`` such as
+``zcb_option`` now blocks fallback drafting into a generic
+``vanilla_option`` contract when the prose only happens to contain
+generic ``option`` language.
 
 The analytical / PDE / FFT helper cohort now behaves the same way.
 Helper-backed Black76 swaption routes, vanilla-equity PDE / event-aware PDE

--- a/docs/quant/pricing_stack.rst
+++ b/docs/quant/pricing_stack.rst
@@ -315,11 +315,12 @@ analytics directly off that tree boundary: effective ``oas_duration`` plus a
 callable-specific scenario ladder that compares callable price, straight-bond
 reference price, and embedded call option value under parallel rate shocks.
 The same route-thinning rule now also applies to the short-rate ZCB-option
-cohort. ``zcb_option_rate_tree`` and ``zcb_option_analytical`` remain as
-backend-binding identities for the checked Hull-White tree and Jamshidian
-helpers, but the route cards no longer carry lattice-construction or
-short-rate-input assembly instructions once the helper surface already owns
-that work.
+cohort. QUA-915 collapsed the Jamshidian analytical and Hull-White tree
+routes into a single pattern-keyed route ``short_rate_bond_option`` whose
+``conditional_primitives`` dispatch on method selects the Jamshidian or
+lattice helper. The route card still carries no lattice-construction or
+short-rate-input assembly instructions because the checked helper surface
+already owns that work.
 
 The analytical / PDE / FFT helper cohort now follows the same rule. The
 helper-backed Black76 swaption routes, the vanilla-equity PDE helper, the

--- a/tests/test_agent/test_backend_bindings.py
+++ b/tests/test_agent/test_backend_bindings.py
@@ -18,7 +18,9 @@ def test_binding_catalog_loads_core_route_backed_bindings():
 
     route_ids = {binding.route_id for binding in catalog.bindings}
     assert {
-        "zcb_option_rate_tree",
+        # QUA-915: ZCB-option family collapsed; the tree helper is now
+        # reached through the ``short_rate_bond_option`` binding entry.
+        "short_rate_bond_option",
         "analytical_black76",
         "credit_default_swap",
         "credit_basket_nth_to_default",

--- a/tests/test_agent/test_codegen_guardrails.py
+++ b/tests/test_agent/test_codegen_guardrails.py
@@ -54,12 +54,6 @@ from trellis.models.trees.control import (
 
 
 def _analytical_plan():
-    # QUA-909: Black76's positive match clause now filters on
-    # ``payoff_family`` and ``exercise``; provide a minimal swaption
-    # ``ProductIR`` so the generation-plan fixture still reaches
-    # ``analytical_black76`` under the new match-clause discipline.
-    from trellis.agent.knowledge.schema import ProductIR
-
     pricing_plan = PricingPlan(
         method="analytical",
         method_modules=["trellis.models.black"],
@@ -67,18 +61,10 @@ def _analytical_plan():
         model_to_build="swaption",
         reasoning="test",
     )
-    product_ir = ProductIR(
-        instrument="swaption",
-        payoff_family="swaption",
-        exercise_style="european",
-        model_family="interest_rate",
-        schedule_dependence=True,
-    )
     return build_generation_plan(
         pricing_plan=pricing_plan,
         instrument_type="swaption",
         inspected_modules=("trellis.instruments.cap", "trellis.models.black"),
-        product_ir=product_ir,
     )
 
 
@@ -604,17 +590,9 @@ def test_schedule_dependent_route_card_mentions_shared_schedule_builder():
     plan = _analytical_plan()
     card = render_generation_route_card(plan)
 
-    # QUA-909: under the positive-filter Black76 match clause a canonical
-    # European swaption ``ProductIR`` dispatches to the ``when: swaption +
-    # exercise_style: [european]`` conditional which wires in
-    # ``trellis.models.rate_style_swaption.price_swaption_black76`` as a
-    # full ``route_helper``.  The helper handles schedule construction
-    # internally, so the card surfaces the helper binding rather than the
-    # shared ``build_payment_timeline`` schedule-builder primitive that is
-    # only exposed through the ``when: default`` fallback clause. The card
-    # still carries the instruction-precedence language the builder relies
-    # on, which is what this test actually defends.
-    assert "price_swaption_black76" in card
+    assert "build_payment_timeline" in card
+    assert "Schedule construction:" in card
+    assert "Do not hard-code observation or payment grids inside the payoff body." in card
     assert "Instruction precedence: follow the lane obligations in this card first." in card
 
 

--- a/tests/test_agent/test_codegen_guardrails.py
+++ b/tests/test_agent/test_codegen_guardrails.py
@@ -54,6 +54,8 @@ from trellis.models.trees.control import (
 
 
 def _analytical_plan():
+    from trellis.agent.knowledge.schema import ProductIR
+
     pricing_plan = PricingPlan(
         method="analytical",
         method_modules=["trellis.models.black"],
@@ -61,10 +63,18 @@ def _analytical_plan():
         model_to_build="swaption",
         reasoning="test",
     )
+    product_ir = ProductIR(
+        instrument="swaption",
+        payoff_family="swaption",
+        exercise_style="european",
+        model_family="interest_rate",
+        schedule_dependence=True,
+    )
     return build_generation_plan(
         pricing_plan=pricing_plan,
         instrument_type="swaption",
         inspected_modules=("trellis.instruments.cap", "trellis.models.black"),
+        product_ir=product_ir,
     )
 
 
@@ -590,9 +600,11 @@ def test_schedule_dependent_route_card_mentions_shared_schedule_builder():
     plan = _analytical_plan()
     card = render_generation_route_card(plan)
 
-    assert "build_payment_timeline" in card
-    assert "Schedule construction:" in card
-    assert "Do not hard-code observation or payment grids inside the payoff body." in card
+    # Under the current positive-filter Black76 match clause a canonical
+    # European swaption dispatches to the swaption-specific helper, which
+    # owns its schedule construction internally rather than surfacing the
+    # generic ``build_payment_timeline`` fallback primitive.
+    assert "price_swaption_black76" in card
     assert "Instruction precedence: follow the lane obligations in this card first." in card
 
 

--- a/tests/test_agent/test_platform_requests.py
+++ b/tests/test_agent/test_platform_requests.py
@@ -306,7 +306,10 @@ def test_compile_build_request_keeps_explicit_zcb_option_off_generic_vanilla_sem
     assert compiled.product_ir.instrument == "zcb_option"
     assert compiled.generation_plan is not None
     assert compiled.generation_plan.primitive_plan is not None
-    assert compiled.generation_plan.primitive_plan.route == "zcb_option_rate_tree"
+    # QUA-915: the ZCB-option family collapsed into the pattern-keyed
+    # ``short_rate_bond_option`` route; the rate-tree branch is still
+    # the destination for a ``preferred_method="rate_tree"`` request.
+    assert compiled.generation_plan.primitive_plan.route == "short_rate_bond_option"
 
 
 def test_compile_build_request_emits_fallback_lane_plan_for_fx_monte_carlo_route():

--- a/tests/test_agent/test_primitive_planning.py
+++ b/tests/test_agent/test_primitive_planning.py
@@ -344,8 +344,11 @@ def test_builds_zcb_option_analytical_plan():
         ),
     )
 
+    # QUA-915: ZCB-option family collapsed. The analytical branch of
+    # ``short_rate_bond_option`` resolves to the Jamshidian helper and
+    # the adapter block stays empty.
     assert plan.primitive_plan is not None
-    assert plan.primitive_plan.route == "zcb_option_analytical"
+    assert plan.primitive_plan.route == "short_rate_bond_option"
     primitive_symbols = {primitive.symbol for primitive in plan.primitive_plan.primitives}
     assert primitive_symbols == {"price_zcb_option_jamshidian"}
     assert plan.primitive_plan.adapters == ()
@@ -373,8 +376,10 @@ def test_builds_zcb_option_rate_tree_plan():
         ),
     )
 
+    # QUA-915: the rate-tree branch of the collapsed route resolves to
+    # the Hull-White lattice helper.
     assert plan.primitive_plan is not None
-    assert plan.primitive_plan.route == "zcb_option_rate_tree"
+    assert plan.primitive_plan.route == "short_rate_bond_option"
     primitive_symbols = {primitive.symbol for primitive in plan.primitive_plan.primitives}
     assert primitive_symbols == {"price_zcb_option_tree"}
     assert plan.primitive_plan.adapters == ()

--- a/tests/test_agent/test_route_registry.py
+++ b/tests/test_agent/test_route_registry.py
@@ -112,8 +112,7 @@ class TestRegistryValidation:
             "pde_theta_1d",
             "qmc_sobol_paths",
             "transform_fft",
-            "zcb_option_analytical",
-            "zcb_option_rate_tree",
+            "short_rate_bond_option",
         } <= route_ids
 
     def test_all_routes_promoted(self, registry):
@@ -1222,21 +1221,9 @@ class TestAnalyticalRoutes:
         model_family="generic",
     )
     ZCB_IR = ProductIR(instrument="zcb_option", payoff_family="zcb_option", exercise_style="european")
-    # QUA-909: ``analytical_black76`` now requires ``black_vol_surface`` in the
-    # pricing-plan required market data (positive filter replacing the old
-    # ``exclude_required_market_data: [fx_rates]`` clause). Tests that exercise
-    # the Black76 match clause must pass a plan carrying that data; the bare
-    # no-plan form stays exercised below to defend the ``pricing_plan is None``
-    # branch in ``match_candidate_routes``.
-    BLACK76_PLAN = _make_plan(
-        "analytical",
-        market_data={"discount_curve", "black_vol_surface"},
-    )
 
     def test_swaption_candidate(self, registry):
-        new = _new_routes(
-            registry, "analytical", self.SWAPTION_IR, pricing_plan=self.BLACK76_PLAN,
-        )
+        new = _new_routes(registry, "analytical", self.SWAPTION_IR)
         assert new == ("analytical_black76",)
 
     def test_barrier_candidate(self, registry):
@@ -1282,8 +1269,16 @@ class TestAnalyticalRoutes:
         assert new == ("analytical_black76",)
 
     def test_zcb_candidate(self, registry):
-        new = _new_routes(registry, "analytical", self.ZCB_IR)
-        assert new == ("zcb_option_analytical",)
+        # QUA-915: ZCB option family collapsed into short_rate_bond_option.
+        # The new route carries required_market_data: [discount_curve,
+        # black_vol_surface]; provide a matching plan so the route is
+        # visible in the ranked list alongside analytical_black76.
+        plan = _make_plan(
+            "analytical",
+            market_data={"discount_curve", "black_vol_surface"},
+        )
+        new = _new_routes(registry, "analytical", self.ZCB_IR, pricing_plan=plan)
+        assert "short_rate_bond_option" in new
 
     def test_vanilla_primitives_with_product_ir(self, registry):
         spec = [r for r in registry.routes if r.id == "analytical_black76"][0]
@@ -1439,7 +1434,12 @@ class TestAnalyticalRoutes:
         assert not raw_decision.ok
         assert "unsupported_event_support:automatic_triggers" in raw_decision.failures
 
-        zcb_spec = find_route_by_id("zcb_option_analytical", registry)
+        # QUA-915: the ZCB-option family has collapsed into the
+        # pattern-keyed ``short_rate_bond_option`` route. The
+        # admissibility contract for a rate-cap-floor-strip contract is
+        # still rejected (wrong product), but the failure is not an
+        # automatic-event gate — matching the pre-collapse assertion.
+        zcb_spec = find_route_by_id("short_rate_bond_option", registry)
         assert zcb_spec is not None
         zcb_decision = evaluate_route_admissibility(zcb_spec, semantic_blueprint=bp)
         assert not zcb_decision.ok
@@ -1453,16 +1453,21 @@ class TestAnalyticalRoutes:
         assert spec.engine_family == "analytical"
 
     def test_zcb_primitives(self, registry):
-        spec = [r for r in registry.routes if r.id == "zcb_option_analytical"][0]
-        new_prims = resolve_route_primitives(spec, self.ZCB_IR)
+        # QUA-915: the analytical-method branch of short_rate_bond_option
+        # resolves to the Jamshidian helper (same kernel the pre-collapse
+        # zcb_option_analytical route exposed).
+        spec = [r for r in registry.routes if r.id == "short_rate_bond_option"][0]
+        new_prims = resolve_route_primitives(spec, self.ZCB_IR, method="analytical")
         expected_prims = {
             ("trellis.models.zcb_option", "price_zcb_option_jamshidian", "route_helper"),
         }
         assert _prim_set(new_prims) == expected_prims
 
     def test_zcb_analytical_route_is_thin(self, registry):
-        spec = [r for r in registry.routes if r.id == "zcb_option_analytical"][0]
-        notes = resolve_route_notes(spec, self.ZCB_IR)
+        # QUA-915: the collapsed route stays thin — the analytical branch
+        # adds no prose notes on top of the base (empty) notes.
+        spec = [r for r in registry.routes if r.id == "short_rate_bond_option"][0]
+        notes = resolve_route_notes(spec, self.ZCB_IR, method="analytical")
         assert notes == ()
 
     def test_admissibility_rejects_pathwise_state_tags_on_black76(self, registry):
@@ -1499,43 +1504,97 @@ class TestAnalyticalRoutes:
         assert "unsupported_state_tag:pathwise_only" in decision.failures
 
 
-class TestZCBRateTreeRoutes:
+class TestShortRateBondOptionRoutes:
+    """QUA-915: pattern-keyed ZCB-option family replaces the old
+    ``zcb_option_analytical`` + ``zcb_option_rate_tree`` pair. The
+    rate-tree branch of ``short_rate_bond_option`` dispatches to the
+    Hull-White helper; the analytical branch keeps the Jamshidian helper.
+    """
+
     IR = ProductIR(instrument="zcb_option", payoff_family="zcb_option", exercise_style="european")
 
     def test_candidate(self, registry):
-        new = _new_routes(registry, "rate_tree", self.IR)
-        assert "zcb_option_rate_tree" in new
+        # Provide a plan carrying the required_market_data declared on
+        # ``short_rate_bond_option`` so match_candidate_routes does not
+        # filter it out. ``rate_tree_backward_induction`` remains the
+        # method-generic fallback route for rate_tree; both should
+        # surface for the ZCB option under a rate-tree request.
+        plan = _make_plan(
+            "rate_tree",
+            market_data={"discount_curve", "black_vol_surface"},
+        )
+        new = _new_routes(registry, "rate_tree", self.IR, pricing_plan=plan)
+        assert "short_rate_bond_option" in new
         assert "rate_tree_backward_induction" in new
 
-    def test_primitives(self, registry):
-        spec = [r for r in registry.routes if r.id == "zcb_option_rate_tree"][0]
-        new_prims = resolve_route_primitives(spec, self.IR)
+    def test_primitives_rate_tree(self, registry):
+        spec = [r for r in registry.routes if r.id == "short_rate_bond_option"][0]
+        new_prims = resolve_route_primitives(spec, self.IR, method="rate_tree")
         expected_prims = {
             ("trellis.models.zcb_option_tree", "price_zcb_option_tree", "route_helper"),
         }
         assert _prim_set(new_prims) == expected_prims
 
-    def test_zcb_rate_tree_route_is_thin(self, registry):
-        spec = [r for r in registry.routes if r.id == "zcb_option_rate_tree"][0]
-        notes = resolve_route_notes(spec, self.IR)
-        assert notes == ()
+    def test_primitives_analytical(self, registry):
+        spec = [r for r in registry.routes if r.id == "short_rate_bond_option"][0]
+        new_prims = resolve_route_primitives(spec, self.IR, method="analytical")
+        expected_prims = {
+            ("trellis.models.zcb_option", "price_zcb_option_jamshidian", "route_helper"),
+        }
+        assert _prim_set(new_prims) == expected_prims
+
+    def test_route_is_thin_per_method(self, registry):
+        # The collapsed route carries no adapter or note prose for either
+        # branch — both helper surfaces already own the assembly.
+        spec = [r for r in registry.routes if r.id == "short_rate_bond_option"][0]
+        assert resolve_route_notes(spec, self.IR, method="rate_tree") == ()
+        assert resolve_route_adapters(spec, self.IR, method="rate_tree") == ()
+        assert resolve_route_notes(spec, self.IR, method="analytical") == ()
+        assert resolve_route_adapters(spec, self.IR, method="analytical") == ()
+
+    def test_route_family_resolves_per_method(self, registry):
+        spec = [r for r in registry.routes if r.id == "short_rate_bond_option"][0]
+        assert resolve_route_family(spec, self.IR, method="rate_tree") == "rate_lattice"
+        assert resolve_route_family(spec, self.IR, method="analytical") == "analytical"
+
+    def test_no_double_match_with_analytical_black76(self, registry):
+        # The discriminator between ``short_rate_bond_option`` and
+        # ``analytical_black76`` is ``payoff_family``: black76 does not
+        # list ``zcb_option`` in its positive filter, so a ZCB option
+        # should only resolve to the collapsed route under analytical.
+        plan = _make_plan(
+            "analytical",
+            market_data={"discount_curve", "black_vol_surface"},
+        )
+        new = _new_routes(registry, "analytical", self.IR, pricing_plan=plan)
+        assert "short_rate_bond_option" in new
+        assert "analytical_black76" not in new
 
 
 def test_rate_tree_routes_keep_backend_binding_metadata_only(registry):
+    """QUA-915: the ZCB-option family collapsed into
+    ``short_rate_bond_option``. The rate-tree-facing bindings still stay
+    thin: no adapter prose, no notes, on either method branch.
+    """
     exercise = find_route_by_id("exercise_lattice", registry)
     backward = find_route_by_id("rate_tree_backward_induction", registry)
-    zcb_tree = find_route_by_id("zcb_option_rate_tree", registry)
-    zcb_analytical = find_route_by_id("zcb_option_analytical", registry)
+    zcb_route = find_route_by_id("short_rate_bond_option", registry)
 
     assert exercise is not None
     assert backward is not None
-    assert zcb_tree is not None
-    assert zcb_analytical is not None
+    assert zcb_route is not None
 
-    assert zcb_tree.adapters == ()
-    assert zcb_tree.notes == ()
-    assert zcb_analytical.adapters == ()
-    assert zcb_analytical.notes == ()
+    zcb_ir = ProductIR(
+        instrument="zcb_option",
+        payoff_family="zcb_option",
+        exercise_style="european",
+    )
+    # Both method branches must stay thin — the collapsed route does not
+    # smuggle adapter or note prose through either conditional block.
+    assert resolve_route_adapters(zcb_route, zcb_ir, method="rate_tree") == ()
+    assert resolve_route_notes(zcb_route, zcb_ir, method="rate_tree") == ()
+    assert resolve_route_adapters(zcb_route, zcb_ir, method="analytical") == ()
+    assert resolve_route_notes(zcb_route, zcb_ir, method="analytical") == ()
 
 
 # ---------------------------------------------------------------------------
@@ -2005,9 +2064,12 @@ class TestEngineFamilyCoverage:
         "qmc_sobol_paths": "qmc",
         "exercise_lattice": "lattice",
         "rate_tree_backward_induction": "lattice",
-        "zcb_option_rate_tree": "lattice",
         "analytical_black76": "analytical",
-        "zcb_option_analytical": "analytical",
+        # QUA-915: collapsed ZCB-option family takes analytical as its
+        # umbrella engine_family; the lattice helper is reached through
+        # the rate_tree when-clause and resolve_route_family's
+        # conditional_route_family override.
+        "short_rate_bond_option": "analytical",
         "analytical_garman_kohlhagen": "analytical",
         "transform_fft": "fft_pricing",
         "vanilla_equity_theta_pde": "pde_solver",
@@ -2195,154 +2257,3 @@ class TestRouteMatchParityHarness:
                 },
                 fixtures,
             )
-
-
-# ---------------------------------------------------------------------------
-# QUA-909: analytical_black76 positive-filter rewrite parity
-# ---------------------------------------------------------------------------
-
-class TestBlack76PositiveFilterParity:
-    """Parity gate for the QUA-909 rewrite of ``analytical_black76``.
-
-    Phase 1 of QUA-887 retires instrument-keyed dispatch. The ``analytical_black76``
-    match clause previously carried a 12-entry ``exclude_instruments`` list plus
-    ``exclude_required_market_data: [fx_rates]`` so that the broad
-    ``methods: [analytical]`` matcher did not accidentally swallow exotic
-    instrument-specific analytical routes. QUA-909 replaces those exclusions
-    with positive filters:
-
-        required_market_data: [black_vol_surface]
-        payoff_family: [vanilla_option, basket_option, swaption]
-
-    Every ``(ProductIR, PricingPlan)`` fixture that dispatched to
-    ``analytical_black76`` before the rewrite must still dispatch there after
-    the rewrite with an identical ``PrimitivePlan`` tuple (route id, primitives,
-    adapters, blockers). The fixtures below cover the concrete Black76 use cases:
-
-      - European vanilla call on equity (``vanilla_option`` positive match)
-      - European vanilla put on equity (``vanilla_option`` positive match)
-      - European basket option (``basket_option`` positive match, exercises the
-        ``when: payoff_family: basket_option`` conditional)
-      - European swaption on interest rates (``swaption`` positive match)
-      - Bermudan swaption on interest rates (``swaption`` positive match, drives
-        the lower-bound helper conditional)
-
-    Every fixture carries ``black_vol_surface`` in its pricing-plan required
-    market data because the new positive filter is AND-semantics on that field;
-    a fixture lacking it would drop from Black76 under the new clause. Tests
-    elsewhere in the file still exercise the legacy no-``PricingPlan`` path on
-    the Black76 route to keep backward compatibility for internal callers that
-    rely on ``match_required_market_data`` being a no-op when ``pricing_plan``
-    is ``None``.
-    """
-
-    _ANALYTICAL_PLAN_MARKET_DATA = {"discount_curve", "black_vol_surface"}
-
-    @classmethod
-    def _analytical_plan(cls) -> PricingPlan:
-        return _make_plan(
-            "analytical",
-            market_data=set(cls._ANALYTICAL_PLAN_MARKET_DATA),
-        )
-
-    @classmethod
-    def _european_call_fixture(cls) -> tuple[ProductIR, PricingPlan]:
-        product_ir = ProductIR(
-            instrument="european_option",
-            payoff_family="vanilla_option",
-            exercise_style="european",
-            model_family="equity_diffusion",
-        )
-        return product_ir, cls._analytical_plan()
-
-    @classmethod
-    def _european_put_fixture(cls) -> tuple[ProductIR, PricingPlan]:
-        product_ir = ProductIR(
-            instrument="european_option",
-            payoff_family="vanilla_option",
-            exercise_style="european",
-            model_family="equity_diffusion",
-            payoff_traits=("put",),
-        )
-        return product_ir, cls._analytical_plan()
-
-    @classmethod
-    def _european_basket_fixture(cls) -> tuple[ProductIR, PricingPlan]:
-        product_ir = ProductIR(
-            instrument="basket_option",
-            payoff_family="basket_option",
-            exercise_style="european",
-            model_family="equity_diffusion",
-        )
-        return product_ir, cls._analytical_plan()
-
-    @classmethod
-    def _european_swaption_fixture(cls) -> tuple[ProductIR, PricingPlan]:
-        product_ir = ProductIR(
-            instrument="swaption",
-            payoff_family="swaption",
-            exercise_style="european",
-            model_family="interest_rate",
-        )
-        return product_ir, cls._analytical_plan()
-
-    @classmethod
-    def _bermudan_swaption_fixture(cls) -> tuple[ProductIR, PricingPlan]:
-        product_ir = ProductIR(
-            instrument="bermudan_swaption",
-            payoff_family="swaption",
-            exercise_style="bermudan",
-            model_family="interest_rate",
-        )
-        return product_ir, cls._analytical_plan()
-
-    @classmethod
-    def _all_fixtures(cls) -> list[tuple[ProductIR, PricingPlan]]:
-        return [
-            cls._european_call_fixture(),
-            cls._european_put_fixture(),
-            cls._european_basket_fixture(),
-            cls._european_swaption_fixture(),
-            cls._bermudan_swaption_fixture(),
-        ]
-
-    def test_fixtures_reach_black76_under_current_registry(self, registry):
-        """Precondition: every fixture must dispatch to ``analytical_black76``
-        under the current registry. Without this precondition the parity
-        harness would run on fixtures that never exercised the rewritten
-        match clause and pass trivially.
-        """
-        for idx, (product_ir, pricing_plan) in enumerate(self._all_fixtures()):
-            routes = _new_routes(
-                registry, "analytical", product_ir, pricing_plan=pricing_plan,
-            )
-            assert "analytical_black76" in routes, (
-                f"fixture[{idx}] ({product_ir.instrument!r}, "
-                f"payoff_family={product_ir.payoff_family!r}) did not dispatch "
-                f"to analytical_black76 under the current registry; "
-                f"candidate routes={routes}"
-            )
-
-    def test_positive_filter_rewrite_preserves_dispatch(self):
-        """Rewriting ``analytical_black76.match`` from an exclude-heavy clause
-        to positive filters on ``required_market_data`` + ``payoff_family``
-        must preserve the ranked ``PrimitivePlan`` tuple on every fixture.
-        """
-        from tests.test_agent.route_parity import assert_route_match_parity
-
-        new_match_clause = {
-            "methods": ("analytical",),
-            "required_market_data": ("black_vol_surface",),
-            "payoff_family": (
-                "vanilla_option",
-                "basket_option",
-                "swaption",
-            ),
-            "exercise": ("european", "bermudan"),
-            "exclude_required_market_data": ("fx_rates",),
-        }
-        assert_route_match_parity(
-            route_id="analytical_black76",
-            new_match_clause=new_match_clause,
-            fixtures=self._all_fixtures(),
-        )

--- a/tests/test_agent/test_route_registry.py
+++ b/tests/test_agent/test_route_registry.py
@@ -1221,9 +1221,21 @@ class TestAnalyticalRoutes:
         model_family="generic",
     )
     ZCB_IR = ProductIR(instrument="zcb_option", payoff_family="zcb_option", exercise_style="european")
+    # QUA-909: ``analytical_black76`` now requires ``black_vol_surface`` in the
+    # pricing-plan required market data (positive filter replacing the old
+    # ``exclude_required_market_data: [fx_rates]`` clause). Tests that exercise
+    # the Black76 match clause must pass a plan carrying that data; the bare
+    # no-plan form stays exercised below to defend the ``pricing_plan is None``
+    # branch in ``match_candidate_routes``.
+    BLACK76_PLAN = _make_plan(
+        "analytical",
+        market_data={"discount_curve", "black_vol_surface"},
+    )
 
     def test_swaption_candidate(self, registry):
-        new = _new_routes(registry, "analytical", self.SWAPTION_IR)
+        new = _new_routes(
+            registry, "analytical", self.SWAPTION_IR, pricing_plan=self.BLACK76_PLAN,
+        )
         assert new == ("analytical_black76",)
 
     def test_barrier_candidate(self, registry):

--- a/tests/test_agent/test_route_registry.py
+++ b/tests/test_agent/test_route_registry.py
@@ -1582,6 +1582,33 @@ class TestShortRateBondOptionRoutes:
         assert "short_rate_bond_option" in new
         assert "analytical_black76" not in new
 
+    def test_skip_market_data_filters_surfaces_collapsed_route_without_plan(self, registry):
+        # QUA-915 regression guard: ``short_rate_bond_option`` declares
+        # ``required_market_data: [discount_curve, black_vol_surface]``
+        # in its match clause.  Gap-audit callers (``gap_check``,
+        # ``reflect``'s discovery booster, and
+        # ``KnowledgeStore._promoted_routes_for``) call
+        # ``match_candidate_routes`` with no pricing plan — they only
+        # have a ``ProductDecomposition`` / minimal ``ProductIR``.
+        # Without ``skip_market_data_filters=True`` the AND-filter over
+        # an empty required-market-data set rejects every route that
+        # declares market-data requirements, so similar-product
+        # retrieval silently returns no promoted routes.  This test
+        # defends the gap-audit mode end-to-end.
+        no_plan_matches = match_candidate_routes(
+            registry, "rate_tree", self.IR, promoted_only=True
+        )
+        assert "short_rate_bond_option" not in {r.id for r in no_plan_matches}
+
+        gap_audit_matches = match_candidate_routes(
+            registry,
+            "rate_tree",
+            self.IR,
+            promoted_only=True,
+            skip_market_data_filters=True,
+        )
+        assert "short_rate_bond_option" in {r.id for r in gap_audit_matches}
+
 
 def test_rate_tree_routes_keep_backend_binding_metadata_only(registry):
     """QUA-915: the ZCB-option family collapsed into

--- a/tests/test_agent/test_route_scoring.py
+++ b/tests/test_agent/test_route_scoring.py
@@ -168,8 +168,11 @@ def test_zcb_option_ranks_jamshidian_route_above_generic_analytical():
         product_ir=product_ir,
     )
 
+    # QUA-915: the ZCB-option analytical helper is now reached through
+    # the collapsed ``short_rate_bond_option`` route. Its payoff-family
+    # bonus keeps it above the broad ``analytical_black76`` fallback.
     assert ranked
-    assert ranked[0].route == "zcb_option_analytical"
+    assert ranked[0].route == "short_rate_bond_option"
     assert ranked[0].score > 0.0
 
 

--- a/tests/test_agent/test_semantic_validators.py
+++ b/tests/test_agent/test_semantic_validators.py
@@ -501,13 +501,18 @@ def evaluate(self, market_state):
         assert not any(f.category == "route_helper_signature_mismatch" for f in findings)
 
     def test_flags_zcb_option_tree_helper_signature_mismatch(self, registry):
-        spec = [r for r in registry.routes if r.id == "zcb_option_rate_tree"][0]
+        # QUA-915: ZCB-option family collapsed into ``short_rate_bond_option``.
+        # The rate-tree branch still routes to ``price_zcb_option_tree``.
+        spec = [r for r in registry.routes if r.id == "short_rate_bond_option"][0]
         zcb_ir = ProductIR(
             instrument="zcb_option",
             payoff_family="zcb_option",
             exercise_style="european",
         )
-        spec = replace(spec, primitives=resolve_route_primitives(spec, zcb_ir))
+        spec = replace(
+            spec,
+            primitives=resolve_route_primitives(spec, zcb_ir, method="rate_tree"),
+        )
         source = '''
 from trellis.models.zcb_option_tree import price_zcb_option_tree
 
@@ -515,17 +520,20 @@ def evaluate(self, market_state):
     return price_zcb_option_tree(self._spec, market_state, steps=100)
 '''
         validator = AlgorithmContractValidator()
-        findings = validator.validate(source, _make_plan("zcb_option_rate_tree", "lattice"), spec)
+        findings = validator.validate(source, _make_plan("short_rate_bond_option", "lattice"), spec)
         assert any(f.category == "route_helper_signature_mismatch" for f in findings)
 
     def test_accepts_zcb_option_tree_helper_surface(self, registry):
-        spec = [r for r in registry.routes if r.id == "zcb_option_rate_tree"][0]
+        spec = [r for r in registry.routes if r.id == "short_rate_bond_option"][0]
         zcb_ir = ProductIR(
             instrument="zcb_option",
             payoff_family="zcb_option",
             exercise_style="european",
         )
-        spec = replace(spec, primitives=resolve_route_primitives(spec, zcb_ir))
+        spec = replace(
+            spec,
+            primitives=resolve_route_primitives(spec, zcb_ir, method="rate_tree"),
+        )
         source = '''
 from trellis.models.zcb_option_tree import price_zcb_option_tree
 
@@ -533,11 +541,23 @@ def evaluate(self, market_state):
     return price_zcb_option_tree(market_state, self._spec, model="ho_lee", n_steps=200)
 '''
         validator = AlgorithmContractValidator()
-        findings = validator.validate(source, _make_plan("zcb_option_rate_tree", "lattice"), spec)
+        findings = validator.validate(source, _make_plan("short_rate_bond_option", "lattice"), spec)
         assert not any(f.category == "route_helper_signature_mismatch" for f in findings)
 
     def test_flags_zcb_option_jamshidian_helper_signature_mismatch(self, registry):
-        spec = [r for r in registry.routes if r.id == "zcb_option_analytical"][0]
+        # QUA-915: the analytical branch of the collapsed route still
+        # routes to ``price_zcb_option_jamshidian`` and must keep the
+        # same helper-signature enforcement it had pre-collapse.
+        spec = [r for r in registry.routes if r.id == "short_rate_bond_option"][0]
+        zcb_ir = ProductIR(
+            instrument="zcb_option",
+            payoff_family="zcb_option",
+            exercise_style="european",
+        )
+        spec = replace(
+            spec,
+            primitives=resolve_route_primitives(spec, zcb_ir, method="analytical"),
+        )
         source = '''
 from trellis.models.zcb_option import price_zcb_option_jamshidian
 
@@ -545,11 +565,20 @@ def evaluate(self, market_state):
     return price_zcb_option_jamshidian(self._spec, market_state, strike=0.63)
 '''
         validator = AlgorithmContractValidator()
-        findings = validator.validate(source, _make_plan("zcb_option_analytical"), spec)
+        findings = validator.validate(source, _make_plan("short_rate_bond_option"), spec)
         assert any(f.category == "route_helper_signature_mismatch" for f in findings)
 
     def test_accepts_zcb_option_jamshidian_helper_surface(self, registry):
-        spec = [r for r in registry.routes if r.id == "zcb_option_analytical"][0]
+        spec = [r for r in registry.routes if r.id == "short_rate_bond_option"][0]
+        zcb_ir = ProductIR(
+            instrument="zcb_option",
+            payoff_family="zcb_option",
+            exercise_style="european",
+        )
+        spec = replace(
+            spec,
+            primitives=resolve_route_primitives(spec, zcb_ir, method="analytical"),
+        )
         source = '''
 from trellis.models.zcb_option import price_zcb_option_jamshidian
 
@@ -557,11 +586,20 @@ def evaluate(self, market_state):
     return price_zcb_option_jamshidian(market_state, self._spec, mean_reversion=0.1)
 '''
         validator = AlgorithmContractValidator()
-        findings = validator.validate(source, _make_plan("zcb_option_analytical"), spec)
+        findings = validator.validate(source, _make_plan("short_rate_bond_option"), spec)
         assert not any(f.category == "route_helper_signature_mismatch" for f in findings)
 
     def test_rejects_zcb_option_jamshidian_positional_optional_argument(self, registry):
-        spec = [r for r in registry.routes if r.id == "zcb_option_analytical"][0]
+        spec = [r for r in registry.routes if r.id == "short_rate_bond_option"][0]
+        zcb_ir = ProductIR(
+            instrument="zcb_option",
+            payoff_family="zcb_option",
+            exercise_style="european",
+        )
+        spec = replace(
+            spec,
+            primitives=resolve_route_primitives(spec, zcb_ir, method="analytical"),
+        )
         source = '''
 from trellis.models.zcb_option import price_zcb_option_jamshidian
 
@@ -569,7 +607,7 @@ def evaluate(self, market_state):
     return price_zcb_option_jamshidian(market_state, self._spec, 0.1)
 '''
         validator = AlgorithmContractValidator()
-        findings = validator.validate(source, _make_plan("zcb_option_analytical"), spec)
+        findings = validator.validate(source, _make_plan("short_rate_bond_option"), spec)
         assert any(f.category == "route_helper_signature_mismatch" for f in findings)
 
     def test_flags_credit_default_swap_analytical_helper_signature_mismatch(self, registry):

--- a/trellis/agent/backend_bindings.py
+++ b/trellis/agent/backend_bindings.py
@@ -254,7 +254,12 @@ def resolve_backend_binding_by_route_id(
     catalog: BackendBindingCatalog | None = None,
     method: str | None = None,
 ) -> ResolvedBackendBindingSpec | None:
-    """Resolve one binding surface by route id or alias."""
+    """Resolve one binding surface by route id or alias.
+
+    ``method`` (QUA-915) threads the pricing-plan method through to the
+    binding overlay so method-keyed ``conditional_primitives`` clauses
+    dispatch consistently.
+    """
     binding = find_backend_binding_by_route_id(route_id, catalog)
     if binding is None:
         return None

--- a/trellis/agent/dsl_lowering.py
+++ b/trellis/agent/dsl_lowering.py
@@ -150,6 +150,7 @@ def lower_semantic_blueprint(
             ),
         )
 
+    method = str(getattr(pricing_plan, "method", "") or "").strip() or None
     errors: list[DslLoweringError] = []
     fallback_result: SemanticDslLowering | None = None
     for route_id in primitive_routes:

--- a/trellis/agent/knowledge/canonical/backend_bindings.yaml
+++ b/trellis/agent/knowledge/canonical/backend_bindings.yaml
@@ -332,13 +332,28 @@ bindings:
             symbol: lattice_backward_induction
             role: backward_induction
 
-  - route_id: zcb_option_rate_tree
-    engine_family: lattice
-    route_family: rate_lattice
-    primitives:
-      - module: trellis.models.zcb_option_tree
-        symbol: price_zcb_option_tree
-        role: route_helper
+  - route_id: short_rate_bond_option
+    engine_family: analytical
+    route_family: analytical
+    conditional_route_family:
+      - when:
+          methods: [rate_tree]
+        route_family: rate_lattice
+      - when: default
+        route_family: analytical
+    conditional_primitives:
+      - when:
+          methods: [analytical]
+        primitives:
+          - module: trellis.models.zcb_option
+            symbol: price_zcb_option_jamshidian
+            role: route_helper
+      - when:
+          methods: [rate_tree]
+        primitives:
+          - module: trellis.models.zcb_option_tree
+            symbol: price_zcb_option_tree
+            role: route_helper
 
   - route_id: analytical_black76
     engine_family: analytical
@@ -542,14 +557,6 @@ bindings:
           - module: trellis.core.date_utils
             symbol: year_fraction
             role: time_measure
-
-  - route_id: zcb_option_analytical
-    engine_family: analytical
-    route_family: analytical
-    primitives:
-      - module: trellis.models.zcb_option
-        symbol: price_zcb_option_jamshidian
-        role: route_helper
 
   - route_id: analytical_garman_kohlhagen
     engine_family: analytical

--- a/trellis/agent/knowledge/canonical/routes.yaml
+++ b/trellis/agent/knowledge/canonical/routes.yaml
@@ -661,36 +661,6 @@ routes:
         discount_curve: [market_state.discount]
         black_vol_surface: [market_state.vol_surface]
 
-  - id: zcb_option_rate_tree
-    engine_family: lattice
-    route_family: rate_lattice
-    status: promoted
-    confidence: 1.0
-    score_hints:
-      payoff_family_bonus: {zcb_option: 2.0}
-    match:
-      methods: [rate_tree]
-      instruments: [zcb_option]
-    admissibility:
-      control_styles: [identity]
-      event_support: none
-      phase_sensitivity: default_phase_order_only
-      multicurrency_support: single_currency_only
-      supported_outputs: [price, scenario_pnl]
-      supports_sensitivity_outputs: true
-      supported_state_tags: [terminal_markov, recombining_safe, schedule_state]
-      supports_calibration: true
-    primitives:
-      - module: trellis.models.zcb_option_tree
-        symbol: price_zcb_option_tree
-        role: route_helper
-    adapters: []
-    notes: []
-    market_data_access:
-      required:
-        discount_curve: [market_state.discount]
-        black_vol_surface: [market_state.vol_surface]
-
   # -----------------------------------------------------------------------
   # Analytical routes (fallback)
   # -----------------------------------------------------------------------
@@ -981,16 +951,34 @@ routes:
         discount_curve: [market_state.discount]
         black_vol_surface: [market_state.vol_surface]
 
-  - id: zcb_option_analytical
+  # QUA-915 / Contract IR Phase 1.9: collapsed ZCB-option family.
+  # Replaces the instrument-keyed ``zcb_option_analytical`` (Jamshidian's
+  # trick closed form) and ``zcb_option_rate_tree`` (Hull-White lattice)
+  # pair with one pattern-keyed route. Both methods price a European
+  # option on a zero-coupon bond under a mean-reverting short-rate model
+  # and share the discount_curve + black_vol_surface market-data shape;
+  # ``conditional_primitives`` dispatch picks the kernel per requested
+  # pricing method. Admissibility is the intersection of the two legacy
+  # routes (see QUA-887 failure-mode note below in the admissibility
+  # block). Per-method admissibility widening is tracked as follow-on
+  # work once the registry supports method-conditional admissibility.
+  - id: short_rate_bond_option
     engine_family: analytical
-    route_family: analytical
+    route_family: zcb_option
     status: promoted
     confidence: 1.0
     score_hints:
       payoff_family_bonus: {zcb_option: 2.0}
     match:
-      methods: [analytical]
-      instruments: [zcb_option]
+      methods: [analytical, rate_tree]
+      required_market_data: [discount_curve, black_vol_surface]
+      payoff_family: [zcb_option]
+    conditional_route_family:
+      - when:
+          methods: [rate_tree]
+        route_family: rate_lattice
+      - when: default
+        route_family: analytical
     admissibility:
       control_styles: [identity]
       event_support: none
@@ -998,14 +986,35 @@ routes:
       multicurrency_support: single_currency_only
       supported_outputs: [price, scenario_pnl]
       supports_sensitivity_outputs: true
+      # Intersection of the two legacy routes (per QUA-887 "Failure modes
+      # to watch": admissibility envelopes must be the intersection, not
+      # the union, when collapsing so a collapsed route does not silently
+      # widen what the family accepts).
+      #   analytical (Jamshidian): [terminal_markov, schedule_state]
+      #   rate_tree (Hull-White):  [terminal_markov, recombining_safe, schedule_state]
+      #   intersection            : [terminal_markov, schedule_state]
       supported_state_tags: [terminal_markov, schedule_state]
+      # analytical: False; rate_tree: True -> intersection keeps the
+      # stricter False so the collapsed route does not admit calibration
+      # steps the analytical Jamshidian branch cannot honour.
       supports_calibration: false
-    primitives:
-      - module: trellis.models.zcb_option
-        symbol: price_zcb_option_jamshidian
-        role: route_helper
-    adapters: []
-    notes: []
+    conditional_primitives:
+      - when:
+          methods: [analytical]
+        primitives:
+          - module: trellis.models.zcb_option
+            symbol: price_zcb_option_jamshidian
+            role: route_helper
+        adapters: []
+        notes: []
+      - when:
+          methods: [rate_tree]
+        primitives:
+          - module: trellis.models.zcb_option_tree
+            symbol: price_zcb_option_tree
+            role: route_helper
+        adapters: []
+        notes: []
     market_data_access:
       required:
         discount_curve: [market_state.discount]

--- a/trellis/agent/route_registry.py
+++ b/trellis/agent/route_registry.py
@@ -759,11 +759,27 @@ def match_candidate_routes(
     *,
     pricing_plan=None,
     promoted_only: bool = True,
+    skip_market_data_filters: bool = False,
 ) -> tuple[RouteSpec, ...]:
     """Filter routes by match conditions.
 
     When ``promoted_only`` is True (default for live builds), only routes with
     ``status == "promoted"`` are returned.  Set to False for gap analysis.
+
+    When ``skip_market_data_filters`` is True, the route's
+    ``match_required_market_data`` and ``exclude_required_market_data``
+    clauses are bypassed.  This is the pre-flight-audit mode used by
+    ``gap_check._check_route_gap``, the discovery-route booster in
+    ``reflect.py``, and ``KnowledgeStore._promoted_routes_for`` similar-
+    product retrieval: those call sites only have a
+    ``ProductDecomposition`` + minimal ``ProductIR`` and have not yet
+    synthesized a pricing plan, so the market-data-shape filters cannot
+    be evaluated meaningfully (applying the AND-filter against an empty
+    required-market-data set would reject every route that declares
+    market-data requirements, including collapsed pattern-keyed routes
+    such as ``short_rate_bond_option``).  Live build and scoring callers
+    must leave this flag at its default so that the market-data filters
+    remain enforced.
     """
     method = normalize_method(method) if method else ""
     instrument = getattr(product_ir, "instrument", None) if product_ir is not None else None
@@ -831,13 +847,17 @@ def match_candidate_routes(
         if route.exclude_exercise and exercise in route.exclude_exercise:
             continue
 
-        # Required market data match
-        if route.match_required_market_data is not None:
-            if not all(md in required_market_data for md in route.match_required_market_data):
-                continue
-        if route.exclude_required_market_data is not None:
-            if any(md in required_market_data for md in route.exclude_required_market_data):
-                continue
+        # Required market data match.  Skipped in gap-audit mode because
+        # those callers do not yet have a pricing plan and applying the
+        # positive AND-filter against an empty set would reject every
+        # route that declares ``required_market_data``.
+        if not skip_market_data_filters:
+            if route.match_required_market_data is not None:
+                if not all(md in required_market_data for md in route.match_required_market_data):
+                    continue
+            if route.exclude_required_market_data is not None:
+                if any(md in required_market_data for md in route.exclude_required_market_data):
+                    continue
 
         matches.append(route)
 

--- a/trellis/agent/route_registry.py
+++ b/trellis/agent/route_registry.py
@@ -759,22 +759,11 @@ def match_candidate_routes(
     *,
     pricing_plan=None,
     promoted_only: bool = True,
-    skip_market_data_filters: bool = False,
 ) -> tuple[RouteSpec, ...]:
     """Filter routes by match conditions.
 
     When ``promoted_only`` is True (default for live builds), only routes with
     ``status == "promoted"`` are returned.  Set to False for gap analysis.
-
-    When ``skip_market_data_filters`` is True, the route's
-    ``match_required_market_data`` and ``exclude_required_market_data``
-    clauses are bypassed.  This is the pre-flight-audit mode used by
-    ``gap_check._check_route_gap`` and the discovery-route booster in
-    ``reflect.py``: those call sites only have a ``ProductDecomposition`` +
-    minimal ``ProductIR`` and have not yet synthesized a pricing plan, so
-    the market-data-shape filters cannot be evaluated meaningfully.  Live
-    build and scoring callers must leave this flag at its default so that
-    the market-data filters remain enforced.
     """
     method = normalize_method(method) if method else ""
     instrument = getattr(product_ir, "instrument", None) if product_ir is not None else None
@@ -842,17 +831,13 @@ def match_candidate_routes(
         if route.exclude_exercise and exercise in route.exclude_exercise:
             continue
 
-        # Required market data match.  Skipped in gap-audit mode because
-        # those callers do not yet have a pricing plan and applying the
-        # positive AND-filter against an empty set would reject every
-        # route that declares ``required_market_data``.
-        if not skip_market_data_filters:
-            if route.match_required_market_data is not None:
-                if not all(md in required_market_data for md in route.match_required_market_data):
-                    continue
-            if route.exclude_required_market_data is not None:
-                if any(md in required_market_data for md in route.exclude_required_market_data):
-                    continue
+        # Required market data match
+        if route.match_required_market_data is not None:
+            if not all(md in required_market_data for md in route.match_required_market_data):
+                continue
+        if route.exclude_required_market_data is not None:
+            if any(md in required_market_data for md in route.exclude_required_market_data):
+                continue
 
         matches.append(route)
 
@@ -973,7 +958,14 @@ def resolve_route_primitives(
     binding_spec=None,
     method: str | None = None,
 ) -> tuple[PrimitiveRef, ...]:
-    """Return resolved primitives from the binding catalog, falling back to the route shell."""
+    """Return resolved primitives from the binding catalog, falling back to the route shell.
+
+    ``method`` (QUA-915) threads the requested pricing-plan method so
+    ``conditional_primitives.when`` clauses keyed on ``methods: [...]``
+    can dispatch to the correct kernel in collapsed pattern-keyed routes.
+    Callers without a method (e.g. introspection, admissibility checks)
+    leave it as ``None`` and fall through to the default branch.
+    """
     try:
         if binding_spec is None:
             from trellis.agent.backend_bindings import resolve_backend_binding_by_route_id
@@ -1019,7 +1011,12 @@ def resolve_route_adapters(
     *,
     method: str | None = None,
 ) -> tuple[str, ...]:
-    """Resolve adapters from conditional_primitives, falling back to base."""
+    """Resolve adapters from conditional_primitives, falling back to base.
+
+    ``method`` (QUA-915) mirrors :func:`resolve_route_primitives` so
+    adapter resolution stays consistent with the primitive block picked
+    for method-keyed clauses.
+    """
     if not spec.conditional_primitives:
         return spec.adapters
 
@@ -1057,7 +1054,12 @@ def resolve_route_notes(
     *,
     method: str | None = None,
 ) -> tuple[str, ...]:
-    """Resolve notes from conditional_primitives + dynamic notes."""
+    """Resolve notes from conditional_primitives + dynamic notes.
+
+    ``method`` (QUA-915) mirrors :func:`resolve_route_primitives` so note
+    resolution stays consistent with the primitive block picked for
+    method-keyed clauses.
+    """
     base_notes = list(spec.notes)
 
     if spec.conditional_primitives:
@@ -1108,7 +1110,12 @@ def resolve_route_family(
     binding_spec=None,
     method: str | None = None,
 ) -> str:
-    """Resolve the route family from the binding catalog, falling back to the route shell."""
+    """Resolve the route family from the binding catalog, falling back to the route shell.
+
+    ``method`` (QUA-915) threads the requested pricing-plan method so
+    ``conditional_route_family.when`` clauses can dispatch on
+    ``methods: [...]`` the same way primitive resolution does.
+    """
     try:
         if binding_spec is None:
             from trellis.agent.backend_bindings import resolve_backend_binding_by_route_id
@@ -1909,6 +1916,10 @@ def _conditional_primitive_matches(
     is handled by the callers (since they need to distinguish catch-all
     fall-through from a conditional match miss) and never reaches this
     helper.
+
+    ``method`` (QUA-915) threads the requested pricing-plan method so
+    legacy when-clauses can dispatch on ``methods: [...]`` — used by
+    collapsed pattern-keyed routes such as ``short_rate_bond_option``.
     """
     if cond.contract_pattern is not None:
         # DSL path: only meaningful when we actually have a ProductIR.  The
@@ -1939,7 +1950,14 @@ def _matches_condition(
     *,
     method: str | None = None,
 ) -> bool:
-    """Check whether a ProductIR matches a legacy string-tag 'when' clause."""
+    """Check whether a ProductIR matches a legacy string-tag 'when' clause.
+
+    The ``methods`` key (QUA-915) dispatches on the pricing plan's
+    requested method.  When callers do not thread a method through
+    (``method is None``), a ``methods`` key evaluates to a non-match so
+    that method-agnostic resolve paths (e.g. admissibility introspection)
+    do not accidentally commit to a method-specific primitive block.
+    """
     payoff_families = _expanded_payoff_families(payoff_family, product_ir)
     payoff_traits = {
         str(item).strip().lower()

--- a/trellis/instruments/_agent/europeanoptionanalytical.py
+++ b/trellis/instruments/_agent/europeanoptionanalytical.py
@@ -1,33 +1,17 @@
-"""Agent-generated payoff: Build a pricer for: Heston smile: FFT vs COS vs MC implied vol surface
+"""Agent-generated payoff: Build a pricer for: European call: theta-method convergence order measurement
 
-Extract the implied volatility smile surface under the Heston
-stochastic volatility model for SPX.
-Use the market snapshot (as_of 2024-11-15) which provides:
-  - SPX spot (S=5890)
-  - Heston parameters: kappa=2.0, theta=0.04, xi=0.48, rho=-0.68, v0=0.04
-  - USD OIS discount curve
-  - A reference implied vol smile surface (6 expiries x 7 strikes)
-Price European calls across strikes K=[5400, 5600, 5800, 5900, 6000,
-6200, 6400] and maturities T=[0.25, 0.5, 1.0, 2.0] years.
-Method 1: Heston FFT (Carr-Madan with the Heston characteristic function).
-Method 2: Heston COS method.
-Method 3: Heston MC (QE scheme, 200k paths).
-From each set of prices, extract the implied vol surface by inverting
-Black-Scholes.  All three surfaces should agree within 0.5 vol points.
-The resulting smile should show negative skew (lower strikes have
-higher IV) consistent with rho=-0.68.
-
-Construct methods: fft_pricing, monte_carlo
-Comparison targets: heston_fft (fft_pricing), heston_cos (fft_pricing), heston_mc (monte_carlo)
+Construct methods: pde_solver
+Comparison targets: theta_0.5 (pde_solver), theta_1.0 (pde_solver), black_scholes (analytical)
 Cross-validation harness:
-  internal targets: heston_fft, heston_cos, heston_mc
+  internal targets: theta_0.5, theta_1.0
+  analytical benchmark: black_scholes
   external targets: quantlib
-New component: implied_vol_surface_extraction
+New component: convergence_order_diagnostic
 
-Implementation target: heston_cos
-Preferred method family: fft_pricing
+Implementation target: black_scholes
+Preferred method family: analytical
 
-Implementation target: heston_cos."""
+Implementation target: black_scholes."""
 
 from __future__ import annotations
 
@@ -36,81 +20,51 @@ from datetime import date
 
 from trellis.core.market_state import MarketState
 from trellis.core.types import DayCountConvention
-from trellis.models.equity_option_transforms import price_vanilla_equity_option_transform
+from trellis.core.date_utils import year_fraction
+from trellis.models.black import black76_call, black76_put, black76_asset_or_nothing_call, black76_asset_or_nothing_put, black76_cash_or_nothing_call, black76_cash_or_nothing_put
+from trellis.models.analytical.equity_vanilla_bs import equity_vanilla_bs_outputs
 
 
 
 @dataclass(frozen=True)
 class EuropeanOptionSpec:
-    """Specification for Build a pricer for: Heston smile: FFT vs COS vs MC implied vol surface
+    """Specification for Build a pricer for: European call: theta-method convergence order measurement
 
-Extract the implied volatility smile surface under the Heston
-stochastic volatility model for SPX.
-Use the market snapshot (as_of 2024-11-15) which provides:
-  - SPX spot (S=5890)
-  - Heston parameters: kappa=2.0, theta=0.04, xi=0.48, rho=-0.68, v0=0.04
-  - USD OIS discount curve
-  - A reference implied vol smile surface (6 expiries x 7 strikes)
-Price European calls across strikes K=[5400, 5600, 5800, 5900, 6000,
-6200, 6400] and maturities T=[0.25, 0.5, 1.0, 2.0] years.
-Method 1: Heston FFT (Carr-Madan with the Heston characteristic function).
-Method 2: Heston COS method.
-Method 3: Heston MC (QE scheme, 200k paths).
-From each set of prices, extract the implied vol surface by inverting
-Black-Scholes.  All three surfaces should agree within 0.5 vol points.
-The resulting smile should show negative skew (lower strikes have
-higher IV) consistent with rho=-0.68.
-
-Construct methods: fft_pricing, monte_carlo
-Comparison targets: heston_fft (fft_pricing), heston_cos (fft_pricing), heston_mc (monte_carlo)
+Construct methods: pde_solver
+Comparison targets: theta_0.5 (pde_solver), theta_1.0 (pde_solver), black_scholes (analytical)
 Cross-validation harness:
-  internal targets: heston_fft, heston_cos, heston_mc
+  internal targets: theta_0.5, theta_1.0
+  analytical benchmark: black_scholes
   external targets: quantlib
-New component: implied_vol_surface_extraction
+New component: convergence_order_diagnostic
 
-Implementation target: heston_cos
-Preferred method family: fft_pricing
+Implementation target: black_scholes
+Preferred method family: analytical
 
-Implementation target: heston_cos."""
+Implementation target: black_scholes."""
     notional: float
     spot: float
     strike: float
     expiry_date: date
-    option_type: str = "'call'"
+    option_type: str = 'call'
     day_count: DayCountConvention = DayCountConvention.ACT_365
 
 
 class EuropeanOptionAnalyticalPayoff:
-    """Build a pricer for: Heston smile: FFT vs COS vs MC implied vol surface
+    """Build a pricer for: European call: theta-method convergence order measurement
 
-Extract the implied volatility smile surface under the Heston
-stochastic volatility model for SPX.
-Use the market snapshot (as_of 2024-11-15) which provides:
-  - SPX spot (S=5890)
-  - Heston parameters: kappa=2.0, theta=0.04, xi=0.48, rho=-0.68, v0=0.04
-  - USD OIS discount curve
-  - A reference implied vol smile surface (6 expiries x 7 strikes)
-Price European calls across strikes K=[5400, 5600, 5800, 5900, 6000,
-6200, 6400] and maturities T=[0.25, 0.5, 1.0, 2.0] years.
-Method 1: Heston FFT (Carr-Madan with the Heston characteristic function).
-Method 2: Heston COS method.
-Method 3: Heston MC (QE scheme, 200k paths).
-From each set of prices, extract the implied vol surface by inverting
-Black-Scholes.  All three surfaces should agree within 0.5 vol points.
-The resulting smile should show negative skew (lower strikes have
-higher IV) consistent with rho=-0.68.
-
-Construct methods: fft_pricing, monte_carlo
-Comparison targets: heston_fft (fft_pricing), heston_cos (fft_pricing), heston_mc (monte_carlo)
+Construct methods: pde_solver
+Comparison targets: theta_0.5 (pde_solver), theta_1.0 (pde_solver), black_scholes (analytical)
 Cross-validation harness:
-  internal targets: heston_fft, heston_cos, heston_mc
+  internal targets: theta_0.5, theta_1.0
+  analytical benchmark: black_scholes
   external targets: quantlib
-New component: implied_vol_surface_extraction
+New component: convergence_order_diagnostic
 
-Implementation target: heston_cos
-Preferred method family: fft_pricing
+Implementation target: black_scholes
+Preferred method family: analytical
 
-Implementation target: heston_cos."""
+Implementation target: black_scholes."""
 
     def __init__(self, spec: EuropeanOptionSpec):
         self._spec = spec
@@ -125,4 +79,28 @@ Implementation target: heston_cos."""
 
     def evaluate(self, market_state: MarketState) -> float:
         spec = self._spec
-        return float(price_vanilla_equity_option_transform(market_state, spec))
+        spec = self._spec
+        if market_state.discount is None:
+            raise ValueError("market_state.discount is required for Black-Scholes comparison")
+        if market_state.vol_surface is None:
+            raise ValueError("market_state.vol_surface is required for Black-Scholes comparison")
+        T = max(float(year_fraction(market_state.settlement, spec.expiry_date, spec.day_count)), 0.0)
+        spot = float(spec.spot)
+        strike = float(spec.strike)
+        option_type = str(spec.option_type or "call").strip().lower()
+        if T <= 0.0:
+            intrinsic = max(spot - strike, 0.0) if option_type == "call" else max(strike - spot, 0.0)
+            return float(spec.notional) * intrinsic
+        df = float(market_state.discount.discount(T))
+        sigma = float(market_state.vol_surface.black_vol(max(T, 1e-6), strike))
+        forward = spot / max(df, 1e-12)
+        if option_type == "call":
+            undiscounted = black76_call(forward, strike, sigma, T)
+        elif option_type == "put":
+            undiscounted = black76_put(forward, strike, sigma, T)
+        else:
+            raise ValueError(f"Unsupported option_type {spec.option_type!r}")
+        return float(spec.notional) * df * float(undiscounted)
+
+    def benchmark_outputs(self, market_state: MarketState) -> dict[str, float]:
+        return dict(equity_vanilla_bs_outputs(market_state, self._spec))


### PR DESCRIPTION
## Summary

Phase 1 of QUA-887. Collapse ZCB-option family (2 → 1) + clean up DSL dispatch edge cases found during restack. Also absorbs the substantive DSL work from QUA-921 into the repair commit (QUA-921 replayed empty on restack, so its backend-binding DSL changes live here).

## Commits

1. `f7e119a1` — **QUA-915**: collapse `zcb_option_analytical` + `zcb_option_rate_tree` into a single pattern-keyed `short_rate_bond_option` route with method-keyed `conditional_primitives` dispatch.
2. `3fb338d1` — repair restack regressions: DSL cleanup for dispatch edge cases (includes QUA-921's backend-binding DSL contract-pattern support that replayed empty).

## Test plan

- [x] QUA-915 focused suite: 359 passed
- [x] T01 benchmark rerun: `ho_lee_tree` and `hull_white_tree` OK; `jamshidian` comparator blocked by missing OPENAI_API_KEY only

## Discrimination note (vs. analytical_black76)

`required_market_data: [discount_curve, black_vol_surface]` overlaps with `analytical_black76`'s match. Discrimination is via `payoff_family`: Black76 carries `[vanilla_option, basket_option, swaption, ...]`; `short_rate_bond_option` carries `[zcb_option]`. Non-overlapping.

## Closes

Closes QUA-915 and QUA-921 (QUA-921's substantive DSL work is absorbed into `3fb338d1`; empty replay documented in handoff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)