### PR TITLE
Complete ContractIR Phase 2 residual hardening

### DIFF
--- a/docs/quant/contract_ir.rst
+++ b/docs/quant/contract_ir.rst
@@ -201,7 +201,10 @@ directly against ``ContractIR`` trees.
 Regular ``FiniteSchedule`` cadences can now participate in
 ``schedule.frequency`` matching for the common discrete cases
 (``weekly``, ``monthly``, ``quarterly``, ``semiannual``, ``annual``).
-Irregular or cadence-free schedules fail closed instead of guessing.
+Concrete cadence matches fail closed for irregular or cadence-free
+schedules instead of guessing. Frequency wildcards remain unconstrained:
+an anonymous wildcard matches without inference, and a named wildcard
+binds the inferred cadence when one exists or ``None`` otherwise.
 
 That matters for the next phase:
 

--- a/docs/quant/contract_ir.rst
+++ b/docs/quant/contract_ir.rst
@@ -112,6 +112,8 @@ The important current rules are:
 - drop additive and multiplicative identities
 - normalize ``LinearBasket`` zero-weight and singleton cases
 - keep option side in ``Sub`` operand order
+- preserve factorized positive outer scales instead of distributing them
+  across ramps when the factor is already shared structurally
 
 The last rule matters:
 
@@ -130,6 +132,12 @@ common across a ramp, the canonical form keeps:
 
 instead of eagerly expanding the weight across the ``Max`` arguments. This is
 the structural form that downstream pattern matching consumes.
+
+That normalization contract is defended by property-based tests covering:
+
+- idempotence of ``canonicalize``
+- ordering confluence for commutative nodes
+- numerical semantic preservation under synthetic payoff environments
 
 Phase 2 Families
 ----------------
@@ -189,6 +197,11 @@ Pattern Matching
 
 Phase 2 also extends ``ContractPattern`` evaluation so patterns can match
 directly against ``ContractIR`` trees.
+
+Regular ``FiniteSchedule`` cadences can now participate in
+``schedule.frequency`` matching for the common discrete cases
+(``weekly``, ``monthly``, ``quarterly``, ``semiannual``, ``annual``).
+Irregular or cadence-free schedules fail closed instead of guessing.
 
 That matters for the next phase:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ bloomberg = ["blpapi>=3.19"]
 agent = ["anthropic>=0.40", "openai>=1.0"]
 pipeline = ["pandas>=1.5", "pyarrow>=10"]
 mcp = ["mcp>=1.27"]
