### PR TITLE
Add route-retirement readiness ledger and harness

### DIFF
--- a/doc/plan/draft__contract-ir-phase-4-route-retirement.md
+++ b/doc/plan/draft__contract-ir-phase-4-route-retirement.md
@@ -491,6 +491,8 @@ still describe route ids as the primary fresh-build authority.
   reads on migrated fresh-build paths
 - audit test that enumerates forbidden selector reads of non-semantic
   trade-envelope or position-wrapper metadata
+- shared masked-authority harness reuse for later-family cutover tickets
+  so the invariance contract is not redefined family by family
 - residual-inventory audit proving no supported fresh-build family
   remains behind route fallback at phase exit
 
@@ -549,6 +551,10 @@ The stronger rule after Phase 4 is:
    consumers before Phase 4 coding starts.
 4. Keep a per-family closure ledger so route retirement is gated on
    semantic closure, not on intuition or branch-local confidence.
-5. Treat the Phase 4 exit criterion as a hard product rule:
+5. Require post-Phase-4 family migrations to reuse one shared
+   masked-authority harness against `route_id`, `route_family`,
+   `ProductIR.instrument`, and non-semantic wrapper metadata before
+   claiming cutover readiness.
+6. Treat the Phase 4 exit criterion as a hard product rule:
    by phase close, every supported fresh rebuild must go through the
    Semantic Lowering Pipeline, and route must be replay-only.

--- a/doc/plan/draft__post-phase-4-semantic-closure-execution-plan.md
+++ b/doc/plan/draft__post-phase-4-semantic-closure-execution-plan.md
@@ -9,8 +9,9 @@ The umbrella and `CLX.*` child tickets are now filed in Linear. This
 document remains the ordered repo-local mirror for that queue and should
 stay aligned with the live issue graph.
 
-`CLX.1` through `CLX.6` are now implemented and merged. The next
-concrete follow-on tickets are `QUA-936`, `QUA-937`, and `QUA-938`.
+`CLX.1` through `CLX.6` are now implemented and merged, and `QUA-936`
+has already landed the overlay-boundary fixtures under `CLX.7`. The
+current `CLX.8` implementation tranche is `QUA-937` and `QUA-938`.
 
 Status mirror last synced: `2026-04-20`
 
@@ -123,8 +124,6 @@ post-Phase-4 work risks stalling in familiar ways:
 
 Current next pickup:
 
-- `QUA-936` — overlay boundary fixtures for financial-control vs
-  policy-state overlays
 - `QUA-937` — readiness ledger for dynamic closure cohorts
 - `QUA-938` — reusable masked-authority harness for later-family
   cutovers
@@ -275,6 +274,15 @@ Filed follow-ons:
 - `QUA-937` — readiness ledger for dynamic closure cohorts
 - `QUA-938` — reusable masked-authority harness for later-family
   cutovers
+
+Implementation note for the current tranche:
+
+- the shared readiness ledger now lives in
+  `trellis.agent.route_retirement_readiness.dynamic_route_retirement_readiness_ledger`
+- the shared masking harness now lives in
+  `trellis.agent.route_retirement_readiness.require_masked_authority_invariant`
+- the seeded dynamic cohorts still remain blocked on parity /
+  provenance even after the masking harness lands
 
 ## Family-to-Queue Map
 

--- a/docs/developer/contract_ir_solver_compiler.rst
+++ b/docs/developer/contract_ir_solver_compiler.rst
@@ -158,6 +158,31 @@ A family should not be treated as route-retirement-ready merely because it
 binds structurally; the ledger must also show sufficient comparison evidence
 and an explicit non-blocked status.
 
+Later-Family Readiness And Harness Reuse
+----------------------------------------
+
+Post-Phase-4 semantic families should not invent their own cutover checklist
+or their own authority-masking assertions.
+
+``trellis.agent.route_retirement_readiness`` is now the shared developer-facing
+support module for that follow-on work. It provides:
+
+- a seeded readiness ledger for the current dynamic cohorts
+- a generic masked-authority invariance harness
+- bounded dynamic probe capture that later-family tickets can extend before a
+  real executable cutover exists
+
+The operational rule is:
+
+1. a later-family ticket records its readiness state in the ledger vocabulary
+2. the ticket reuses the shared masking harness against its bounded selector or
+   cutover probe
+3. the family is still blocked from real route retirement until parity and
+   provenance gates flip from planned to ready
+
+That keeps later-family migrations aligned with the existing Phase 4 authority
+contract rather than recreating route-local review logic in each family wave.
+
 Extension Guidance
 ------------------
 

