### PR TITLE
[codex] Add Phase 2 Contract IR foundation

### DIFF
--- a/docs/quant/contract_algebra.rst
+++ b/docs/quant/contract_algebra.rst
@@ -20,6 +20,9 @@ The canonical semantic object is still ``SemanticContract`` in
 ``trellis.agent.semantic_contracts``. It now carries typed sub-objects rather
 than relying only on flat semantic strings.
 
+For the additive structural payoff tree that now accompanies the semantic
+surface, see :doc:`contract_ir`.
+
 Semantic Contract
 -----------------
 
@@ -91,6 +94,55 @@ specialization authority when a contract needs to be rebuilt for a different
 preferred method. Request compilation, semantic compilation, and runtime
 metadata all consume the same family/method surface instead of each carrying
 its own family-local branching.
+
+Observable Naming Discipline
+----------------------------
+
+Observable and quote names are part of the semantic contract boundary, not
+just local implementation detail. Future contract and IR node names should
+follow these rules so semantics stay stable across compiler and lowering work.
+
+Use ``Observable`` for a node that denotes an economic or contractual quantity
+the payoff depends on.
+
+Use ``Quote`` for a narrower case: an observable that is read from a quoted
+market object together with an explicit quote convention and coordinate system.
+
+So the intended relationship is:
+
+- quote-specific observable ``⊂`` observable
+
+Practical naming rules:
+
+- name contract nodes after contractual meaning or observed market quantity
+- do not name contract nodes after pricing methods, numerical schemes, or
+  lowering strategies
+- if the node means "read this coordinate from a quote map", include
+  ``Quote`` in the name
+- if the node means "the contract-defined quantity associated with this
+  schedule / interval / underlier", use the semantic quantity name instead
+
+Examples:
+
+- prefer ``VarianceObservable`` over ``VarianceReplication``
+- a future terminal variance-family node may still lower through static option
+  replication, but replication is a pricing method, not the contract meaning
+- a future market-map node such as ``SurfaceQuote`` or ``CurveQuote`` should
+  carry explicit quote convention and coordinates because it denotes a quoted
+  market point rather than a generic economic quantity
+- ``SwapRate(schedule)`` and ``Annuity(schedule)`` are semantic observables
+  tied to a contract-defined schedule, not quote-map nodes
+
+Rule of thumb:
+
+- if the quantity is defined by the contract or by a financial identity,
+  prefer ``Observable``
+- if the quantity is defined by a named market quote map plus quoting
+  convention, prefer ``Quote``
+
+This naming discipline keeps the semantic layer honest: the contract says what
+quantity matters, and lowerings decide how that quantity is priced, simulated,
+approximated, or extracted from market data.
 
 Valuation Context
 -----------------

--- a/docs/quant/contract_ir.rst
+++ b/docs/quant/contract_ir.rst
@@ -1,0 +1,203 @@
+Contract IR
+===========
+
+``ContractIR`` is the additive structural payoff tree introduced for the
+Phase 2 contract-compiler work. It does not replace ``ProductIR`` yet.
+Instead, it sits beside the flat routing record and captures the part that
+Phase 3 and Phase 4 actually need for route-free fresh builds:
+
+- the payoff expression tree
+- the exercise surface
+- the observation surface
+- the underlier specification
+
+Why It Exists
+-------------
+
+``ProductIR`` is intentionally coarse. It is good for broad routing and
+knowledge retrieval, but it collapses structurally different contracts onto
+shared string families such as ``vanilla_option`` or ``swaption``.
+
+``ContractIR`` keeps the structural information that a kernel matcher needs.
+For example, these two products are no longer separated only by instrument
+name:
+
+- ``max(Spot - Strike, 0)``
+- ``Annuity * max(SwapRate - Strike, 0)``
+
+The second still carries swaption-specific structure, but the shared ramp
+shape is now explicit and machine-readable.
+
+Phase 2 keeps the rollout additive:
+
+- existing routing still reads ``ProductIR``
+- ``SemanticImplementationBlueprint`` now also carries ``contract_ir``
+- unsupported or out-of-scope products attach ``None`` instead of failing
+
+Current Surface
+---------------
+
+The shipped Phase 2 AST lives in ``trellis.agent.contract_ir`` and is built
+from frozen dataclasses.
+
+Top-level contract:
+
+.. code-block:: python
+
+   ContractIR(
+       payoff=...,
+       exercise=Exercise(...),
+       observation=Observation(...),
+       underlying=Underlying(...),
+   )
+
+Schedules:
+
+- ``Singleton(date)``
+- ``FiniteSchedule(tuple[date, ...])``
+- ``ContinuousInterval(start, end)``
+
+Underliers:
+
+- ``EquitySpot(name, dynamics)``
+- ``ForwardRate(name, dynamics)``
+- ``RateCurve(name, dynamics)``
+- ``CompositeUnderlying(parts=...)``
+
+Payoff nodes:
+
+- leaves: ``Constant``, ``Strike``, ``Spot``, ``Forward``, ``SwapRate``,
+  ``Annuity``, ``VarianceObservable``
+- structural nodes: ``LinearBasket``, ``ArithmeticMean``, ``Max``, ``Min``,
+  ``Add``, ``Sub``, ``Mul``, ``Scaled``, ``Indicator``
+
+Naming follows the semantic ``Observable`` versus quote-map ``Quote``
+discipline documented in :doc:`contract_algebra`: nodes are named after the
+contractual quantity they denote, not after a downstream pricing method.
+
+Predicates:
+
+- comparisons: ``Gt``, ``Ge``, ``Lt``, ``Le``
+- boolean combinators: ``And``, ``Or``, ``Not``
+
+Well-Formedness
+---------------
+
+The constructors enforce the local Phase 2 invariants:
+
+- underlier names must be unique
+- every payoff underlier reference must resolve against the root underlier set
+- schedule-bearing leaves must use concrete schedule objects, not string refs
+- ``FiniteSchedule`` must be non-empty and strictly increasing
+- ``SwapRate`` and ``Annuity`` require ``FiniteSchedule``
+- ``VarianceObservable`` requires ``ContinuousInterval``
+- European exercise uses ``Singleton``
+- terminal observation uses ``Singleton``
+
+Phase 2 intentionally does not introduce top-level heterogeneous composites.
+If multiple legs can share one root surface, they stay inside ``payoff`` via
+``Add``, ``Mul``, or ``LinearBasket``. A richer leg-based root is tracked
+separately.
+
+Canonicalization
+----------------
+
+``canonicalize(expr)`` puts payoff expressions into a stable structural form
+for matching.
+
+The important current rules are:
+
+- flatten and sort commutative nodes
+- fuse constants in ``Add`` and ``Mul``
+- drop additive and multiplicative identities
+- normalize ``LinearBasket`` zero-weight and singleton cases
+- keep option side in ``Sub`` operand order
+
+The last rule matters:
+
+- call ramp: ``Max(Sub(X, Strike(K)), Constant(0))``
+- put ramp: ``Max(Sub(Strike(K), X), Constant(0))``
+
+A put is not a negatively scaled call. The canonicalizer does not rewrite
+short-call exposure into put orientation.
+
+Phase 2 also prefers factored positive outer scales. When a positive scalar is
+common across a ramp, the canonical form keeps:
+
+.. code-block:: python
+
+   Scaled(weight, Max(Sub(lhs, rhs), Constant(0)))
+
+instead of eagerly expanding the weight across the ``Max`` arguments. This is
+the structural form that downstream pattern matching consumes.
+
+Phase 2 Families
+----------------
+
+The bounded family set implemented today is:
+
+1. European terminal linear payoffs
+2. variance-settled payoffs
+3. digital payoffs
+4. arithmetic Asians
+
+Examples:
+
+.. code-block:: python
+
+   # Vanilla call
+   Max((Sub(Spot("AAPL"), Strike(150.0)), Constant(0.0)))
+
+   # European payer swaption
+   Scaled(
+       Annuity("USD-IRS-5Y", schedule),
+       Max((Sub(SwapRate("USD-IRS-5Y", schedule), Strike(0.05)), Constant(0.0))),
+   )
+
+   # Variance swap
+   Scaled(
+       Constant(10000.0),
+       Sub(VarianceObservable("SPX", interval), Strike(0.04)),
+   )
+
+   # Cash-or-nothing digital
+   Mul((Constant(2.0), Indicator(Gt(Spot("AAPL"), Strike(150.0)))))
+
+   # Arithmetic Asian
+   Max((Sub(ArithmeticMean(Spot("SPX"), avg_schedule), Strike(4500.0)), Constant(0.0)))
+
+Decomposition And Compilation
+-----------------------------
+
+``trellis.agent.knowledge.decompose.decompose_to_contract_ir(...)`` provides a
+bounded, fixture-driven natural-language bridge for the four Phase 2 families.
+It returns:
+
+- a well-formed ``ContractIR`` for supported descriptions
+- ``None`` for out-of-scope families such as barriers, lookbacks, callable
+  bonds, Bermudan exercise, or leg-based products
+
+``trellis.agent.semantic_contract_compiler.compile_semantic_contract(...)``
+threads that result onto ``SemanticImplementationBlueprint.contract_ir``.
+
+That field is attached before route-specific lowering choices. In other words,
+``contract_ir`` is intended to be route-free compiler input, not a derived
+summary of the selected route.
+
+Pattern Matching
+----------------
+
+Phase 2 also extends ``ContractPattern`` evaluation so patterns can match
+directly against ``ContractIR`` trees.
+
+That matters for the next phase:
+
+- Phase 3 kernel declarations match structural payoff templates against
+  ``blueprint.contract_ir``
+- Phase 4 can retire direct dependence on hard-coded instrument routing for
+  fresh builds, because the structural contract tree becomes the primary match
+  surface
+
+The target state is explicit: even a simple rebuilt vanilla option should be
+able to go through ``ContractIR -> pattern match -> lowering obligations``
+without needing a direct hard-coded route by instrument name.

--- a/docs/quant/index.rst
+++ b/docs/quant/index.rst
@@ -21,6 +21,7 @@ Core Quant Topics
 
    pricing_stack
    contract_algebra
+   contract_ir
    dsl_algebra
    lattice_algebra
    differentiable_pricing

--- a/tests/test_agent/test_contract_ir_simplify.py
+++ b/tests/test_agent/test_contract_ir_simplify.py
@@ -1,0 +1,293 @@
+from __future__ import annotations
+
+from datetime import date
+import random
+
+from trellis.agent.contract_ir import (
+    Add,
+    Annuity,
+    ArithmeticMean,
+    Constant,
+    ContinuousInterval,
+    FiniteSchedule,
+    Gt,
+    Indicator,
+    LinearBasket,
+    Max,
+    Mul,
+    PayoffEvalEnv,
+    Scaled,
+    Singleton,
+    Spot,
+    Strike,
+    Sub,
+    SwapRate,
+    VarianceObservable,
+    canonicalize,
+    evaluate_payoff_expr,
+)
+
+
+def _singleton(day: str) -> Singleton:
+    year, month, day_value = map(int, day.split("-"))
+    return Singleton(date(year, month, day_value))
+
+
+def _finite_schedule(*days: str) -> FiniteSchedule:
+    return FiniteSchedule(
+        tuple(date(*map(int, day.split("-"))) for day in days)
+    )
+
+
+def _interval(start_day: str, end_day: str) -> ContinuousInterval:
+    return ContinuousInterval(
+        date(*map(int, start_day.split("-"))),
+        date(*map(int, end_day.split("-"))),
+    )
+
+
+def _environment() -> PayoffEvalEnv:
+    jan = date(2025, 1, 1)
+    feb = date(2025, 2, 1)
+    mar = date(2025, 3, 1)
+    apr = date(2025, 4, 1)
+    swap_schedule = _finite_schedule("2026-11-15", "2027-11-15")
+    return PayoffEvalEnv(
+        values={
+            ("spot", "AAPL"): 162.0,
+            ("spot", "SPX"): 4525.0,
+            ("spot", "NDX"): 18100.0,
+            ("spot", "SPX", jan): 4410.0,
+            ("spot", "SPX", feb): 4475.0,
+            ("spot", "SPX", mar): 4510.0,
+            ("spot", "SPX", apr): 4555.0,
+            ("swap_rate", "USD-IRS-5Y", swap_schedule.key()): 0.047,
+            ("annuity", "USD-IRS-5Y", swap_schedule.key()): 4.25,
+            ("variance_observable", "SPX", date(2025, 1, 1), date(2025, 11, 15)): 0.052,
+        }
+    )
+
+
+def _random_leaf(rng: random.Random):
+    leaf_type = rng.choice(
+        (
+            "constant",
+            "spot",
+            "strike",
+            "swap_rate",
+            "annuity",
+            "variance",
+            "arithmetic_mean",
+        )
+    )
+    if leaf_type == "constant":
+        return Constant(rng.choice((-3.0, -1.0, 0.0, 1.0, 2.0, 5.0)))
+    if leaf_type == "spot":
+        return Spot(rng.choice(("AAPL", "SPX", "NDX")))
+    if leaf_type == "strike":
+        return Strike(rng.choice((0.0, 1.0, 2.0, 150.0, 4500.0)))
+    if leaf_type == "swap_rate":
+        return SwapRate(
+            "USD-IRS-5Y",
+            _finite_schedule("2026-11-15", "2027-11-15"),
+        )
+    if leaf_type == "annuity":
+        return Annuity(
+            "USD-IRS-5Y",
+            _finite_schedule("2026-11-15", "2027-11-15"),
+        )
+    if leaf_type == "variance":
+        return VarianceObservable(
+            "SPX",
+            _interval("2025-01-01", "2025-11-15"),
+        )
+    return ArithmeticMean(
+        Spot("SPX"),
+        _finite_schedule("2025-01-01", "2025-02-01", "2025-03-01", "2025-04-01"),
+    )
+
+
+def _random_expr(rng: random.Random, depth: int):
+    if depth <= 0:
+        return _random_leaf(rng)
+
+    kind = rng.choice(
+        (
+            "leaf",
+            "add",
+            "max",
+            "mul",
+            "sub",
+            "scaled",
+            "indicator",
+            "basket",
+        )
+    )
+    if kind == "leaf":
+        return _random_leaf(rng)
+    if kind == "add":
+        return Add((_random_expr(rng, depth - 1), _random_expr(rng, depth - 1)))
+    if kind == "max":
+        return Max((_random_expr(rng, depth - 1), _random_expr(rng, depth - 1)))
+    if kind == "mul":
+        return Mul((_random_expr(rng, depth - 1), _random_expr(rng, depth - 1)))
+    if kind == "sub":
+        return Sub(_random_expr(rng, depth - 1), _random_expr(rng, depth - 1))
+    if kind == "scaled":
+        scalar = rng.choice(
+            (
+                Constant(rng.choice((-2.0, -1.0, 0.0, 1.0, 2.0))),
+                Annuity(
+                    "USD-IRS-5Y",
+                    _finite_schedule("2026-11-15", "2027-11-15"),
+                ),
+            )
+        )
+        return Scaled(scalar, _random_expr(rng, depth - 1))
+    if kind == "indicator":
+        return Indicator(
+            Gt(_random_expr(rng, depth - 1), _random_expr(rng, depth - 1))
+        )
+    return LinearBasket(
+        (
+            (0.5, Spot("SPX")),
+            (0.5, Spot("NDX")),
+        )
+    )
+
+
+class TestContractIRSimplify:
+    def test_call_shape_sorts_zero_to_second_argument(self):
+        expr = Max((Constant(0.0), Sub(Spot("AAPL"), Strike(150.0))))
+        assert canonicalize(expr) == Max(
+            (Sub(Spot("AAPL"), Strike(150.0)), Constant(0.0))
+        )
+
+    def test_negative_short_call_is_not_rewritten_into_put_orientation(self):
+        short_call = Scaled(
+            Constant(-1.0),
+            Max((Sub(Spot("AAPL"), Strike(150.0)), Constant(0.0))),
+        )
+        canonical = canonicalize(short_call)
+        assert canonical == short_call
+        assert canonical != Max((Sub(Strike(150.0), Spot("AAPL")), Constant(0.0)))
+
+    def test_linear_basket_zero_and_singleton_rules(self):
+        assert canonicalize(
+            LinearBasket(((0.0, Spot("SPX")), (0.0, Spot("NDX"))))
+        ) == Constant(0.0)
+        assert canonicalize(
+            LinearBasket(((2.0, Spot("SPX")),))
+        ) == Scaled(Constant(2.0), Spot("SPX"))
+
+    def test_factor_common_positive_scalar_out_of_max(self):
+        annuity = Annuity(
+            "USD-IRS-5Y",
+            _finite_schedule("2026-11-15", "2027-11-15"),
+        )
+        expr = Max(
+            (
+                Scaled(annuity, Sub(SwapRate("USD-IRS-5Y", _finite_schedule("2026-11-15", "2027-11-15")), Strike(0.05))),
+                Constant(0.0),
+            )
+        )
+        assert canonicalize(expr) == Scaled(
+            annuity,
+            Max(
+                (
+                    Sub(
+                        SwapRate("USD-IRS-5Y", _finite_schedule("2026-11-15", "2027-11-15")),
+                        Strike(0.05),
+                    ),
+                    Constant(0.0),
+                )
+            ),
+        )
+
+    def test_family_templates_canonicalize_to_expected_forms(self):
+        assert canonicalize(
+            Max((Sub(Spot("AAPL"), Strike(150.0)), Constant(0.0)))
+        ) == Max((Sub(Spot("AAPL"), Strike(150.0)), Constant(0.0)))
+
+        assert canonicalize(
+            Scaled(
+                Constant(10000.0),
+                Sub(
+                    VarianceObservable("SPX", _interval("2025-01-01", "2025-11-15")),
+                    Strike(0.04),
+                ),
+            )
+        ) == Scaled(
+            Constant(10000.0),
+            Sub(
+                VarianceObservable("SPX", _interval("2025-01-01", "2025-11-15")),
+                Strike(0.04),
+            ),
+        )
+
+        assert canonicalize(
+            Mul((Constant(2.0), Indicator(Gt(Spot("AAPL"), Strike(150.0)))))
+        ) == Mul((Constant(2.0), Indicator(Gt(Spot("AAPL"), Strike(150.0)))))
+
+        assert canonicalize(
+            Max(
+                (
+                    Sub(
+                        ArithmeticMean(
+                            Spot("SPX"),
+                            _finite_schedule(
+                                "2025-01-01",
+                                "2025-02-01",
+                                "2025-03-01",
+                                "2025-04-01",
+                            ),
+                        ),
+                        Strike(4500.0),
+                    ),
+                    Constant(0.0),
+                )
+            )
+        ) == Max(
+            (
+                Sub(
+                    ArithmeticMean(
+                        Spot("SPX"),
+                        _finite_schedule(
+                            "2025-01-01",
+                            "2025-02-01",
+                            "2025-03-01",
+                            "2025-04-01",
+                        ),
+                    ),
+                    Strike(4500.0),
+                ),
+                Constant(0.0),
+            )
+        )
+
+    def test_canonicalize_is_idempotent_on_deterministic_random_trees(self):
+        rng = random.Random(917)
+        for _ in range(200):
+            expr = _random_expr(rng, depth=3)
+            once = canonicalize(expr)
+            twice = canonicalize(once)
+            assert twice == once
+
+    def test_canonicalize_agrees_on_equivalent_orderings(self):
+        rng = random.Random(918)
+        for _ in range(150):
+            a = _random_expr(rng, depth=2)
+            b = _random_expr(rng, depth=2)
+            c = _random_expr(rng, depth=2)
+            assert canonicalize(Max((a, b, c))) == canonicalize(Max((c, a, b)))
+            assert canonicalize(Add((a, b, c))) == canonicalize(Add((b, c, a)))
+            assert canonicalize(Mul((a, b, c))) == canonicalize(Mul((c, b, a)))
+
+    def test_canonicalize_preserves_numeric_semantics(self):
+        rng = random.Random(919)
+        env = _environment()
+        for _ in range(150):
+            expr = _random_expr(rng, depth=3)
+            before = evaluate_payoff_expr(expr, env)
+            after = evaluate_payoff_expr(canonicalize(expr), env)
+            assert abs(after - before) <= 5e-12

