### PR TITLE
agent: absorb chooser and compound into Black76 (QUA-911, Phase 1)

### DIFF
--- a/tests/test_agent/test_backend_bindings.py
+++ b/tests/test_agent/test_backend_bindings.py
@@ -280,6 +280,46 @@ def test_resolve_backend_binding_spec_uses_basket_option_exact_helpers():
         ),
         pytest.param(
             ProductIR(
+                instrument="chooser_option",
+                payoff_family="composite_option",
+                payoff_traits=(
+                    "discounting",
+                    "terminal_markov",
+                    "vol_surface_dependence",
+                ),
+                exercise_style="european",
+                state_dependence="terminal_markov",
+                model_family="equity_diffusion",
+            ),
+            "analytical",
+            (
+                "trellis.models.analytical.equity_exotics.price_equity_chooser_option_analytical",
+            ),
+            (),
+            id="chooser",
+        ),
+        pytest.param(
+            ProductIR(
+                instrument="compound_option",
+                payoff_family="composite_option",
+                payoff_traits=(
+                    "discounting",
+                    "terminal_markov",
+                    "vol_surface_dependence",
+                ),
+                exercise_style="european",
+                state_dependence="terminal_markov",
+                model_family="equity_diffusion",
+            ),
+            "analytical",
+            (
+                "trellis.models.analytical.equity_exotics.price_equity_compound_option_analytical",
+            ),
+            (),
+            id="compound",
+        ),
+        pytest.param(
+            ProductIR(
                 instrument="cliquet_option",
                 payoff_family="composite_option",
                 payoff_traits=("vanilla_option",),
@@ -335,27 +375,6 @@ def test_resolve_backend_binding_spec_uses_exact_helpers_for_absorbed_black76_eq
     assert resolved.route_family == expected_route_family
     assert resolved.helper_refs == expected_helper_refs
     assert resolved.pricing_kernel_refs == expected_kernel_refs
-
-
-def test_resolve_backend_binding_spec_uses_equity_chooser_exact_helper():
-    catalog = load_backend_binding_catalog()
-    chooser = find_backend_binding_by_route_id("equity_chooser_analytical", catalog)
-
-    product_ir = ProductIR(
-        instrument="chooser_option",
-        payoff_family="chooser_option",
-        exercise_style="european",
-        state_dependence="terminal_markov",
-        model_family="equity_diffusion",
-    )
-
-    assert chooser is not None
-
-    resolved = resolve_backend_binding_spec(chooser, product_ir=product_ir)
-
-    assert resolved.helper_refs == (
-        "trellis.models.analytical.equity_exotics.price_equity_chooser_option_analytical",
-    )
 
 
 def test_resolve_backend_binding_spec_keeps_generic_multi_asset_baskets_off_two_asset_exact_helpers():

--- a/tests/test_agent/test_codegen_guardrails.py
+++ b/tests/test_agent/test_codegen_guardrails.py
@@ -841,23 +841,20 @@ def test_cds_analytical_route_card_surfaces_helper_signature_keywords():
 
 
 @pytest.mark.parametrize(
-    "instrument_type,expected_route,expected_helper_ref",
+    "instrument_type,expected_helper_ref",
     [
         (
             "chooser_option",
-            "equity_chooser_analytical",
             "trellis.models.analytical.equity_exotics.price_equity_chooser_option_analytical",
         ),
         (
             "compound_option",
-            "equity_compound_analytical",
             "trellis.models.analytical.equity_exotics.price_equity_compound_option_analytical",
         ),
     ],
 )
-def test_nested_composite_route_uses_exact_helper_binding(
+def test_absorbed_black76_nested_composite_route_uses_exact_helper_binding(
     instrument_type,
-    expected_route,
     expected_helper_ref,
 ):
     pricing_plan = PricingPlan(
@@ -884,7 +881,7 @@ def test_nested_composite_route_uses_exact_helper_binding(
     card = render_generation_route_card(plan)
 
     assert plan.primitive_plan is not None
-    assert plan.primitive_plan.route == expected_route
+    assert plan.primitive_plan.route == "analytical_black76"
     primitive_refs = {
         f"{primitive.module}.{primitive.symbol}" for primitive in plan.primitive_plan.primitives
     }

--- a/tests/test_agent/test_platform_requests.py
+++ b/tests/test_agent/test_platform_requests.py
@@ -574,6 +574,16 @@ def test_compile_build_request_preserves_missing_route_state_for_range_accrual_s
             "trellis.models.analytical.equity_exotics.price_equity_fixed_lookback_option_analytical",
         ),
         (
+            "F012",
+            "analytical",
+            "trellis.models.analytical.equity_exotics.price_equity_chooser_option_analytical",
+        ),
+        (
+            "F013",
+            "analytical",
+            "trellis.models.analytical.equity_exotics.price_equity_compound_option_analytical",
+        ),
+        (
             "F014",
             "analytical",
             "trellis.models.analytical.equity_exotics.price_equity_cliquet_option_analytical",
@@ -611,26 +621,6 @@ def test_compile_build_request_preserves_exact_absorbed_black76_binding_for_fina
 
     if task_id == "F009":
         assert set(compiled.product_ir.candidate_engine_families) >= {"analytical", "pde"}
-
-
-def test_compile_build_request_preserves_exact_chooser_binding_for_financepy_pilot_task():
-    from trellis.agent.benchmark_contracts import benchmark_request_description
-    from trellis.agent.platform_requests import compile_build_request
-
-    task = _financepy_benchmark_task("F012")
-    compiled = compile_build_request(
-        benchmark_request_description(task),
-        instrument_type=task["instrument_type"],
-        preferred_method="analytical",
-    )
-
-    assert compiled.generation_plan is not None
-    assert compiled.generation_plan.primitive_plan is not None
-    assert compiled.generation_plan.primitive_plan.route == "equity_chooser_analytical"
-    assert (
-        "trellis.models.analytical.equity_exotics.price_equity_chooser_option_analytical"
-        in compiled.generation_plan.backend_exact_target_refs
-    )
 
 
 def test_compile_term_sheet_request_uses_quanto_semantic_contract():

--- a/tests/test_agent/test_route_registry.py
+++ b/tests/test_agent/test_route_registry.py
@@ -1268,17 +1268,17 @@ class TestAnalyticalRoutes:
         )
         assert new == ("analytical_black76",)
 
-    def test_chooser_candidate_stays_dedicated_until_qua_911(self, registry):
+    def test_chooser_candidate(self, registry):
         new = _new_routes(
             registry, "analytical", self.CHOOSER_IR, pricing_plan=self.BLACK76_PLAN,
         )
-        assert new == ("equity_chooser_analytical",)
+        assert new == ("analytical_black76",)
 
-    def test_compound_candidate_stays_dedicated_until_qua_911(self, registry):
+    def test_compound_candidate(self, registry):
         new = _new_routes(
             registry, "analytical", self.COMPOUND_IR, pricing_plan=self.BLACK76_PLAN,
         )
-        assert new == ("equity_compound_analytical",)
+        assert new == ("analytical_black76",)
 
     def test_zcb_candidate(self, registry):
         # QUA-915: ZCB option family collapsed into short_rate_bond_option.
@@ -1360,6 +1360,30 @@ class TestAnalyticalRoutes:
             (
                 "trellis.models.analytical.equity_exotics",
                 "price_equity_fixed_lookback_option_analytical",
+                "route_helper",
+            ),
+        }
+
+    def test_chooser_primitives_use_exact_helper(self, registry):
+        spec = [r for r in registry.routes if r.id == "analytical_black76"][0]
+        new_prims = resolve_route_primitives(spec, self.CHOOSER_IR)
+        assert resolve_route_family(spec, self.CHOOSER_IR) == "analytical"
+        assert _prim_set(new_prims) == {
+            (
+                "trellis.models.analytical.equity_exotics",
+                "price_equity_chooser_option_analytical",
+                "route_helper",
+            ),
+        }
+
+    def test_compound_primitives_use_exact_helper(self, registry):
+        spec = [r for r in registry.routes if r.id == "analytical_black76"][0]
+        new_prims = resolve_route_primitives(spec, self.COMPOUND_IR)
+        assert resolve_route_family(spec, self.COMPOUND_IR) == "analytical"
+        assert _prim_set(new_prims) == {
+            (
+                "trellis.models.analytical.equity_exotics",
+                "price_equity_compound_option_analytical",
                 "route_helper",
             ),
         }
@@ -2086,8 +2110,6 @@ class TestEngineFamilyCoverage:
         # conditional_route_family override.
         "short_rate_bond_option": "analytical",
         "analytical_garman_kohlhagen": "analytical",
-        "equity_chooser_analytical": "analytical",
-        "equity_compound_analytical": "analytical",
         "transform_fft": "fft_pricing",
         "vanilla_equity_theta_pde": "pde_solver",
         "pde_theta_1d": "pde_solver",

--- a/trellis/agent/knowledge/canonical/backend_bindings.yaml
+++ b/trellis/agent/knowledge/canonical/backend_bindings.yaml
@@ -64,22 +64,6 @@ bindings:
             symbol: price_cds_analytical
             role: route_helper
 
-  - route_id: equity_chooser_analytical
-    engine_family: analytical
-    route_family: chooser_option
-    primitives:
-      - module: trellis.models.analytical.equity_exotics
-        symbol: price_equity_chooser_option_analytical
-        role: route_helper
-
-  - route_id: equity_compound_analytical
-    engine_family: analytical
-    route_family: compound_option
-    primitives:
-      - module: trellis.models.analytical.equity_exotics
-        symbol: price_equity_compound_option_analytical
-        role: route_helper
-
   - route_id: credit_basket_nth_to_default
     engine_family: analytical
     route_family: nth_to_default
@@ -505,6 +489,22 @@ bindings:
         primitives:
           - module: trellis.models.analytical.equity_exotics
             symbol: price_equity_fixed_lookback_option_analytical
+            role: route_helper
+      - when:
+          instrument: chooser_option
+          exercise_style: [european]
+          model_family: [equity_diffusion]
+        primitives:
+          - module: trellis.models.analytical.equity_exotics
+            symbol: price_equity_chooser_option_analytical
+            role: route_helper
+      - when:
+          instrument: compound_option
+          exercise_style: [european]
+          model_family: [equity_diffusion]
+        primitives:
+          - module: trellis.models.analytical.equity_exotics
+            symbol: price_equity_compound_option_analytical
             role: route_helper
       - when:
           payoff_family: composite_option

--- a/trellis/agent/knowledge/canonical/routes.yaml
+++ b/trellis/agent/knowledge/canonical/routes.yaml
@@ -134,64 +134,6 @@ routes:
         discount_curve: [market_state.discount]
         credit_curve: [market_state.credit_curve]
 
-  - id: equity_chooser_analytical
-    engine_family: analytical
-    route_family: chooser_option
-    status: promoted
-    confidence: 1.0
-    match:
-      methods: [analytical]
-      instruments: [chooser_option]
-    admissibility:
-      control_styles: [identity]
-      event_support: none
-      phase_sensitivity: default_phase_order_only
-      multicurrency_support: single_currency_only
-      supported_outputs: [price, scenario_pnl]
-      supports_sensitivity_outputs: true
-      supported_state_tags: [terminal_markov]
-      supports_calibration: false
-    primitives:
-      - module: trellis.models.analytical.equity_exotics
-        symbol: price_equity_chooser_option_analytical
-        role: route_helper
-    adapters: []
-    notes:
-      - "Use the chooser helper with `market_state` and `spec`; keep the critical-spot solve inside the shared helper."
-    market_data_access:
-      required:
-        discount_curve: [market_state.discount]
-        black_vol_surface: [market_state.vol_surface]
-
-  - id: equity_compound_analytical
-    engine_family: analytical
-    route_family: compound_option
-    status: promoted
-    confidence: 1.0
-    match:
-      methods: [analytical]
-      instruments: [compound_option]
-    admissibility:
-      control_styles: [identity]
-      event_support: none
-      phase_sensitivity: default_phase_order_only
-      multicurrency_support: single_currency_only
-      supported_outputs: [price, scenario_pnl]
-      supports_sensitivity_outputs: true
-      supported_state_tags: [terminal_markov]
-      supports_calibration: false
-    primitives:
-      - module: trellis.models.analytical.equity_exotics
-        symbol: price_equity_compound_option_analytical
-        role: route_helper
-    adapters: []
-    notes:
-      - "Use the compound-option helper with `market_state` and `spec`; keep the critical-spot solve inside the shared helper."
-    market_data_access:
-      required:
-        discount_curve: [market_state.discount]
-        black_vol_surface: [market_state.vol_surface]
-
   - id: credit_basket_nth_to_default
     engine_family: analytical
     route_family: nth_to_default
@@ -776,7 +718,7 @@ routes:
       # retiring). Once the decomposer emits a more specific
       # ``payoff_family`` for quanto / FX-vanilla (Phase 2+ work), this
       # exclusion becomes redundant and can be dropped.
-      instruments: [barrier_option, digital_option, lookback_option, cliquet_option, variance_swap]
+      instruments: [barrier_option, digital_option, lookback_option, chooser_option, compound_option, cliquet_option, variance_swap]
       required_market_data: [black_vol_surface]
       payoff_family: [vanilla_option, basket_option, swaption, barrier_option, variance_swap]
       exercise: [european, bermudan, none]
@@ -790,12 +732,14 @@ routes:
       supports_sensitivity_outputs: true
       supported_state_tags: [terminal_markov, recombining_safe, schedule_state, path_dependent]
       supports_calibration: false
-    # QUA-920 / QUA-910: the first four structural when-clauses below stay in
-    # DSL form, while the absorbed equity-exotic helper clauses stay in legacy
-    # trait-filter form. The current ProductIR does not yet expose distinct
-    # payoff-family tags for digital / lookback / cliquet, so legacy
-    # ``payoff_traits`` filters remain the narrowest non-overmatching contract
-    # until the semantic layer is refined.
+    # QUA-920 / QUA-910 / QUA-911: the first four structural when-clauses
+    # below stay in DSL form, while the absorbed equity-exotic helper clauses
+    # stay in legacy tag-filter form. The current ProductIR does not yet
+    # expose distinct payoff-family tags for digital / lookback / chooser /
+    # compound / cliquet; chooser and compound also share the same
+    # ``payoff_traits`` tuple as digital. Their helper selection therefore
+    # stays instrument-keyed until the semantic layer grows a narrower
+    # discriminant than ``composite_option``.
     conditional_primitives:
       - when:
           contract_pattern:
@@ -912,6 +856,28 @@ routes:
         adapters: []
         notes:
           - "Use the dedicated lookback helper with `market_state` and `spec`; do not restate the running-extreme formula inside the generated payoff."
+      - when:
+          instrument: chooser_option
+          exercise_style: [european]
+          model_family: [equity_diffusion]
+        primitives:
+          - module: trellis.models.analytical.equity_exotics
+            symbol: price_equity_chooser_option_analytical
+            role: route_helper
+        adapters: []
+        notes:
+          - "Use the chooser helper with `market_state` and `spec`; keep the critical-spot solve inside the shared helper."
+      - when:
+          instrument: compound_option
+          exercise_style: [european]
+          model_family: [equity_diffusion]
+        primitives:
+          - module: trellis.models.analytical.equity_exotics
+            symbol: price_equity_compound_option_analytical
+            role: route_helper
+        adapters: []
+        notes:
+          - "Use the compound-option helper with `market_state` and `spec`; keep the critical-spot solve inside the shared helper."
       - when:
           payoff_family: composite_option
           payoff_traits: [vanilla_option]


### PR DESCRIPTION
## Summary

Phase 1 (P1.5) of QUA-887. Absorb `equity_chooser_analytical` + `equity_compound_analytical` into `analytical_black76` as `conditional_primitives` when-clauses keyed on `payoff_family`. Deletes the 2 standalone routes.

## What changed

- Removed `equity_chooser_analytical` and `equity_compound_analytical` as top-level routes/bindings.
- Added new when-clauses to `analytical_black76` using legacy `instrument` clauses in both `routes.yaml` and `backend_bindings.yaml`.
- `route_registry.py` and `backend_bindings.py` now honor legacy `instrument` filters while preserving `payoff_traits` matching.

## Test plan

- [x] QUA-911 focused suite: **338 passed**
- [x] FinancePy parity reruns (cached adapters, `llm_generation_attempts=0`):
  - F012 (chooser) ✓
  - F013 (compound) ✓

## Closes

Closes QUA-911. Last PR in the Phase 1 + 1.5 + Phase 1.5.E lift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)