### PR TITLE
QUA-925: add ContractIR solver declaration registry substrate

### DIFF
--- a/tests/test_agent/test_contract_ir_solver_registry.py
+++ b/tests/test_agent/test_contract_ir_solver_registry.py
@@ -1,0 +1,129 @@
+"""Tests for the Phase 3 structural solver declaration substrate (QUA-925)."""
+
+from __future__ import annotations
+
+import pytest
+
+from trellis.agent.contract_ir_solver_registry import (
+    ContractIRSolverDeclaration,
+    ContractIRSolverMaterialization,
+    ContractIRSolverOutputSupport,
+    ContractIRSolverOverlapError,
+    ContractIRSolverProvenance,
+    ContractIRSolverRegistryError,
+    ContractIRSolverSelectionAuthority,
+    build_contract_ir_solver_registry,
+)
+from trellis.agent.contract_pattern import parse_contract_pattern
+
+
+def _declaration(
+    declaration_id: str,
+    *,
+    payoff_kind: str,
+    precedence: int = 0,
+    methods: tuple[str, ...] = ("analytical",),
+    exercise_style: str | None = None,
+    subordinates_to: tuple[str, ...] = (),
+) -> ContractIRSolverDeclaration:
+    payload: dict[str, object] = {
+        "payoff": {"kind": payoff_kind},
+    }
+    if exercise_style is not None:
+        payload["exercise"] = {"style": exercise_style}
+    return ContractIRSolverDeclaration(
+        authority=ContractIRSolverSelectionAuthority(
+            contract_pattern=parse_contract_pattern(payload),
+            admissible_methods=methods,
+        ),
+        outputs=ContractIRSolverOutputSupport(supported_outputs=("price",)),
+        materialization=ContractIRSolverMaterialization(
+            callable_ref=f"trellis.models.synthetic.{declaration_id}",
+            call_style="helper_call",
+        ),
+        provenance=ContractIRSolverProvenance(declaration_id=declaration_id),
+        precedence=precedence,
+        subordinates_to=subordinates_to,
+    )
+
+
+class TestContractIRSolverRegistry:
+    def test_selection_order_uses_precedence_then_registration_order(self):
+        low_a = _declaration("low_a", payoff_kind="vanilla_payoff", precedence=10)
+        low_b = _declaration("low_b", payoff_kind="digital_payoff", precedence=10)
+        high = _declaration("high", payoff_kind="swaption_payoff", precedence=20)
+
+        registry = build_contract_ir_solver_registry((low_a, low_b, high))
+
+        assert tuple(item.declaration_id for item in registry.selection_order()) == (
+            "high",
+            "low_a",
+            "low_b",
+        )
+        assert tuple(item.registration_index for item in registry.declarations) == (0, 1, 2)
+
+    def test_equal_precedence_overlapping_declarations_fail_closed(self):
+        left = _declaration("left", payoff_kind="vanilla_payoff", precedence=10)
+        right = _declaration("right", payoff_kind="vanilla_payoff", precedence=10)
+
+        with pytest.raises(ContractIRSolverOverlapError, match="left.*right|right.*left"):
+            build_contract_ir_solver_registry((left, right))
+
+    def test_subordinate_overlap_is_allowed_when_precedence_is_lower(self):
+        specific = _declaration("specific", payoff_kind="vanilla_payoff", precedence=20)
+        general = _declaration(
+            "general",
+            payoff_kind="vanilla_payoff",
+            precedence=10,
+            subordinates_to=("specific",),
+        )
+
+        registry = build_contract_ir_solver_registry((general, specific))
+
+        assert tuple(item.declaration_id for item in registry.selection_order()) == (
+            "specific",
+            "general",
+        )
+
+    def test_subordinate_overlap_requires_strictly_lower_precedence(self):
+        specific = _declaration("specific", payoff_kind="vanilla_payoff", precedence=20)
+        general = _declaration(
+            "general",
+            payoff_kind="vanilla_payoff",
+            precedence=20,
+            subordinates_to=("specific",),
+        )
+
+        with pytest.raises(ContractIRSolverRegistryError, match="general.*specific.*precedence"):
+            build_contract_ir_solver_registry((general, specific))
+
+    def test_unknown_subordinate_target_is_rejected(self):
+        declaration = _declaration(
+            "orphan",
+            payoff_kind="vanilla_payoff",
+            subordinates_to=("missing",),
+        )
+
+        with pytest.raises(ContractIRSolverRegistryError, match="missing"):
+            build_contract_ir_solver_registry((declaration,))
+
+    def test_distinct_literal_exercise_styles_are_not_treated_as_overlapping(self):
+        european = _declaration(
+            "european_vanilla",
+            payoff_kind="vanilla_payoff",
+            precedence=10,
+            exercise_style="european",
+        )
+        american = _declaration(
+            "american_vanilla",
+            payoff_kind="vanilla_payoff",
+            precedence=10,
+            exercise_style="american",
+        )
+
+        registry = build_contract_ir_solver_registry((european, american))
+
+        assert tuple(item.declaration_id for item in registry.selection_order()) == (
+            "european_vanilla",
+            "american_vanilla",
+        )