--- a/tests/test_agent/test_contract_ir_types.py
+++ b/tests/test_agent/test_contract_ir_types.py
@@ -143,6 +143,15 @@ class TestContractIRTypes:
                 ),
             )
 
+    def test_composite_underlying_rejects_non_leaf_parts(self):
+        with pytest.raises(ContractIRWellFormednessError, match="UnderlyingSpecLeaf"):
+            CompositeUnderlying(
+                (
+                    EquitySpot("SPX", "gbm"),
+                    "not-a-leaf",  # type: ignore[arg-type]
+                )
+            )
+
     def test_rule_2_unknown_underlier_id_is_rejected(self):
         expiry = _singleton("2025-11-15")
         with pytest.raises(ContractIRWellFormednessError, match="underlier"):

--- a/tests/test_agent/test_contract_ir_types.py
+++ b/tests/test_agent/test_contract_ir_types.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from trellis.agent.contract_ir import (
+    Add,
+    And,
+    Annuity,
+    ArithmeticMean,
+    CompositeUnderlying,
+    Constant,
+    ContractIR,
+    ContractIRWellFormednessError,
+    ContinuousInterval,
+    EquitySpot,
+    Exercise,
+    FiniteSchedule,
+    ForwardRate,
+    Gt,
+    Indicator,
+    LinearBasket,
+    Max,
+    Mul,
+    Observation,
+    Scaled,
+    Singleton,
+    Spot,
+    Strike,
+    Sub,
+    SwapRate,
+    Underlying,
+    VarianceObservable,
+)
+
+
+def _singleton(day: str) -> Singleton:
+    year, month, day_value = map(int, day.split("-"))
+    return Singleton(date(year, month, day_value))
+
+
+def _finite_schedule(*days: str) -> FiniteSchedule:
+    dates = []
+    for day in days:
+        year, month, day_value = map(int, day.split("-"))
+        dates.append(date(year, month, day_value))
+    return FiniteSchedule(tuple(dates))
+
+
+def _continuous_interval(start_day: str, end_day: str) -> ContinuousInterval:
+    start_year, start_month, start_date = map(int, start_day.split("-"))
+    end_year, end_month, end_date = map(int, end_day.split("-"))
+    return ContinuousInterval(
+        date(start_year, start_month, start_date),
+        date(end_year, end_month, end_date),
+    )
+
+
+def _equity_call_fixture() -> ContractIR:
+    expiry = _singleton("2025-11-15")
+    return ContractIR(
+        payoff=Max((Sub(Spot("AAPL"), Strike(150.0)), Constant(0.0))),
+        exercise=Exercise(style="european", schedule=expiry),
+        observation=Observation(kind="terminal", schedule=expiry),
+        underlying=Underlying(spec=EquitySpot("AAPL", "gbm")),
+    )
+
+
+def _variance_fixture() -> ContractIR:
+    expiry = _singleton("2025-11-15")
+    return ContractIR(
+        payoff=Scaled(
+            Constant(10000.0),
+            Sub(
+                VarianceObservable("SPX", _continuous_interval("2025-01-01", "2025-11-15")),
+                Strike(0.04),
+            ),
+        ),
+        exercise=Exercise(style="european", schedule=expiry),
+        observation=Observation(kind="terminal", schedule=expiry),
+        underlying=Underlying(spec=EquitySpot("SPX", "gbm")),
+    )
+
+
+def _digital_fixture() -> ContractIR:
+    expiry = _singleton("2025-11-15")
+    return ContractIR(
+        payoff=Mul(
+            (
+                Constant(1.0),
+                Indicator(Gt(Spot("AAPL"), Strike(150.0))),
+            )
+        ),
+        exercise=Exercise(style="european", schedule=expiry),
+        observation=Observation(kind="terminal", schedule=expiry),
+        underlying=Underlying(spec=EquitySpot("AAPL", "gbm")),
+    )
+
+
+def _asian_fixture() -> ContractIR:
+    expiry = _singleton("2025-12-31")
+    averaging = _finite_schedule(
+        "2025-01-01",
+        "2025-02-01",
+        "2025-03-01",
+        "2025-04-01",
+    )
+    return ContractIR(
+        payoff=Max(
+            (
+                Sub(ArithmeticMean(Spot("SPX"), averaging), Strike(4500.0)),
+                Constant(0.0),
+            )
+        ),
+        exercise=Exercise(style="european", schedule=expiry),
+        observation=Observation(kind="schedule", schedule=averaging),
+        underlying=Underlying(spec=EquitySpot("SPX", "gbm")),
+    )
+
+
+class TestContractIRTypes:
+    def test_four_phase_two_family_fixtures_are_structurally_equal(self):
+        assert _equity_call_fixture() == _equity_call_fixture()
+        assert _variance_fixture() == _variance_fixture()
+        assert _digital_fixture() == _digital_fixture()
+        assert _asian_fixture() == _asian_fixture()
+
+    def test_rule_1_duplicate_underlying_names_are_rejected(self):
+        expiry = _singleton("2025-11-15")
+        with pytest.raises(ContractIRWellFormednessError, match="unique"):
+            ContractIR(
+                payoff=Max((Sub(Spot("SPX"), Strike(4500.0)), Constant(0.0))),
+                exercise=Exercise(style="european", schedule=expiry),
+                observation=Observation(kind="terminal", schedule=expiry),
+                underlying=Underlying(
+                    spec=CompositeUnderlying(
+                        (
+                            EquitySpot("SPX", "gbm"),
+                            EquitySpot("SPX", "gbm"),
+                        )
+                    )
+                ),
+            )
+
+    def test_rule_2_unknown_underlier_id_is_rejected(self):
+        expiry = _singleton("2025-11-15")
+        with pytest.raises(ContractIRWellFormednessError, match="underlier"):
+            ContractIR(
+                payoff=Max((Sub(Spot("MISSING"), Strike(150.0)), Constant(0.0))),
+                exercise=Exercise(style="european", schedule=expiry),
+                observation=Observation(kind="terminal", schedule=expiry),
+                underlying=Underlying(spec=EquitySpot("AAPL", "gbm")),
+            )
+
+    def test_rule_3_payoff_schedules_must_be_schedule_values(self):
+        expiry = _singleton("2025-11-15")
+        with pytest.raises(ContractIRWellFormednessError, match="schedule"):
+            ContractIR(
+                payoff=Scaled(
+                    Annuity("USD-IRS-5Y", "bad-schedule"),  # type: ignore[arg-type]
+                    Max(
+                        (
+                            Sub(
+                                SwapRate("USD-IRS-5Y", _finite_schedule("2026-11-15", "2027-11-15")),
+                                Strike(0.05),
+                            ),
+                            Constant(0.0),
+                        )
+                    ),
+                ),
+                exercise=Exercise(style="european", schedule=expiry),
+                observation=Observation(kind="terminal", schedule=expiry),
+                underlying=Underlying(spec=ForwardRate("USD-IRS-5Y", "lognormal_forward")),
+            )
+
+    def test_rule_4_finite_schedule_must_be_non_empty_and_increasing(self):
+        with pytest.raises(ContractIRWellFormednessError, match="strictly increasing"):
+            FiniteSchedule((date(2025, 2, 1), date(2025, 1, 1)))
+        with pytest.raises(ContractIRWellFormednessError, match="non-empty"):
+            FiniteSchedule(())
+
+    def test_rule_5_node_local_schedule_discipline_is_enforced(self):
+        expiry = _singleton("2025-11-15")
+        with pytest.raises(ContractIRWellFormednessError, match="ArithmeticMean"):
+            ContractIR(
+                payoff=Max(
+                    (
+                        Sub(
+                            ArithmeticMean(Spot("SPX"), expiry),  # type: ignore[arg-type]
+                            Strike(4500.0),
+                        ),
+                        Constant(0.0),
+                    )
+                ),
+                exercise=Exercise(style="european", schedule=expiry),
+                observation=Observation(kind="terminal", schedule=expiry),
+                underlying=Underlying(spec=EquitySpot("SPX", "gbm")),
+            )
+
+    def test_rule_6_european_requires_singleton_exercise_schedule(self):
+        with pytest.raises(ContractIRWellFormednessError, match="european"):
+            Exercise(
+                style="european",
+                schedule=_finite_schedule("2025-11-15", "2025-12-15"),
+            )
+
+    def test_rule_7_terminal_observation_requires_singleton_schedule(self):
+        with pytest.raises(ContractIRWellFormednessError, match="terminal"):
+            Observation(
+                kind="terminal",
+                schedule=_finite_schedule("2025-11-15", "2025-12-15"),
+            )
+
+    def test_rule_8_arity_mismatch_is_rejected(self):
+        with pytest.raises(ContractIRWellFormednessError, match="Max"):
+            Max(())
+        with pytest.raises(ContractIRWellFormednessError, match="Add"):
+            Add((Constant(1.0),))
+        with pytest.raises(ContractIRWellFormednessError, match="Mul"):
+            Mul((Constant(1.0),))
+
+    def test_rule_9_linear_basket_must_be_non_empty(self):
+        with pytest.raises(ContractIRWellFormednessError, match="LinearBasket"):
+            LinearBasket(())
+
+    def test_american_uses_continuous_interval(self):
+        american = Exercise(
+            style="american",
+            schedule=_continuous_interval("2025-01-01", "2025-12-31"),
+        )
+        assert american.style == "american"
+
+    def test_path_dependent_observation_accepts_interval(self):
+        observation = Observation(
+            kind="path_dependent",
+            schedule=_continuous_interval("2025-01-01", "2025-12-31"),
+        )
+        assert observation.kind == "path_dependent"

--- a/tests/test_agent/test_contract_pattern_eval_contract_ir.py
+++ b/tests/test_agent/test_contract_pattern_eval_contract_ir.py
@@ -232,6 +232,25 @@ class TestContractPatternEvalContractIR:
         assert isinstance(result.bindings["schedule"], FiniteSchedule)
         assert result.bindings["K"] == 0.05
 