--- a/docs/quant/dynamic_contract_ir.rst
+++ b/docs/quant/dynamic_contract_ir.rst
@@ -155,6 +155,38 @@ contract is:
 - benchmark or parity plans are attached at admission time
 - route-free executable pricing for those lanes remains future work
 
+Later-Family Route-Retirement Readiness
+---------------------------------------
+
+``trellis.agent.route_retirement_readiness`` now seeds the first
+machine-checkable readiness ledger for the dynamic cohorts:
+
+- ``automatic_event_state``
+- ``discrete_control``
+- ``continuous_singular_control``
+
+Each readiness row makes the current migration state explicit across the
+required later-family cutover gates:
+
+- representation closure
+- decomposition closure
+- lowering admission
+- parity or benchmark evidence
+- provenance readiness
+- masked-authority test readiness
+
+The current dynamic cohorts are intentionally **not** cutover-ready yet.
+Their remaining blockers are executable parity or benchmark completion and
+promotion of dynamic provenance onto the Phase 4 valuation-identity surface.
+
+The same module also ships a reusable masked-authority harness for
+later-family route-retirement tickets. The harness proves that changing
+legacy ``route_id`` / ``route_family`` labels, ``ProductIR.instrument``-style
+instrument tags, or non-semantic wrapper metadata does not change the
+authoritative selection snapshot for bounded dynamic probes. That gives later
+family-specific cutover tickets one shared invariance contract instead of
+duplicated family-local assertions.
+
 Classifier Boundary
 -------------------
 