-dev = ["build>=1.2", "mypy>=1.10", "pytest>=7.0", "pytest-cov", "mcp>=1.27"]
+dev = ["build>=1.2", "hypothesis>=6.0", "mypy>=1.10", "pytest>=7.0", "pytest-cov", "mcp>=1.27"]
 crossval = ["QuantLib>=1.30", "financepy>=1.0", "rateslib>=2.0"]
 tfq = ["tf-quant-finance", "tensorflow>=2.15", "tf-keras"]
 

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,8 @@ setuptools.setup(
         "scipy>=1.10",
     ],
     extras_require={
-        "test": ["pytest", "pytest-cov"],
-        "develop": ["wheel", "pytest", "pytest-cov"],
+        "test": ["hypothesis>=6.0", "pytest", "pytest-cov"],
+        "develop": ["hypothesis>=6.0", "wheel", "pytest", "pytest-cov"],
     },
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/tests/test_agent/test_contract_ir_simplify.py
+++ b/tests/test_agent/test_contract_ir_simplify.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from datetime import date
-import random
+import math
+
+from hypothesis import HealthCheck, given, settings, strategies as st
 
 from trellis.agent.contract_ir import (
     Add,
@@ -14,6 +16,7 @@ from trellis.agent.contract_ir import (
     Indicator,
     LinearBasket,
     Max,
+    Min,
     Mul,
     PayoffEvalEnv,
     Scaled,
@@ -34,9 +37,7 @@ def _singleton(day: str) -> Singleton:
 
 
 def _finite_schedule(*days: str) -> FiniteSchedule:
-    return FiniteSchedule(
-        tuple(date(*map(int, day.split("-"))) for day in days)
-    )
+    return FiniteSchedule(tuple(date(*map(int, day.split("-"))) for day in days))
 
 
 def _interval(start_day: str, end_day: str) -> ContinuousInterval:
@@ -68,91 +69,87 @@ def _environment() -> PayoffEvalEnv:
     )
 
 
-def _random_leaf(rng: random.Random):
-    leaf_type = rng.choice(
-        (
-            "constant",
-            "spot",
-            "strike",
-            "swap_rate",
-            "annuity",
-            "variance",
-            "arithmetic_mean",
-        )
-    )
-    if leaf_type == "constant":
-        return Constant(rng.choice((-3.0, -1.0, 0.0, 1.0, 2.0, 5.0)))
-    if leaf_type == "spot":
-        return Spot(rng.choice(("AAPL", "SPX", "NDX")))
-    if leaf_type == "strike":
-        return Strike(rng.choice((0.0, 1.0, 2.0, 150.0, 4500.0)))
-    if leaf_type == "swap_rate":
-        return SwapRate(
-            "USD-IRS-5Y",
-            _finite_schedule("2026-11-15", "2027-11-15"),
-        )
-    if leaf_type == "annuity":
-        return Annuity(
-            "USD-IRS-5Y",
-            _finite_schedule("2026-11-15", "2027-11-15"),
-        )
-    if leaf_type == "variance":
-        return VarianceObservable(
-            "SPX",
-            _interval("2025-01-01", "2025-11-15"),
-        )
-    return ArithmeticMean(
-        Spot("SPX"),
-        _finite_schedule("2025-01-01", "2025-02-01", "2025-03-01", "2025-04-01"),
+_SWAP_SCHEDULE = _finite_schedule("2026-11-15", "2027-11-15")
+_ASIAN_SCHEDULE = _finite_schedule("2025-01-01", "2025-02-01", "2025-03-01", "2025-04-01")
+_VARIANCE_INTERVAL = _interval("2025-01-01", "2025-11-15")
+
+
+def _finite_float(min_value: float, max_value: float):
+    return st.floats(
+        min_value=min_value,
+        max_value=max_value,
+        allow_nan=False,
+        allow_infinity=False,
     )
 
 
-def _random_expr(rng: random.Random, depth: int):
-    if depth <= 0:
-        return _random_leaf(rng)
-
-    kind = rng.choice(
-        (
-            "leaf",
-            "add",
-            "max",
-            "mul",
-            "sub",
-            "scaled",
-            "indicator",
-            "basket",
-        )
+def _payoff_expr_strategy():
+    leaf = st.one_of(
+        _finite_float(-5.0, 5.0).map(Constant),
+        st.sampled_from(("AAPL", "SPX", "NDX")).map(Spot),
+        st.sampled_from((-10.0, 0.0, 1.0, 2.0, 150.0, 4500.0)).map(Strike),
+        st.just(SwapRate("USD-IRS-5Y", _SWAP_SCHEDULE)),
+        st.just(Annuity("USD-IRS-5Y", _SWAP_SCHEDULE)),
+        st.just(VarianceObservable("SPX", _VARIANCE_INTERVAL)),
+        st.just(ArithmeticMean(Spot("SPX"), _ASIAN_SCHEDULE)),
     )
-    if kind == "leaf":
-        return _random_leaf(rng)
-    if kind == "add":
-        return Add((_random_expr(rng, depth - 1), _random_expr(rng, depth - 1)))
-    if kind == "max":
-        return Max((_random_expr(rng, depth - 1), _random_expr(rng, depth - 1)))
-    if kind == "mul":
-        return Mul((_random_expr(rng, depth - 1), _random_expr(rng, depth - 1)))
-    if kind == "sub":
-        return Sub(_random_expr(rng, depth - 1), _random_expr(rng, depth - 1))
-    if kind == "scaled":
-        scalar = rng.choice(
+
+    scalar = st.one_of(
+        _finite_float(-2.0, 2.0).map(Constant),
+        st.just(Annuity("USD-IRS-5Y", _SWAP_SCHEDULE)),
+    )
+
+    return st.recursive(
+        leaf,
+        lambda children: st.one_of(
+            st.tuples(children, children).map(Add),
+            st.tuples(children, children).map(Mul),
+            st.tuples(children, children).map(lambda pair: Max(tuple(pair))),
+            st.tuples(children, children).map(lambda pair: Min(tuple(pair))),
+            st.tuples(children, children).map(lambda pair: Sub(pair[0], pair[1])),
+            st.tuples(scalar, children).map(lambda pair: Scaled(pair[0], pair[1])),
+            st.tuples(children, children).map(
+                lambda pair: Indicator(Gt(pair[0], pair[1]))
+            ),
+            st.just(LinearBasket(((0.5, Spot("SPX")), (0.5, Spot("NDX"))))),
+        ),
+        max_leaves=8,
+    )
+
+
+@st.composite
+def _environment_strategy(draw):
+    jan = date(2025, 1, 1)
+    feb = date(2025, 2, 1)
+    mar = date(2025, 3, 1)
+    apr = date(2025, 4, 1)
+    return PayoffEvalEnv(
+        values={
+            ("spot", "AAPL"): draw(_finite_float(50.0, 250.0)),
+            ("spot", "SPX"): draw(_finite_float(3000.0, 6000.0)),
+            ("spot", "NDX"): draw(_finite_float(10000.0, 25000.0)),
+            ("spot", "SPX", jan): draw(_finite_float(3000.0, 6000.0)),
+            ("spot", "SPX", feb): draw(_finite_float(3000.0, 6000.0)),
+            ("spot", "SPX", mar): draw(_finite_float(3000.0, 6000.0)),
+            ("spot", "SPX", apr): draw(_finite_float(3000.0, 6000.0)),
+            ("swap_rate", "USD-IRS-5Y", _SWAP_SCHEDULE.key()): draw(_finite_float(-0.05, 0.15)),
+            ("annuity", "USD-IRS-5Y", _SWAP_SCHEDULE.key()): draw(_finite_float(0.1, 10.0)),
             (
-                Constant(rng.choice((-2.0, -1.0, 0.0, 1.0, 2.0))),
-                Annuity(
-                    "USD-IRS-5Y",
-                    _finite_schedule("2026-11-15", "2027-11-15"),
-                ),
-            )
-        )
-        return Scaled(scalar, _random_expr(rng, depth - 1))
-    if kind == "indicator":
-        return Indicator(
-            Gt(_random_expr(rng, depth - 1), _random_expr(rng, depth - 1))
-        )
-    return LinearBasket(
-        (
-            (0.5, Spot("SPX")),
-            (0.5, Spot("NDX")),
-        )
+                "variance_observable",
+                "SPX",
+                date(2025, 1, 1),
+                date(2025, 11, 15),
+            ): draw(_finite_float(0.0, 0.5)),
+        }
+    )
+
+
+def _property_settings(*, max_examples: int):
+    return settings(
+        max_examples=max_examples,
+        deadline=None,
+        derandomize=True,
+        suppress_health_check=[HealthCheck.too_slow],
     )
 
 
@@ -187,7 +184,13 @@ class TestContractIRSimplify:
         )
         expr = Max(
             (
-                Scaled(annuity, Sub(SwapRate("USD-IRS-5Y", _finite_schedule("2026-11-15", "2027-11-15")), Strike(0.05))),
+                Scaled(
+                    annuity,
+                    Sub(
+                        SwapRate("USD-IRS-5Y", _finite_schedule("2026-11-15", "2027-11-15")),
+                        Strike(0.05),
+                    ),
+                ),
                 Constant(0.0),
             )
         )
@@ -202,6 +205,13 @@ class TestContractIRSimplify:
                     Constant(0.0),
                 )
             ),
