### PR TITLE
Normalize scheduled rate option strip semantics

### DIFF
--- a/doc/plan/draft__leg-based-contract-ir-foundation.md
+++ b/doc/plan/draft__leg-based-contract-ir-foundation.md
@@ -300,6 +300,34 @@ that dynamic leg products can remain permanently under-specified. They
 are there to keep the design honest about where ACTUS-style semantics
 must land once the event/state/control companion track becomes active.
 
+## Scheduled Rate-Option-Strip Follow-On
+
+The static-leg track should own the semantic normalization of
+schedule-driven cap/floor products.
+
+Concretely, the canonical semantic home should be a scheduled
+rate-option-strip family, not the legacy wrapper-shaped
+``rate_cap_floor_strip`` name. The current bounded implementation slice
+therefore treats:
+
+- ``period_rate_option_strip`` as the canonical semantic family name
+- public ``cap`` and ``floor`` wrappers as thin compatibility surfaces
+- legacy ``rate_cap_floor_strip`` as a compatibility alias rather than
+  the long-run canonical representation
+
+This is not just naming cleanup. It clarifies the decomposition
+boundary:
+
+- a cap or floor is still a schedule of period rate options
+- the semantic core is the scheduled strip structure
+- the wrapper only decides whether each period option is call-like or
+  put-like
+
+That normalization matters for later closure work because the deferred
+`F003`-`F005` analytical binding repair should target the canonical
+scheduled-strip abstraction rather than hardening the transitional
+wrapper family.
+
 ## Examples
 
 ### Example 1 — Vanilla fixed-float IRS

--- a/doc/plan/draft__post-phase-4-semantic-closure-execution-plan.md
+++ b/doc/plan/draft__post-phase-4-semantic-closure-execution-plan.md
@@ -26,6 +26,7 @@ Status mirror last synced: `2026-04-20`
 - QUA-927 — Post-Phase-4 semantic closure umbrella
 - QUA-928 — `CLX.1` quoted-observable snapshot closure
 - QUA-929 — `CLX.2` static leg-based closure
+- QUA-940 — `CLX.2` follow-on: normalize scheduled rate option strips onto the static-leg semantic track
 - QUA-930 — `CLX.3` event/state/control semantic foundation
 - QUA-931 — `CLX.4` automatic event/state lowering lane
 - QUA-932 — `CLX.5` discrete control lowering lane
@@ -130,6 +131,12 @@ Current next pickup:
 
 - `QUA-934` — insurance-style overlays on top of financial control
 
+Active out-of-order follow-on:
+
+- `QUA-940` — normalize the legacy `rate_cap_floor_strip` wrapper family
+  onto the canonical static-leg `period_rate_option_strip` semantic
+  home without changing the main post-Phase-4 queue order
+
 ## Queue Details
 
 ### CLX.1 — Quoted-observable snapshot closure
@@ -173,6 +180,13 @@ Required artifacts:
 - static coupon-formula surface
 - boundary fixtures against quoted snapshot contracts
 - first lowering declarations on existing checked cashflow engines
+
+Filed follow-on:
+
+- `QUA-940` — normalize scheduled cap/floor strips onto the canonical
+  `period_rate_option_strip` semantic family and treat
+  `rate_cap_floor_strip` as a compatibility alias before repairing the
+  deferred `F003`-`F005` analytical binding gap
 
 ### CLX.3 — Event/state/control semantic foundation
 

--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -360,11 +360,13 @@ explicitly allowed refinement of that family.
 
 The rate cap/floor stress lane now follows that same authority rule through a
 dedicated semantic family rather than a classifier exception. Cap and floor
-requests now draft into the ``rate_cap_floor_strip`` semantic contract, which
-materializes the schedule-driven rate-option-strip shape, required market
-inputs, and route surface before generic semantic-gap handling runs. That
-keeps compare-ready tasks such as ``E22`` on the actual pricing route without
-teaching the generic classifier any instrument-specific special cases.
+requests now draft into the canonical ``period_rate_option_strip`` semantic
+contract, with legacy ``rate_cap_floor_strip`` retained as a compatibility
+alias. That semantic contract materializes the schedule-driven
+rate-option-strip shape, required market inputs, and route surface before
+generic semantic-gap handling runs. That keeps compare-ready tasks such as
+``E22`` on the actual pricing route without teaching the generic classifier
+any instrument-specific special cases.
 
 Comparison pricing now also prefers market-aligned smoke fixtures when the
 route family needs them. For the supported quanto slice, the comparison

--- a/tests/test_agent/test_family_lowering_ir.py
+++ b/tests/test_agent/test_family_lowering_ir.py
@@ -312,6 +312,34 @@ def test_rate_cap_floor_strip_monte_carlo_compiles_to_event_aware_family_ir():
     assert family_ir.market_mapping == "discount_curve_forward_curve_black_vol_to_rate_option_strip_mc"
 
 