--- a/tests/test_agent/test_route_retirement_readiness.py
+++ b/tests/test_agent/test_route_retirement_readiness.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import pytest
+
+from trellis.agent.knowledge.decompose import decompose_to_dynamic_contract_ir
+
+
+def test_dynamic_route_retirement_readiness_ledger_seeds_dynamic_cohorts():
+    from trellis.agent.route_retirement_readiness import (
+        dynamic_route_retirement_readiness_ledger,
+        get_dynamic_route_retirement_readiness,
+        is_route_retirement_ready,
+        missing_route_retirement_gates,
+    )
+
+    ledger = dynamic_route_retirement_readiness_ledger()
+
+    assert tuple(entry.cohort_id for entry in ledger) == (
+        "automatic_event_state",
+        "discrete_control",
+        "continuous_singular_control",
+    )
+
+    automatic = get_dynamic_route_retirement_readiness("automatic_event_state")
+    discrete = get_dynamic_route_retirement_readiness("discrete_control")
+    continuous = get_dynamic_route_retirement_readiness("continuous_singular_control")
+
+    assert automatic.proving_families == ("autocallable", "tarn")
+    assert "callable_cms_range_accrual" in automatic.honest_block_relatives
+    assert discrete.proving_families == ("callable_bond", "swing_option")
+    assert "autocallable" in discrete.honest_block_relatives
+    assert continuous.proving_families == ("gmwb_financial_control",)
+    assert "insurance_overlay" in continuous.honest_block_relatives
+
+    for entry in ledger:
+        assert entry.representation_closure.ready is True
+        assert entry.decomposition_closure.ready is True
+        assert entry.lowering_admission.ready is True
+        assert entry.masked_authority_readiness.ready is True
+        assert missing_route_retirement_gates(entry) == (
+            "parity_or_benchmark",
+            "provenance_readiness",
+        )
+        assert is_route_retirement_ready(entry) is False
+
+
+@pytest.mark.parametrize(
+    ("description", "instrument_type", "expected_lane", "expected_ref"),
+    [
+        (
+            "Phoenix autocallable note on SPX notional 1000000 coupon 8% "
+            "autocall barrier 100% observation dates 2025-07-15, 2026-01-15, "
+            "2026-07-15, 2027-01-15 maturity 2027-01-15",
+            "autocallable",
+            "automatic_event_state",
+            "autocallable_note",
+        ),
+        (
+            "Issuer callable fixed coupon bond USD face 1000000 coupon 5% issue "
+            "2025-01-15 maturity 2030-01-15 semiannual day count ACT/ACT "
+            "call dates 2027-01-15, 2028-01-15, 2029-01-15",
+            "callable_bond",
+            "discrete_control",
+            "callable_bond",
+        ),
+        (
+            "GMWB contract premium 100000 guarantee base 100000 account value 100000 "
+            "withdrawal dates 2026-01-15, 2027-01-15, 2028-01-15",
+            "gmwb",
+            "continuous_control",
+            "gmwb_financial_control",
+        ),
+    ],
+)
+def test_masked_authority_harness_supports_dynamic_later_family_probes(
+    description: str,
+    instrument_type: str,
+    expected_lane: str,
+    expected_ref: str,
+):
+    from trellis.agent.route_retirement_readiness import (
+        capture_dynamic_lane_probe_authority_snapshot,
+        default_masked_authority_variants,
+        require_masked_authority_invariant,
+    )
+
+    contract = decompose_to_dynamic_contract_ir(description, instrument_type=instrument_type)
+
+    baseline = require_masked_authority_invariant(
+        default_masked_authority_variants(),
+        lambda variant: capture_dynamic_lane_probe_authority_snapshot(
+            contract,
+            variant=variant,
+        ),
+    )
+
+    assert baseline.selection_surface == "dynamic_lane_probe"
+    assert baseline.lane_family == expected_lane
+    assert baseline.authoritative_ref == expected_ref
+
+
+def test_masked_authority_harness_reuses_phase4_route_free_build_surface():
+    from trellis.agent.platform_requests import compile_build_request
+    from trellis.agent.route_retirement_readiness import (
+        capture_compiled_request_authority_snapshot,
+        default_masked_authority_variants,
+        require_masked_authority_invariant,
+    )
+
+    description = "European call on AAPL strike 150 expiring 2025-11-15"
+
+    baseline = require_masked_authority_invariant(
+        default_masked_authority_variants(),
+        lambda variant: capture_compiled_request_authority_snapshot(
+            compile_build_request(
+                description,
+                instrument_type="european_option",
+                preferred_method="analytical",
+                metadata=dict(variant.wrapper_metadata),
+            )
+        ),
+    )
+
+    assert baseline.selection_surface == "platform_request"
+    assert baseline.authoritative_ref == "black76_vanilla_call"
+    assert baseline.lane_family == "analytical"
+    assert baseline.binding_id == "trellis.models.black.black76_call"

--- a/tests/test_agent/test_route_retirement_readiness.py
+++ b/tests/test_agent/test_route_retirement_readiness.py
@@ -116,7 +116,12 @@ def test_masked_authority_harness_reuses_phase4_route_free_build_surface():
                 description,
                 instrument_type="european_option",
                 preferred_method="analytical",
-                metadata=dict(variant.wrapper_metadata),
+                metadata={
+                    "route_id": variant.route_id,
+                    "route_family": variant.route_family,
+                    "product_instrument": variant.product_instrument,
+                    **dict(variant.wrapper_metadata),
+                },
             )
         ),
     )

--- a/trellis/agent/route_retirement_readiness.py
+++ b/trellis/agent/route_retirement_readiness.py
@@ -253,9 +253,8 @@ def capture_compiled_request_authority_snapshot(compiled_request) -> AuthoritySe
         raise ValueError("compiled request does not carry route-free authority metadata")
 
     lane_family = (
-        str(authority.get("route_family") or "").strip()
-        or str(authority.get("engine_family") or "").strip()
-        or str(backend_binding.get("engine_family") or "").strip()
+        str(backend_binding.get("engine_family") or "").strip()
+        or str(selection.get("requested_method") or "").strip()
     )
     if not lane_family:
         raise ValueError("compiled request does not carry a lane family")