+        )
+
+    def test_positive_scaled_sum_stays_factorized(self):
+        expr = Scaled(Constant(2.0), Add((Spot("AAPL"), Constant(1.0))))
+        assert canonicalize(expr) == Scaled(
+            Constant(2.0),
+            Add((Spot("AAPL"), Constant(1.0))),
         )
 
     def test_family_templates_canonicalize_to_expected_forms(self):
@@ -265,29 +275,37 @@ class TestContractIRSimplify:
             )
         )
 
-    def test_canonicalize_is_idempotent_on_deterministic_random_trees(self):
-        rng = random.Random(917)
-        for _ in range(200):
-            expr = _random_expr(rng, depth=3)
-            once = canonicalize(expr)
-            twice = canonicalize(once)
-            assert twice == once
+    @_property_settings(max_examples=1000)
+    @given(_payoff_expr_strategy())
+    def test_canonicalize_is_idempotent_property(self, expr):
+        once = canonicalize(expr)
+        twice = canonicalize(once)
+        assert twice == once
 
-    def test_canonicalize_agrees_on_equivalent_orderings(self):
-        rng = random.Random(918)
-        for _ in range(150):
-            a = _random_expr(rng, depth=2)
-            b = _random_expr(rng, depth=2)
-            c = _random_expr(rng, depth=2)
-            assert canonicalize(Max((a, b, c))) == canonicalize(Max((c, a, b)))
-            assert canonicalize(Add((a, b, c))) == canonicalize(Add((b, c, a)))
-            assert canonicalize(Mul((a, b, c))) == canonicalize(Mul((c, b, a)))
+    @_property_settings(max_examples=500)
+    @given(_payoff_expr_strategy(), _payoff_expr_strategy(), _payoff_expr_strategy())
+    def test_canonicalize_agrees_on_equivalent_orderings(self, a, b, c):
+        assert canonicalize(Max((a, b, c))) == canonicalize(Max((c, a, b)))
+        assert canonicalize(Add((a, b, c))) == canonicalize(Add((b, c, a)))
+        assert canonicalize(Mul((a, b, c))) == canonicalize(Mul((c, b, a)))
 
-    def test_canonicalize_preserves_numeric_semantics(self):
-        rng = random.Random(919)
-        env = _environment()
-        for _ in range(150):
-            expr = _random_expr(rng, depth=3)
-            before = evaluate_payoff_expr(expr, env)
-            after = evaluate_payoff_expr(canonicalize(expr), env)
-            assert abs(after - before) <= 5e-12
+    @_property_settings(max_examples=500)
+    @given(_payoff_expr_strategy(), _environment_strategy())
+    def test_canonicalize_preserves_numeric_semantics(self, expr, env):
+        before = evaluate_payoff_expr(expr, env)
+        after = evaluate_payoff_expr(canonicalize(expr), env)
+        assert math.isclose(after, before, rel_tol=1e-12, abs_tol=5e-12)
+
+    def test_canonicalize_preserves_numeric_semantics_on_reference_environment(self):
+        expr = Add(
+            (
+                Max((Sub(Spot("AAPL"), Strike(150.0)), Constant(0.0))),
+                Scaled(
+                    Constant(2.0),
+                    Mul((Constant(2.0), Indicator(Gt(Spot("AAPL"), Strike(150.0))))),
+                ),
+            )
+        )
+        before = evaluate_payoff_expr(expr, _environment())
+        after = evaluate_payoff_expr(canonicalize(expr), _environment())
+        assert math.isclose(after, before, rel_tol=1e-12, abs_tol=5e-12)

--- a/tests/test_agent/test_contract_pattern_eval_contract_ir.py
+++ b/tests/test_agent/test_contract_pattern_eval_contract_ir.py
@@ -292,6 +292,49 @@ class TestContractPatternEvalContractIR:
         assert result.ok is True
         assert result.bindings["freq"] == "quarterly"
 