+    def test_concrete_schedule_frequency_reports_contract_ir_gap_clearly(self):
+        pattern = parse_contract_pattern(
+            {
+                "exercise": {
+                    "style": "european",
+                    "schedule": {"frequency": "monthly"},
+                }
+            }
+        )
+
+        result = evaluate_pattern(pattern, _asian_contract_ir())
+
+        assert result.ok is False
+        assert result.mismatch_reason is not None
+        assert (
+            "schedule.frequency matching against a concrete value is not yet implemented"
+            in result.mismatch_reason
+        )
+
     def test_zero_arity_family_tags_match_phase_two_contract_ir_fixtures(self):
         fixtures = {
             "vanilla_payoff": _vanilla_call_contract_ir(),

--- a/tests/test_agent/test_contract_pattern_eval_contract_ir.py
+++ b/tests/test_agent/test_contract_pattern_eval_contract_ir.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+from datetime import date
+
+from trellis.agent.contract_ir import (
+    Annuity,
+    ArithmeticMean,
+    CompositeUnderlying,
+    Constant,
+    ContractIR,
+    ContinuousInterval,
+    EquitySpot,
+    Exercise,
+    FiniteSchedule,
+    ForwardRate,
+    Gt,
+    Indicator,
+    LinearBasket,
+    Max,
+    Mul,
+    Observation,
+    Scaled,
+    Singleton,
+    Spot,
+    Strike,
+    Sub,
+    SwapRate,
+    Underlying,
+    VarianceObservable,
+)
+from trellis.agent.contract_pattern import (
+    ContractPattern,
+    ExercisePattern,
+    PayoffPattern,
+    UnderlyingPattern,
+    dump_contract_pattern,
+    parse_contract_pattern,
+)
+from trellis.agent.contract_pattern_eval import evaluate_pattern
+
+
+def _singleton(day: str) -> Singleton:
+    return Singleton(date(*map(int, day.split("-"))))
+
+
+def _finite_schedule(*days: str) -> FiniteSchedule:
+    return FiniteSchedule(tuple(date(*map(int, day.split("-"))) for day in days))
+
+
+def _vanilla_call_contract_ir() -> ContractIR:
+    expiry = _singleton("2025-11-15")
+    return ContractIR(
+        payoff=Max((Sub(Spot("AAPL"), Strike(150.0)), Constant(0.0))),
+        exercise=Exercise(style="european", schedule=expiry),
+        observation=Observation(kind="terminal", schedule=expiry),
+        underlying=Underlying(spec=EquitySpot("AAPL", "gbm")),
+    )
+
+
+def _basket_call_contract_ir() -> ContractIR:
+    expiry = _singleton("2025-11-15")
+    return ContractIR(
+        payoff=Max(
+            (
+                Sub(
+                    LinearBasket(((0.5, Spot("SPX")), (0.5, Spot("NDX")))),
+                    Strike(4500.0),
+                ),
+                Constant(0.0),
+            )
+        ),
+        exercise=Exercise(style="european", schedule=expiry),
+        observation=Observation(kind="terminal", schedule=expiry),
+        underlying=Underlying(
+            spec=CompositeUnderlying((EquitySpot("SPX", "gbm"), EquitySpot("NDX", "gbm")))
+        ),
+    )
+
+
+def _swaption_contract_ir() -> ContractIR:
+    expiry = _singleton("2025-11-15")
+    schedule = _finite_schedule(
+        "2026-11-15",
+        "2027-11-15",
+        "2028-11-15",
+        "2029-11-15",
+        "2030-11-15",
+    )
+    return ContractIR(
+        payoff=Scaled(
+            Annuity("USD-IRS-5Y", schedule),
+            Max((Sub(SwapRate("USD-IRS-5Y", schedule), Strike(0.05)), Constant(0.0))),
+        ),
+        exercise=Exercise(style="european", schedule=expiry),
+        observation=Observation(kind="terminal", schedule=expiry),
+        underlying=Underlying(spec=ForwardRate("USD-IRS-5Y", "lognormal_forward")),
+    )
+
+
+def _variance_contract_ir() -> ContractIR:
+    expiry = _singleton("2025-11-15")
+    return ContractIR(
+        payoff=Scaled(
+            Constant(10000.0),
+            Sub(
+                VarianceObservable(
+                    "SPX",
+                    ContinuousInterval(date(2025, 1, 1), date(2025, 11, 15)),
+                ),
+                Strike(0.04),
+            ),
+        ),
+        exercise=Exercise(style="european", schedule=expiry),
+        observation=Observation(kind="terminal", schedule=expiry),
+        underlying=Underlying(spec=EquitySpot("SPX", "gbm")),
+    )
+
+
+def _digital_contract_ir() -> ContractIR:
+    expiry = _singleton("2025-11-15")
+    return ContractIR(
+        payoff=Mul((Constant(2.0), Indicator(Gt(Spot("AAPL"), Strike(150.0))))),
+        exercise=Exercise(style="european", schedule=expiry),
+        observation=Observation(kind="terminal", schedule=expiry),
+        underlying=Underlying(spec=EquitySpot("AAPL", "gbm")),
+    )
+
+
+def _asian_contract_ir() -> ContractIR:
+    averaging = _finite_schedule(
+        "2025-01-31",
+        "2025-02-28",
+        "2025-03-31",
+        "2025-04-30",
+    )
+    expiry = Singleton(date(2025, 4, 30))
+    return ContractIR(
+        payoff=Max(
+            (
+                Sub(ArithmeticMean(Spot("SPX"), averaging), Strike(4500.0)),
+                Constant(0.0),
+            )
+        ),
+        exercise=Exercise(style="european", schedule=expiry),
+        observation=Observation(kind="schedule", schedule=averaging),
+        underlying=Underlying(spec=EquitySpot("SPX", "gbm")),
+    )
+
+
+class TestContractPatternEvalContractIR:
+    def test_new_ir_heads_round_trip_through_parser(self):
+        payload = {
+            "payoff": {
+                "kind": "scaled",
+                "args": [
+                    {"kind": "annuity", "args": ["_u", "_schedule"]},
+                    {
+                        "kind": "max",
+                        "args": [
+                            {
+                                "kind": "sub",
+                                "args": [
+                                    {"kind": "swap_rate", "args": ["_u", "_schedule"]},
+                                    {"kind": "strike", "value": "_K"},
+                                ],
+                            },
+                            {"kind": "constant", "value": 0},
+                        ],
+                    },
+                ],
+            }
+        }
+
+        pattern = parse_contract_pattern(payload)
+
+        assert parse_contract_pattern(dump_contract_pattern(pattern)) == pattern
+
+    def test_structural_vanilla_pattern_matches_contract_ir_and_binds(self):
+        pattern = parse_contract_pattern(
+            {
+                "payoff": {
+                    "kind": "max",
+                    "args": [
+                        {
+                            "kind": "sub",
+                            "args": [
+                                {"kind": "spot", "underlier": "_u"},
+                                {"kind": "strike", "value": "_k"},
+                            ],
+                        },
+                        {"kind": "constant", "value": 0},
+                    ],
+                }
+            }
+        )
+
+        result = evaluate_pattern(pattern, _vanilla_call_contract_ir())
+
+        assert result.ok is True
+        assert result.bindings["u"] == "AAPL"
+        assert result.bindings["k"] == 150.0
+
+    def test_swaption_leaf_heads_match_contract_ir_and_bind_schedule(self):
+        pattern = parse_contract_pattern(
+            {
+                "payoff": {
+                    "kind": "scaled",
+                    "args": [
+                        {"kind": "annuity", "args": ["_u", "_schedule"]},
+                        {
+                            "kind": "max",
+                            "args": [
+                                {
+                                    "kind": "sub",
+                                    "args": [
+                                        {"kind": "swap_rate", "args": ["_u", "_schedule"]},
+                                        {"kind": "strike", "value": "_K"},
+                                    ],
+                                },
+                                {"kind": "constant", "value": 0},
+                            ],
+                        },
+                    ],
+                }
+            }
+        )
+
+        result = evaluate_pattern(pattern, _swaption_contract_ir())
+
+        assert result.ok is True
+        assert result.bindings["u"] == "USD-IRS-5Y"
+        assert isinstance(result.bindings["schedule"], FiniteSchedule)
+        assert result.bindings["K"] == 0.05
+
+    def test_zero_arity_family_tags_match_phase_two_contract_ir_fixtures(self):
+        fixtures = {
+            "vanilla_payoff": _vanilla_call_contract_ir(),
+            "basket_payoff": _basket_call_contract_ir(),
+            "swaption_payoff": _swaption_contract_ir(),
+            "variance_payoff": _variance_contract_ir(),
+            "digital_payoff": _digital_contract_ir(),
+            "asian_payoff": _asian_contract_ir(),
+        }
+
+        for tag, fixture in fixtures.items():
+            result = evaluate_pattern(
+                ContractPattern(payoff=PayoffPattern(kind=tag)),
+                fixture,
+            )
+            assert result.ok is True
+
+    def test_analytical_black76_style_patterns_preserve_contract_ir_parity(self):
+        vanilla = ContractPattern(payoff=PayoffPattern(kind="vanilla_payoff"))
+        basket = ContractPattern(
+            payoff=PayoffPattern(kind="basket_payoff"),
+            exercise=ExercisePattern(style="european"),
+            underlying=UnderlyingPattern(kind="equity_diffusion"),
+        )
+        swaption_european = ContractPattern(
+            payoff=PayoffPattern(kind="swaption_payoff"),
+            exercise=ExercisePattern(style="european"),
+        )
+
+        assert evaluate_pattern(vanilla, _vanilla_call_contract_ir()).ok is True
+        assert evaluate_pattern(vanilla, _swaption_contract_ir()).ok is False
+
+        assert evaluate_pattern(basket, _basket_call_contract_ir()).ok is True
+        assert evaluate_pattern(basket, _vanilla_call_contract_ir()).ok is False
+
+        assert evaluate_pattern(swaption_european, _swaption_contract_ir()).ok is True
+        assert evaluate_pattern(swaption_european, _vanilla_call_contract_ir()).ok is False

--- a/tests/test_agent/test_decompose_contract_ir.py
+++ b/tests/test_agent/test_decompose_contract_ir.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pytest
+
+from trellis.agent.contract_ir import (
+    Annuity,
+    ArithmeticMean,
+    CompositeUnderlying,
+    Constant,
+    ContractIR,
+    ContinuousInterval,
+    EquitySpot,
+    Exercise,
+    FiniteSchedule,
+    ForwardRate,
+    Gt,
+    Indicator,
+    LinearBasket,
+    Lt,
+    Max,
+    Mul,
+    Observation,
+    Scaled,
+    Singleton,
+    Spot,
+    Strike,
+    Sub,
+    SwapRate,
+    Underlying,
+    VarianceObservable,
+    canonicalize,
+)
+from trellis.agent.knowledge.decompose import decompose_to_contract_ir, decompose_to_ir
+
+
+def _singleton(day: str) -> Singleton:
+    return Singleton(date(*map(int, day.split("-"))))
+
+
+def _interval(start_day: str, end_day: str) -> ContinuousInterval:
+    return ContinuousInterval(
+        date(*map(int, start_day.split("-"))),
+        date(*map(int, end_day.split("-"))),
+    )
+
+
+def _month_end_schedule(year: int) -> FiniteSchedule:
+    month_ends = (
+        date(year, 1, 31),
+        date(year, 2, 28),
+        date(year, 3, 31),
+        date(year, 4, 30),
+        date(year, 5, 31),
+        date(year, 6, 30),
+        date(year, 7, 31),
+        date(year, 8, 31),
+        date(year, 9, 30),
+        date(year, 10, 31),
+        date(year, 11, 30),
+        date(year, 12, 31),
+    )
+    return FiniteSchedule(month_ends)
+
+
+def _weekly_schedule(start_day: str, end_day: str) -> FiniteSchedule:
+    start = date(*map(int, start_day.split("-")))
+    end = date(*map(int, end_day.split("-")))
+    dates = []
+    current = start
+    while current <= end:
+        dates.append(current)
+        current = current + timedelta(days=7)
+    if dates[-1] != end:
+        dates.append(end)
+    return FiniteSchedule(tuple(dates))
+
+
+def _swap_schedule(expiry_day: str, tenor_years: int) -> FiniteSchedule:
+    expiry = date(*map(int, expiry_day.split("-")))
+    dates = tuple(date(expiry.year + offset, expiry.month, expiry.day) for offset in range(1, tenor_years + 1))
+    return FiniteSchedule(dates)
+
+
+def _contracts():
+    swap_schedule = _swap_schedule("2025-11-15", 5)
+    asian_monthly = _month_end_schedule(2025)
+    asian_weekly = _weekly_schedule("2025-01-03", "2025-01-31")
+    return [
+        (
+            "European call on AAPL strike 150 expiring 2025-11-15",
+            "european_option",
+            ContractIR(
+                payoff=Max((Sub(Spot("AAPL"), Strike(150.0)), Constant(0.0))),
+                exercise=Exercise(style="european", schedule=_singleton("2025-11-15")),
+                observation=Observation(kind="terminal", schedule=_singleton("2025-11-15")),
+                underlying=Underlying(spec=EquitySpot("AAPL", "gbm")),
+            ),
+        ),
+        (
+            "European put on SPX strike 4500 expiring 2025-11-15",
+            "european_option",
+            ContractIR(
+                payoff=Max((Sub(Strike(4500.0), Spot("SPX")), Constant(0.0))),
+                exercise=Exercise(style="european", schedule=_singleton("2025-11-15")),
+                observation=Observation(kind="terminal", schedule=_singleton("2025-11-15")),
+                underlying=Underlying(spec=EquitySpot("SPX", "gbm")),
+            ),
+        ),
+        (
+            "European call on AAPL strike 0 expiring 2025-11-15",
+            "european_option",
+            ContractIR(
+                payoff=Max((Sub(Spot("AAPL"), Strike(0.0)), Constant(0.0))),
+                exercise=Exercise(style="european", schedule=_singleton("2025-11-15")),
+                observation=Observation(kind="terminal", schedule=_singleton("2025-11-15")),
+                underlying=Underlying(spec=EquitySpot("AAPL", "gbm")),
+            ),
+        ),
+        (
+            "European payer swaption on 5Y USD IRS strike 5% expiring 2025-11-15",
+            "swaption",
+            ContractIR(
+                payoff=Scaled(
+                    Annuity("USD-IRS-5Y", swap_schedule),
+                    Max((Sub(SwapRate("USD-IRS-5Y", swap_schedule), Strike(0.05)), Constant(0.0))),
+                ),
+                exercise=Exercise(style="european", schedule=_singleton("2025-11-15")),
+                observation=Observation(kind="terminal", schedule=_singleton("2025-11-15")),
+                underlying=Underlying(spec=ForwardRate("USD-IRS-5Y", "lognormal_forward")),
+            ),
+        ),
+        (
+            "European receiver swaption on 5Y USD IRS strike 5% expiring 2025-11-15",
+            "swaption",
+            ContractIR(
+                payoff=Scaled(
+                    Annuity("USD-IRS-5Y", swap_schedule),
+                    Max((Sub(Strike(0.05), SwapRate("USD-IRS-5Y", swap_schedule)), Constant(0.0))),
+                ),
+                exercise=Exercise(style="european", schedule=_singleton("2025-11-15")),
+                observation=Observation(kind="terminal", schedule=_singleton("2025-11-15")),
+                underlying=Underlying(spec=ForwardRate("USD-IRS-5Y", "lognormal_forward")),
+            ),
+        ),
+        (
+            "European basket call on {SPX 50%, NDX 50%} strike 4500 expiring 2025-11-15",
+            "basket_option",
+            ContractIR(
+                payoff=Max(
+                    (
+                        Sub(
+                            LinearBasket(((0.5, Spot("SPX")), (0.5, Spot("NDX")))),
+                            Strike(4500.0),
+                        ),
+                        Constant(0.0),
+                    )
+                ),
+                exercise=Exercise(style="european", schedule=_singleton("2025-11-15")),
+                observation=Observation(kind="terminal", schedule=_singleton("2025-11-15")),
+                underlying=Underlying(
+                    spec=CompositeUnderlying((EquitySpot("SPX", "gbm"), EquitySpot("NDX", "gbm")))
+                ),
+            ),
+        ),
+        (
+            "Equity variance swap on SPX, variance strike 0.04, notional 10000, expiry 2025-11-15",
+            "variance_swap",
+            ContractIR(
+                payoff=Scaled(
+                    Constant(10000.0),
+                    Sub(
+                        VarianceObservable("SPX", _interval("2025-01-01", "2025-11-15")),
+                        Strike(0.04),
+                    ),
+                ),
+                exercise=Exercise(style="european", schedule=_singleton("2025-11-15")),
+                observation=Observation(kind="terminal", schedule=_singleton("2025-11-15")),
+                underlying=Underlying(spec=EquitySpot("SPX", "gbm")),
+            ),
+        ),
+        (
+            "Cash-or-nothing digital call on AAPL paying $2 if spot > 150 at expiry 2025-11-15",
+            "digital_option",
+            ContractIR(
+                payoff=Mul((Constant(2.0), Indicator(Gt(Spot("AAPL"), Strike(150.0))))),
+                exercise=Exercise(style="european", schedule=_singleton("2025-11-15")),
+                observation=Observation(kind="terminal", schedule=_singleton("2025-11-15")),
+                underlying=Underlying(spec=EquitySpot("AAPL", "gbm")),
+            ),
+        ),
+        (
+            "Asset-or-nothing digital put on AAPL if spot < 150 at expiry 2025-11-15",
+            "digital_option",
+            ContractIR(
+                payoff=Mul((Spot("AAPL"), Indicator(Lt(Spot("AAPL"), Strike(150.0))))),
+                exercise=Exercise(style="european", schedule=_singleton("2025-11-15")),
+                observation=Observation(kind="terminal", schedule=_singleton("2025-11-15")),
+                underlying=Underlying(spec=EquitySpot("AAPL", "gbm")),
+            ),
+        ),
+        (
+            "Arithmetic Asian call on SPX monthly average over 2025 strike 4500",
+            "asian_option",
+            ContractIR(
+                payoff=Max(
+                    (
+                        Sub(ArithmeticMean(Spot("SPX"), asian_monthly), Strike(4500.0)),
+                        Constant(0.0),
+                    )
+                ),
+                exercise=Exercise(style="european", schedule=Singleton(date(2025, 12, 31))),
+                observation=Observation(kind="schedule", schedule=asian_monthly),
+                underlying=Underlying(spec=EquitySpot("SPX", "gbm")),
+            ),
+        ),
+        (
+            "Arithmetic Asian put on SPX weekly average from 2025-01-03 to 2025-01-31 strike 4500",
+            "asian_option",
+            ContractIR(
+                payoff=Max(
+                    (
+                        Sub(Strike(4500.0), ArithmeticMean(Spot("SPX"), asian_weekly)),
+                        Constant(0.0),
+                    )
+                ),
+                exercise=Exercise(style="european", schedule=Singleton(date(2025, 1, 31))),
+                observation=Observation(kind="schedule", schedule=asian_weekly),
+                underlying=Underlying(spec=EquitySpot("SPX", "gbm")),
+            ),
+        ),
+    ]
+
+
+class TestDecomposeContractIR:
+    @pytest.mark.parametrize(
+        "description,instrument_type,expected",
+        _contracts(),
+    )
+    def test_supported_descriptions_emit_expected_contract_ir(
+        self,
+        description: str,
+        instrument_type: str,
+        expected: ContractIR,
+    ):
+        product_ir = decompose_to_ir(description, instrument_type=instrument_type)
+        observed = decompose_to_contract_ir(
+            description,
+            instrument_type=instrument_type,
+            product_ir=product_ir,
+        )
+        assert observed == expected
+        assert observed is not None
+        assert canonicalize(observed.payoff) == observed.payoff
+
+    @pytest.mark.parametrize(
+        "description,instrument_type",
+        [
+            ("American put on AAPL strike 150 expiring 2025-11-15", "american_option"),
+            ("Barrier option with 200 knock-out on AAPL expiring 2025-11-15", "barrier_option"),
+            ("Lookback option on AAPL expiring 2025-11-15", "lookback_option"),
+            ("Chooser option on AAPL strike 150 expiring 2025-11-15", "chooser_option"),
+            ("Callable bond with semiannual coupon and call schedule", "callable_bond"),
+            ("CDS on Ford 5Y", "cds"),
+            ("Caplet on SOFR strike 4% expiring 2025-11-15", "cap"),
+        ],
+    )
+    def test_out_of_family_descriptions_return_none(
+        self,
+        description: str,
+        instrument_type: str,
+    ):
+        product_ir = decompose_to_ir(description, instrument_type=instrument_type)
+        assert (
+            decompose_to_contract_ir(
+                description,
+                instrument_type=instrument_type,
+                product_ir=product_ir,
+            )
+            is None
+        )

--- a/tests/test_agent/test_decompose_contract_ir.py
+++ b/tests/test_agent/test_decompose_contract_ir.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from calendar import monthrange
 from datetime import date, timedelta
 
 import pytest
@@ -47,19 +48,9 @@ def _interval(start_day: str, end_day: str) -> ContinuousInterval:
 
 
 def _month_end_schedule(year: int) -> FiniteSchedule:
-    month_ends = (
-        date(year, 1, 31),
-        date(year, 2, 28),
-        date(year, 3, 31),
-        date(year, 4, 30),
-        date(year, 5, 31),
-        date(year, 6, 30),
-        date(year, 7, 31),
-        date(year, 8, 31),
-        date(year, 9, 30),
-        date(year, 10, 31),
-        date(year, 11, 30),
-        date(year, 12, 31),
+    month_ends = tuple(
+        date(year, month, monthrange(year, month)[1])
+        for month in range(1, 13)
     )
     return FiniteSchedule(month_ends)
 
@@ -79,7 +70,14 @@ def _weekly_schedule(start_day: str, end_day: str) -> FiniteSchedule:
 
 def _swap_schedule(expiry_day: str, tenor_years: int) -> FiniteSchedule:
     expiry = date(*map(int, expiry_day.split("-")))
-    dates = tuple(date(expiry.year + offset, expiry.month, expiry.day) for offset in range(1, tenor_years + 1))
+    dates = tuple(
+        date(
+            expiry.year + offset,
+            expiry.month,
+            min(expiry.day, monthrange(expiry.year + offset, expiry.month)[1]),
+        )
+        for offset in range(1, tenor_years + 1)
+    )
     return FiniteSchedule(dates)
 
 
@@ -280,3 +278,70 @@ class TestDecomposeContractIR:
             )
             is None
         )