--- a/trellis/agent/route_retirement_readiness.py
+++ b/trellis/agent/route_retirement_readiness.py
@@ -1,0 +1,506 @@
+"""Readiness ledger and masked-authority harness for later route retirement.
+
+This module turns the post-Phase-4 closure requirements into executable
+artifacts:
+
+- one seeded readiness ledger for the landed dynamic cohorts
+- one reusable masked-authority harness that later-family cutovers can extend
+
+The harness intentionally separates selector-forbidden metadata from the
+authoritative snapshot that should remain invariant under those variations.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from types import MappingProxyType
+
+from trellis.agent.dynamic_contract_ir import DynamicContractIR
+from trellis.agent.dynamic_lane_admission import compile_dynamic_lane_admission
+
+
+def _freeze_mapping(mapping: Mapping[str, object] | None) -> Mapping[str, object]:
+    return MappingProxyType(dict(mapping or {}))
+
+
+def _freeze_tuple(values: Sequence[str] | None) -> tuple[str, ...]:
+    return tuple(values or ())
+
+
+@dataclass(frozen=True)
+class RouteRetirementGate:
+    """One gate in the route-retirement readiness ledger."""
+
+    ready: bool
+    evidence_refs: tuple[str, ...] = ()
+    notes: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "evidence_refs", _freeze_tuple(self.evidence_refs))
+        object.__setattr__(self, "notes", _freeze_tuple(self.notes))
+
+
+@dataclass(frozen=True)
+class RouteRetirementReadinessRecord:
+    """Machine-checkable readiness row for one later-family migration cohort."""
+
+    cohort_id: str
+    semantic_track: str
+    proving_families: tuple[str, ...]
+    honest_block_relatives: tuple[str, ...]
+    representation_closure: RouteRetirementGate
+    decomposition_closure: RouteRetirementGate
+    lowering_admission: RouteRetirementGate
+    parity_or_benchmark: RouteRetirementGate
+    provenance_readiness: RouteRetirementGate
+    masked_authority_readiness: RouteRetirementGate
+    notes: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "proving_families", _freeze_tuple(self.proving_families))
+        object.__setattr__(
+            self,
+            "honest_block_relatives",
+            _freeze_tuple(self.honest_block_relatives),
+        )
+        object.__setattr__(self, "notes", _freeze_tuple(self.notes))
+
+
+_READINESS_GATE_NAMES = (
+    "representation_closure",
+    "decomposition_closure",
+    "lowering_admission",
+    "parity_or_benchmark",
+    "provenance_readiness",
+    "masked_authority_readiness",
+)
+
+
+def missing_route_retirement_gates(record: RouteRetirementReadinessRecord) -> tuple[str, ...]:
+    """Return the not-yet-ready route-retirement gates for one cohort."""
+
+    missing: list[str] = []
+    for name in _READINESS_GATE_NAMES:
+        gate = getattr(record, name)
+        if not gate.ready:
+            missing.append(name)
+    return tuple(missing)
+
+
+def is_route_retirement_ready(record: RouteRetirementReadinessRecord) -> bool:
+    """Return ``True`` when the cohort can enter a real route-retirement ticket."""
+
+    return not missing_route_retirement_gates(record)
+
+
+@dataclass(frozen=True)
+class MaskedAuthorityVariant:
+    """Selector-forbidden metadata that a route-retirement harness may perturb."""
+
+    label: str
+    route_id: str | None = None
+    route_family: str | None = None
+    product_instrument: str | None = None
+    wrapper_metadata: Mapping[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "label", str(self.label or "").strip())
+        object.__setattr__(self, "route_id", str(self.route_id or "").strip() or None)
+        object.__setattr__(self, "route_family", str(self.route_family or "").strip() or None)
+        object.__setattr__(
+            self,
+            "product_instrument",
+            str(self.product_instrument or "").strip() or None,
+        )
+        object.__setattr__(self, "wrapper_metadata", _freeze_mapping(self.wrapper_metadata))
+
+
+@dataclass(frozen=True)
+class AuthoritySelectionSnapshot:
+    """Canonical authority snapshot used by masked-authority invariance tests."""
+
+    selection_surface: str
+    authoritative_ref: str
+    lane_family: str
+    semantic_family: str | None = None
+    binding_id: str | None = None
+    validation_bundle_id: str | None = None
+    candidate_lanes: tuple[str, ...] = ()
+    requested_outputs: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "selection_surface", str(self.selection_surface or "").strip())
+        object.__setattr__(self, "authoritative_ref", str(self.authoritative_ref or "").strip())
+        object.__setattr__(self, "lane_family", str(self.lane_family or "").strip())
+        object.__setattr__(
+            self,
+            "semantic_family",
+            str(self.semantic_family or "").strip() or None,
+        )
+        object.__setattr__(self, "binding_id", str(self.binding_id or "").strip() or None)
+        object.__setattr__(
+            self,
+            "validation_bundle_id",
+            str(self.validation_bundle_id or "").strip() or None,
+        )
+        object.__setattr__(self, "candidate_lanes", _freeze_tuple(self.candidate_lanes))
+        object.__setattr__(self, "requested_outputs", _freeze_tuple(self.requested_outputs))
+
+
+class MaskedAuthorityInvariantError(AssertionError):
+    """Raised when selector-forbidden metadata changes authoritative selection."""
+
+
+def default_masked_authority_variants() -> tuple[MaskedAuthorityVariant, ...]:
+    """Return the default selector-forbidden metadata perturbations.
+
+    These variants intentionally cover every field called out by the Phase 4
+    authority contract: route ids, route families, product-instrument labels,
+    and non-semantic trade-envelope metadata.
+    """
+
+    return (
+        MaskedAuthorityVariant(
+            label="baseline",
+            route_id="legacy_route_alpha",
+            route_family="legacy_family_alpha",
+            product_instrument="legacy_product_alpha",
+            wrapper_metadata={
+                "external_id": "TRADE-ALPHA",
+                "booking_tags": ["desk-alpha", "ops-rebook-a"],
+                "package_wrapper": {
+                    "package_id": "PKG-ALPHA",
+                    "position_id": "POS-ALPHA",
+                },
+            },
+        ),
+        MaskedAuthorityVariant(
+            label="rebooked_wrapper",
+            route_id="legacy_route_bravo",
+            route_family="legacy_family_bravo",
+            product_instrument="legacy_product_bravo",
+            wrapper_metadata={
+                "external_id": "TRADE-BRAVO",
+                "booking_tags": ["desk-bravo", "manual-rebook"],
+                "package_wrapper": {
+                    "package_id": "PKG-BRAVO",
+                    "position_id": "POS-BRAVO",
+                },
+            },
+        ),
+        MaskedAuthorityVariant(
+            label="audit_clone",
+            route_id="legacy_route_charlie",
+            route_family="legacy_family_charlie",
+            product_instrument="legacy_product_charlie",
+            wrapper_metadata={
+                "external_id": "TRADE-CHARLIE",
+                "booking_tags": ["desk-charlie", "audit-clone"],
+                "package_wrapper": {
+                    "package_id": "PKG-CHARLIE",
+                    "position_id": "POS-CHARLIE",
+                },
+            },
+        ),
+    )
+
+
+def require_masked_authority_invariant(
+    variants: Sequence[MaskedAuthorityVariant],
+    snapshot_builder: Callable[[MaskedAuthorityVariant], AuthoritySelectionSnapshot],
+) -> AuthoritySelectionSnapshot:
+    """Require the authoritative selection snapshot to stay invariant.
+
+    The caller decides how each variant is threaded through its compiler or
+    probe surface. The resulting snapshots must be identical if the varied
+    fields are truly selector-forbidden.
+    """
+
+    if not variants:
+        raise ValueError("variants must be non-empty")
+
+    baseline_variant = variants[0]
+    baseline = snapshot_builder(baseline_variant)
+    if not isinstance(baseline, AuthoritySelectionSnapshot):
+        raise TypeError("snapshot_builder must return AuthoritySelectionSnapshot")
+
+    for variant in variants[1:]:
+        candidate = snapshot_builder(variant)
+        if not isinstance(candidate, AuthoritySelectionSnapshot):
+            raise TypeError("snapshot_builder must return AuthoritySelectionSnapshot")
+        if candidate != baseline:
+            raise MaskedAuthorityInvariantError(
+                "selector-forbidden metadata changed authoritative selection: "
+                f"baseline={baseline_variant.label!r} -> {baseline!r}, "
+                f"candidate={variant.label!r} -> {candidate!r}"
+            )
+    return baseline
+
+
+def capture_compiled_request_authority_snapshot(compiled_request) -> AuthoritySelectionSnapshot:
+    """Capture the authoritative snapshot from the current Phase 4 request path."""
+
+    request = getattr(compiled_request, "request", None)
+    metadata = dict(getattr(request, "metadata", {}) or {})
+    semantic_blueprint = dict(metadata.get("semantic_blueprint") or {})
+    selection = dict(semantic_blueprint.get("contract_ir_solver_selection") or {})
+    authority = dict(metadata.get("route_binding_authority") or {})
+    backend_binding = dict(authority.get("backend_binding") or {})
+    authoritative_ref = str(selection.get("declaration_id") or "").strip()
+    binding_id = str(backend_binding.get("binding_id") or "").strip() or None
+    if not authoritative_ref and binding_id is None:
+        raise ValueError("compiled request does not carry route-free authority metadata")
+
+    lane_family = (
+        str(authority.get("route_family") or "").strip()
+        or str(authority.get("engine_family") or "").strip()
+        or str(backend_binding.get("engine_family") or "").strip()
+    )
+    if not lane_family:
+        raise ValueError("compiled request does not carry a lane family")
+
+    return AuthoritySelectionSnapshot(
+        selection_surface="platform_request",
+        authoritative_ref=authoritative_ref or str(binding_id or ""),
+        lane_family=lane_family,
+        binding_id=binding_id,
+        validation_bundle_id=str(authority.get("validation_bundle_id") or "").strip() or None,
+        requested_outputs=tuple(getattr(request, "requested_outputs", ()) or ()),
+    )
+
+
+def capture_dynamic_lane_probe_authority_snapshot(
+    contract: DynamicContractIR,
+    *,
+    variant: MaskedAuthorityVariant | None = None,
+) -> AuthoritySelectionSnapshot:
+    """Capture a bounded later-family authority snapshot from dynamic admission.
+
+    ``variant`` exists only to make the selector-forbidden surface explicit.
+    Dynamic lane admission remains authoritative on the semantic contract and
+    ignores legacy route labels and wrapper metadata entirely.
+    """
+
+    if not isinstance(contract, DynamicContractIR):
+        raise TypeError("dynamic lane probe requires a DynamicContractIR")
+    if variant is not None and not isinstance(variant, MaskedAuthorityVariant):
+        raise TypeError("variant must be a MaskedAuthorityVariant")
+
+    admission = compile_dynamic_lane_admission(contract)
+    benchmark_plan = admission.benchmark_plan
+    return AuthoritySelectionSnapshot(
+        selection_surface="dynamic_lane_probe",
+        authoritative_ref=benchmark_plan.cohort_id,
+        lane_family=admission.lane,
+        semantic_family=admission.semantic_family,
+        candidate_lanes=tuple(admission.candidate_numerical_lanes),
+    )
+
+
+_DYNAMIC_ROUTE_RETIREMENT_READINESS_LEDGER = (
+    RouteRetirementReadinessRecord(
+        cohort_id="automatic_event_state",
+        semantic_track="dynamic_wrapper",
+        proving_families=("autocallable", "tarn"),
+        honest_block_relatives=("callable_cms_range_accrual", "prdc_hybrid", "swing_option"),
+        representation_closure=RouteRetirementGate(
+            ready=True,
+            evidence_refs=(
+                "trellis.agent.dynamic_contract_ir",
+                "docs/quant/dynamic_contract_ir.rst",
+            ),
+        ),
+        decomposition_closure=RouteRetirementGate(
+            ready=True,
+            evidence_refs=(
+                "trellis.agent.knowledge.decompose.decompose_to_dynamic_contract_ir",
+                "tests/test_agent/test_decompose_static_and_dynamic_contracts.py",
+            ),
+        ),
+        lowering_admission=RouteRetirementGate(
+            ready=True,
+            evidence_refs=(
+                "trellis.agent.dynamic_lane_admission.compile_dynamic_lane_admission",
+                "doc/plan/draft__automatic-event-state-lowering-plan.md",
+            ),
+        ),
+        parity_or_benchmark=RouteRetirementGate(
+            ready=False,
+            evidence_refs=("doc/plan/draft__automatic-event-state-lowering-plan.md",),
+            notes=(
+                "benchmark plans exist via DynamicBenchmarkPlan, but no parity-proven executable fresh-build lane has landed yet",
+            ),
+        ),
+        provenance_readiness=RouteRetirementGate(
+            ready=False,
+            evidence_refs=(
+                "doc/plan/draft__contract-ir-phase-4-route-retirement.md",
+                "doc/plan/draft__valuation-result-identity-and-provenance.md",
+            ),
+            notes=(
+                "dynamic-lane provenance has not yet been promoted onto the Phase 4 valuation identity surface",
+            ),
+        ),
+        masked_authority_readiness=RouteRetirementGate(
+            ready=True,
+            evidence_refs=(
+                "trellis.agent.route_retirement_readiness.require_masked_authority_invariant",
+                "tests/test_agent/test_route_retirement_readiness.py",
+            ),
+            notes=(
+                "synthetic later-family probe now masks route ids, route families, ProductIR.instrument labels, and wrapper metadata",
+            ),
+        ),
+        notes=(
+            "automatic event/state semantics are closed for bounded proving cohorts but not yet cutover-ready",
+        ),
+    ),
+    RouteRetirementReadinessRecord(
+        cohort_id="discrete_control",
+        semantic_track="dynamic_wrapper",
+        proving_families=("callable_bond", "swing_option"),
+        honest_block_relatives=("autocallable", "gmwb_financial_control", "insurance_overlay"),
+        representation_closure=RouteRetirementGate(
+            ready=True,
+            evidence_refs=(
+                "trellis.agent.dynamic_contract_ir",
+                "docs/quant/dynamic_contract_ir.rst",
+            ),
+        ),
+        decomposition_closure=RouteRetirementGate(
+            ready=True,
+            evidence_refs=(
+                "trellis.agent.knowledge.decompose.decompose_to_dynamic_contract_ir",
+                "tests/test_agent/test_decompose_static_and_dynamic_contracts.py",
+            ),
+        ),
+        lowering_admission=RouteRetirementGate(
+            ready=True,
+            evidence_refs=(
+                "trellis.agent.dynamic_lane_admission.compile_dynamic_lane_admission",
+                "doc/plan/draft__discrete-control-lowering-plan.md",
+            ),
+        ),
+        parity_or_benchmark=RouteRetirementGate(
+            ready=False,
+            evidence_refs=("doc/plan/draft__discrete-control-lowering-plan.md",),
+            notes=(
+                "benchmark and parity plans exist, but the route-free executable lane has not been validated for cutover",
+            ),
+        ),
+        provenance_readiness=RouteRetirementGate(
+            ready=False,
+            evidence_refs=(
+                "doc/plan/draft__contract-ir-phase-4-route-retirement.md",
+                "doc/plan/draft__valuation-result-identity-and-provenance.md",
+            ),
+            notes=(
+                "controller-role and decision-timing provenance still needs the later-family result packet contract",
+            ),
+        ),
+        masked_authority_readiness=RouteRetirementGate(
+            ready=True,
+            evidence_refs=(
+                "trellis.agent.route_retirement_readiness.require_masked_authority_invariant",
+                "tests/test_agent/test_route_retirement_readiness.py",
+            ),
+            notes=(
+                "bounded callable-bond and swing-style probes can now reuse the shared masked-authority harness",
+            ),
+        ),
+        notes=(
+            "discrete-control route retirement remains blocked on real parity and provenance evidence, not on representation",
+        ),
+    ),
+    RouteRetirementReadinessRecord(
+        cohort_id="continuous_singular_control",
+        semantic_track="dynamic_wrapper",
+        proving_families=("gmwb_financial_control",),
+        honest_block_relatives=("insurance_overlay", "mortality_overlay", "lapse_overlay"),
+        representation_closure=RouteRetirementGate(
+            ready=True,
+            evidence_refs=(
+                "trellis.agent.dynamic_contract_ir",
+                "docs/quant/dynamic_contract_ir.rst",
+            ),
+        ),
+        decomposition_closure=RouteRetirementGate(
+            ready=True,
+            evidence_refs=(
+                "trellis.agent.knowledge.decompose.decompose_to_dynamic_contract_ir",
+                "tests/test_agent/test_decompose_static_and_dynamic_contracts.py",
+            ),
+        ),
+        lowering_admission=RouteRetirementGate(
+            ready=True,
+            evidence_refs=(
+                "trellis.agent.dynamic_lane_admission.compile_dynamic_lane_admission",
+                "doc/plan/draft__continuous-singular-control-lowering-plan.md",
+            ),
+        ),
+        parity_or_benchmark=RouteRetirementGate(
+            ready=False,
+            evidence_refs=("doc/plan/draft__continuous-singular-control-lowering-plan.md",),
+            notes=(
+                "approximation-policy and literature-benchmark plans exist, but no cutover-grade parity evidence has landed",
+            ),
+        ),
+        provenance_readiness=RouteRetirementGate(
+            ready=False,
+            evidence_refs=(
+                "doc/plan/draft__contract-ir-phase-4-route-retirement.md",
+                "doc/plan/draft__valuation-result-identity-and-provenance.md",
+            ),
+            notes=(
+                "control-magnitude and approximation-policy provenance is still planned work",
+            ),
+        ),
+        masked_authority_readiness=RouteRetirementGate(
+            ready=True,
+            evidence_refs=(
+                "trellis.agent.route_retirement_readiness.require_masked_authority_invariant",
+                "tests/test_agent/test_route_retirement_readiness.py",
+            ),
+            notes=(
+                "financial-control-only GMWB probes can now inherit the shared masked-authority contract without claiming insurance-overlay support",
+            ),
+        ),
+        notes=(
+            "continuous-control remains bounded to overlay-free financial control until CLX.7 expands the state space",
+        ),
+    ),
+)
+
+
+def dynamic_route_retirement_readiness_ledger() -> tuple[RouteRetirementReadinessRecord, ...]:
+    """Return the seeded later-family readiness ledger for dynamic cohorts."""
+
+    return _DYNAMIC_ROUTE_RETIREMENT_READINESS_LEDGER
+
+
+def get_dynamic_route_retirement_readiness(cohort_id: str) -> RouteRetirementReadinessRecord:
+    """Return one dynamic route-retirement readiness record by cohort id."""
+
+    normalized = str(cohort_id or "").strip().lower()
+    for record in _DYNAMIC_ROUTE_RETIREMENT_READINESS_LEDGER:
+        if record.cohort_id == normalized:
+            return record
+    raise KeyError(f"unknown dynamic route-retirement cohort {cohort_id!r}")
+
+
+__all__ = [
+    "AuthoritySelectionSnapshot",
+    "MaskedAuthorityInvariantError",
+    "MaskedAuthorityVariant",
+    "RouteRetirementGate",
+    "RouteRetirementReadinessRecord",
+    "capture_compiled_request_authority_snapshot",
+    "capture_dynamic_lane_probe_authority_snapshot",
+    "default_masked_authority_variants",
+    "dynamic_route_retirement_readiness_ledger",
+    "get_dynamic_route_retirement_readiness",
+    "is_route_retirement_ready",
+    "missing_route_retirement_gates",
+    "require_masked_authority_invariant",
+]


### PR DESCRIPTION
## Summary
- add a shared later-family route-retirement readiness ledger for the seeded dynamic cohorts
- add a reusable masked-authority harness and bounded dynamic authority probes for post-Phase-4 cutover tickets
- document the remaining parity/provenance blockers and the reuse contract in the dynamic and Phase 4 plan docs

## Testing
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_route_retirement_readiness.py -q
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_route_retirement_readiness.py tests/test_agent/test_dynamic_lane_admission.py -q
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_platform_requests.py -k "route_free_vanilla or route_free_basket or explicit_terminal_basket_request" -q