+    def test_unnamed_schedule_frequency_wildcard_matches_irregular_schedule(self):
+        pattern = parse_contract_pattern(
+            {
+                "exercise": {
+                    "style": "bermudan",
+                    "schedule": {"frequency": "_"},
+                }
+            }
+        )
+
+        result = evaluate_pattern(pattern, _bermudan_irregular_contract_ir())
+
+        assert result.ok is True
+
+    def test_named_schedule_frequency_wildcard_binds_none_when_cadence_missing(self):
+        pattern = parse_contract_pattern(
+            {
+                "exercise": {
+                    "style": "bermudan",
+                    "schedule": {"frequency": "_freq"},
+                }
+            }
+        )
+
+        result = evaluate_pattern(pattern, _bermudan_irregular_contract_ir())
+
+        assert result.ok is True
+        assert result.bindings["freq"] is None
+
+    def test_unnamed_schedule_frequency_wildcard_matches_singleton_schedule(self):
+        pattern = parse_contract_pattern(
+            {
+                "exercise": {
+                    "style": "european",
+                    "schedule": {"frequency": "_"},
+                }
+            }
+        )
+
+        result = evaluate_pattern(pattern, _vanilla_call_contract_ir())
+
+        assert result.ok is True
+
     def test_irregular_schedule_frequency_fails_closed(self):
         pattern = parse_contract_pattern(
             {

--- a/tests/test_agent/test_contract_pattern_eval_contract_ir.py
+++ b/tests/test_agent/test_contract_pattern_eval_contract_ir.py
@@ -147,6 +147,37 @@ def _asian_contract_ir() -> ContractIR:
     )
 
 
+def _bermudan_quarterly_contract_ir() -> ContractIR:
+    exercise_schedule = _finite_schedule(
+        "2025-03-31",
+        "2025-06-30",
+        "2025-09-30",
+        "2025-12-31",
+    )
+    expiry = _singleton("2025-12-31")
+    return ContractIR(
+        payoff=Max((Sub(Spot("AAPL"), Strike(150.0)), Constant(0.0))),
+        exercise=Exercise(style="bermudan", schedule=exercise_schedule),
+        observation=Observation(kind="terminal", schedule=expiry),
+        underlying=Underlying(spec=EquitySpot("AAPL", "gbm")),
+    )
+
+
+def _bermudan_irregular_contract_ir() -> ContractIR:
+    exercise_schedule = _finite_schedule(
+        "2025-01-31",
+        "2025-03-17",
+        "2025-07-01",
+    )
+    expiry = _singleton("2025-07-01")
+    return ContractIR(
+        payoff=Max((Sub(Spot("AAPL"), Strike(150.0)), Constant(0.0))),
+        exercise=Exercise(style="bermudan", schedule=exercise_schedule),
+        observation=Observation(kind="terminal", schedule=expiry),
+        underlying=Underlying(spec=EquitySpot("AAPL", "gbm")),
+    )
+
+
 class TestContractPatternEvalContractIR:
     def test_new_ir_heads_round_trip_through_parser(self):
         payload = {
@@ -232,24 +263,50 @@ class TestContractPatternEvalContractIR:
         assert isinstance(result.bindings["schedule"], FiniteSchedule)
         assert result.bindings["K"] == 0.05
 
-    def test_concrete_schedule_frequency_reports_contract_ir_gap_clearly(self):
+    def test_concrete_schedule_frequency_matches_regular_contract_ir_schedule(self):
         pattern = parse_contract_pattern(
             {
                 "exercise": {
-                    "style": "european",
-                    "schedule": {"frequency": "monthly"},
+                    "style": "bermudan",
+                    "schedule": {"frequency": "quarterly"},
                 }
             }
         )
 
-        result = evaluate_pattern(pattern, _asian_contract_ir())
+        result = evaluate_pattern(pattern, _bermudan_quarterly_contract_ir())
+
+        assert result.ok is True
+
+    def test_named_schedule_frequency_wildcard_binds_inferred_cadence(self):
+        pattern = parse_contract_pattern(
+            {
+                "exercise": {
+                    "style": "bermudan",
+                    "schedule": {"frequency": "_freq"},
+                }
+            }
+        )
+
+        result = evaluate_pattern(pattern, _bermudan_quarterly_contract_ir())
+
+        assert result.ok is True
+        assert result.bindings["freq"] == "quarterly"
+
+    def test_irregular_schedule_frequency_fails_closed(self):
+        pattern = parse_contract_pattern(
+            {
+                "exercise": {
+                    "style": "bermudan",
+                    "schedule": {"frequency": "quarterly"},
+                }
+            }
+        )
+
+        result = evaluate_pattern(pattern, _bermudan_irregular_contract_ir())
 
         assert result.ok is False
         assert result.mismatch_reason is not None
-        assert (
-            "schedule.frequency matching against a concrete value is not yet implemented"
-            in result.mismatch_reason
-        )
+        assert "could not infer a regular frequency" in result.mismatch_reason
 
     def test_zero_arity_family_tags_match_phase_two_contract_ir_fixtures(self):
         fixtures = {

--- a/tests/test_agent/test_decompose_contract_ir.py
+++ b/tests/test_agent/test_decompose_contract_ir.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from calendar import monthrange
+from dataclasses import replace
 from datetime import date, timedelta
 
 import pytest
@@ -48,10 +49,7 @@ def _interval(start_day: str, end_day: str) -> ContinuousInterval:
 
 
 def _month_end_schedule(year: int) -> FiniteSchedule:
-    month_ends = tuple(
-        date(year, month, monthrange(year, month)[1])
-        for month in range(1, 13)
-    )
+    month_ends = tuple(date(year, month, monthrange(year, month)[1]) for month in range(1, 13))
     return FiniteSchedule(month_ends)
 
 
@@ -83,8 +81,12 @@ def _swap_schedule(expiry_day: str, tenor_years: int) -> FiniteSchedule:
 
 def _contracts():
     swap_schedule = _swap_schedule("2025-11-15", 5)
-    asian_monthly = _month_end_schedule(2025)
-    asian_weekly = _weekly_schedule("2025-01-03", "2025-01-31")
+    short_swap_schedule = _swap_schedule("2024-02-29", 2)
+    mid_swap_schedule = _swap_schedule("2025-06-30", 2)
+    asian_monthly_2024 = _month_end_schedule(2024)
+    asian_monthly_2025 = _month_end_schedule(2025)
+    asian_monthly_2026 = _month_end_schedule(2026)
+    asian_weekly_jan = _weekly_schedule("2025-01-03", "2025-01-31")
     return [
         (
             "European call on AAPL strike 150 expiring 2025-11-15",
@@ -117,6 +119,26 @@ def _contracts():
             ),
         ),
         (
+            "European put on AAPL strike 0 expiring 2025-11-15",
+            "european_option",
+            ContractIR(
+                payoff=Max((Sub(Strike(0.0), Spot("AAPL")), Constant(0.0))),
+                exercise=Exercise(style="european", schedule=_singleton("2025-11-15")),
+                observation=Observation(kind="terminal", schedule=_singleton("2025-11-15")),
+                underlying=Underlying(spec=EquitySpot("AAPL", "gbm")),
+            ),
+        ),
+        (
+            "European call on SPX strike -25 expiring 2025-11-15",
+            "european_option",
+            ContractIR(
+                payoff=Max((Sub(Spot("SPX"), Strike(-25.0)), Constant(0.0))),
+                exercise=Exercise(style="european", schedule=_singleton("2025-11-15")),
+                observation=Observation(kind="terminal", schedule=_singleton("2025-11-15")),
+                underlying=Underlying(spec=EquitySpot("SPX", "gbm")),
+            ),
+        ),
+        (
             "European payer swaption on 5Y USD IRS strike 5% expiring 2025-11-15",
             "swaption",
             ContractIR(
@@ -143,6 +165,32 @@ def _contracts():
             ),
         ),
         (
+            "European receiver swaption on 2Y USD IRS strike 3.5% expiring 2024-02-29",
+            "swaption",
+            ContractIR(
+                payoff=Scaled(
+                    Annuity("USD-IRS-2Y", short_swap_schedule),
+                    Max((Sub(Strike(0.035), SwapRate("USD-IRS-2Y", short_swap_schedule)), Constant(0.0))),
+                ),
+                exercise=Exercise(style="european", schedule=_singleton("2024-02-29")),
+                observation=Observation(kind="terminal", schedule=_singleton("2024-02-29")),
+                underlying=Underlying(spec=ForwardRate("USD-IRS-2Y", "lognormal_forward")),
+            ),
+        ),
+        (
+            "European payer swaption on USD-IRS-2Y strike 4% expiring 2025-06-30",
+            "swaption",
+            ContractIR(
+                payoff=Scaled(
+                    Annuity("USD-IRS-2Y", mid_swap_schedule),
+                    Max((Sub(SwapRate("USD-IRS-2Y", mid_swap_schedule), Strike(0.04)), Constant(0.0))),
+                ),
+                exercise=Exercise(style="european", schedule=_singleton("2025-06-30")),
+                observation=Observation(kind="terminal", schedule=_singleton("2025-06-30")),
+                underlying=Underlying(spec=ForwardRate("USD-IRS-2Y", "lognormal_forward")),
+            ),
+        ),
+        (
             "European basket call on {SPX 50%, NDX 50%} strike 4500 expiring 2025-11-15",
             "basket_option",
             ContractIR(
@@ -151,6 +199,46 @@ def _contracts():
                         Sub(
                             LinearBasket(((0.5, Spot("SPX")), (0.5, Spot("NDX")))),
                             Strike(4500.0),
+                        ),
+                        Constant(0.0),
+                    )
+                ),
+                exercise=Exercise(style="european", schedule=_singleton("2025-11-15")),
+                observation=Observation(kind="terminal", schedule=_singleton("2025-11-15")),
+                underlying=Underlying(
+                    spec=CompositeUnderlying((EquitySpot("SPX", "gbm"), EquitySpot("NDX", "gbm")))
+                ),
+            ),
+        ),
+        (
+            "European basket put on {SPX, NDX} strike 4300 expiring 2025-11-15",
+            "basket_option",
+            ContractIR(
+                payoff=Max(
+                    (
+                        Sub(
+                            Strike(4300.0),
+                            LinearBasket(((0.5, Spot("SPX")), (0.5, Spot("NDX")))),
+                        ),
+                        Constant(0.0),
+                    )
+                ),
+                exercise=Exercise(style="european", schedule=_singleton("2025-11-15")),
+                observation=Observation(kind="terminal", schedule=_singleton("2025-11-15")),
+                underlying=Underlying(
+                    spec=CompositeUnderlying((EquitySpot("SPX", "gbm"), EquitySpot("NDX", "gbm")))
+                ),
+            ),
+        ),
+        (
+            "European basket call on {SPX 25%, NDX 75%} strike -100 expiring 2025-11-15",
+            "basket_option",
+            ContractIR(
+                payoff=Max(
+                    (
+                        Sub(
+                            LinearBasket(((0.25, Spot("SPX")), (0.75, Spot("NDX")))),
+                            Strike(-100.0),
                         ),
                         Constant(0.0),
                     )
@@ -179,6 +267,38 @@ def _contracts():
             ),
         ),
         (
+            "Equity variance swap on NDX, variance strike 0, notional 2500, expiry 2026-06-30",
+            "variance_swap",
+            ContractIR(
+                payoff=Scaled(
+                    Constant(2500.0),
+                    Sub(
+                        VarianceObservable("NDX", _interval("2026-01-01", "2026-06-30")),
+                        Strike(0.0),
+                    ),
+                ),
+                exercise=Exercise(style="european", schedule=_singleton("2026-06-30")),
+                observation=Observation(kind="terminal", schedule=_singleton("2026-06-30")),
+                underlying=Underlying(spec=EquitySpot("NDX", "gbm")),
+            ),
+        ),
+        (
+            "Equity variance swap on SPX, variance strike -0.01, notional 5000, expiry 2025-12-31",
+            "variance_swap",
+            ContractIR(
+                payoff=Scaled(
+                    Constant(5000.0),
+                    Sub(
+                        VarianceObservable("SPX", _interval("2025-01-01", "2025-12-31")),
+                        Strike(-0.01),
+                    ),
+                ),
+                exercise=Exercise(style="european", schedule=_singleton("2025-12-31")),
+                observation=Observation(kind="terminal", schedule=_singleton("2025-12-31")),
+                underlying=Underlying(spec=EquitySpot("SPX", "gbm")),
+            ),
+        ),
+        (
             "Cash-or-nothing digital call on AAPL paying $2 if spot > 150 at expiry 2025-11-15",
             "digital_option",
             ContractIR(
@@ -186,6 +306,26 @@ def _contracts():
                 exercise=Exercise(style="european", schedule=_singleton("2025-11-15")),
                 observation=Observation(kind="terminal", schedule=_singleton("2025-11-15")),
                 underlying=Underlying(spec=EquitySpot("AAPL", "gbm")),
+            ),
+        ),
+        (
+            "Cash-or-nothing digital put on AAPL paying $1 if spot < 150 at expiry 2025-11-15",
+            "digital_option",
+            ContractIR(
+                payoff=Indicator(Lt(Spot("AAPL"), Strike(150.0))),
+                exercise=Exercise(style="european", schedule=_singleton("2025-11-15")),
+                observation=Observation(kind="terminal", schedule=_singleton("2025-11-15")),
+                underlying=Underlying(spec=EquitySpot("AAPL", "gbm")),
+            ),
+        ),
+        (
+            "Cash-or-nothing digital call on SPX if spot > 4500 at expiry 2025-11-15",
+            "digital_option",
+            ContractIR(
+                payoff=Indicator(Gt(Spot("SPX"), Strike(4500.0))),
+                exercise=Exercise(style="european", schedule=_singleton("2025-11-15")),
+                observation=Observation(kind="terminal", schedule=_singleton("2025-11-15")),
+                underlying=Underlying(spec=EquitySpot("SPX", "gbm")),
             ),
         ),
         (
@@ -199,17 +339,27 @@ def _contracts():
             ),
         ),
         (
+            "Asset-or-nothing digital call on SPX if spot > 4500 at expiry 2025-11-15",
+            "digital_option",
+            ContractIR(
+                payoff=Mul((Spot("SPX"), Indicator(Gt(Spot("SPX"), Strike(4500.0))))),
+                exercise=Exercise(style="european", schedule=_singleton("2025-11-15")),
+                observation=Observation(kind="terminal", schedule=_singleton("2025-11-15")),
+                underlying=Underlying(spec=EquitySpot("SPX", "gbm")),
+            ),
+        ),
+        (
             "Arithmetic Asian call on SPX monthly average over 2025 strike 4500",
             "asian_option",
             ContractIR(
                 payoff=Max(
                     (
-                        Sub(ArithmeticMean(Spot("SPX"), asian_monthly), Strike(4500.0)),
+                        Sub(ArithmeticMean(Spot("SPX"), asian_monthly_2025), Strike(4500.0)),
                         Constant(0.0),
                     )
                 ),
                 exercise=Exercise(style="european", schedule=Singleton(date(2025, 12, 31))),
-                observation=Observation(kind="schedule", schedule=asian_monthly),
+                observation=Observation(kind="schedule", schedule=asian_monthly_2025),
                 underlying=Underlying(spec=EquitySpot("SPX", "gbm")),
             ),
         ),
@@ -219,13 +369,58 @@ def _contracts():
             ContractIR(
                 payoff=Max(
                     (
-                        Sub(Strike(4500.0), ArithmeticMean(Spot("SPX"), asian_weekly)),
+                        Sub(Strike(4500.0), ArithmeticMean(Spot("SPX"), asian_weekly_jan)),
                         Constant(0.0),
                     )
                 ),
                 exercise=Exercise(style="european", schedule=Singleton(date(2025, 1, 31))),
-                observation=Observation(kind="schedule", schedule=asian_weekly),
+                observation=Observation(kind="schedule", schedule=asian_weekly_jan),
                 underlying=Underlying(spec=EquitySpot("SPX", "gbm")),
+            ),
+        ),
+        (
+            "Arithmetic Asian put on SPX monthly average over 2024 strike 0",
+            "asian_option",
+            ContractIR(
+                payoff=Max(
+                    (
+                        Sub(Strike(0.0), ArithmeticMean(Spot("SPX"), asian_monthly_2024)),
+                        Constant(0.0),
+                    )
+                ),
+                exercise=Exercise(style="european", schedule=Singleton(date(2024, 12, 31))),
+                observation=Observation(kind="schedule", schedule=asian_monthly_2024),
+                underlying=Underlying(spec=EquitySpot("SPX", "gbm")),
+            ),
+        ),
+        (
+            "Arithmetic Asian call on SPX weekly average from 2025-01-03 to 2025-01-31 strike -50",
+            "asian_option",
+            ContractIR(
+                payoff=Max(
+                    (
+                        Sub(ArithmeticMean(Spot("SPX"), asian_weekly_jan), Strike(-50.0)),
+                        Constant(0.0),
+                    )
+                ),
+                exercise=Exercise(style="european", schedule=Singleton(date(2025, 1, 31))),
+                observation=Observation(kind="schedule", schedule=asian_weekly_jan),
+                underlying=Underlying(spec=EquitySpot("SPX", "gbm")),
+            ),
+        ),
+        (
+            "Arithmetic Asian call on AAPL monthly average over 2026 strike 200",
+            "asian_option",
+            ContractIR(
+                payoff=Max(
+                    (
+                        Sub(ArithmeticMean(Spot("AAPL"), asian_monthly_2026), Strike(200.0)),
+                        Constant(0.0),
+                    )
+                ),
+                exercise=Exercise(style="european", schedule=Singleton(date(2026, 12, 31))),
+                observation=Observation(kind="schedule", schedule=asian_monthly_2026),
+                underlying=Underlying(spec=EquitySpot("AAPL", "gbm")),
             ),
         ),
     ]