+
+    def test_forwards_store_to_product_ir_decomposition_when_product_ir_is_absent(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        from importlib import import_module
+
+        decompose_module = import_module("trellis.agent.knowledge.decompose")
+
+        original = decompose_module.decompose_to_ir
+        seen: dict[str, object | None] = {}
+        sentinel_store = object()
+
+        def recording_decompose_to_ir(
+            description: str,
+            instrument_type: str | None = None,
+            *,
+            store: object | None = None,
+        ):
+            seen["store"] = store
+            return original(description, instrument_type=instrument_type)
+
+        monkeypatch.setattr(
+            decompose_module,
+            "decompose_to_ir",
+            recording_decompose_to_ir,
+        )
+
+        observed = decompose_to_contract_ir(
+            "European call on AAPL strike 150 expiring 2025-11-15",
+            instrument_type="european_option",
+            store=sentinel_store,  # type: ignore[arg-type]
+        )
+
+        assert observed is not None
+        assert seen["store"] is sentinel_store
+
+    def test_leap_year_monthly_asian_uses_true_month_ends(self):
+        observed = decompose_to_contract_ir(
+            "Arithmetic Asian call on SPX monthly average over 2024 strike 4500",
+            instrument_type="asian_option",
+        )
+
+        assert observed is not None
+        assert isinstance(observed.observation.schedule, FiniteSchedule)
+        assert observed.observation.schedule.dates[1] == date(2024, 2, 29)
+        assert observed.exercise.schedule == Singleton(date(2024, 12, 31))
+
+    def test_leap_day_swaption_expiry_clamps_non_leap_coupon_years(self):
+        observed = decompose_to_contract_ir(
+            "European payer swaption on 2Y USD IRS strike 5% expiring 2024-02-29",
+            instrument_type="swaption",
+        )
+
+        assert observed is not None
+        assert isinstance(observed.payoff, Scaled)
+        annuity = observed.payoff.scalar
+        assert isinstance(annuity, Annuity)
+        assert annuity.schedule == FiniteSchedule((date(2025, 2, 28), date(2026, 2, 28)))
+
+    def test_reversed_weekly_asian_window_returns_none(self):
+        observed = decompose_to_contract_ir(
+            "Arithmetic Asian put on SPX weekly average from 2025-02-01 to 2025-01-01 strike 4500",
+            instrument_type="asian_option",
+        )
+
+        assert observed is None

--- a/tests/test_agent/test_semantic_contract_compiler_contract_ir.py
+++ b/tests/test_agent/test_semantic_contract_compiler_contract_ir.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from trellis.agent.contract_ir import ContractIR
+from trellis.agent.platform_requests import compile_build_request
+from trellis.agent.semantic_contract_compiler import compile_semantic_contract
+from trellis.agent.semantic_contracts import (
+    make_american_option_contract,
+    make_rate_style_swaption_contract,
+    make_vanilla_option_contract,
+)
+
+
+class TestSemanticCompilerContractIR:
+    def test_vanilla_semantic_blueprint_attaches_contract_ir(self):
+        contract = make_vanilla_option_contract(
+            description="European call on AAPL strike 150 expiring 2025-11-15",
+            underliers=("AAPL",),
+            observation_schedule=("2025-11-15",),
+            preferred_method="analytical",
+        )
+
+        blueprint = compile_semantic_contract(contract)
+
+        assert isinstance(blueprint.contract_ir, ContractIR)
+        assert blueprint.contract_ir.underlying.spec.name == "AAPL"
+
+    def test_swaption_semantic_blueprint_attaches_contract_ir(self):
+        contract = make_rate_style_swaption_contract(
+            description="European payer swaption on 5Y USD IRS strike 5% expiring 2025-11-15",
+            observation_schedule=("2025-11-15",),
+            preferred_method="analytical",
+        )
+
+        blueprint = compile_semantic_contract(contract)
+
+        assert isinstance(blueprint.contract_ir, ContractIR)
+        assert blueprint.contract_ir.underlying.spec.name == "USD-IRS-5Y"
+
+    def test_out_of_family_semantic_contract_attaches_none(self):
+        contract = make_american_option_contract(
+            description="American put on AAPL strike 150 expiring 2025-11-15",
+            underliers=("AAPL",),
+            observation_schedule=("2025-11-15",),
+            preferred_method="rate_tree",
+            exercise_style="american",
+        )
+
+        blueprint = compile_semantic_contract(contract)
+
+        assert blueprint.contract_ir is None
+
+    def test_contract_ir_is_route_independent_across_preferred_methods(self):
+        contract = make_vanilla_option_contract(
+            description="European call on AAPL strike 150 expiring 2025-11-15",
+            underliers=("AAPL",),
+            observation_schedule=("2025-11-15",),
+            preferred_method="analytical",
+        )
+
+        analytical = compile_semantic_contract(contract, preferred_method="analytical")
+        monte_carlo = compile_semantic_contract(contract, preferred_method="monte_carlo")
+
+        assert analytical.contract_ir == monte_carlo.contract_ir
+
+    def test_compile_build_request_metadata_surfaces_contract_ir(self):
+        compiled = compile_build_request(
+            "European call on AAPL strike 150 expiring 2025-11-15",
+            instrument_type="european_option",
+        )
+
+        summary = compiled.request.metadata["semantic_blueprint"]
+        assert summary["contract_ir"] is not None

--- a/trellis/agent/contract_ir.py
+++ b/trellis/agent/contract_ir.py
@@ -149,6 +149,11 @@ class CompositeUnderlying:
             object.__setattr__(self, "parts", tuple(self.parts))
         if not self.parts:
             raise ContractIRWellFormednessError("CompositeUnderlying must be non-empty")
+        for part in self.parts:
+            if not isinstance(part, (EquitySpot, RateCurve, ForwardRate)):
+                raise ContractIRWellFormednessError(
+                    "CompositeUnderlying.parts must contain only UnderlyingSpecLeaf values"
+                )
         names = [part.name for part in self.parts]
         if len(set(names)) != len(names):
             raise ContractIRWellFormednessError(

--- a/trellis/agent/contract_ir.py
+++ b/trellis/agent/contract_ir.py
@@ -1,0 +1,1065 @@
+"""Algebraic Contract IR for structural payoff matching.
+
+This module is intentionally additive to the existing ``ProductIR`` surface.
+It introduces a richer tree representation for contract payoff structure
+without changing any existing route selection paths.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+import math
+from types import MappingProxyType
+from typing import Any, Mapping
+
+
+class ContractIRWellFormednessError(ValueError):
+    """Raised when a Contract IR node violates a local or global invariant."""
+
+
+def _freeze_mapping(mapping: Mapping[tuple[object, ...], float] | None) -> Mapping[tuple[object, ...], float]:
+    return MappingProxyType(dict(mapping or {}))
+
+
+def _require_non_empty_text(value: str, *, label: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ContractIRWellFormednessError(f"{label} must be a non-empty string")
+    return text
+
+
+def _as_float(value: float | int, *, label: str) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError) as exc:  # pragma: no cover - defensive only
+        raise ContractIRWellFormednessError(f"{label} must be numeric") from exc
+
+
+@dataclass(frozen=True)
+class Singleton:
+    t: date
+
+    def __post_init__(self):
+        if not isinstance(self.t, date):
+            raise ContractIRWellFormednessError("Singleton schedule requires a date")
+
+    def key(self) -> tuple[date, ...]:
+        return (self.t,)
+
+
+@dataclass(frozen=True)
+class FiniteSchedule:
+    dates: tuple[date, ...]
+
+    def __post_init__(self):
+        if not isinstance(self.dates, tuple):
+            object.__setattr__(self, "dates", tuple(self.dates))
+        if not self.dates:
+            raise ContractIRWellFormednessError("FiniteSchedule must be non-empty")
+        for item in self.dates:
+            if not isinstance(item, date):
+                raise ContractIRWellFormednessError("FiniteSchedule entries must be dates")
+        if any(left >= right for left, right in zip(self.dates, self.dates[1:])):
+            raise ContractIRWellFormednessError(
+                "FiniteSchedule dates must be strictly increasing"
+            )
+
+    def key(self) -> tuple[date, ...]:
+        return self.dates
+
+
+@dataclass(frozen=True)
+class ContinuousInterval:
+    t_start: date
+    t_end: date
+
+    def __post_init__(self):
+        if not isinstance(self.t_start, date) or not isinstance(self.t_end, date):
+            raise ContractIRWellFormednessError(
+                "ContinuousInterval requires date endpoints"
+            )
+        if self.t_start > self.t_end:
+            raise ContractIRWellFormednessError(
+                "ContinuousInterval requires t_start <= t_end"
+            )
+
+    def key(self) -> tuple[date, date]:
+        return (self.t_start, self.t_end)
+
+
+Schedule = Singleton | FiniteSchedule | ContinuousInterval
+
+
+@dataclass(frozen=True)
+class EquitySpot:
+    name: str
+    dynamics: str
+
+    def __post_init__(self):
+        object.__setattr__(self, "name", _require_non_empty_text(self.name, label="EquitySpot.name"))
+        object.__setattr__(
+            self,
+            "dynamics",
+            _require_non_empty_text(self.dynamics, label="EquitySpot.dynamics"),
+        )
+
+
+@dataclass(frozen=True)
+class RateCurve:
+    name: str
+    dynamics: str
+
+    def __post_init__(self):
+        object.__setattr__(self, "name", _require_non_empty_text(self.name, label="RateCurve.name"))
+        object.__setattr__(
+            self,
+            "dynamics",
+            _require_non_empty_text(self.dynamics, label="RateCurve.dynamics"),
+        )
+
+
+@dataclass(frozen=True)
+class ForwardRate:
+    name: str
+    dynamics: str
+
+    def __post_init__(self):
+        object.__setattr__(
+            self,
+            "name",
+            _require_non_empty_text(self.name, label="ForwardRate.name"),
+        )
+        object.__setattr__(
+            self,
+            "dynamics",
+            _require_non_empty_text(self.dynamics, label="ForwardRate.dynamics"),
+        )
+
+
+UnderlyingSpecLeaf = EquitySpot | RateCurve | ForwardRate
+
+
+@dataclass(frozen=True)
+class CompositeUnderlying:
+    parts: tuple[UnderlyingSpecLeaf, ...]
+
+    def __post_init__(self):
+        if not isinstance(self.parts, tuple):
+            object.__setattr__(self, "parts", tuple(self.parts))
+        if not self.parts:
+            raise ContractIRWellFormednessError("CompositeUnderlying must be non-empty")
+        names = [part.name for part in self.parts]
+        if len(set(names)) != len(names):
+            raise ContractIRWellFormednessError(
+                "CompositeUnderlying leaf names must be unique"
+            )
+
+
+UnderlyingSpec = EquitySpot | RateCurve | ForwardRate | CompositeUnderlying
+
+
+@dataclass(frozen=True)
+class Underlying:
+    spec: UnderlyingSpec
+
+    def __post_init__(self):
+        if not isinstance(
+            self.spec,
+            (EquitySpot, RateCurve, ForwardRate, CompositeUnderlying),
+        ):
+            raise ContractIRWellFormednessError(
+                "Underlying.spec must be an UnderlyingSpec"
+            )
+
+
+@dataclass(frozen=True)
+class Exercise:
+    style: str
+    schedule: Schedule
+
+    def __post_init__(self):
+        normalized_style = _require_non_empty_text(self.style, label="Exercise.style").lower()
+        object.__setattr__(self, "style", normalized_style)
+        if normalized_style == "european" and not isinstance(self.schedule, Singleton):
+            raise ContractIRWellFormednessError(
+                "Exercise(style='european') requires a Singleton schedule"
+            )
+        if normalized_style == "bermudan" and not isinstance(self.schedule, FiniteSchedule):
+            raise ContractIRWellFormednessError(
+                "Exercise(style='bermudan') requires a FiniteSchedule"
+            )
+        if normalized_style == "american" and not isinstance(self.schedule, ContinuousInterval):
+            raise ContractIRWellFormednessError(
+                "Exercise(style='american') requires a ContinuousInterval"
+            )
+        if normalized_style not in {"european", "bermudan", "american"}:
+            raise ContractIRWellFormednessError(
+                f"unsupported Exercise.style {normalized_style!r}"
+            )
+
+
+@dataclass(frozen=True)
+class Observation:
+    kind: str
+    schedule: Schedule
+
+    def __post_init__(self):
+        normalized_kind = _require_non_empty_text(self.kind, label="Observation.kind").lower()
+        object.__setattr__(self, "kind", normalized_kind)
+        if normalized_kind == "terminal" and not isinstance(self.schedule, Singleton):
+            raise ContractIRWellFormednessError(
+                "Observation(kind='terminal') requires a Singleton schedule"
+            )
+        if normalized_kind == "schedule" and not isinstance(self.schedule, FiniteSchedule):
+            raise ContractIRWellFormednessError(
+                "Observation(kind='schedule') requires a FiniteSchedule"
+            )
+        if normalized_kind == "path_dependent" and not isinstance(
+            self.schedule,
+            (FiniteSchedule, ContinuousInterval),
+        ):
+            raise ContractIRWellFormednessError(
+                "Observation(kind='path_dependent') requires a FiniteSchedule or ContinuousInterval"
+            )
+        if normalized_kind not in {"terminal", "schedule", "path_dependent"}:
+            raise ContractIRWellFormednessError(
+                f"unsupported Observation.kind {normalized_kind!r}"
+            )
+
+
+@dataclass(frozen=True)
+class Constant:
+    value: float
+
+    def __post_init__(self):
+        object.__setattr__(self, "value", _as_float(self.value, label="Constant.value"))
+
+
+@dataclass(frozen=True)
+class Spot:
+    underlier_id: str
+
+    def __post_init__(self):
+        object.__setattr__(
+            self,
+            "underlier_id",
+            _require_non_empty_text(self.underlier_id, label="Spot.underlier_id"),
+        )
+
+
+@dataclass(frozen=True)
+class Forward:
+    underlier_id: str
+    schedule: Schedule
+
+    def __post_init__(self):
+        object.__setattr__(
+            self,
+            "underlier_id",
+            _require_non_empty_text(self.underlier_id, label="Forward.underlier_id"),
+        )
+        if not isinstance(self.schedule, (Singleton, FiniteSchedule, ContinuousInterval)):
+            raise ContractIRWellFormednessError("Forward schedule must be a Schedule")
+
+
+@dataclass(frozen=True)
+class SwapRate:
+    underlier_id: str
+    schedule: FiniteSchedule
+
+    def __post_init__(self):
+        object.__setattr__(
+            self,
+            "underlier_id",
+            _require_non_empty_text(self.underlier_id, label="SwapRate.underlier_id"),
+        )
+        if not isinstance(self.schedule, FiniteSchedule):
+            raise ContractIRWellFormednessError(
+                "SwapRate schedule must be a FiniteSchedule"
+            )
+
+
+@dataclass(frozen=True)
+class Annuity:
+    underlier_id: str
+    schedule: FiniteSchedule
+
+    def __post_init__(self):
+        object.__setattr__(
+            self,
+            "underlier_id",
+            _require_non_empty_text(self.underlier_id, label="Annuity.underlier_id"),
+        )
+        if not isinstance(self.schedule, FiniteSchedule):
+            raise ContractIRWellFormednessError(
+                "Annuity schedule must be a FiniteSchedule"
+            )
+
+
+@dataclass(frozen=True)
+class Strike:
+    value: float
+
+    def __post_init__(self):
+        object.__setattr__(self, "value", _as_float(self.value, label="Strike.value"))
+
+
+PayoffExpr = Any
+Predicate = Any
+
+
+@dataclass(frozen=True)
+class LinearBasket:
+    terms: tuple[tuple[float, PayoffExpr], ...]
+
+    def __post_init__(self):
+        if not isinstance(self.terms, tuple):
+            object.__setattr__(self, "terms", tuple(self.terms))
+        if not self.terms:
+            raise ContractIRWellFormednessError("LinearBasket must be non-empty")
+        normalized: list[tuple[float, PayoffExpr]] = []
+        for weight, expr in self.terms:
+            normalized.append((_as_float(weight, label="LinearBasket weight"), expr))
+        object.__setattr__(self, "terms", tuple(normalized))
+
+
+@dataclass(frozen=True)
+class ArithmeticMean:
+    expr: PayoffExpr
+    schedule: FiniteSchedule
+
+    def __post_init__(self):
+        if not isinstance(self.schedule, FiniteSchedule):
+            raise ContractIRWellFormednessError(
+                "ArithmeticMean schedule must be a FiniteSchedule"
+            )
+
+
+@dataclass(frozen=True)
+class VarianceObservable:
+    underlier_id: str
+    interval: ContinuousInterval
+
+    def __post_init__(self):
+        object.__setattr__(
+            self,
+            "underlier_id",
+            _require_non_empty_text(
+                self.underlier_id,
+                label="VarianceObservable.underlier_id",
+            ),
+        )
+        if not isinstance(self.interval, ContinuousInterval):
+            raise ContractIRWellFormednessError(
+                "VarianceObservable interval must be a ContinuousInterval"
+            )
+
+
+@dataclass(frozen=True)
+class Max:
+    args: tuple[PayoffExpr, ...]
+
+    def __post_init__(self):
+        if not isinstance(self.args, tuple):
+            object.__setattr__(self, "args", tuple(self.args))
+        if len(self.args) < 1:
+            raise ContractIRWellFormednessError("Max requires at least one argument")
+
+
+@dataclass(frozen=True)
+class Min:
+    args: tuple[PayoffExpr, ...]
+
+    def __post_init__(self):
+        if not isinstance(self.args, tuple):
+            object.__setattr__(self, "args", tuple(self.args))
+        if len(self.args) < 1:
+            raise ContractIRWellFormednessError("Min requires at least one argument")
+
+
+@dataclass(frozen=True)
+class Add:
+    args: tuple[PayoffExpr, ...]
+
+    def __post_init__(self):
+        if not isinstance(self.args, tuple):
+            object.__setattr__(self, "args", tuple(self.args))
+        if len(self.args) < 2:
+            raise ContractIRWellFormednessError("Add requires at least two arguments")
+
+
+@dataclass(frozen=True)
+class Sub:
+    lhs: PayoffExpr
+    rhs: PayoffExpr
+
+
+@dataclass(frozen=True)
+class Mul:
+    args: tuple[PayoffExpr, ...]
+
+    def __post_init__(self):
+        if not isinstance(self.args, tuple):
+            object.__setattr__(self, "args", tuple(self.args))
+        if len(self.args) < 2:
+            raise ContractIRWellFormednessError("Mul requires at least two arguments")
+
+
+@dataclass(frozen=True)
+class Scaled:
+    scalar: PayoffExpr
+    body: PayoffExpr
+
+
+@dataclass(frozen=True)
+class Gt:
+    lhs: PayoffExpr
+    rhs: PayoffExpr
+
+
+@dataclass(frozen=True)
+class Ge:
+    lhs: PayoffExpr
+    rhs: PayoffExpr
+
+
+@dataclass(frozen=True)
+class Lt:
+    lhs: PayoffExpr
+    rhs: PayoffExpr
+
+
+@dataclass(frozen=True)
+class Le:
+    lhs: PayoffExpr
+    rhs: PayoffExpr
+
+
+@dataclass(frozen=True)
+class And:
+    args: tuple[Predicate, ...]
+
+    def __post_init__(self):
+        if not isinstance(self.args, tuple):
+            object.__setattr__(self, "args", tuple(self.args))
+        if not self.args:
+            raise ContractIRWellFormednessError("And requires at least one predicate")
+
+
+@dataclass(frozen=True)
+class Or:
+    args: tuple[Predicate, ...]
+
+    def __post_init__(self):
+        if not isinstance(self.args, tuple):
+            object.__setattr__(self, "args", tuple(self.args))
+        if not self.args:
+            raise ContractIRWellFormednessError("Or requires at least one predicate")
+
+
+@dataclass(frozen=True)
+class Not:
+    arg: Predicate
+
+
+@dataclass(frozen=True)
+class Indicator:
+    predicate: Predicate
+
+
+PayoffExpr = (
+    Constant
+    | Spot
+    | Forward
+    | SwapRate
+    | Annuity
+    | Strike
+    | LinearBasket
+    | ArithmeticMean
+    | VarianceObservable
+    | Max
+    | Min
+    | Add
+    | Sub
+    | Mul
+    | Scaled
+    | Indicator
+)
+
+Predicate = Gt | Ge | Lt | Le | And | Or | Not
+
+
+@dataclass(frozen=True)
+class ContractIR:
+    payoff: PayoffExpr
+    exercise: Exercise
+    observation: Observation
+    underlying: Underlying
+
+    def __post_init__(self):
+        namespace = _underlier_namespace(self.underlying.spec)
+        _validate_payoff_expr(self.payoff, namespace=namespace)
+        _validate_schedule_alignment(self)
+
+
+def _underlier_namespace(spec: UnderlyingSpec) -> tuple[str, ...]:
+    if isinstance(spec, CompositeUnderlying):
+        return tuple(part.name for part in spec.parts)
+    return (spec.name,)
+
+
+def _validate_underlier_reference(underlier_id: str, *, namespace: tuple[str, ...]) -> None:
+    if underlier_id not in namespace:
+        raise ContractIRWellFormednessError(
+            f"payoff underlier {underlier_id!r} is not present in the contract underlier namespace"
+        )
+
+
+def _validate_predicate(predicate: Predicate, *, namespace: tuple[str, ...]) -> None:
+    if isinstance(predicate, (Gt, Ge, Lt, Le)):
+        _validate_payoff_expr(predicate.lhs, namespace=namespace)
+        _validate_payoff_expr(predicate.rhs, namespace=namespace)
+        return
+    if isinstance(predicate, (And, Or)):
+        for child in predicate.args:
+            _validate_predicate(child, namespace=namespace)
+        return
+    if isinstance(predicate, Not):
+        _validate_predicate(predicate.arg, namespace=namespace)
+        return
+    raise ContractIRWellFormednessError(
+        f"unsupported predicate node {type(predicate).__name__}"
+    )
+
+
+def _validate_payoff_expr(expr: PayoffExpr, *, namespace: tuple[str, ...]) -> None:
+    if isinstance(expr, (Constant, Strike)):
+        return
+    if isinstance(expr, Spot):
+        _validate_underlier_reference(expr.underlier_id, namespace=namespace)
+        return
+    if isinstance(expr, Forward):
+        _validate_underlier_reference(expr.underlier_id, namespace=namespace)
+        return
+    if isinstance(expr, (SwapRate, Annuity)):
+        _validate_underlier_reference(expr.underlier_id, namespace=namespace)
+        return
+    if isinstance(expr, VarianceObservable):
+        _validate_underlier_reference(expr.underlier_id, namespace=namespace)
+        return
+    if isinstance(expr, ArithmeticMean):
+        _validate_payoff_expr(expr.expr, namespace=namespace)
+        return
+    if isinstance(expr, LinearBasket):
+        for _, child in expr.terms:
+            _validate_payoff_expr(child, namespace=namespace)
+        return
+    if isinstance(expr, (Max, Min, Add, Mul)):
+        for child in expr.args:
+            _validate_payoff_expr(child, namespace=namespace)
+        return
+    if isinstance(expr, Sub):
+        _validate_payoff_expr(expr.lhs, namespace=namespace)
+        _validate_payoff_expr(expr.rhs, namespace=namespace)
+        return
+    if isinstance(expr, Scaled):
+        _validate_payoff_expr(expr.scalar, namespace=namespace)
+        _validate_payoff_expr(expr.body, namespace=namespace)
+        return
+    if isinstance(expr, Indicator):
+        _validate_predicate(expr.predicate, namespace=namespace)
+        return
+    raise ContractIRWellFormednessError(
+        f"unsupported payoff node {type(expr).__name__}"
+    )
+
+
+def _validate_schedule_alignment(contract: ContractIR) -> None:
+    if contract.observation.kind == "terminal" and contract.exercise.style == "european":
+        return
+    # Phase 2 does not require exercise/observation schedule equality globally.
+
+
+@dataclass(frozen=True)
+class PayoffEvalEnv:
+    """Sparse numeric environment for payoff-level semantic checks."""
+
+    values: Mapping[tuple[object, ...], float] = field(default_factory=dict)
+
+    def __post_init__(self):
+        object.__setattr__(self, "values", _freeze_mapping(self.values))
+
+
+def _lookup_value(
+    env: PayoffEvalEnv,
+    *,
+    key: tuple[object, ...],
+    fallback: tuple[object, ...] | None = None,
+) -> float:
+    values = env.values
+    if key in values:
+        return float(values[key])
+    if fallback is not None and fallback in values:
+        return float(values[fallback])
+    raise KeyError(f"missing payoff-evaluation input for key {key!r}")
+
+
+def evaluate_payoff_expr(
+    expr: PayoffExpr,
+    env: PayoffEvalEnv,
+    *,
+    as_of: date | None = None,
+) -> float:
+    if isinstance(expr, Constant):
+        return expr.value
+    if isinstance(expr, Strike):
+        return expr.value
+    if isinstance(expr, Spot):
+        if as_of is not None:
+            try:
+                return _lookup_value(
+                    env,
+                    key=("spot", expr.underlier_id, as_of),
+                    fallback=("spot", expr.underlier_id),
+                )
+            except KeyError:
+                return _lookup_value(env, key=("spot", expr.underlier_id))
+        return _lookup_value(env, key=("spot", expr.underlier_id))
+    if isinstance(expr, Forward):
+        schedule_key = expr.schedule.key()
+        if as_of is not None:
+            return _lookup_value(
+                env,
+                key=("forward", expr.underlier_id, schedule_key, as_of),
+                fallback=("forward", expr.underlier_id, schedule_key),
+            )
+        return _lookup_value(env, key=("forward", expr.underlier_id, schedule_key))
+    if isinstance(expr, SwapRate):
+        schedule_key = expr.schedule.key()
+        if as_of is not None:
+            return _lookup_value(
+                env,
+                key=("swap_rate", expr.underlier_id, schedule_key, as_of),
+                fallback=("swap_rate", expr.underlier_id, schedule_key),
+            )
+        return _lookup_value(env, key=("swap_rate", expr.underlier_id, schedule_key))
+    if isinstance(expr, Annuity):
+        schedule_key = expr.schedule.key()
+        if as_of is not None:
+            return _lookup_value(
+                env,
+                key=("annuity", expr.underlier_id, schedule_key, as_of),
+                fallback=("annuity", expr.underlier_id, schedule_key),
+            )
+        return _lookup_value(env, key=("annuity", expr.underlier_id, schedule_key))
+    if isinstance(expr, VarianceObservable):
+        return _lookup_value(
+            env,
+            key=(
+                "variance_observable",
+                expr.underlier_id,
+                expr.interval.t_start,
+                expr.interval.t_end,
+            ),
+        )
+    if isinstance(expr, LinearBasket):
+        return math.fsum(
+            weight * evaluate_payoff_expr(child, env, as_of=as_of)
+            for weight, child in expr.terms
+        )
+    if isinstance(expr, ArithmeticMean):
+        return math.fsum(
+            evaluate_payoff_expr(expr.expr, env, as_of=scheduled_date)
+            for scheduled_date in expr.schedule.dates
+        ) / len(expr.schedule.dates)
+    if isinstance(expr, Max):
+        return max(evaluate_payoff_expr(child, env, as_of=as_of) for child in expr.args)
+    if isinstance(expr, Min):
+        return min(evaluate_payoff_expr(child, env, as_of=as_of) for child in expr.args)
+    if isinstance(expr, Add):
+        return math.fsum(
+            evaluate_payoff_expr(child, env, as_of=as_of) for child in expr.args
+        )
+    if isinstance(expr, Sub):
+        return evaluate_payoff_expr(expr.lhs, env, as_of=as_of) - evaluate_payoff_expr(
+            expr.rhs,
+            env,
+            as_of=as_of,
+        )
+    if isinstance(expr, Mul):
+        result = 1.0
+        for child in expr.args:
+            result *= evaluate_payoff_expr(child, env, as_of=as_of)
+        return result
+    if isinstance(expr, Scaled):
+        return evaluate_payoff_expr(expr.scalar, env, as_of=as_of) * evaluate_payoff_expr(
+            expr.body,
+            env,
+            as_of=as_of,
+        )
+    if isinstance(expr, Indicator):
+        return 1.0 if evaluate_predicate(expr.predicate, env, as_of=as_of) else 0.0
+    raise TypeError(f"unsupported payoff node {type(expr).__name__}")
+
+
+def evaluate_predicate(
+    predicate: Predicate,
+    env: PayoffEvalEnv,
+    *,
+    as_of: date | None = None,
+) -> bool:
+    if isinstance(predicate, Gt):
+        return evaluate_payoff_expr(predicate.lhs, env, as_of=as_of) > evaluate_payoff_expr(
+            predicate.rhs,
+            env,
+            as_of=as_of,
+        )
+    if isinstance(predicate, Ge):
+        return evaluate_payoff_expr(predicate.lhs, env, as_of=as_of) >= evaluate_payoff_expr(
+            predicate.rhs,
+            env,
+            as_of=as_of,
+        )
+    if isinstance(predicate, Lt):
+        return evaluate_payoff_expr(predicate.lhs, env, as_of=as_of) < evaluate_payoff_expr(
+            predicate.rhs,
+            env,
+            as_of=as_of,
+        )
+    if isinstance(predicate, Le):
+        return evaluate_payoff_expr(predicate.lhs, env, as_of=as_of) <= evaluate_payoff_expr(
+            predicate.rhs,
+            env,
+            as_of=as_of,
+        )
+    if isinstance(predicate, And):
+        return all(evaluate_predicate(child, env, as_of=as_of) for child in predicate.args)
+    if isinstance(predicate, Or):
+        return any(evaluate_predicate(child, env, as_of=as_of) for child in predicate.args)
+    if isinstance(predicate, Not):
+        return not evaluate_predicate(predicate.arg, env, as_of=as_of)
+    raise TypeError(f"unsupported predicate node {type(predicate).__name__}")
+
+
+def canonicalize(expr: PayoffExpr) -> PayoffExpr:
+    if isinstance(expr, (Constant, Spot, Forward, SwapRate, Annuity, Strike, VarianceObservable)):
+        return expr
+    if isinstance(expr, ArithmeticMean):
+        return ArithmeticMean(canonicalize(expr.expr), expr.schedule)
+    if isinstance(expr, LinearBasket):
+        normalized_terms: list[tuple[float, PayoffExpr]] = []
+        for weight, child in expr.terms:
+            if float(weight) == 0.0:
+                continue
+            normalized_terms.append((float(weight), canonicalize(child)))
+        if not normalized_terms:
+            return Constant(0.0)
+        if len(normalized_terms) == 1:
+            weight, child = normalized_terms[0]
+            return canonicalize(Scaled(Constant(weight), child))
+        return LinearBasket(tuple(normalized_terms))
+    if isinstance(expr, Sub):
+        lhs = canonicalize(expr.lhs)
+        rhs = canonicalize(expr.rhs)
+        if isinstance(lhs, Constant) and isinstance(rhs, Constant):
+            return Constant(lhs.value - rhs.value)
+        if isinstance(rhs, Constant) and rhs.value == 0.0:
+            return lhs
+        if lhs == rhs:
+            return Constant(0.0)
+        return Sub(lhs, rhs)
+    if isinstance(expr, Scaled):
+        scalar = canonicalize(expr.scalar)
+        body = canonicalize(expr.body)
+        if isinstance(body, Constant) and body.value == 0.0:
+            return Constant(0.0)
+        if isinstance(scalar, Constant):
+            if scalar.value == 0.0:
+                return Constant(0.0)
+            if scalar.value == 1.0:
+                return body
+            if isinstance(body, Constant):
+                return Constant(scalar.value * body.value)
+            if isinstance(body, Scaled) and isinstance(body.scalar, Constant):
+                return canonicalize(
+                    Scaled(Constant(scalar.value * body.scalar.value), body.body)
+                )
+        return Scaled(scalar, body)
+    if isinstance(expr, Add):
+        normalized = _canonicalize_variadic_children(expr.args, Add)
+        constant_sum = 0.0
+        out: list[PayoffExpr] = []
+        for child in normalized:
+            if isinstance(child, Constant):
+                constant_sum += child.value
+            else:
+                out.append(child)
+        if constant_sum != 0.0:
+            out.append(Constant(constant_sum))
+        out.sort(key=_expr_sort_key)
+        if not out:
+            return Constant(0.0)
+        if len(out) == 1:
+            return out[0]
+        return Add(tuple(out))
+    if isinstance(expr, Mul):
+        normalized = _canonicalize_variadic_children(expr.args, Mul)
+        constant_product = 1.0
+        out: list[PayoffExpr] = []
+        for child in normalized:
+            if isinstance(child, Constant):
+                if child.value == 0.0:
+                    return Constant(0.0)
+                constant_product *= child.value
+            else:
+                out.append(child)
+        if constant_product != 1.0 or not out:
+            out.append(Constant(constant_product))
+        out = [child for child in out if not (isinstance(child, Constant) and child.value == 1.0 and len(out) > 1)]
+        out.sort(key=_expr_sort_key)
+        if not out:
+            return Constant(1.0)
+        if len(out) == 1:
+            return out[0]
+        return Mul(tuple(out))
+    if isinstance(expr, Max):
+        return _canonicalize_extrema(Max, expr.args)
+    if isinstance(expr, Min):
+        return _canonicalize_extrema(Min, expr.args)
+    if isinstance(expr, Indicator):
+        return Indicator(_canonicalize_predicate(expr.predicate))
+    raise TypeError(f"unsupported payoff node {type(expr).__name__}")
+
+
+def _canonicalize_extrema(cls, args: tuple[PayoffExpr, ...]) -> PayoffExpr:
+    normalized = _canonicalize_variadic_children(args, cls)
+    if all(isinstance(child, Constant) for child in normalized):
+        values = [child.value for child in normalized]
+        return Constant(max(values) if cls is Max else min(values))
+
+    factored = _factor_common_positive_scalar(cls, tuple(normalized))
+    if factored is not None:
+        return canonicalize(factored)
+
+    unique: list[PayoffExpr] = []
+    seen: set[tuple[object, ...]] = set()
+    for child in sorted(normalized, key=_expr_sort_key):
+        key = _expr_sort_key(child)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(child)
+    if len(unique) == 1:
+        return unique[0]
+    return cls(tuple(unique))
+
+
+def _factor_common_positive_scalar(cls, args: tuple[PayoffExpr, ...]) -> PayoffExpr | None:
+    scaled_args = [child for child in args if isinstance(child, Scaled)]
+    if not scaled_args:
+        return None
+    common_scalar = scaled_args[0].scalar
+    if not _is_locally_nonnegative(common_scalar):
+        return None
+    if any(child.scalar != common_scalar for child in scaled_args[1:]):
+        return None
+    inner_args: list[PayoffExpr] = []
+    for child in args:
+        if isinstance(child, Scaled) and child.scalar == common_scalar:
+            inner_args.append(child.body)
+            continue
+        if isinstance(child, Constant) and child.value == 0.0:
+            inner_args.append(Constant(0.0))
+            continue
+        return None
+    return Scaled(common_scalar, cls(tuple(inner_args)))
+
+
+def _flatten_variadic(args: tuple[PayoffExpr, ...], cls) -> list[PayoffExpr]:
+    out: list[PayoffExpr] = []
+    for child in args:
+        if isinstance(child, cls):
+            out.extend(_flatten_variadic(child.args, cls))
+        else:
+            out.append(child)
+    return out
+
+
+def _canonicalize_variadic_children(args: tuple[PayoffExpr, ...], cls) -> list[PayoffExpr]:
+    out: list[PayoffExpr] = []
+    for child in args:
+        normalized = canonicalize(child)
+        if isinstance(normalized, cls):
+            out.extend(_flatten_variadic(normalized.args, cls))
+        else:
+            out.append(normalized)
+    return out
+
+
+def _canonicalize_predicate(predicate: Predicate) -> Predicate:
+    if isinstance(predicate, Gt):
+        return Gt(canonicalize(predicate.lhs), canonicalize(predicate.rhs))
+    if isinstance(predicate, Ge):
+        return Ge(canonicalize(predicate.lhs), canonicalize(predicate.rhs))
+    if isinstance(predicate, Lt):
+        return Lt(canonicalize(predicate.lhs), canonicalize(predicate.rhs))
+    if isinstance(predicate, Le):
+        return Le(canonicalize(predicate.lhs), canonicalize(predicate.rhs))
+    if isinstance(predicate, And):
+        children = _flatten_predicates(predicate.args, And)
+        normalized = [_canonicalize_predicate(child) for child in children]
+        deduped = _dedupe_predicates(normalized)
+        if len(deduped) == 1:
+            return deduped[0]
+        return And(tuple(sorted(deduped, key=_predicate_sort_key)))
+    if isinstance(predicate, Or):
+        children = _flatten_predicates(predicate.args, Or)
+        normalized = [_canonicalize_predicate(child) for child in children]
+        deduped = _dedupe_predicates(normalized)
+        if len(deduped) == 1:
+            return deduped[0]
+        return Or(tuple(sorted(deduped, key=_predicate_sort_key)))
+    if isinstance(predicate, Not):
+        return Not(_canonicalize_predicate(predicate.arg))
+    raise TypeError(f"unsupported predicate node {type(predicate).__name__}")
+
+
+def _flatten_predicates(args: tuple[Predicate, ...], cls) -> list[Predicate]:
+    out: list[Predicate] = []
+    for child in args:
+        if isinstance(child, cls):
+            out.extend(_flatten_predicates(child.args, cls))
+        else:
+            out.append(child)
+    return out
+
+
+def _dedupe_predicates(args: list[Predicate]) -> list[Predicate]:
+    out: list[Predicate] = []
+    seen: set[tuple[object, ...]] = set()
+    for child in args:
+        key = _predicate_sort_key(child)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(child)
+    return out
+
+
+def _is_locally_nonnegative(expr: PayoffExpr) -> bool:
+    if isinstance(expr, Constant):
+        return expr.value >= 0.0
+    if isinstance(expr, Annuity):
+        return True
+    return False
+
+
+def _schedule_key(schedule: Schedule) -> tuple[object, ...]:
+    if isinstance(schedule, Singleton):
+        return ("singleton", schedule.t)
+    if isinstance(schedule, FiniteSchedule):
+        return ("finite", *schedule.dates)
+    if isinstance(schedule, ContinuousInterval):
+        return ("interval", schedule.t_start, schedule.t_end)
+    raise TypeError(f"unsupported schedule {type(schedule).__name__}")
+
+
+def _expr_sort_key(expr: PayoffExpr) -> tuple[object, ...]:
+    if isinstance(expr, Sub):
+        return (0, _expr_sort_key(expr.lhs), _expr_sort_key(expr.rhs))
+    if isinstance(expr, Spot):
+        return (1, expr.underlier_id)
+    if isinstance(expr, Forward):
+        return (2, expr.underlier_id, _schedule_key(expr.schedule))
+    if isinstance(expr, SwapRate):
+        return (3, expr.underlier_id, _schedule_key(expr.schedule))
+    if isinstance(expr, Annuity):
+        return (4, expr.underlier_id, _schedule_key(expr.schedule))
+    if isinstance(expr, LinearBasket):
+        return (
+            5,
+            tuple((weight, _expr_sort_key(child)) for weight, child in expr.terms),
+        )
+    if isinstance(expr, ArithmeticMean):
+        return (6, _expr_sort_key(expr.expr), _schedule_key(expr.schedule))
+    if isinstance(expr, VarianceObservable):
+        return (7, expr.underlier_id, expr.interval.t_start, expr.interval.t_end)
+    if isinstance(expr, Constant):
+        return (8, expr.value)
+    if isinstance(expr, Indicator):
+        return (9, _predicate_sort_key(expr.predicate))
+    if isinstance(expr, Scaled):
+        return (10, _expr_sort_key(expr.scalar), _expr_sort_key(expr.body))
+    if isinstance(expr, Add):
+        return (11, tuple(_expr_sort_key(child) for child in expr.args))
+    if isinstance(expr, Mul):
+        return (12, tuple(_expr_sort_key(child) for child in expr.args))
+    if isinstance(expr, Max):
+        return (13, tuple(_expr_sort_key(child) for child in expr.args))
+    if isinstance(expr, Min):
+        return (14, tuple(_expr_sort_key(child) for child in expr.args))
+    if isinstance(expr, Strike):
+        return (15, expr.value)
+    raise TypeError(f"unsupported payoff node {type(expr).__name__}")
+
+
+def _predicate_sort_key(predicate: Predicate) -> tuple[object, ...]:
+    if isinstance(predicate, Gt):
+        return (0, _expr_sort_key(predicate.lhs), _expr_sort_key(predicate.rhs))
+    if isinstance(predicate, Ge):
+        return (1, _expr_sort_key(predicate.lhs), _expr_sort_key(predicate.rhs))
+    if isinstance(predicate, Lt):
+        return (2, _expr_sort_key(predicate.lhs), _expr_sort_key(predicate.rhs))
+    if isinstance(predicate, Le):
+        return (3, _expr_sort_key(predicate.lhs), _expr_sort_key(predicate.rhs))
+    if isinstance(predicate, And):
+        return (4, tuple(_predicate_sort_key(child) for child in predicate.args))
+    if isinstance(predicate, Or):
+        return (5, tuple(_predicate_sort_key(child) for child in predicate.args))
+    if isinstance(predicate, Not):
+        return (6, _predicate_sort_key(predicate.arg))
+    raise TypeError(f"unsupported predicate node {type(predicate).__name__}")
+
+
+__all__ = [
+    "Add",
+    "And",
+    "Annuity",
+    "ArithmeticMean",
+    "CompositeUnderlying",
+    "Constant",
+    "ContinuousInterval",
+    "ContractIR",
+    "ContractIRWellFormednessError",
+    "EquitySpot",
+    "Exercise",
+    "FiniteSchedule",
+    "Forward",
+    "ForwardRate",
+    "Ge",
+    "Gt",
+    "Indicator",
+    "Le",
+    "LinearBasket",
+    "Lt",
+    "Max",
+    "Min",
+    "Mul",
+    "Not",
+    "Observation",
+    "Or",
+    "PayoffEvalEnv",
+    "RateCurve",
+    "Scaled",
+    "Singleton",
+    "Spot",
+    "Strike",
+    "Sub",
+    "SwapRate",
+    "Underlying",
+    "VarianceObservable",
+    "canonicalize",
+    "evaluate_payoff_expr",
+    "evaluate_predicate",
+]

--- a/trellis/agent/contract_pattern.py
+++ b/trellis/agent/contract_pattern.py
@@ -266,6 +266,12 @@ _PAYOFF_KINDS = {
     "mul",
     "scaled",
     "indicator",
+    "forward",
+    "swap_rate",
+    "annuity",
+    "linear_basket",
+    "arithmetic_mean",
+    "variance_observable",
     "constant",
     "spot",
     "strike",
@@ -681,10 +687,16 @@ _ARITY_TABLE: dict[str, int | None] = {
     "mul": 2,
     "scaled": 2,
     "indicator": 1,
+    "forward": 2,
+    "swap_rate": 2,
+    "annuity": 2,
+    "arithmetic_mean": 2,
+    "variance_observable": 2,
     # Variadic (>=1) head tags — we accept any non-zero arity.
     "max": None,
     "min": None,
     "sum": None,
+    "linear_basket": None,
     # Instrument-level payoff tags have no structural sub-args requirement.
     "swaption_payoff": 0,
     "basket_payoff": 0,
@@ -705,7 +717,7 @@ def _validate_arity(kind: str, args: tuple[Pattern, ...]) -> None:
     expected = _ARITY_TABLE.get(kind)
     if expected is None:
         # Variadic — require at least one child.
-        if kind in {"max", "min", "sum"} and len(args) < 1:
+        if kind in {"max", "min", "sum", "linear_basket"} and len(args) < 1:
             raise ContractPatternParseError(
                 f"payoff node {kind!r} requires at least one 'args' entry"
             )

--- a/trellis/agent/contract_pattern_eval.py
+++ b/trellis/agent/contract_pattern_eval.py
@@ -1,19 +1,19 @@
-"""Contract pattern evaluator against ProductIR (QUA-918 / Phase 1.5.B).
+"""Contract pattern evaluator against ProductIR and ContractIR.
 
 This module makes the :class:`~trellis.agent.contract_pattern.ContractPattern`
 AST built in QUA-917 executable: given a pattern and a
-:class:`~trellis.agent.knowledge.schema.ProductIR`, :func:`evaluate_pattern`
-decides whether the pattern matches and returns any captured bindings for
-named wildcards.
+:class:`~trellis.agent.knowledge.schema.ProductIR` or
+:class:`~trellis.agent.contract_ir.ContractIR`, :func:`evaluate_pattern`
+decides whether the pattern matches and returns any captured bindings for named
+wildcards.
 
 Design notes
 ------------
 
-**Target surface.** The evaluator matches against ``ProductIR`` only.  Phase 2
-may extend to ``ContractIR`` (tracked separately); the AST is expressive
-enough that the walker does not need to change when a richer target is added,
-only the per-slot matchers (:func:`_match_exercise`, :func:`_match_underlying`,
-etc.) that bridge pattern fields onto concrete target fields.
+**Target surface.** The evaluator now matches against both ``ProductIR`` and
+``ContractIR``.  The AST stays stable across the two targets; only the
+per-slot matchers (:func:`_match_exercise`, :func:`_match_underlying`, etc.)
+that bridge pattern fields onto concrete target fields differ.
 
 **Bare strings vs :class:`AtomPattern`.** ``UnderlyingPattern.kind``,
 ``ExercisePattern.style``, and ``ObservationPattern.kind`` can carry either a
@@ -56,12 +56,13 @@ Follow-ups for downstream slices
   semantics.
 - Phase 3 ``@solves_pattern`` uses :func:`evaluate_pattern` to dispatch
   kernel implementations.
-- Phase 2 extends the walker to match against the richer ``ContractIR``;
-  the AST does not change.
+- Phase 3 ``@solves_pattern`` will read the richer ``ContractIR`` path during
+  kernel selection; the AST does not need to change again for that step.
 """
 
 from __future__ import annotations
 
+import trellis.agent.contract_ir as contract_ir_types
 from dataclasses import dataclass, field
 from typing import Any, Mapping
 
@@ -144,7 +145,10 @@ _INSTRUMENT_TAG_TO_PAYOFF_FAMILIES: Mapping[str, frozenset[str]] = {
 # ---------------------------------------------------------------------------
 
 
-def evaluate_pattern(pattern: ContractPattern, target: ProductIR) -> MatchResult:
+def evaluate_pattern(
+    pattern: ContractPattern,
+    target: ProductIR | contract_ir_types.ContractIR,
+) -> MatchResult:
     """Evaluate ``pattern`` against ``target`` and return a :class:`MatchResult`.
 
     A :class:`ContractPattern` matches a :class:`ProductIR` when every
@@ -160,11 +164,19 @@ def evaluate_pattern(pattern: ContractPattern, target: ProductIR) -> MatchResult
         raise TypeError(
             f"evaluate_pattern expects a ContractPattern, got {type(pattern).__name__}"
         )
-    if not isinstance(target, ProductIR):
-        raise TypeError(
-            f"evaluate_pattern expects a ProductIR target, got {type(target).__name__}"
-        )
+    if isinstance(target, ProductIR):
+        return _evaluate_pattern_product_ir(pattern, target)
+    if isinstance(target, contract_ir_types.ContractIR):
+        return _evaluate_pattern_contract_ir(pattern, target)
+    raise TypeError(
+        f"evaluate_pattern expects a ProductIR or ContractIR target, got {type(target).__name__}"
+    )
 
+
+def _evaluate_pattern_product_ir(
+    pattern: ContractPattern,
+    target: ProductIR,
+) -> MatchResult:
     bindings: dict[str, Any] = {}
 
     # Top-level fields compose with AND semantics: every non-None slot must
@@ -194,6 +206,583 @@ def evaluate_pattern(pattern: ContractPattern, target: ProductIR) -> MatchResult
         bindings = outcome.bindings
 
     return MatchResult(ok=True, bindings=bindings)
+
+
+def _evaluate_pattern_contract_ir(
+    pattern: ContractPattern,
+    target: contract_ir_types.ContractIR,
+) -> MatchResult:
+    bindings: dict[str, Any] = {}
+
+    if pattern.payoff is not None:
+        outcome = _match_contract_ir_payoff(
+            pattern.payoff,
+            target.payoff,
+            bindings,
+            contract=target,
+        )
+        if not outcome.ok:
+            return outcome
+        bindings = outcome.bindings
+
+    if pattern.exercise is not None:
+        outcome = _match_contract_ir_exercise(pattern.exercise, target, bindings)
+        if not outcome.ok:
+            return outcome
+        bindings = outcome.bindings
+
+    if pattern.observation is not None:
+        outcome = _match_contract_ir_observation(pattern.observation, target, bindings)
+        if not outcome.ok:
+            return outcome
+        bindings = outcome.bindings
+
+    if pattern.underlying is not None:
+        outcome = _match_contract_ir_underlying(pattern.underlying, target, bindings)
+        if not outcome.ok:
+            return outcome
+        bindings = outcome.bindings
+
+    return MatchResult(ok=True, bindings=bindings)
+
+
+# ---------------------------------------------------------------------------
+# ContractIR matchers
+# ---------------------------------------------------------------------------
+
+
+def _match_contract_ir_exercise(
+    pattern: ExercisePattern,
+    target: contract_ir_types.ContractIR,
+    bindings: dict[str, Any],
+) -> MatchResult:
+    style_outcome = _match_field(
+        pattern.style,
+        target.exercise.style,
+        bindings,
+        field_label="exercise_style",
+    )
+    if not style_outcome.ok:
+        return style_outcome
+    if pattern.schedule is None:
+        return style_outcome
+    return _match_contract_ir_schedule(
+        pattern.schedule,
+        target.exercise.schedule,
+        style_outcome.bindings,
+        field_label="exercise.schedule",
+    )
+
+
+def _match_contract_ir_observation(
+    pattern: ObservationPattern,
+    target: contract_ir_types.ContractIR,
+    bindings: dict[str, Any],
+) -> MatchResult:
+    return _match_field(
+        pattern.kind,
+        target.observation.kind,
+        bindings,
+        field_label="observation.kind",
+    )
+
+
+def _match_contract_ir_underlying(
+    pattern: UnderlyingPattern,
+    target: contract_ir_types.ContractIR,
+    bindings: dict[str, Any],
+) -> MatchResult:
+    kind_values, primary_kind = _contract_ir_underlying_kind_candidates(
+        target.underlying.spec
+    )
+    kind_outcome = _match_field_multivalued(
+        pattern.kind,
+        candidate_values=kind_values,
+        bindings=bindings,
+        field_label="underlying.kind",
+        primary_value=primary_kind,
+    )
+    if not kind_outcome.ok:
+        return kind_outcome
+    if pattern.dynamics is None:
+        return kind_outcome
+    dynamics_values, primary_dynamics = _contract_ir_underlying_dynamics_candidates(
+        target.underlying.spec
+    )
+    return _match_field_multivalued(
+        pattern.dynamics,
+        candidate_values=dynamics_values,
+        bindings=kind_outcome.bindings,
+        field_label="underlying.dynamics",
+        primary_value=primary_dynamics,
+    )
+
+
+def _match_contract_ir_schedule(
+    pattern: SchedulePattern,
+    observed: object,
+    bindings: dict[str, Any],
+    *,
+    field_label: str,
+) -> MatchResult:
+    if pattern.frequency is None:
+        return MatchResult(ok=True, bindings=bindings)
+    return _match_field(
+        pattern.frequency,
+        observed,
+        bindings,
+        field_label=field_label,
+    )
+
+
+def _match_contract_ir_payoff(
+    pattern: Any,
+    observed: object,
+    bindings: dict[str, Any],
+    *,
+    contract: contract_ir_types.ContractIR,
+) -> MatchResult:
+    if isinstance(pattern, AndPattern):
+        current = bindings
+        for child in pattern.patterns:
+            outcome = _match_contract_ir_payoff(
+                child,
+                observed,
+                current,
+                contract=contract,
+            )
+            if not outcome.ok:
+                return outcome
+            current = outcome.bindings
+        return MatchResult(ok=True, bindings=current)
+    if isinstance(pattern, OrPattern):
+        last_reason: str | None = None
+        for child in pattern.patterns:
+            outcome = _match_contract_ir_payoff(
+                child,
+                observed,
+                bindings,
+                contract=contract,
+            )
+            if outcome.ok:
+                return outcome
+            last_reason = outcome.mismatch_reason
+        return MatchResult(
+            ok=False,
+            bindings=bindings,
+            mismatch_reason=last_reason or "no OR branch matched",
+        )
+    if isinstance(pattern, NotPattern):
+        outcome = _match_contract_ir_payoff(
+            pattern.pattern,
+            observed,
+            bindings,
+            contract=contract,
+        )
+        if outcome.ok:
+            return MatchResult(
+                ok=False,
+                bindings=bindings,
+                mismatch_reason="NOT sub-pattern unexpectedly matched",
+            )
+        return MatchResult(ok=True, bindings=bindings)
+    if isinstance(pattern, Wildcard):
+        return _match_field(
+            pattern,
+            observed,
+            bindings,
+            field_label="payoff",
+        )
+    if isinstance(pattern, AtomPattern):
+        return _match_field(
+            pattern,
+            observed,
+            bindings,
+            field_label="payoff",
+        )
+    if isinstance(pattern, SpotPattern):
+        if not isinstance(observed, contract_ir_types.Spot):
+            return MatchResult(
+                ok=False,
+                bindings=bindings,
+                mismatch_reason=(
+                    f"expected Spot leaf, got {type(observed).__name__}"
+                ),
+            )
+        return _match_field(
+            pattern.underlier,
+            observed.underlier_id,
+            bindings,
+            field_label="spot.underlier",
+        )
+    if isinstance(pattern, StrikePattern):
+        if not isinstance(observed, contract_ir_types.Strike):
+            return MatchResult(
+                ok=False,
+                bindings=bindings,
+                mismatch_reason=(
+                    f"expected Strike leaf, got {type(observed).__name__}"
+                ),
+            )
+        return _match_field(
+            pattern.value,
+            observed.value,
+            bindings,
+            field_label="strike.value",
+        )
+    if isinstance(pattern, ConstantPattern):
+        if not isinstance(observed, contract_ir_types.Constant):
+            return MatchResult(
+                ok=False,
+                bindings=bindings,
+                mismatch_reason=(
+                    f"expected Constant leaf, got {type(observed).__name__}"
+                ),
+            )
+        return _match_field(
+            pattern.value,
+            observed.value,
+            bindings,
+            field_label="constant.value",
+        )
+    if isinstance(pattern, PayoffPattern):
+        return _match_contract_ir_payoff_head(pattern, observed, bindings, contract=contract)
+    return MatchResult(
+        ok=False,
+        bindings=bindings,
+        mismatch_reason=f"unsupported payoff pattern type {type(pattern).__name__}",
+    )
+
+
+def _match_contract_ir_payoff_head(
+    pattern: PayoffPattern,
+    observed: object,
+    bindings: dict[str, Any],
+    *,
+    contract: contract_ir_types.ContractIR,
+) -> MatchResult:
+    if pattern.kind in _INSTRUMENT_TAG_TO_PAYOFF_FAMILIES and not pattern.args:
+        return _match_contract_ir_instrument_tag(pattern.kind, contract, bindings)
+
+    if pattern.kind == "max":
+        return _match_contract_ir_variadic(pattern.args, observed, contract_ir_types.Max, bindings, contract=contract)
+    if pattern.kind == "min":
+        return _match_contract_ir_variadic(pattern.args, observed, contract_ir_types.Min, bindings, contract=contract)
+    if pattern.kind == "sum":
+        return _match_contract_ir_variadic(pattern.args, observed, contract_ir_types.Add, bindings, contract=contract)
+    if pattern.kind == "mul":
+        return _match_contract_ir_variadic(pattern.args, observed, contract_ir_types.Mul, bindings, contract=contract)
+    if pattern.kind == "sub":
+        if not isinstance(observed, contract_ir_types.Sub):
+            return _contract_ir_kind_mismatch("sub", observed, bindings)
+        return _match_contract_ir_children(
+            pattern.args,
+            (observed.lhs, observed.rhs),
+            bindings,
+            contract=contract,
+            kind_label="sub",
+        )
+    if pattern.kind == "scaled":
+        if not isinstance(observed, contract_ir_types.Scaled):
+            return _contract_ir_kind_mismatch("scaled", observed, bindings)
+        return _match_contract_ir_children(
+            pattern.args,
+            (observed.scalar, observed.body),
+            bindings,
+            contract=contract,
+            kind_label="scaled",
+        )
+    if pattern.kind == "indicator":
+        if not isinstance(observed, contract_ir_types.Indicator):
+            return _contract_ir_kind_mismatch("indicator", observed, bindings)
+        if len(pattern.args) != 1:
+            return MatchResult(
+                ok=False,
+                bindings=bindings,
+                mismatch_reason="indicator expects exactly one child pattern",
+            )
+        return _match_field(
+            pattern.args[0],
+            observed.predicate,
+            bindings,
+            field_label="indicator.predicate",
+        )
+    if pattern.kind == "forward":
+        if not isinstance(observed, contract_ir_types.Forward):
+            return _contract_ir_kind_mismatch("forward", observed, bindings)
+        return _match_contract_ir_value_args(
+            pattern.args,
+            (observed.underlier_id, observed.schedule),
+            bindings,
+            labels=("forward.underlier", "forward.schedule"),
+        )
+    if pattern.kind == "swap_rate":
+        if not isinstance(observed, contract_ir_types.SwapRate):
+            return _contract_ir_kind_mismatch("swap_rate", observed, bindings)
+        return _match_contract_ir_value_args(
+            pattern.args,
+            (observed.underlier_id, observed.schedule),
+            bindings,
+            labels=("swap_rate.underlier", "swap_rate.schedule"),
+        )
+    if pattern.kind == "annuity":
+        if not isinstance(observed, contract_ir_types.Annuity):
+            return _contract_ir_kind_mismatch("annuity", observed, bindings)
+        return _match_contract_ir_value_args(
+            pattern.args,
+            (observed.underlier_id, observed.schedule),
+            bindings,
+            labels=("annuity.underlier", "annuity.schedule"),
+        )
+    if pattern.kind == "arithmetic_mean":
+        if not isinstance(observed, contract_ir_types.ArithmeticMean):
+            return _contract_ir_kind_mismatch("arithmetic_mean", observed, bindings)
+        expr_outcome = _match_contract_ir_payoff(
+            pattern.args[0],
+            observed.expr,
+            bindings,
+            contract=contract,
+        )
+        if not expr_outcome.ok:
+            return expr_outcome
+        return _match_field(
+            pattern.args[1],
+            observed.schedule,
+            expr_outcome.bindings,
+            field_label="arithmetic_mean.schedule",
+        )
+    if pattern.kind == "variance_observable":
+        if not isinstance(observed, contract_ir_types.VarianceObservable):
+            return _contract_ir_kind_mismatch("variance_observable", observed, bindings)
+        return _match_contract_ir_value_args(
+            pattern.args,
+            (observed.underlier_id, observed.interval),
+            bindings,
+            labels=("variance_observable.underlier", "variance_observable.interval"),
+        )
+    if pattern.kind == "linear_basket":
+        if not isinstance(observed, contract_ir_types.LinearBasket):
+            return _contract_ir_kind_mismatch("linear_basket", observed, bindings)
+        converted_terms = tuple(
+            contract_ir_types.Scaled(contract_ir_types.Constant(weight), child)
+            for weight, child in observed.terms
+        )
+        return _match_contract_ir_children(
+            pattern.args,
+            converted_terms,
+            bindings,
+            contract=contract,
+            kind_label="linear_basket",
+        )
+    return MatchResult(
+        ok=False,
+        bindings=bindings,
+        mismatch_reason=f"unsupported ContractIR payoff head {pattern.kind!r}",
+    )
+
+
+def _match_contract_ir_variadic(
+    pattern_args: tuple[Any, ...],
+    observed: object,
+    expected_type,
+    bindings: dict[str, Any],
+    *,
+    contract: contract_ir_types.ContractIR,
+) -> MatchResult:
+    if not isinstance(observed, expected_type):
+        return _contract_ir_kind_mismatch(expected_type.__name__.lower(), observed, bindings)
+    return _match_contract_ir_children(
+        pattern_args,
+        observed.args,
+        bindings,
+        contract=contract,
+        kind_label=expected_type.__name__.lower(),
+    )
+
+
+def _match_contract_ir_children(
+    pattern_args: tuple[Any, ...],
+    observed_args: tuple[Any, ...],
+    bindings: dict[str, Any],
+    *,
+    contract: contract_ir_types.ContractIR,
+    kind_label: str,
+) -> MatchResult:
+    if len(pattern_args) != len(observed_args):
+        return MatchResult(
+            ok=False,
+            bindings=bindings,
+            mismatch_reason=(
+                f"{kind_label} expected {len(pattern_args)} child(ren), got {len(observed_args)}"
+            ),
+        )
+    current = bindings
+    for pattern_child, observed_child in zip(pattern_args, observed_args):
+        outcome = _match_contract_ir_payoff(
+            pattern_child,
+            observed_child,
+            current,
+            contract=contract,
+        )
+        if not outcome.ok:
+            return outcome
+        current = outcome.bindings
+    return MatchResult(ok=True, bindings=current)
+
+
+def _match_contract_ir_value_args(
+    pattern_args: tuple[Any, ...],
+    observed_values: tuple[Any, ...],
+    bindings: dict[str, Any],
+    *,
+    labels: tuple[str, ...],
+) -> MatchResult:
+    if len(pattern_args) != len(observed_values):
+        return MatchResult(
+            ok=False,
+            bindings=bindings,
+            mismatch_reason=(
+                f"expected {len(pattern_args)} value arg(s), got {len(observed_values)}"
+            ),
+        )
+    current = bindings
+    for pattern_child, observed_child, label in zip(pattern_args, observed_values, labels):
+        outcome = _match_field(
+            pattern_child,
+            observed_child,
+            current,
+            field_label=label,
+        )
+        if not outcome.ok:
+            return outcome
+        current = outcome.bindings
+    return MatchResult(ok=True, bindings=current)
+
+
+def _contract_ir_kind_mismatch(
+    expected_kind: str,
+    observed: object,
+    bindings: dict[str, Any],
+) -> MatchResult:
+    return MatchResult(
+        ok=False,
+        bindings=bindings,
+        mismatch_reason=(
+            f"expected ContractIR node {expected_kind!r}, got {type(observed).__name__}"
+        ),
+    )
+
+
+def _match_contract_ir_instrument_tag(
+    tag: str,
+    contract: contract_ir_types.ContractIR,
+    bindings: dict[str, Any],
+) -> MatchResult:
+    observed_tags = _contract_ir_family_tags(contract)
+    if tag in observed_tags:
+        return MatchResult(ok=True, bindings=bindings)
+    return MatchResult(
+        ok=False,
+        bindings=bindings,
+        mismatch_reason=(
+            f"payoff tag {tag!r} did not match ContractIR family tags {sorted(observed_tags)}"
+        ),
+    )
+
+
+def _contract_ir_family_tags(contract: contract_ir_types.ContractIR) -> set[str]:
+    tags: set[str] = set()
+    ramp = _extract_ramp_core(contract.payoff)
+    if ramp is not None:
+        _, lhs, rhs = ramp
+        if isinstance(lhs, contract_ir_types.LinearBasket) or isinstance(rhs, contract_ir_types.LinearBasket):
+            tags.add("basket_payoff")
+        elif (
+            isinstance(contract.payoff, contract_ir_types.Scaled)
+            and isinstance(contract.payoff.scalar, contract_ir_types.Annuity)
+            and (isinstance(lhs, contract_ir_types.SwapRate) or isinstance(rhs, contract_ir_types.SwapRate))
+        ):
+            tags.add("swaption_payoff")
+        elif isinstance(lhs, contract_ir_types.ArithmeticMean) or isinstance(rhs, contract_ir_types.ArithmeticMean):
+            tags.add("asian_payoff")
+        elif isinstance(lhs, contract_ir_types.Spot) or isinstance(rhs, contract_ir_types.Spot):
+            tags.add("vanilla_payoff")
+    if (
+        isinstance(contract.payoff, contract_ir_types.Scaled)
+        and isinstance(contract.payoff.body, contract_ir_types.Sub)
+        and isinstance(contract.payoff.body.lhs, contract_ir_types.VarianceObservable)
+        and isinstance(contract.payoff.body.rhs, contract_ir_types.Strike)
+    ):
+        tags.add("variance_payoff")
+    if _is_digital_contract_ir(contract.payoff):
+        tags.add("digital_payoff")
+    return tags
+
+
+def _extract_ramp_core(
+    payoff: object,
+) -> tuple[object | None, object, object] | None:
+    scale = None
+    body = payoff
+    if isinstance(payoff, contract_ir_types.Scaled):
+        scale = payoff.scalar
+        body = payoff.body
+    if not isinstance(body, contract_ir_types.Max) or len(body.args) != 2:
+        return None
+    if not isinstance(body.args[0], contract_ir_types.Sub):
+        return None
+    if not isinstance(body.args[1], contract_ir_types.Constant) or body.args[1].value != 0.0:
+        return None
+    return scale, body.args[0].lhs, body.args[0].rhs
+
+
+def _is_digital_contract_ir(payoff: object) -> bool:
+    if isinstance(payoff, contract_ir_types.Indicator):
+        return True
+    if isinstance(payoff, contract_ir_types.Mul):
+        return any(
+            isinstance(child, contract_ir_types.Indicator) for child in payoff.args
+        )
+    return False
+
+
+def _contract_ir_underlying_kind_candidates(
+    spec: object,
+) -> tuple[tuple[str, ...], str]:
+    if isinstance(spec, contract_ir_types.CompositeUnderlying):
+        all_equity = all(isinstance(part, contract_ir_types.EquitySpot) for part in spec.parts)
+        candidates = ["linear_basket", "composite_underlying"]
+        primary = "linear_basket"
+        if all_equity:
+            candidates.append("equity_diffusion")
+        return tuple(dict.fromkeys(candidates)), ("equity_diffusion" if all_equity else primary)
+    if isinstance(spec, contract_ir_types.EquitySpot):
+        return ("equity_diffusion", "equity_spot"), "equity_diffusion"
+    if isinstance(spec, contract_ir_types.ForwardRate):
+        return ("interest_rate", "forward_rate", "rate_style"), "interest_rate"
+    if isinstance(spec, contract_ir_types.RateCurve):
+        return ("interest_rate", "rate_curve"), "interest_rate"
+    return ("generic",), "generic"
+
+
+def _contract_ir_underlying_dynamics_candidates(
+    spec: object,
+) -> tuple[tuple[str, ...], str]:
+    if isinstance(spec, contract_ir_types.CompositeUnderlying):
+        dynamics = [part.dynamics for part in spec.parts]
+        primary = dynamics[0] if dynamics else "generic"
+        if all(isinstance(part, contract_ir_types.EquitySpot) for part in spec.parts):
+            dynamics.append("equity_diffusion")
+        return tuple(dict.fromkeys(dynamics)), primary
+    if isinstance(spec, (contract_ir_types.EquitySpot, contract_ir_types.ForwardRate, contract_ir_types.RateCurve)):
+        candidates = [spec.dynamics]
+        if isinstance(spec, contract_ir_types.EquitySpot):
+            candidates.append("equity_diffusion")
+        if isinstance(spec, (contract_ir_types.ForwardRate, contract_ir_types.RateCurve)):
+            candidates.append("interest_rate")
+        return tuple(dict.fromkeys(candidates)), spec.dynamics
+    return ("generic",), "generic"
+
 
 
 # ---------------------------------------------------------------------------

--- a/trellis/agent/contract_pattern_eval.py
+++ b/trellis/agent/contract_pattern_eval.py
@@ -327,11 +327,32 @@ def _match_contract_ir_schedule(
 ) -> MatchResult:
     if pattern.frequency is None:
         return MatchResult(ok=True, bindings=bindings)
-    return _match_field(
-        pattern.frequency,
-        observed,
-        bindings,
-        field_label=field_label,
+    if isinstance(pattern.frequency, Wildcard):
+        new_bindings = bindings
+        if pattern.frequency.name is not None:
+            new_bindings = _bind(
+                bindings,
+                pattern.frequency.name,
+                None,
+                field_label=f"{field_label}.frequency",
+            )
+            if new_bindings is None:
+                return MatchResult(
+                    ok=False,
+                    bindings=bindings,
+                    mismatch_reason=(
+                        f"binding conflict on '{pattern.frequency.name}' "
+                        f"while matching {field_label}.frequency"
+                    ),
+                )
+        return MatchResult(ok=True, bindings=new_bindings)
+    return MatchResult(
+        ok=False,
+        bindings=bindings,
+        mismatch_reason=(
+            "schedule.frequency matching against a concrete value is not "
+            "yet implemented for ContractIR schedules"
+        ),
     )
 
 

--- a/trellis/agent/knowledge/decompose.py
+++ b/trellis/agent/knowledge/decompose.py
@@ -8,10 +8,39 @@ uses LLM to decompose into known features from the taxonomy.
 from __future__ import annotations
 
 from dataclasses import replace
+from datetime import date, timedelta
 import re
 from typing import Any
 from typing import TYPE_CHECKING
 
+from trellis.agent.contract_ir import (
+    Annuity,
+    ArithmeticMean,
+    CompositeUnderlying,
+    Constant,
+    ContractIR,
+    ContinuousInterval,
+    EquitySpot,
+    Exercise,
+    FiniteSchedule,
+    ForwardRate,
+    Gt,
+    Indicator,
+    LinearBasket,
+    Lt,
+    Max,
+    Mul,
+    Observation,
+    Scaled,
+    Singleton,
+    Spot,
+    Strike,
+    Sub,
+    SwapRate,
+    Underlying,
+    VarianceObservable,
+    canonicalize,
+)
 from trellis.agent.knowledge.methods import normalize_method
 from trellis.agent.knowledge.schema import ProductDecomposition, ProductIR, RetrievalSpec
 from trellis.agent.semantic_tokens import (
@@ -156,6 +185,69 @@ def decompose_to_ir(
     return _infer_composite_ir(description, inferred_instrument, store)
 
 
+def decompose_to_contract_ir(
+    description: str,
+    instrument_type: str | None = None,
+    *,
+    product_ir: ProductIR | None = None,
+    store: KnowledgeStore | None = None,
+) -> ContractIR | None:
+    """Build a bounded Contract IR for the four Phase 2 payoff families.
+
+    This parser is deliberately fixture-driven and route-free. It handles:
+
+    - European terminal vanilla/basket/swaption ramps
+    - variance-settled contracts
+    - cash-or-nothing / asset-or-nothing digitals
+    - arithmetic Asians with bounded monthly/weekly schedule phrases
+
+    Everything outside that surface returns ``None``.
+    """
+    del store
+    product_ir = product_ir or decompose_to_ir(description, instrument_type=instrument_type)
+    instrument = _normalise(instrument_type or getattr(product_ir, "instrument", ""))
+    lower = str(description or "").lower()
+
+    if instrument in {
+        "american_option",
+        "american_put",
+        "bermudan_swaption",
+        "barrier_option",
+        "lookback_option",
+        "chooser_option",
+        "callable_bond",
+        "puttable_bond",
+        "cds",
+        "credit_default_swap",
+        "cap",
+        "floor",
+        "range_accrual",
+        "compound_option",
+        "cliquet_option",
+    }:
+        return None
+    if any(marker in lower for marker in ("american ", "bermudan ", "barrier ", "lookback", "chooser", "callable bond", " cds ", " caplet", " floorlet")):
+        return None
+
+    builders = (
+        _build_swaption_contract_ir,
+        _build_basket_contract_ir,
+        _build_variance_contract_ir,
+        _build_digital_contract_ir,
+        _build_asian_contract_ir,
+        _build_vanilla_contract_ir,
+    )
+    for builder in builders:
+        contract_ir = builder(
+            description,
+            instrument=instrument,
+            product_ir=product_ir,
+        )
+        if contract_ir is not None:
+            return contract_ir
+    return None
+
+
 def build_product_ir(
     *,
     description: str,
@@ -266,6 +358,325 @@ def build_product_ir(
         supported=len(resolved_unresolved_primitives) == 0 if supported is None else supported,
         event_machine=event_machine,
     ), description))
+
+
+def _build_vanilla_contract_ir(
+    description: str,
+    *,
+    instrument: str,
+    product_ir: ProductIR,
+) -> ContractIR | None:
+    lower = description.lower()
+    if instrument not in {"", "european_option", "vanilla_option"} and getattr(product_ir, "payoff_family", "") != "vanilla_option":
+        return None
+    if any(marker in lower for marker in ("basket", "digital", "asian", "variance", "swaption")):
+        return None
+    option_side = _extract_option_side(description)
+    underlier = _extract_single_underlier(description)
+    strike = _extract_numeric_after(description, labels=("strike",))
+    expiry = _extract_expiry_date(description)
+    if option_side not in {"call", "put"} or underlier is None or strike is None or expiry is None:
+        return None
+    core = Sub(Spot(underlier), Strike(strike)) if option_side == "call" else Sub(Strike(strike), Spot(underlier))
+    return ContractIR(
+        payoff=canonicalize(Max((core, Constant(0.0)))),
+        exercise=Exercise(style="european", schedule=Singleton(expiry)),
+        observation=Observation(kind="terminal", schedule=Singleton(expiry)),
+        underlying=Underlying(spec=EquitySpot(underlier, "gbm")),
+    )
+
+
+def _build_swaption_contract_ir(
+    description: str,
+    *,
+    instrument: str,
+    product_ir: ProductIR,
+) -> ContractIR | None:
+    if instrument not in {"", "swaption"} and getattr(product_ir, "payoff_family", "") != "swaption":
+        return None
+    lower = description.lower()
+    if "swaption" not in lower or "bermudan" in lower:
+        return None
+    expiry = _extract_expiry_date(description)
+    strike = _extract_numeric_after(description, labels=("strike",))
+    underlier_id, tenor_years = _extract_swaption_underlier(description)
+    direction = _extract_swaption_direction(description)
+    if expiry is None or strike is None or underlier_id is None or tenor_years is None or direction is None:
+        return None
+    schedule = _annual_schedule_from_expiry(expiry, tenor_years)
+    rate_expr = SwapRate(underlier_id, schedule)
+    ramp = Sub(rate_expr, Strike(strike)) if direction == "payer" else Sub(Strike(strike), rate_expr)
+    return ContractIR(
+        payoff=canonicalize(
+            Scaled(
+                Annuity(underlier_id, schedule),
+                Max((ramp, Constant(0.0))),
+            )
+        ),
+        exercise=Exercise(style="european", schedule=Singleton(expiry)),
+        observation=Observation(kind="terminal", schedule=Singleton(expiry)),
+        underlying=Underlying(spec=ForwardRate(underlier_id, "lognormal_forward")),
+    )
+
+
+def _build_basket_contract_ir(
+    description: str,
+    *,
+    instrument: str,
+    product_ir: ProductIR,
+) -> ContractIR | None:
+    if instrument not in {"", "basket_option"} and getattr(product_ir, "payoff_family", "") != "basket_option":
+        return None
+    lower = description.lower()
+    if "basket" not in lower:
+        return None
+    option_side = _extract_option_side(description)
+    strike = _extract_numeric_after(description, labels=("strike",))
+    expiry = _extract_expiry_date(description)
+    basket_terms = _extract_basket_terms(description)
+    if option_side not in {"call", "put"} or strike is None or expiry is None or basket_terms is None:
+        return None
+    basket_expr = LinearBasket(tuple((weight, Spot(name)) for name, weight in basket_terms))
+    core = Sub(basket_expr, Strike(strike)) if option_side == "call" else Sub(Strike(strike), basket_expr)
+    return ContractIR(
+        payoff=canonicalize(Max((core, Constant(0.0)))),
+        exercise=Exercise(style="european", schedule=Singleton(expiry)),
+        observation=Observation(kind="terminal", schedule=Singleton(expiry)),
+        underlying=Underlying(
+            spec=CompositeUnderlying(tuple(EquitySpot(name, "gbm") for name, _ in basket_terms))
+        ),
+    )
+
+
+def _build_variance_contract_ir(
+    description: str,
+    *,
+    instrument: str,
+    product_ir: ProductIR,
+) -> ContractIR | None:
+    if instrument not in {"", "variance_swap"} and getattr(product_ir, "instrument", "") != "variance_swap":
+        return None
+    lower = description.lower()
+    if "variance swap" not in lower:
+        return None
+    underlier = _extract_single_underlier(description)
+    strike = _extract_numeric_after(description, labels=("variance strike", "strike variance"))
+    notional = _extract_numeric_after(description, labels=("notional",))
+    expiry = _extract_expiry_date(description)
+    if underlier is None or strike is None or notional is None or expiry is None:
+        return None
+    interval = ContinuousInterval(date(expiry.year, 1, 1), expiry)
+    return ContractIR(
+        payoff=canonicalize(
+            Scaled(
+                Constant(notional),
+                Sub(VarianceObservable(underlier, interval), Strike(strike)),
+            )
+        ),
+        exercise=Exercise(style="european", schedule=Singleton(expiry)),
+        observation=Observation(kind="terminal", schedule=Singleton(expiry)),
+        underlying=Underlying(spec=EquitySpot(underlier, "gbm")),
+    )
+
+
+def _build_digital_contract_ir(
+    description: str,
+    *,
+    instrument: str,
+    product_ir: ProductIR,
+) -> ContractIR | None:
+    if instrument not in {"", "digital_option"} and getattr(product_ir, "instrument", "") != "digital_option":
+        return None
+    lower = description.lower()
+    if "digital" not in lower:
+        return None
+    underlier = _extract_single_underlier(description)
+    strike = _extract_numeric_after(description, labels=("strike",))
+    if strike is None:
+        strike = _extract_digital_threshold(description)
+    expiry = _extract_expiry_date(description)
+    option_side = _extract_option_side(description)
+    if underlier is None or strike is None or expiry is None or option_side not in {"call", "put"}:
+        return None
+    predicate = Gt(Spot(underlier), Strike(strike)) if option_side == "call" else Lt(Spot(underlier), Strike(strike))
+    if "asset-or-nothing" in lower or "asset or nothing" in lower:
+        payout_expr = Spot(underlier)
+    else:
+        payout = _extract_numeric_after(description, labels=("paying",)) or 1.0
+        payout_expr = Constant(payout)
+    payoff = canonicalize(Mul((payout_expr, Indicator(predicate))))
+    return ContractIR(
+        payoff=payoff,
+        exercise=Exercise(style="european", schedule=Singleton(expiry)),
+        observation=Observation(kind="terminal", schedule=Singleton(expiry)),
+        underlying=Underlying(spec=EquitySpot(underlier, "gbm")),
+    )
+
+
+def _build_asian_contract_ir(
+    description: str,
+    *,
+    instrument: str,
+    product_ir: ProductIR,
+) -> ContractIR | None:
+    if instrument not in {"", "asian_option"} and getattr(product_ir, "payoff_family", "") != "asian_option":
+        return None
+    lower = description.lower()
+    if "asian" not in lower or "arithmetic" not in lower:
+        return None
+    underlier = _extract_single_underlier(description)
+    strike = _extract_numeric_after(description, labels=("strike",))
+    option_side = _extract_option_side(description)
+    averaging_schedule = _extract_asian_schedule(description)
+    if underlier is None or strike is None or option_side not in {"call", "put"} or averaging_schedule is None:
+        return None
+    mean_expr = ArithmeticMean(Spot(underlier), averaging_schedule)
+    core = Sub(mean_expr, Strike(strike)) if option_side == "call" else Sub(Strike(strike), mean_expr)
+    expiry = averaging_schedule.dates[-1]
+    return ContractIR(
+        payoff=canonicalize(Max((core, Constant(0.0)))),
+        exercise=Exercise(style="european", schedule=Singleton(expiry)),
+        observation=Observation(kind="schedule", schedule=averaging_schedule),
+        underlying=Underlying(spec=EquitySpot(underlier, "gbm")),
+    )
+
+
+def _extract_expiry_date(description: str) -> date | None:
+    match = re.search(
+        r"\b(?:expiring|expiry|at expiry|maturity)\b[^0-9]*(\d{4}-\d{2}-\d{2})",
+        description,
+        flags=re.IGNORECASE,
+    )
+    if match is not None:
+        return date.fromisoformat(match.group(1))
+    iso_dates = re.findall(r"\b\d{4}-\d{2}-\d{2}\b", description)
+    return date.fromisoformat(iso_dates[-1]) if iso_dates else None
+
+
+def _extract_numeric_after(description: str, *, labels: tuple[str, ...]) -> float | None:
+    for label in labels:
+        pattern = rf"\b{re.escape(label)}\b[^0-9-]*\$?(-?\d+(?:\.\d+)?%?)"
+        match = re.search(pattern, description, flags=re.IGNORECASE)
+        if match is None:
+            continue
+        token = match.group(1).strip()
+        if token.endswith("%"):
+            return float(token[:-1]) / 100.0
+        return float(token)
+    return None
+
+
+def _extract_single_underlier(description: str) -> str | None:
+    match = re.search(r"\bon\s+([A-Z][A-Z0-9_.-]*)\b", description)
+    if match is not None:
+        return match.group(1)
+    tokens = re.findall(r"\b[A-Z][A-Z0-9_.-]{1,}\b", description)
+    return tokens[0] if tokens else None
+
+
+def _extract_digital_threshold(description: str) -> float | None:
+    match = re.search(r"\bspot\s*[<>]\s*(-?\d+(?:\.\d+)?)", description, flags=re.IGNORECASE)
+    if match is None:
+        return None
+    return float(match.group(1))
+
+
+def _extract_option_side(description: str) -> str | None:
+    lower = description.lower()
+    if re.search(r"\bcall\b", lower):
+        return "call"
+    if re.search(r"\bput\b", lower):
+        return "put"
+    return None
+
+
+def _extract_swaption_direction(description: str) -> str | None:
+    lower = description.lower()
+    if "payer swaption" in lower:
+        return "payer"
+    if "receiver swaption" in lower:
+        return "receiver"
+    return None
+
+
+def _extract_swaption_underlier(description: str) -> tuple[str | None, int | None]:
+    explicit = re.search(r"\b([A-Z]{3}-IRS-\d+Y)\b", description)
+    if explicit is not None:
+        tenor_match = re.search(r"-(\d+)Y$", explicit.group(1))
+        return explicit.group(1), int(tenor_match.group(1)) if tenor_match is not None else None
+    match = re.search(r"\b(\d+)Y\s+([A-Z]{3})\s+IRS\b", description, flags=re.IGNORECASE)
+    if match is None:
+        return None, None
+    tenor = int(match.group(1))
+    currency = match.group(2).upper()
+    return f"{currency}-IRS-{tenor}Y", tenor
+
+
+def _annual_schedule_from_expiry(expiry: date, tenor_years: int) -> FiniteSchedule:
+    return FiniteSchedule(
+        tuple(date(expiry.year + offset, expiry.month, expiry.day) for offset in range(1, tenor_years + 1))
+    )
+
+
+def _extract_basket_terms(description: str) -> tuple[tuple[str, float], ...] | None:
+    basket_match = re.search(r"\{([^}]+)\}", description)
+    if basket_match is None:
+        return None
+    inside = basket_match.group(1)
+    weighted = re.findall(r"([A-Z][A-Z0-9_.-]*)\s+(-?\d+(?:\.\d+)?)\s*%", inside)
+    if weighted:
+        return tuple((name, float(weight) / 100.0) for name, weight in weighted)
+    names = re.findall(r"[A-Z][A-Z0-9_.-]*", inside)
+    if len(names) < 2:
+        return None
+    equal_weight = 1.0 / len(names)
+    return tuple((name, equal_weight) for name in names)
+
+
+def _extract_asian_schedule(description: str) -> FiniteSchedule | None:
+    yearly = re.search(r"\bmonthly average over (\d{4})\b", description, flags=re.IGNORECASE)
+    if yearly is not None:
+        return _month_end_schedule(int(yearly.group(1)))
+    weekly = re.search(
+        r"\bweekly average from (\d{4}-\d{2}-\d{2}) to (\d{4}-\d{2}-\d{2})\b",
+        description,
+        flags=re.IGNORECASE,
+    )
+    if weekly is not None:
+        return _weekly_schedule(
+            date.fromisoformat(weekly.group(1)),
+            date.fromisoformat(weekly.group(2)),
+        )
+    return None
+
+
+def _month_end_schedule(year: int) -> FiniteSchedule:
+    month_ends = (
+        date(year, 1, 31),
+        date(year, 2, 28),
+        date(year, 3, 31),
+        date(year, 4, 30),
+        date(year, 5, 31),
+        date(year, 6, 30),
+        date(year, 7, 31),
+        date(year, 8, 31),
+        date(year, 9, 30),
+        date(year, 10, 31),
+        date(year, 11, 30),
+        date(year, 12, 31),
+    )
+    return FiniteSchedule(month_ends)
+
+
+def _weekly_schedule(start: date, end: date) -> FiniteSchedule:
+    dates = []
+    current = start
+    while current <= end:
+        dates.append(current)
+        current = current + timedelta(days=7)
+    if dates[-1] != end:
+        dates.append(end)
+    return FiniteSchedule(tuple(dates))
 
 
 def retrieval_spec_from_ir(

--- a/trellis/agent/knowledge/decompose.py
+++ b/trellis/agent/knowledge/decompose.py
@@ -8,6 +8,7 @@ uses LLM to decompose into known features from the taxonomy.
 from __future__ import annotations
 
 from dataclasses import replace
+from calendar import monthrange
 from datetime import date, timedelta
 import re
 from typing import Any
@@ -203,8 +204,11 @@ def decompose_to_contract_ir(
 
     Everything outside that surface returns ``None``.
     """
-    del store
-    product_ir = product_ir or decompose_to_ir(description, instrument_type=instrument_type)
+    product_ir = product_ir or decompose_to_ir(
+        description,
+        instrument_type=instrument_type,
+        store=store,
+    )
     instrument = _normalise(instrument_type or getattr(product_ir, "instrument", ""))
     lower = str(description or "").lower()
 
@@ -614,7 +618,10 @@ def _extract_swaption_underlier(description: str) -> tuple[str | None, int | Non
 
 def _annual_schedule_from_expiry(expiry: date, tenor_years: int) -> FiniteSchedule:
     return FiniteSchedule(
-        tuple(date(expiry.year + offset, expiry.month, expiry.day) for offset in range(1, tenor_years + 1))
+        tuple(
+            _clamp_to_valid_day(expiry.year + offset, expiry.month, expiry.day)
+            for offset in range(1, tenor_years + 1)
+        )
     )
 
 
@@ -651,24 +658,16 @@ def _extract_asian_schedule(description: str) -> FiniteSchedule | None:
 
 
 def _month_end_schedule(year: int) -> FiniteSchedule:
-    month_ends = (
-        date(year, 1, 31),
-        date(year, 2, 28),
-        date(year, 3, 31),
-        date(year, 4, 30),
-        date(year, 5, 31),
-        date(year, 6, 30),
-        date(year, 7, 31),
-        date(year, 8, 31),
-        date(year, 9, 30),
-        date(year, 10, 31),
-        date(year, 11, 30),
-        date(year, 12, 31),
+    month_ends = tuple(
+        date(year, month, monthrange(year, month)[1])
+        for month in range(1, 13)
     )
     return FiniteSchedule(month_ends)
 
 
-def _weekly_schedule(start: date, end: date) -> FiniteSchedule:
+def _weekly_schedule(start: date, end: date) -> FiniteSchedule | None:
+    if start > end:
+        return None
     dates = []
     current = start
     while current <= end:
@@ -677,6 +676,10 @@ def _weekly_schedule(start: date, end: date) -> FiniteSchedule:
     if dates[-1] != end:
         dates.append(end)
     return FiniteSchedule(tuple(dates))
+
+
+def _clamp_to_valid_day(year: int, month: int, day: int) -> date:
+    return date(year, month, min(day, monthrange(year, month)[1]))
 
 
 def retrieval_spec_from_ir(

--- a/trellis/agent/platform_requests.py
+++ b/trellis/agent/platform_requests.py
@@ -565,6 +565,7 @@ def _semantic_blueprint_summary(semantic_blueprint) -> dict[str, object]:
     )
     return {
         "preferred_method": semantic_blueprint.preferred_method,
+        "contract_ir": _yaml_safe_value(getattr(semantic_blueprint, "contract_ir", None)),
         "primitive_routes": list(getattr(semantic_blueprint, "primitive_routes", ()) or ()),
         "route_modules": list(getattr(semantic_blueprint, "route_modules", ()) or ()),
         "dsl_route": getattr(lowering, "route_id", None),

--- a/trellis/agent/semantic_contract_compiler.py
+++ b/trellis/agent/semantic_contract_compiler.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field, replace
+import logging
 from types import MappingProxyType
 from typing import Mapping
 
 from trellis.agent.codegen_guardrails import rank_primitive_routes
-from trellis.agent.knowledge.decompose import build_product_ir
+from trellis.agent.contract_ir import ContractIR
+from trellis.agent.knowledge.decompose import build_product_ir, decompose_to_contract_ir
 from trellis.agent.knowledge.methods import normalize_method
 from trellis.agent.market_binding import (
     build_market_binding_spec,
@@ -24,6 +26,8 @@ from trellis.agent.sensitivity_support import (
     support_for_method,
 )
 from trellis.agent.valuation_context import normalize_valuation_context
+
+_LOG = logging.getLogger(__name__)
 
 
 def _freeze_mapping(mapping: Mapping[str, object] | None) -> Mapping[str, object]:
@@ -73,6 +77,7 @@ class SemanticImplementationBlueprint:
     calibration_step: object | None = None  # CalibrationContract when present
     dsl_lowering: object | None = None
     lane_plan: object | None = None
+    contract_ir: ContractIR | None = None
 
     def __post_init__(self):
         """Freeze mapping metadata for stable traces and tests."""
@@ -140,6 +145,22 @@ def compile_semantic_contract(
         event_machine=getattr(contract.product, "event_machine", None),
     )
     product_ir = _augment_product_ir_with_contract_route_hints(product_ir, contract)
+    contract_ir = None
+    try:
+        contract_ir = decompose_to_contract_ir(
+            contract.description or contract.semantic_id,
+            instrument_type=(
+                getattr(getattr(contract, "product", None), "instrument_class", None)
+                or getattr(product_ir, "instrument", None)
+            ),
+            product_ir=product_ir,
+        )
+    except Exception:
+        _LOG.warning(
+            "Contract IR decomposition failed for semantic contract %s",
+            getattr(contract, "semantic_id", "<unknown>"),
+            exc_info=True,
+        )
     pricing_plan = select_pricing_method_for_product_ir(
         product_ir,
         preferred_method=preferred_method,
@@ -244,6 +265,7 @@ def compile_semantic_contract(
         calibration_step=getattr(contract, "calibration", None),
         dsl_lowering=dsl_lowering,
         lane_plan=lane_plan,
+        contract_ir=contract_ir,
     )
 
 


### PR DESCRIPTION
## Summary
- add the Phase 2 `ContractIR` AST with well-formedness checks, canonicalization, and semantic-preservation evaluation helpers
- emit bounded `contract_ir` trees from the decomposer, attach them to `SemanticImplementationBlueprint`, and expose them in blueprint summaries
- extend `ContractPattern` parsing and evaluation so the existing pattern vocabulary can match against `ContractIR`, and document the new quant surface

## Validation
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_contract_ir_types.py tests/test_agent/test_contract_ir_simplify.py -q`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_decompose_contract_ir.py -q`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_semantic_contract_compiler_contract_ir.py -q`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_contract_pattern_eval_contract_ir.py -q`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_contract_pattern.py tests/test_agent/test_contract_pattern_eval.py tests/test_agent/test_decomposition_ir.py tests/test_agent/test_semantic_contract_compiler.py -q`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_semantic_contract_compiler_contract_ir.py tests/test_agent/test_semantic_contract_compiler.py tests/test_agent/test_contract_pattern_eval_contract_ir.py tests/test_agent/test_contract_pattern_eval.py -q`
- `make gate-pr`

## Notes
- Phase 2 remains additive by design: it carries `contract_ir` through the build path but does not yet make route selection depend on it.
- The remaining compiler work is Phase 3 / Phase 4: select kernels from `blueprint.contract_ir` and then retire direct hard-coded fresh-build routes.