--- a/tests/test_agent/test_contract_ir_solver_registry.py
+++ b/tests/test_agent/test_contract_ir_solver_registry.py
@@ -25,10 +25,9 @@ def _declaration(
     methods: tuple[str, ...] = ("analytical",),
     exercise_style: str | None = None,
     subordinates_to: tuple[str, ...] = (),
+    payload: dict[str, object] | None = None,
 ) -> ContractIRSolverDeclaration:
-    payload: dict[str, object] = {
-        "payoff": {"kind": payoff_kind},
-    }
+    payload = dict(payload or {"payoff": {"kind": payoff_kind}})
     if exercise_style is not None:
         payload["exercise"] = {"style": exercise_style}
     return ContractIRSolverDeclaration(
@@ -68,6 +67,32 @@ class TestContractIRSolverRegistry:
 
         with pytest.raises(ContractIRSolverOverlapError, match="left.*right|right.*left"):
             build_contract_ir_solver_registry((left, right))
+
+    def test_instrument_tag_and_structural_vanilla_overlap_fail_closed(self):
+        tag_decl = _declaration("tag", payoff_kind="vanilla_payoff", precedence=10)
+        structural_decl = _declaration(
+            "structural",
+            payoff_kind="unused",
+            precedence=10,
+            payload={
+                "payoff": {
+                    "kind": "max",
+                    "args": [
+                        {
+                            "kind": "sub",
+                            "args": [
+                                {"kind": "spot", "underlier": "_u"},
+                                {"kind": "strike", "value": "_k"},
+                            ],
+                        },
+                        {"kind": "constant", "value": 0.0},
+                    ],
+                }
+            },
+        )
+
+        with pytest.raises(ContractIRSolverOverlapError, match="tag.*structural|structural.*tag"):
+            build_contract_ir_solver_registry((tag_decl, structural_decl))
 
     def test_subordinate_overlap_is_allowed_when_precedence_is_lower(self):
         specific = _declaration("specific", payoff_kind="vanilla_payoff", precedence=20)

--- a/trellis/agent/contract_ir_solver_registry.py
+++ b/trellis/agent/contract_ir_solver_registry.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from itertools import combinations
-from typing import Iterable
+from typing import AbstractSet, Iterable
 
 from trellis.agent.contract_pattern import (
     AtomPattern,
@@ -314,7 +314,11 @@ def _method_sets_intersect(left: tuple[str, ...], right: tuple[str, ...]) -> boo
 
 
 def _selectors_conflict(left: object | None, right: object | None) -> bool:
-    return left is not None and right is not None and left != right
+    if left is None or right is None:
+        return False
+    if isinstance(left, AbstractSet) and isinstance(right, AbstractSet):
+        return left.isdisjoint(right)
+    return left != right
 
 
 def _contract_pattern_overlap_signature(pattern: ContractPattern) -> dict[str, object | None]:
@@ -340,14 +344,70 @@ def _payoff_selector(node: object | None) -> object | None:
     if node is None:
         return None
     if isinstance(node, PayoffPattern):
-        return node.kind
+        inferred_tags = _payoff_family_tags(node)
+        if inferred_tags:
+            return inferred_tags
+        return frozenset({f"head:{node.kind}"})
     if isinstance(node, SpotPattern):
-        return "spot"
+        return frozenset({"head:spot"})
     if isinstance(node, StrikePattern):
-        return "strike"
+        return frozenset({"head:strike"})
     if isinstance(node, ConstantPattern):
-        return "constant"
+        return frozenset({"head:constant"})
     return None
+
+
+_INSTRUMENT_PAYOFF_TAGS = frozenset(
+    {
+        "swaption_payoff",
+        "basket_payoff",
+        "variance_payoff",
+        "digital_payoff",
+        "barrier_payoff",
+        "vanilla_payoff",
+        "rate_payoff",
+        "lookback_payoff",
+        "asian_payoff",
+        "cliquet_payoff",
+        "chooser_payoff",
+        "compound_payoff",
+    }
+)
+
+
+def _payoff_family_tags(node: PayoffPattern) -> frozenset[str]:
+    if node.kind in _INSTRUMENT_PAYOFF_TAGS and not node.args:
+        return frozenset({node.kind})
+    tags: set[str] = set()
+    if _is_vanilla_intrinsic_shape(node):
+        tags.add("vanilla_payoff")
+    return frozenset(tags)
+
+
+def _is_vanilla_intrinsic_shape(node: PayoffPattern) -> bool:
+    if node.kind != "max" or len(node.args) != 2:
+        return False
+    sub_node, zero_node = node.args
+    if not isinstance(sub_node, PayoffPattern) or sub_node.kind != "sub":
+        return False
+    if len(sub_node.args) != 2:
+        return False
+    lhs, rhs = sub_node.args
+    if not isinstance(lhs, SpotPattern):
+        return False
+    if not isinstance(rhs, StrikePattern):
+        return False
+    if not isinstance(zero_node, ConstantPattern):
+        return False
+    zero_value = zero_node.value
+    if isinstance(zero_value, Wildcard):
+        return True
+    if isinstance(zero_value, AtomPattern):
+        zero_value = zero_value.value
+    try:
+        return float(zero_value) == 0.0
+    except (TypeError, ValueError):
+        return False
 
 
 def _schedule_frequency_selector(node: SchedulePattern | None) -> object | None:

--- a/trellis/agent/contract_ir_solver_registry.py
+++ b/trellis/agent/contract_ir_solver_registry.py
@@ -1,0 +1,383 @@
+"""Structural solver declaration substrate for ContractIR selection (QUA-925).
+
+This module is intentionally narrow. It introduces the typed declaration and
+registry surface that later Phase 3 slices will use, but it does not yet
+compile or execute solver calls.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from itertools import combinations
+from typing import Iterable
+
+from trellis.agent.contract_pattern import (
+    AtomPattern,
+    ConstantPattern,
+    ContractPattern,
+    ExercisePattern,
+    ObservationPattern,
+    PayoffPattern,
+    SchedulePattern,
+    SpotPattern,
+    StrikePattern,
+    UnderlyingPattern,
+    Wildcard,
+)
+from trellis.agent.knowledge.methods import normalize_method
+
+
+def _unique_strings(values: Iterable[str]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(value for value in values if value))
+
+
+def _normalize_methods(methods: Iterable[str]) -> tuple[str, ...]:
+    return _unique_strings(normalize_method(method) for method in methods)
+
+
+class ContractIRSolverRegistryError(ValueError):
+    """Base error for malformed declaration registries."""
+
+
+class ContractIRSolverOverlapError(ContractIRSolverRegistryError):
+    """Raised when two declarations conservatively overlap without resolution."""
+
+
+@dataclass(frozen=True)
+class ContractIRSolverSelectionAuthority:
+    """The structural selection contract for a solver declaration."""
+
+    contract_pattern: ContractPattern
+    admissible_methods: tuple[str, ...] = ()
+    required_term_groups: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "admissible_methods", _normalize_methods(self.admissible_methods))
+        object.__setattr__(self, "required_term_groups", _unique_strings(self.required_term_groups))
+
+
+@dataclass(frozen=True)
+class ContractIRSolverOutputSupport:
+    """Requested-output support declared by a solver binding."""
+
+    supported_outputs: tuple[str, ...] = ("price",)
+    supported_measures: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "supported_outputs", _unique_strings(self.supported_outputs))
+        object.__setattr__(self, "supported_measures", _unique_strings(self.supported_measures))
+
+
+@dataclass(frozen=True)
+class ContractIRSolverMarketRequirements:
+    """Market capability requirements for a solver declaration."""
+
+    required_capabilities: tuple[str, ...] = ()
+    optional_capabilities: tuple[str, ...] = ()
+    required_coordinate_kinds: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "required_capabilities", _unique_strings(self.required_capabilities))
+        object.__setattr__(self, "optional_capabilities", _unique_strings(self.optional_capabilities))
+        object.__setattr__(
+            self,
+            "required_coordinate_kinds",
+            _unique_strings(self.required_coordinate_kinds),
+        )
+
+
+@dataclass(frozen=True)
+class ContractIRSolverMaterialization:
+    """How a selected declaration will eventually materialize a callable."""
+
+    callable_ref: str
+    call_style: str
+    adapter_ref: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.callable_ref:
+            raise ContractIRSolverRegistryError("materialization.callable_ref must be non-empty")
+        if self.call_style not in {"helper_call", "raw_kernel_kwargs"}:
+            raise ContractIRSolverRegistryError(
+                "materialization.call_style must be 'helper_call' or 'raw_kernel_kwargs'"
+            )
+
+
+@dataclass(frozen=True)
+class ContractIRSolverProvenance:
+    """Stable identifier and binding provenance for one declaration."""
+
+    declaration_id: str
+    validation_bundle_id: str = ""
+    compatibility_alias_policy: str = "operator_visible"
+    helper_refs: tuple[str, ...] = ()
+    pricing_kernel_refs: tuple[str, ...] = ()
+    schedule_builder_refs: tuple[str, ...] = ()
+    cashflow_engine_refs: tuple[str, ...] = ()
+    market_binding_refs: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not self.declaration_id:
+            raise ContractIRSolverRegistryError("provenance.declaration_id must be non-empty")
+        object.__setattr__(self, "helper_refs", _unique_strings(self.helper_refs))
+        object.__setattr__(self, "pricing_kernel_refs", _unique_strings(self.pricing_kernel_refs))
+        object.__setattr__(
+            self,
+            "schedule_builder_refs",
+            _unique_strings(self.schedule_builder_refs),
+        )
+        object.__setattr__(
+            self,
+            "cashflow_engine_refs",
+            _unique_strings(self.cashflow_engine_refs),
+        )
+        object.__setattr__(
+            self,
+            "market_binding_refs",
+            _unique_strings(self.market_binding_refs),
+        )
+
+
+@dataclass(frozen=True)
+class ContractIRSolverDeclaration:
+    """A single structural solver declaration."""
+
+    authority: ContractIRSolverSelectionAuthority
+    materialization: ContractIRSolverMaterialization
+    provenance: ContractIRSolverProvenance
+    outputs: ContractIRSolverOutputSupport = field(default_factory=ContractIRSolverOutputSupport)
+    market_requirements: ContractIRSolverMarketRequirements = field(
+        default_factory=ContractIRSolverMarketRequirements
+    )
+    precedence: int = 0
+    subordinates_to: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "subordinates_to", _unique_strings(self.subordinates_to))
+
+
+@dataclass(frozen=True)
+class RegisteredContractIRSolverDeclaration:
+    """A declaration paired with its deterministic registration index."""
+
+    declaration: ContractIRSolverDeclaration
+    registration_index: int
+
+    @property
+    def declaration_id(self) -> str:
+        return self.declaration.provenance.declaration_id
+
+
+@dataclass(frozen=True)
+class ContractIRSolverRegistry:
+    """Validated structural declarations in deterministic registration order."""
+
+    declarations: tuple[RegisteredContractIRSolverDeclaration, ...]
+
+    def selection_order(self) -> tuple[RegisteredContractIRSolverDeclaration, ...]:
+        return tuple(
+            sorted(
+                self.declarations,
+                key=lambda item: (-item.declaration.precedence, item.registration_index),
+            )
+        )
+
+    def get(self, declaration_id: str) -> RegisteredContractIRSolverDeclaration:
+        for item in self.declarations:
+            if item.declaration_id == declaration_id:
+                return item
+        raise KeyError(declaration_id)
+
+
+def build_contract_ir_solver_registry(
+    declarations: Iterable[ContractIRSolverDeclaration],
+) -> ContractIRSolverRegistry:
+    """Validate and register structural solver declarations."""
+
+    registered = tuple(
+        RegisteredContractIRSolverDeclaration(declaration=declaration, registration_index=index)
+        for index, declaration in enumerate(declarations)
+    )
+    _validate_unique_ids(registered)
+    by_id = {item.declaration_id: item for item in registered}
+    _validate_subordination_graph(registered, by_id)
+    _validate_overlap_resolution(registered)
+    return ContractIRSolverRegistry(declarations=registered)
+
+
+def _validate_unique_ids(
+    declarations: tuple[RegisteredContractIRSolverDeclaration, ...],
+) -> None:
+    seen: set[str] = set()
+    for item in declarations:
+        declaration_id = item.declaration_id
+        if declaration_id in seen:
+            raise ContractIRSolverRegistryError(
+                f"duplicate ContractIR solver declaration id {declaration_id!r}"
+            )
+        seen.add(declaration_id)
+
+
+def _validate_subordination_graph(
+    declarations: tuple[RegisteredContractIRSolverDeclaration, ...],
+    by_id: dict[str, RegisteredContractIRSolverDeclaration],
+) -> None:
+    for item in declarations:
+        for superior_id in item.declaration.subordinates_to:
+            if superior_id not in by_id:
+                raise ContractIRSolverRegistryError(
+                    f"declaration {item.declaration_id!r} subordinates_to unknown id {superior_id!r}"
+                )
+            superior = by_id[superior_id]
+            if item.declaration_id == superior_id:
+                raise ContractIRSolverRegistryError(
+                    f"declaration {item.declaration_id!r} cannot subordinate to itself"
+                )
+            if item.declaration.precedence >= superior.declaration.precedence:
+                raise ContractIRSolverRegistryError(
+                    "subordinate declarations "
+                    f"{item.declaration_id!r} -> {superior_id!r} require strictly lower precedence"
+                )
+    _validate_subordination_acyclic(declarations)
+
+
+def _validate_subordination_acyclic(
+    declarations: tuple[RegisteredContractIRSolverDeclaration, ...],
+) -> None:
+    graph = {
+        item.declaration_id: tuple(item.declaration.subordinates_to) for item in declarations
+    }
+    visiting: set[str] = set()
+    visited: set[str] = set()
+
+    def _visit(node: str) -> None:
+        if node in visited:
+            return
+        if node in visiting:
+            raise ContractIRSolverRegistryError(
+                f"cyclic subordination detected at declaration {node!r}"
+            )
+        visiting.add(node)
+        for parent in graph[node]:
+            _visit(parent)
+        visiting.remove(node)
+        visited.add(node)
+
+    for node in graph:
+        _visit(node)
+
+
+def _validate_overlap_resolution(
+    declarations: tuple[RegisteredContractIRSolverDeclaration, ...],
+) -> None:
+    for left, right in combinations(declarations, 2):
+        if not _declarations_may_overlap(left.declaration, right.declaration):
+            continue
+        left_subordinate = right.declaration_id in left.declaration.subordinates_to
+        right_subordinate = left.declaration_id in right.declaration.subordinates_to
+        if left_subordinate and right_subordinate:
+            raise ContractIRSolverRegistryError(
+                "mutual subordination is not allowed for overlapping declarations "
+                f"{left.declaration_id!r} and {right.declaration_id!r}"
+            )
+        if left_subordinate or right_subordinate:
+            continue
+        if left.declaration.precedence == right.declaration.precedence:
+            raise ContractIRSolverOverlapError(
+                "equal-precedence overlapping ContractIR solver declarations "
+                f"{left.declaration_id!r} and {right.declaration_id!r} require "
+                "an explicit precedence split or subordinate relation"
+            )
+
+
+def _declarations_may_overlap(
+    left: ContractIRSolverDeclaration,
+    right: ContractIRSolverDeclaration,
+) -> bool:
+    if not _method_sets_intersect(
+        left.authority.admissible_methods,
+        right.authority.admissible_methods,
+    ):
+        return False
+    left_signature = _contract_pattern_overlap_signature(left.authority.contract_pattern)
+    right_signature = _contract_pattern_overlap_signature(right.authority.contract_pattern)
+    for key in left_signature:
+        if _selectors_conflict(left_signature[key], right_signature[key]):
+            return False
+    return True
+
+
+def _method_sets_intersect(left: tuple[str, ...], right: tuple[str, ...]) -> bool:
+    if not left or not right:
+        return True
+    return bool(set(left) & set(right))
+
+
+def _selectors_conflict(left: object | None, right: object | None) -> bool:
+    return left is not None and right is not None and left != right
+
+
+def _contract_pattern_overlap_signature(pattern: ContractPattern) -> dict[str, object | None]:
+    return {
+        "payoff_kind": _payoff_selector(pattern.payoff),
+        "exercise_style": _literal_selector(pattern.exercise.style if pattern.exercise else None),
+        "exercise_frequency": _schedule_frequency_selector(
+            pattern.exercise.schedule if pattern.exercise else None
+        ),
+        "observation_kind": _literal_selector(
+            pattern.observation.kind if pattern.observation else None
+        ),
+        "underlying_kind": _literal_selector(
+            pattern.underlying.kind if pattern.underlying else None
+        ),
+        "underlying_dynamics": _literal_selector(
+            pattern.underlying.dynamics if pattern.underlying else None
+        ),
+    }
+
+
+def _payoff_selector(node: object | None) -> object | None:
+    if node is None:
+        return None
+    if isinstance(node, PayoffPattern):
+        return node.kind
+    if isinstance(node, SpotPattern):
+        return "spot"
+    if isinstance(node, StrikePattern):
+        return "strike"
+    if isinstance(node, ConstantPattern):
+        return "constant"
+    return None
+
+
+def _schedule_frequency_selector(node: SchedulePattern | None) -> object | None:
+    if node is None:
+        return None
+    return _literal_selector(node.frequency)
+
+
+def _literal_selector(node: object | None) -> object | None:
+    if node is None or isinstance(node, Wildcard):
+        return None
+    if isinstance(node, AtomPattern):
+        return node.value
+    if isinstance(node, (str, int, float, bool)):
+        return node
+    if isinstance(node, (ExercisePattern, ObservationPattern, UnderlyingPattern, SchedulePattern)):
+        return None
+    return None
+
+
+__all__ = [
+    "ContractIRSolverDeclaration",
+    "ContractIRSolverMaterialization",
+    "ContractIRSolverMarketRequirements",
+    "ContractIRSolverOutputSupport",
+    "ContractIRSolverOverlapError",
+    "ContractIRSolverProvenance",
+    "ContractIRSolverRegistry",
+    "ContractIRSolverRegistryError",
+    "ContractIRSolverSelectionAuthority",
+    "RegisteredContractIRSolverDeclaration",
+    "build_contract_ir_solver_registry",
+]


### PR DESCRIPTION
## Summary
- add the Phase 3 `ContractIR` solver declaration registry substrate
- introduce declaration, provenance, materialization, and registry dataclasses with deterministic registration order
- validate subordinate relationships and fail closed on equal-precedence overlapping declarations

## Testing
- `PATH=/Users/steveyang/miniforge3/bin:$PATH /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_contract_ir_solver_registry.py -q`
- `PATH=/Users/steveyang/miniforge3/bin:$PATH /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_contract_ir_solver_registry.py tests/test_agent/test_contract_pattern_eval_contract_ir.py tests/test_agent/test_semantic_contract_compiler_contract_ir.py -q`