@@ -251,6 +446,50 @@ class TestDecomposeContractIR:
         assert observed == expected
         assert observed is not None
         assert canonicalize(observed.payoff) == observed.payoff
+
+    @pytest.mark.parametrize(
+        "description,instrument_type,_expected",
+        _contracts(),
+    )
+    def test_supported_contract_ir_ignores_route_metadata(
+        self,
+        description: str,
+        instrument_type: str,
+        _expected: ContractIR,
+    ):
+        product_ir = decompose_to_ir(description, instrument_type=instrument_type)
+        stripped = replace(
+            product_ir,
+            route_families=(),
+            candidate_engine_families=(),
+            required_market_data=frozenset(),
+            reusable_primitives=(),
+            unresolved_primitives=(),
+        )
+        enriched = replace(
+            product_ir,
+            route_families=("synthetic_route",),
+            candidate_engine_families=("synthetic_engine",),
+            required_market_data=frozenset({"synthetic_capability"}),
+            reusable_primitives=("synthetic_primitive",),
+            unresolved_primitives=("synthetic_gap",),
+        )
+
+        baseline = decompose_to_contract_ir(
+            description,
+            instrument_type=instrument_type,
+            product_ir=product_ir,
+        )
+        assert baseline == decompose_to_contract_ir(
+            description,
+            instrument_type=instrument_type,
+            product_ir=stripped,
+        )
+        assert baseline == decompose_to_contract_ir(
+            description,
+            instrument_type=instrument_type,
+            product_ir=enriched,
+        )
 
     @pytest.mark.parametrize(
         "description,instrument_type",

--- a/trellis/agent/contract_pattern_eval.py
+++ b/trellis/agent/contract_pattern_eval.py
@@ -328,6 +328,27 @@ def _match_contract_ir_schedule(
 ) -> MatchResult:
     if pattern.frequency is None:
         return MatchResult(ok=True, bindings=bindings)
+    if isinstance(pattern.frequency, Wildcard):
+        if pattern.frequency.name is None:
+            return MatchResult(ok=True, bindings=bindings)
+        inferred_frequency = _infer_contract_ir_schedule_frequency(observed)
+        primary_value = None if inferred_frequency is None else inferred_frequency[1]
+        new_bindings = _bind(
+            bindings,
+            pattern.frequency.name,
+            primary_value,
+            field_label=f"{field_label}.frequency",
+        )
+        if new_bindings is None:
+            return MatchResult(
+                ok=False,
+                bindings=bindings,
+                mismatch_reason=(
+                    f"binding conflict on '{pattern.frequency.name}' "
+                    f"while matching {field_label}.frequency"
+                ),
+            )
+        return MatchResult(ok=True, bindings=new_bindings)
     inferred_frequency = _infer_contract_ir_schedule_frequency(observed)
     if inferred_frequency is None:
         return MatchResult(

--- a/trellis/agent/contract_pattern_eval.py
+++ b/trellis/agent/contract_pattern_eval.py
@@ -62,6 +62,7 @@ Follow-ups for downstream slices
 
 from __future__ import annotations
 
+from calendar import monthrange
 import trellis.agent.contract_ir as contract_ir_types
 from dataclasses import dataclass, field
 from typing import Any, Mapping
@@ -327,32 +328,88 @@ def _match_contract_ir_schedule(
 ) -> MatchResult:
     if pattern.frequency is None:
         return MatchResult(ok=True, bindings=bindings)
-    if isinstance(pattern.frequency, Wildcard):
-        new_bindings = bindings
-        if pattern.frequency.name is not None:
-            new_bindings = _bind(
-                bindings,
-                pattern.frequency.name,
-                None,
-                field_label=f"{field_label}.frequency",
-            )
-            if new_bindings is None:
-                return MatchResult(
-                    ok=False,
-                    bindings=bindings,
-                    mismatch_reason=(
-                        f"binding conflict on '{pattern.frequency.name}' "
-                        f"while matching {field_label}.frequency"
-                    ),
-                )
-        return MatchResult(ok=True, bindings=new_bindings)
-    return MatchResult(
-        ok=False,
+    inferred_frequency = _infer_contract_ir_schedule_frequency(observed)
+    if inferred_frequency is None:
+        return MatchResult(
+            ok=False,
+            bindings=bindings,
+            mismatch_reason=(
+                f"could not infer a regular frequency from {field_label}; "
+                "the schedule is irregular or has no cadence"
+            ),
+        )
+    candidate_values, primary_value = inferred_frequency
+    return _match_field_multivalued(
+        pattern.frequency,
+        candidate_values=candidate_values,
         bindings=bindings,
-        mismatch_reason=(
-            "schedule.frequency matching against a concrete value is not "
-            "yet implemented for ContractIR schedules"
-        ),
+        field_label=f"{field_label}.frequency",
+        primary_value=primary_value,
+    )
+
+
+_FREQUENCY_ALIASES: Mapping[str, tuple[str, ...]] = {
+    "weekly": ("weekly",),
+    "monthly": ("monthly",),
+    "quarterly": ("quarterly",),
+    "semiannual": ("semiannual", "semi_annual", "semi-annual"),
+    "annual": ("annual", "yearly"),
+}
+
+
+def _infer_contract_ir_schedule_frequency(
+    observed: object,
+) -> tuple[tuple[str, ...], str] | None:
+    if not isinstance(observed, contract_ir_types.FiniteSchedule):
+        return None
+    canonical = _infer_regular_frequency_label(observed)
+    if canonical is None:
+        return None
+    return _FREQUENCY_ALIASES[canonical], canonical
+
+
+def _infer_regular_frequency_label(
+    schedule: contract_ir_types.FiniteSchedule,
+) -> str | None:
+    if len(schedule.dates) < 2:
+        return None
+    day_deltas = tuple(
+        (right - left).days for left, right in zip(schedule.dates, schedule.dates[1:])
+    )
+    if day_deltas and all(delta == 7 for delta in day_deltas):
+        return "weekly"
+
+    month_steps = tuple(
+        (right.year - left.year) * 12 + (right.month - left.month)
+        for left, right in zip(schedule.dates, schedule.dates[1:])
+    )
+    if len(set(month_steps)) != 1:
+        return None
+    step = month_steps[0]
+    if step not in {1, 3, 6, 12}:
+        return None
+
+    if _all_same_day_of_month(schedule.dates) or _all_month_end(schedule.dates):
+        if step == 1:
+            return "monthly"
+        if step == 3:
+            return "quarterly"
+        if step == 6:
+            return "semiannual"
+        if step == 12:
+            return "annual"
+    return None
+
+
+def _all_same_day_of_month(dates: tuple[object, ...]) -> bool:
+    day_values = {getattr(item, "day", None) for item in dates}
+    return len(day_values) == 1
+
+
+def _all_month_end(dates: tuple[object, ...]) -> bool:
+    return all(
+        getattr(item, "day", None) == monthrange(item.year, item.month)[1]
+        for item in dates
     )
 
 


### PR DESCRIPTION
## Summary
- add regular cadence inference for `ContractIR` schedule-frequency matching and fail-closed handling for irregular schedules
- replace the small ContractIR canonicalization fuzz loops with a Hypothesis-backed property harness and document the factorized normal form
- expand the `decompose_to_contract_ir(...)` fixture matrix and add explicit route-metadata-independence regression coverage

## Testing
- `PATH=/Users/steveyang/miniforge3/bin:$PATH /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_contract_pattern_eval.py tests/test_agent/test_contract_pattern_eval_contract_ir.py tests/test_agent/test_contract_ir_types.py tests/test_agent/test_contract_ir_simplify.py tests/test_agent/test_decompose_contract_ir.py tests/test_agent/test_semantic_contract_compiler_contract_ir.py -q`
- `make gate-pr`