+def test_legacy_rate_cap_floor_strip_semantic_id_still_reaches_family_ir():
+    from trellis.agent.semantic_contract_compiler import compile_semantic_contract
+    from trellis.agent.semantic_contracts import make_rate_cap_floor_strip_contract
+
+    contract = make_rate_cap_floor_strip_contract(
+        description="Legacy cap strip semantic id under Black pricing",
+        instrument_class="cap",
+        observation_schedule=("cap_schedule_placeholder",),
+        preferred_method="analytical",
+    )
+    legacy_contract = replace(
+        contract,
+        product=replace(
+            contract.product,
+            semantic_id="rate_cap_floor_strip",
+            payoff_family="rate_cap_floor_strip",
+        ),
+    )
+
+    blueprint = compile_semantic_contract(legacy_contract, preferred_method="analytical")
+
+    family_ir = blueprint.dsl_lowering.family_ir
+    assert isinstance(family_ir, AnalyticalBlack76IR)
+    assert family_ir.payoff_family in {"period_rate_option_strip", "rate_cap_floor_strip"}
+    assert family_ir.route_id == "analytical_black76"
+    assert family_ir.kernel_symbol == "black76_call"
+
+
 def test_vanilla_option_monte_carlo_compiles_to_terminal_only_event_aware_family_ir():
     from trellis.agent.semantic_contract_compiler import compile_semantic_contract
     from trellis.agent.semantic_contracts import make_vanilla_option_contract

--- a/tests/test_agent/test_family_lowering_ir.py
+++ b/tests/test_agent/test_family_lowering_ir.py
@@ -231,7 +231,7 @@ def test_rate_cap_floor_strip_analytical_compiles_to_black76_family_ir():
     assert isinstance(family_ir, AnalyticalBlack76IR)
     assert family_ir.route_id == "analytical_black76"
     assert family_ir.product_instrument == "cap"
-    assert family_ir.payoff_family == "rate_cap_floor_strip"
+    assert family_ir.payoff_family == "period_rate_option_strip"
     assert family_ir.option_type == "call"
     assert family_ir.kernel_symbol == "black76_call"
     assert family_ir.market_mapping == "discount_curve_forward_curve_black_vol_to_caplet_strip"
@@ -303,7 +303,7 @@ def test_rate_cap_floor_strip_monte_carlo_compiles_to_event_aware_family_ir():
     assert isinstance(family_ir, EventAwareMonteCarloIR)
     assert family_ir.route_id == "monte_carlo_paths"
     assert family_ir.product_instrument == "floor"
-    assert family_ir.payoff_family == "rate_cap_floor_strip"
+    assert family_ir.payoff_family == "period_rate_option_strip"
     assert family_ir.state_spec.state_variable == "short_rate"
     assert family_ir.process_spec.process_family == "hull_white_1f"
     assert family_ir.helper_symbol == "price_rate_cap_floor_strip_monte_carlo"

--- a/tests/test_agent/test_platform_requests.py
+++ b/tests/test_agent/test_platform_requests.py
@@ -859,10 +859,10 @@ def test_compile_build_request_routes_rate_cap_family_through_semantic_contract(
     assert compiled.execution_plan.reason == "semantic_contract_request"
     assert compiled.execution_plan.route_method == "analytical"
     assert compiled.semantic_contract is not None
-    assert compiled.semantic_contract.semantic_id == "rate_cap_floor_strip"
+    assert compiled.semantic_contract.semantic_id == "period_rate_option_strip"
     assert compiled.product_ir is not None
     assert compiled.product_ir.instrument == "cap"
-    assert compiled.request.metadata["semantic_contract"]["semantic_id"] == "rate_cap_floor_strip"
+    assert compiled.request.metadata["semantic_contract"]["semantic_id"] == "period_rate_option_strip"
     assert "semantic_gap" not in compiled.request.metadata
 
 
@@ -887,7 +887,7 @@ def test_compile_build_request_bootstraps_title_only_rate_cap_task_into_exact_mc
 
     assert compiled.execution_plan.reason == "semantic_contract_request"
     assert compiled.semantic_contract is not None
-    assert compiled.semantic_contract.semantic_id == "rate_cap_floor_strip"
+    assert compiled.semantic_contract.semantic_id == "period_rate_option_strip"
     assert "Start date: 2025-02-15." in description
     assert "End date: 2030-02-15." in description
     assert compiled.generation_plan is not None

--- a/tests/test_agent/test_semantic_contracts.py
+++ b/tests/test_agent/test_semantic_contracts.py
@@ -774,6 +774,30 @@ def test_rate_cap_floor_strip_contract_uses_registered_surface_schema_hints():
     assert legacy_surface == surface
 
 
+def test_legacy_rate_cap_floor_strip_contract_still_validates_after_canonical_rename():
+    from trellis.agent.semantic_contract_validation import validate_semantic_contract
+    from trellis.agent.semantic_contracts import make_rate_cap_floor_strip_contract
+
+    contract = make_rate_cap_floor_strip_contract(
+        description="Legacy serialized cap/floor strip payload",
+        instrument_class="cap",
+        observation_schedule=("2026-11-15",),
+        preferred_method="analytical",
+    )
+    legacy_contract = replace(
+        contract,
+        product=replace(
+            contract.product,
+            semantic_id="rate_cap_floor_strip",
+            payoff_family="rate_cap_floor_strip",
+        ),
+    )
+
+    report = validate_semantic_contract(legacy_contract)
+
+    assert report.ok, report.errors
+
+
 def test_migrated_contract_allows_missing_settlement_rule_mirror_with_warning():
     from trellis.agent.semantic_contract_validation import validate_semantic_contract
 

--- a/tests/test_agent/test_semantic_contracts.py
+++ b/tests/test_agent/test_semantic_contracts.py
@@ -58,7 +58,7 @@ def test_semantic_draft_rule_registry_exposes_stable_order():
         "callable_bond",
         "vanilla_option",
         "rate_style_swaption",
-        "rate_cap_floor_strip",
+        "period_rate_option_strip",
         "credit_basket_tranche",
         "nth_to_default",
         "credit_default_swap",
@@ -72,15 +72,17 @@ def test_semantic_family_registry_exposes_supported_method_surfaces():
     )
 
     assert "vanilla_option" in registered_semantic_family_keys()
-    assert "rate_cap_floor_strip" in registered_semantic_family_keys()
+    assert "period_rate_option_strip" in registered_semantic_family_keys()
     surface = resolve_semantic_method_surface("vanilla_option", "fft_pricing")
-    cap_surface = resolve_semantic_method_surface("rate_cap_floor_strip", "monte_carlo")
+    cap_surface = resolve_semantic_method_surface("period_rate_option_strip", "monte_carlo")
+    legacy_cap_surface = resolve_semantic_method_surface("rate_cap_floor_strip", "monte_carlo")
 
     assert surface.method == "fft_pricing"
     assert surface.target_modules == ("trellis.models.equity_option_transforms",)
     assert surface.primitive_families == ("transform_fft",)
     assert cap_surface.primitive_families == ("monte_carlo_paths",)
     assert "trellis.instruments.cap" in cap_surface.target_modules
+    assert legacy_cap_surface == cap_surface
 
 
 def test_semantic_contract_summary_emits_registered_family_surface_metadata():
@@ -680,9 +682,9 @@ def test_contract_requires_correlation_for_multi_asset_mc():
         (
             "Build a pricer for: Cap/floor: Black caplet stack vs MC rate simulation",
             "cap",
-            "rate_cap_floor_strip",
+            "period_rate_option_strip",
             "cap",
-            "rate_cap_floor_strip",
+            "period_rate_option_strip",
             "single_curve_rate_style",
             "coupon_period_cash_settlement",
             "analytical",
@@ -745,8 +747,9 @@ def test_rate_cap_floor_strip_draft_uses_structural_schedule_placeholder_when_da
     )
 
     assert contract is not None
-    assert contract.semantic_id == "rate_cap_floor_strip"
+    assert contract.semantic_id == "period_rate_option_strip"
     assert contract.product.instrument_class == "cap"
+    assert contract.product.payoff_family == "period_rate_option_strip"
     assert contract.product.observation_schedule
     assert contract.product.term_fields["schedule_authority"] == "structural_placeholder"
     assert contract.product.term_fields["option_type"] == "call"
@@ -764,9 +767,11 @@ def test_rate_cap_floor_strip_contract_uses_registered_surface_schema_hints():
         observation_schedule=("2026-11-15", "2027-11-15", "2028-11-15", "2029-11-15"),
         preferred_method="monte_carlo",
     )
-    surface = resolve_semantic_method_surface("rate_cap_floor_strip", "monte_carlo")
+    surface = resolve_semantic_method_surface("period_rate_option_strip", "monte_carlo")
+    legacy_surface = resolve_semantic_method_surface("rate_cap_floor_strip", "monte_carlo")
 
     assert contract.blueprint.spec_schema_hints == surface.spec_schema_hints
+    assert legacy_surface == surface
 
 
 def test_migrated_contract_allows_missing_settlement_rule_mirror_with_warning():
@@ -953,7 +958,7 @@ def test_semantic_concept_resolution_maps_cap_wrapper_to_rate_option_strip():
         instrument_type="cap",
     )
 
-    assert resolution.concept_id == "rate_cap_floor_strip"
+    assert resolution.concept_id == "period_rate_option_strip"
     assert resolution.resolution_kind == "thin_compatibility_wrapper"
     assert resolution.matched_wrapper == "cap"
 

--- a/trellis/agent/backend_bindings.py
+++ b/trellis/agent/backend_bindings.py
@@ -737,6 +737,8 @@ def _expanded_payoff_families(
 ) -> frozenset[str]:
     families = {str(payoff_family or "")}
     instrument = str(getattr(product_ir, "instrument", "") or "").strip().lower()
+    if instrument in {"cap", "floor"} or payoff_family in {"period_rate_option_strip", "rate_cap_floor_strip"}:
+        families.update({"period_rate_option_strip", "rate_cap_floor_strip"})
     if instrument == "puttable_bond" or payoff_family == "puttable_fixed_income":
         families.update({"puttable_fixed_income", "callable_fixed_income", "callable_bond", "bond"})
     elif instrument == "callable_bond" or payoff_family == "callable_fixed_income":

--- a/trellis/agent/contract_pattern_eval.py
+++ b/trellis/agent/contract_pattern_eval.py
@@ -128,6 +128,7 @@ _INSTRUMENT_TAG_TO_PAYOFF_FAMILIES: Mapping[str, frozenset[str]] = {
     "barrier_payoff": frozenset({"barrier_option"}),
     "rate_payoff": frozenset(
         {
+            "period_rate_option_strip",
             "rate_cap_floor_strip",
             "range_accrual_coupon",
             "fixed_coupon",

--- a/trellis/agent/family_lowering_ir.py
+++ b/trellis/agent/family_lowering_ir.py
@@ -669,6 +669,7 @@ class FamilyIRMatchProfile:
     """Declarative family-IR match profile for one semantic slice."""
 
     semantic_id: str
+    allowed_semantic_ids: tuple[str, ...] = ()
     allowed_instruments: tuple[str, ...] = ()
     allowed_payoff_families: tuple[str, ...] = ()
     allowed_product_instruments: tuple[str, ...] = ()
@@ -699,6 +700,7 @@ _FAMILY_IR_MATCH_PROFILES = {
     ),
     "period_rate_option_strip": FamilyIRMatchProfile(
         semantic_id="period_rate_option_strip",
+        allowed_semantic_ids=("period_rate_option_strip", "rate_cap_floor_strip"),
         allowed_instruments=("cap", "floor"),
         allowed_payoff_families=("period_rate_option_strip", "rate_cap_floor_strip"),
         allowed_product_instruments=("cap", "floor"),
@@ -869,7 +871,9 @@ def _matches_family_ir_profile(contract, product_ir, profile: FamilyIRMatchProfi
         str(item).strip().lower()
         for item in getattr(product_ir, "payoff_traits", ()) or ()
     }
-    if str(getattr(contract, "semantic_id", "") or "").strip() != profile.semantic_id:
+    semantic_id = str(getattr(contract, "semantic_id", "") or "").strip()
+    allowed_semantic_ids = profile.allowed_semantic_ids or (profile.semantic_id,)
+    if semantic_id not in allowed_semantic_ids:
         return False
     if profile.allowed_instruments and instrument not in profile.allowed_instruments:
         return False

--- a/trellis/agent/family_lowering_ir.py
+++ b/trellis/agent/family_lowering_ir.py
@@ -697,12 +697,12 @@ _FAMILY_IR_MATCH_PROFILES = {
         allowed_product_instruments=("european_option",),
         allowed_exercise_styles=("european",),
     ),
-    "rate_cap_floor_strip": FamilyIRMatchProfile(
-        semantic_id="rate_cap_floor_strip",
+    "period_rate_option_strip": FamilyIRMatchProfile(
+        semantic_id="period_rate_option_strip",
         allowed_instruments=("cap", "floor"),
-        allowed_payoff_families=("rate_cap_floor_strip",),
+        allowed_payoff_families=("period_rate_option_strip", "rate_cap_floor_strip"),
         allowed_product_instruments=("cap", "floor"),
-        allowed_product_payoff_families=("rate_cap_floor_strip",),
+        allowed_product_payoff_families=("period_rate_option_strip", "rate_cap_floor_strip"),
     ),
     "ranked_observation_basket": FamilyIRMatchProfile(
         semantic_id="ranked_observation_basket",
@@ -788,6 +788,7 @@ _TRANSFORM_MARKET_MAPPINGS = {
 
 _MC_MARKET_MAPPINGS = {
     ("hull_white_1f", "swaption"): "discount_curve_forward_curve_black_vol_to_short_rate_mc",
+    ("hull_white_1f", "period_rate_option_strip"): "discount_curve_forward_curve_black_vol_to_rate_option_strip_mc",
     ("hull_white_1f", "rate_cap_floor_strip"): "discount_curve_forward_curve_black_vol_to_rate_option_strip_mc",
     ("local_vol_1d", ""): "equity_spot_discount_local_vol_to_mc",
     ("gbm_1d", ""): "equity_spot_discount_black_vol_to_mc",
@@ -796,6 +797,7 @@ _MC_MARKET_MAPPINGS = {
 
 _MC_HELPER_BINDINGS = {
     ("gbm_1d", "vanilla_option", "european"): "price_vanilla_equity_option_monte_carlo",
+    ("hull_white_1f", "period_rate_option_strip", ""): "price_rate_cap_floor_strip_monte_carlo",
     ("hull_white_1f", "rate_cap_floor_strip", ""): "price_rate_cap_floor_strip_monte_carlo",
     ("hull_white_1f", "swaption", ""): "price_swaption_monte_carlo",
 }
@@ -803,6 +805,7 @@ _MC_HELPER_BINDINGS = {
 
 _MC_REDUCER_BINDINGS = {
     "swaption": ("discounted_swap_pv",),
+    "period_rate_option_strip": ("period_option_cashflow_strip",),
     "rate_cap_floor_strip": ("period_option_cashflow_strip",),
     "vanilla_option": ("terminal_payoff",),
 }
@@ -818,6 +821,7 @@ _MC_TERMINAL_ONLY_FAMILY_EXERCISE = frozenset(
 _MC_PAYOFF_REDUCER_OUTPUTS = {
     "swaption": ("swaption_exercise_payoff", "swaption_exercise_payoff"),
     "vanilla_option": ("terminal_payoff", "vanilla_option_payoff"),
+    "period_rate_option_strip": ("period_option_cashflow_strip", "rate_cap_floor_strip_payoff"),
     "rate_cap_floor_strip": ("period_option_cashflow_strip", "rate_cap_floor_strip_payoff"),
 }
 
@@ -2033,7 +2037,7 @@ def _mc_payoff_reducer_spec_for_product(
     reducer_profile = _MC_PAYOFF_REDUCER_OUTPUTS.get(payoff_family)
     if reducer_profile is not None:
         reducer_kind, output_semantics = reducer_profile
-        if payoff_family in {"swaption", "rate_cap_floor_strip"}:
+        if payoff_family in {"swaption", "rate_cap_floor_strip", "period_rate_option_strip"}:
             dependencies = tuple(
                 event.event_name
                 for bucket in event_timeline
@@ -2596,7 +2600,7 @@ def _is_rate_cap_floor_strip_contract(contract, product_ir) -> bool:
     return _matches_family_ir_profile(
         contract,
         product_ir,
-        _FAMILY_IR_MATCH_PROFILES["rate_cap_floor_strip"],
+        _FAMILY_IR_MATCH_PROFILES["period_rate_option_strip"],
     )
 
 

--- a/trellis/agent/route_registry.py
+++ b/trellis/agent/route_registry.py
@@ -1886,7 +1886,10 @@ def _allows_structural_schedule_strip_on_non_event_route(
         return False
     return (
         isinstance(family_ir, AnalyticalBlack76IR)
-        and str(getattr(family_ir, "payoff_family", "") or "") == "rate_cap_floor_strip"
+        and str(getattr(family_ir, "payoff_family", "") or "") in {
+            "rate_cap_floor_strip",
+            "period_rate_option_strip",
+        }
     )
 
 
@@ -2051,6 +2054,8 @@ def _expanded_payoff_families(
     """
     families = {str(payoff_family or "")}
     instrument = str(getattr(product_ir, "instrument", "") or "").strip().lower()
+    if instrument in {"cap", "floor"} or payoff_family in {"period_rate_option_strip", "rate_cap_floor_strip"}:
+        families.update({"period_rate_option_strip", "rate_cap_floor_strip"})
 
     if instrument == "puttable_bond" or payoff_family == "puttable_fixed_income":
         families.update({"puttable_fixed_income", "callable_fixed_income", "callable_bond", "bond"})

--- a/trellis/agent/semantic_concepts.py
+++ b/trellis/agent/semantic_concepts.py
@@ -488,7 +488,7 @@ SEMANTIC_CONCEPT_REGISTRY: tuple[SemanticConceptDefinition, ...] = (
         ),
     ),
     _concept(
-        semantic_id="rate_cap_floor_strip",
+        semantic_id="period_rate_option_strip",
         semantic_version="c2.1",
         scope="schedule-driven cap/floor strips assembled from caplets or floorlets",
         description=(
@@ -497,6 +497,7 @@ SEMANTIC_CONCEPT_REGISTRY: tuple[SemanticConceptDefinition, ...] = (
         ),
         concept_role="product_contract",
         aliases=(
+            "period_rate_option_strip",
             "rate_cap_floor_strip",
             "rate_option_strip",
             "cap_floor_strip",

--- a/trellis/agent/semantic_concepts.py
+++ b/trellis/agent/semantic_concepts.py
@@ -924,11 +924,21 @@ def _definition_index() -> dict[str, SemanticConceptDefinition]:
     return {definition.semantic_id: definition for definition in SEMANTIC_CONCEPT_REGISTRY}
 
 
+_SEMANTIC_CONCEPT_ID_ALIASES = {
+    "rate_cap_floor_strip": "period_rate_option_strip",
+}
+
+
 def get_semantic_concept_definition(semantic_id: str | None) -> SemanticConceptDefinition | None:
     """Look up one semantic concept by id."""
     if not semantic_id:
         return None
-    return _definition_index().get(str(semantic_id).strip())
+    normalized_semantic_id = str(semantic_id).strip()
+    canonical_semantic_id = _SEMANTIC_CONCEPT_ID_ALIASES.get(
+        normalized_semantic_id,
+        normalized_semantic_id,
+    )
+    return _definition_index().get(canonical_semantic_id)
 
 
 def semantic_concept_summary(

--- a/trellis/agent/semantic_contract_validation.py
+++ b/trellis/agent/semantic_contract_validation.py
@@ -1579,7 +1579,7 @@ def _validate_profile_fields(
     errors: list[str],
     *,
     expected_instrument_class: str | None,
-    expected_payoff_family: str,
+    expected_payoff_family: str | tuple[str, ...],
     expected_underlier_structure: str,
     expected_payoff_rule: str,
     expected_settlement_rule: str,
@@ -1596,13 +1596,23 @@ def _validate_profile_fields(
 ) -> None:
     """Validate a product profile's deterministic structural fields."""
     product = contract.product
+    expected_payoff_families = (
+        expected_payoff_family
+        if isinstance(expected_payoff_family, tuple)
+        else (expected_payoff_family,)
+    )
     if expected_instrument_class is not None and product.instrument_class != expected_instrument_class:
         errors.append(
             f"Semantic slice expects instrument_class `{expected_instrument_class}`, got `{product.instrument_class}`."
         )
-    if product.payoff_family != expected_payoff_family:
+    if product.payoff_family not in expected_payoff_families:
+        expected_display = (
+            expected_payoff_families[0]
+            if len(expected_payoff_families) == 1
+            else " or ".join(f"`{item}`" for item in expected_payoff_families)
+        )
         errors.append(
-            f"Semantic slice expects payoff_family `{expected_payoff_family}`, got `{product.payoff_family}`."
+            f"Semantic slice expects payoff_family {expected_display}, got `{product.payoff_family}`."
         )
     if product.underlier_structure != expected_underlier_structure:
         errors.append(
@@ -1979,7 +1989,7 @@ def _validate_rate_cap_floor_strip_shape(
         contract,
         errors,
         expected_instrument_class=None,
-        expected_payoff_family="period_rate_option_strip",
+        expected_payoff_family=("period_rate_option_strip", "rate_cap_floor_strip"),
         expected_underlier_structure="single_curve_rate_style",
         expected_payoff_rule="period_rate_option_strip_payoff",
         expected_settlement_rule="coupon_period_cash_settlement",

--- a/trellis/agent/semantic_contract_validation.py
+++ b/trellis/agent/semantic_contract_validation.py
@@ -1528,6 +1528,7 @@ def _validate_semantic_shape(
         "callable_bond": _validate_callable_bond_shape,
         "range_accrual": _validate_range_accrual_shape,
         "rate_style_swaption": _validate_rate_style_swaption_shape,
+        "period_rate_option_strip": _validate_rate_cap_floor_strip_shape,
         "rate_cap_floor_strip": _validate_rate_cap_floor_strip_shape,
         "credit_default_swap": _validate_credit_default_swap_shape,
         "nth_to_default": _validate_nth_to_default_shape,
@@ -1968,7 +1969,7 @@ def _validate_rate_cap_floor_strip_shape(
     errors: list[str],
     warnings: list[str],
 ) -> None:
-    """Validate a schedule-driven cap/floor strip semantic shape."""
+    """Validate a schedule-driven period rate-option strip semantic shape."""
     required_capabilities = _validate_market_capabilities(
         contract,
         errors,
@@ -1978,7 +1979,7 @@ def _validate_rate_cap_floor_strip_shape(
         contract,
         errors,
         expected_instrument_class=None,
-        expected_payoff_family="rate_cap_floor_strip",
+        expected_payoff_family="period_rate_option_strip",
         expected_underlier_structure="single_curve_rate_style",
         expected_payoff_rule="period_rate_option_strip_payoff",
         expected_settlement_rule="coupon_period_cash_settlement",

--- a/trellis/agent/semantic_contracts.py
+++ b/trellis/agent/semantic_contracts.py
@@ -66,12 +66,25 @@ def _yaml_safe_value(value):
 
 def _semantic_family_key(semantic_id: str, *, exercise_style: str | None = None) -> str:
     """Return the registered family key for a semantic family and optional variant."""
-    normalized_semantic_id = str(semantic_id or "").strip()
+    normalized_semantic_id = _normalize_semantic_family_alias(semantic_id)
     normalized_exercise = str(exercise_style or "").strip().lower()
     variant_keys = _SEMANTIC_FAMILY_VARIANT_KEYS.get(normalized_semantic_id)
     if variant_keys is not None and normalized_exercise in variant_keys:
         return variant_keys[normalized_exercise]
     return normalized_semantic_id
+
+
+_SEMANTIC_FAMILY_ALIASES = MappingProxyType(
+    {
+        "rate_cap_floor_strip": "period_rate_option_strip",
+    }
+)
+
+
+def _normalize_semantic_family_alias(semantic_id: str) -> str:
+    """Return the canonical semantic-family identifier for one registry lookup."""
+    normalized_semantic_id = str(semantic_id or "").strip()
+    return str(_SEMANTIC_FAMILY_ALIASES.get(normalized_semantic_id, normalized_semantic_id))
 
 
 _SEMANTIC_FAMILY_VARIANT_KEYS = MappingProxyType(
@@ -424,8 +437,8 @@ def _build_semantic_family_registry() -> MappingProxyType:
             ),
         ),
         _family_definition(
-            family_key="rate_cap_floor_strip",
-            semantic_id="rate_cap_floor_strip",
+            family_key="period_rate_option_strip",
+            semantic_id="period_rate_option_strip",
             candidate_methods=("analytical", "monte_carlo"),
             default_preferred_method="analytical",
             method_surfaces=(
@@ -441,7 +454,7 @@ def _build_semantic_family_registry() -> MappingProxyType:
                         "build_caplet_or_floorlet_schedule",
                         "map_period_option_strip_to_black_kernel",
                     ),
-                    spec_schema_hints=("rate_cap_floor_strip",),
+                    spec_schema_hints=("period_rate_option_strip", "rate_cap_floor_strip"),
                 ),
                 _method_surface_definition(
                     "monte_carlo",
@@ -456,7 +469,7 @@ def _build_semantic_family_registry() -> MappingProxyType:
                         "compile_period_option_strip_into_mc_timeline",
                         "reduce_period_option_strip_cashflows",
                     ),
-                    spec_schema_hints=("rate_cap_floor_strip",),
+                    spec_schema_hints=("period_rate_option_strip", "rate_cap_floor_strip"),
                 ),
             ),
         ),
@@ -2640,14 +2653,14 @@ def make_rate_style_swaption_contract(
     )
 
 
-def make_rate_cap_floor_strip_contract(
+def make_period_rate_option_strip_contract(
     *,
     description: str,
     instrument_class: str,
     observation_schedule: tuple[str, ...] | list[str],
     preferred_method: str = "analytical",
 ) -> SemanticContract:
-    """Construct a schedule-driven cap/floor strip semantic contract."""
+    """Construct a schedule-driven period rate-option strip semantic contract."""
     normalized_instrument = str(instrument_class or "").strip().lower()
     wrapper_profile = _RATE_CAP_FLOOR_WRAPPER_PROFILES.get(normalized_instrument)
     if wrapper_profile is None:
@@ -2656,7 +2669,7 @@ def make_rate_cap_floor_strip_contract(
     if not schedule:
         raise ValueError("Rate cap/floor strip contract requires a schedule or structural schedule placeholder.")
     definition, surface, normalized_method = _resolve_registered_family_surface(
-        "rate_cap_floor_strip",
+        "period_rate_option_strip",
         preferred_method=preferred_method,
     )
     option_type = str(wrapper_profile["option_type"])
@@ -2667,11 +2680,16 @@ def make_rate_cap_floor_strip_contract(
     )
 
     product = SemanticProductSemantics(
-        semantic_id="rate_cap_floor_strip",
+        semantic_id="period_rate_option_strip",
         semantic_version="c2.1",
         instrument_class=normalized_instrument,
-        instrument_aliases=("rate_cap_floor_strip", "rate_option_strip", normalized_instrument),
-        payoff_family="rate_cap_floor_strip",
+        instrument_aliases=(
+            "period_rate_option_strip",
+            "rate_cap_floor_strip",
+            "rate_option_strip",
+            normalized_instrument,
+        ),
+        payoff_family="period_rate_option_strip",
         timeline=_default_semantic_timeline(
             schedule,
             settlement_dates=schedule,
@@ -2830,6 +2848,22 @@ def make_rate_cap_floor_strip_contract(
         ),
         spec_schema_hints=surface.spec_schema_hints,
         description=description,
+    )
+
+
+def make_rate_cap_floor_strip_contract(
+    *,
+    description: str,
+    instrument_class: str,
+    observation_schedule: tuple[str, ...] | list[str],
+    preferred_method: str = "analytical",
+) -> SemanticContract:
+    """Compatibility wrapper for the canonical period rate-option strip builder."""
+    return make_period_rate_option_strip_contract(
+        description=description,
+        instrument_class=instrument_class,
+        observation_schedule=observation_schedule,
+        preferred_method=preferred_method,
     )
 
 
@@ -3500,9 +3534,9 @@ def _rebuild_rate_cap_floor_strip_contract(
     contract: SemanticContract,
     normalized_method: str,
 ) -> SemanticContract:
-    """Rebuild a cap/floor strip contract for one preferred method."""
+    """Rebuild a period rate-option strip contract for one preferred method."""
     product = contract.product
-    return make_rate_cap_floor_strip_contract(
+    return make_period_rate_option_strip_contract(
         description=contract.description,
         instrument_class=str(getattr(product, "instrument_class", "") or "cap"),
         observation_schedule=tuple(getattr(product, "observation_schedule", ()) or ()),
@@ -3570,7 +3604,7 @@ _SEMANTIC_CONTRACT_REBUILDERS: Mapping[str, Callable[[SemanticContract, str], Se
         "callable_bond": _rebuild_callable_bond_contract,
         "range_accrual": _rebuild_range_accrual_contract,
         "rate_style_swaption": _rebuild_rate_style_swaption_contract,
-        "rate_cap_floor_strip": _rebuild_rate_cap_floor_strip_contract,
+        "period_rate_option_strip": _rebuild_rate_cap_floor_strip_contract,
         "credit_default_swap": _rebuild_credit_default_swap_contract,
         "nth_to_default": _rebuild_nth_to_default_contract,
         "credit_basket_tranche": _rebuild_credit_basket_tranche_contract,
@@ -3633,7 +3667,9 @@ def specialize_semantic_contract_for_method(
         return semantic_contract
     normalized_method = normalize_method(preferred_method)
     current_method = normalize_method(getattr(semantic_contract.methods, "preferred_method", "") or "")
-    semantic_id = str(getattr(semantic_contract, "semantic_id", "") or "").strip()
+    semantic_id = _normalize_semantic_family_alias(
+        str(getattr(semantic_contract, "semantic_id", "") or "").strip()
+    )
     rebuilder = _SEMANTIC_CONTRACT_REBUILDERS.get(semantic_id)
     if rebuilder is None:
         return semantic_contract
@@ -4869,8 +4905,8 @@ _SEMANTIC_DRAFT_MATCHER_PROFILES = MappingProxyType(
                 "swap exercise",
             ),
         ),
-        "rate_cap_floor_strip": SemanticDraftMatcherProfile(
-            rule_name="rate_cap_floor_strip",
+        "period_rate_option_strip": SemanticDraftMatcherProfile(
+            rule_name="period_rate_option_strip",
             instrument_aliases=("cap", "floor"),
             positive_cues=(
                 "interest rate cap",
@@ -5040,7 +5076,7 @@ def _looks_like_rate_cap_floor_request(text: str, instrument_type: str | None) -
     return _matches_semantic_draft_profile(
         text,
         instrument_type,
-        profile=_SEMANTIC_DRAFT_MATCHER_PROFILES["rate_cap_floor_strip"],
+        profile=_SEMANTIC_DRAFT_MATCHER_PROFILES["period_rate_option_strip"],
     )
 
 
@@ -5435,7 +5471,7 @@ def _build_semantic_draft_rules() -> tuple[SemanticDraftRule, ...]:
             builder=_draft_rate_style_swaption_contract,
         ),
         SemanticDraftRule(
-            name="rate_cap_floor_strip",
+            name="period_rate_option_strip",
             matcher=_looks_like_rate_cap_floor_request,
             builder=_draft_rate_cap_floor_strip_contract,
         ),


### PR DESCRIPTION
## Summary
- canonicalize cap/floor semantic drafting and compilation onto `period_rate_option_strip`
- keep `rate_cap_floor_strip` as a compatibility alias across semantic resolution, lowering, route matching, and binding matching
- record QUA-940 in the static-leg closure plans and update the developer runtime note

## Testing
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_semantic_contracts.py tests/test_agent/test_family_lowering_ir.py tests/test_agent/test_platform_requests.py -q
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_backend_bindings.py tests/test_agent/test_backend_bindings_dsl_when.py tests/test_agent/test_backend_bindings_black76_dsl_parity.py tests/test_agent/test_route_registry_black76_dsl_parity.py tests/test_agent/test_route_registry.py -k 'rate_cap_floor_strip or period_rate_option_strip or cap_floor or caplet_strip' -q\n\n## Notes\n- F003-F005 remain intentionally deferred; their analytical binding repair should target the normalized semantic family in a follow-on slice.