### PR TITLE
[codex] QUA-940: normalize rate option strip semantic alias

### DIFF
--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -362,7 +362,7 @@ The rate cap/floor stress lane now follows that same authority rule through a
 dedicated semantic family rather than a classifier exception. Cap and floor
 requests now draft into the canonical ``period_rate_option_strip`` semantic
 contract, with legacy ``rate_cap_floor_strip`` retained as a compatibility
-alias. That semantic contract materializes the schedule-driven
+alias on ingress only. That semantic contract materializes the schedule-driven
 rate-option-strip shape, required market inputs, and route surface before
 generic semantic-gap handling runs. That keeps compare-ready tasks such as
 ``E22`` on the actual pricing route without teaching the generic classifier

--- a/docs/quant/static_leg_contract_ir.rst
+++ b/docs/quant/static_leg_contract_ir.rst
@@ -63,6 +63,8 @@ leg level:
 - ``cap`` / ``floor`` remain wrapper-level compatibility shells
 - legacy ``rate_cap_floor_strip`` remains an alias, not the long-run leg
   representation name
+- emitted semantic metadata and lowering IR now normalize onto
+  ``period_rate_option_strip`` even when ingress used the legacy alias
 
 In other words, a schedule-driven cap or floor is represented here as a
 strip of period rate options rather than as a helper-shaped wrapper name.

--- a/tests/test_agent/test_benchmark_contracts.py
+++ b/tests/test_agent/test_benchmark_contracts.py
@@ -40,6 +40,16 @@ def test_canonical_benchmark_instrument_type_maps_broad_runtime_families():
     assert canonical_benchmark_instrument_type(tasks["F015"]) == "variance_swap"
 
 
+def test_canonical_benchmark_instrument_type_normalizes_rate_option_strip_alias_fallback():
+    task = {
+        "benchmark_contract": {
+            "product": "rate_cap_floor_strip",
+        }
+    }
+
+    assert canonical_benchmark_instrument_type(task) == "period_rate_option_strip"
+
+
 def test_benchmark_preferred_method_uses_single_declared_construct():
     tasks = _benchmark_tasks()
 

--- a/tests/test_agent/test_family_lowering_ir.py
+++ b/tests/test_agent/test_family_lowering_ir.py
@@ -335,7 +335,7 @@ def test_legacy_rate_cap_floor_strip_semantic_id_still_reaches_family_ir():
 
     family_ir = blueprint.dsl_lowering.family_ir
     assert isinstance(family_ir, AnalyticalBlack76IR)
-    assert family_ir.payoff_family in {"period_rate_option_strip", "rate_cap_floor_strip"}
+    assert family_ir.payoff_family == "period_rate_option_strip"
     assert family_ir.route_id == "analytical_black76"
     assert family_ir.kernel_symbol == "black76_call"
 

--- a/tests/test_agent/test_semantic_contracts.py
+++ b/tests/test_agent/test_semantic_contracts.py
@@ -771,6 +771,9 @@ def test_rate_cap_floor_strip_contract_uses_registered_surface_schema_hints():
     legacy_surface = resolve_semantic_method_surface("rate_cap_floor_strip", "monte_carlo")
 
     assert contract.blueprint.spec_schema_hints == surface.spec_schema_hints
+    assert contract.blueprint.spec_schema_hints == ("period_rate_option_strip",)
+    assert contract.validation.bundle_hints == ("period_rate_option_strip_contract",)
+    assert "validate_period_rate_option_strip_contract" in contract.blueprint.proving_tasks
     assert legacy_surface == surface
 
 

--- a/tests/test_models/test_rate_cap_floor.py
+++ b/tests/test_models/test_rate_cap_floor.py
@@ -14,7 +14,7 @@ from trellis.core.date_utils import build_payment_timeline, year_fraction
 from trellis.core.types import DayCountConvention, Frequency
 from trellis.curves.date_aware_flat_curve import DateAwareFlatYieldCurve
 from trellis.curves.yield_curve import YieldCurve
-from trellis.instruments.cap import CapFloorSpec
+from trellis.instruments.cap import CapFloorSpec, CapPayoff
 from trellis.models.rate_cap_floor import (
     CapFloorPeriod,
     price_rate_cap_floor_strip_analytical,
@@ -131,6 +131,25 @@ def test_rate_cap_floor_strip_helpers_accept_keyword_contract_fields():
 
     assert analytical_from_kwargs == pytest.approx(analytical_from_spec)
     assert monte_carlo_from_kwargs == pytest.approx(monte_carlo_from_spec)
+
+
+def test_rate_cap_floor_strip_matches_legacy_cap_payoff_on_flat_curve():
+    market_state = _market_state(rate=0.05, vol=0.20)
+    spec = _cap_spec(
+        strike=0.05,
+        start_date=date(2025, 2, 15),
+        end_date=date(2027, 2, 15),
+        rate_index="USD-SOFR-3M",
+    )
+
+    helper_price = price_rate_cap_floor_strip_analytical(
+        market_state,
+        spec,
+        instrument_class="cap",
+    )
+    legacy_price = CapPayoff(spec).evaluate(market_state)
+
+    assert helper_price == pytest.approx(legacy_price)
 
 
 @pytest.mark.parametrize(
@@ -277,8 +296,8 @@ def test_rate_cap_floor_strip_includes_known_first_fixing_intrinsic():
         label="cap_floor_known_fixing",
     )
     first_period = timeline[0]
-    payment_years = year_fraction(SETTLE, first_period.payment_date, DayCountConvention.ACT_365)
-    end_years = year_fraction(SETTLE, first_period.end_date, DayCountConvention.ACT_365)
+    payment_years = float(first_period.t_payment or 0.0)
+    end_years = float(first_period.t_end or payment_years)
     expected_first_caplet = (
         today_start.notional
         * year_fraction(first_period.start_date, first_period.end_date, today_start.day_count)

--- a/trellis/agent/benchmark_contracts.py
+++ b/trellis/agent/benchmark_contracts.py
@@ -135,7 +135,7 @@ def canonical_benchmark_instrument_type(task: Mapping[str, Any]) -> str | None:
         cap_floor = str(contract.get("cap_floor") or "").strip().lower()
         if cap_floor in {"cap", "floor"}:
             return cap_floor
-        return "rate_cap_floor_strip"
+        return "period_rate_option_strip"
     return _BENCHMARK_PRODUCT_INSTRUMENT_TYPES.get(product)
 
 

--- a/trellis/agent/family_lowering_ir.py
+++ b/trellis/agent/family_lowering_ir.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 import re
 from typing import TYPE_CHECKING
 
+from trellis.agent.semantic_contracts import _normalize_semantic_family_alias
 from trellis.agent.semantic_tokens import (
     EVENT_TRIGGERED_TWO_LEGGED_CONTRACT_FAMILY,
 )
@@ -13,12 +14,6 @@ from trellis.core.types import TimelineRole
 
 if TYPE_CHECKING:
     from trellis.agent.backend_bindings import ResolvedBackendBindingSpec
-
-
-_SEMANTIC_FAMILY_ALIASES = {
-    "rate_cap_floor_strip": "period_rate_option_strip",
-}
-
 
 def _tuple_unique(values) -> tuple[str, ...]:
     """Return a deduplicated tuple of non-empty string values."""
@@ -33,7 +28,7 @@ def _tuple_unique(values) -> tuple[str, ...]:
 def _canonical_semantic_family(value: str | None) -> str:
     """Normalize one family alias onto its canonical semantic identifier."""
     normalized = str(value or "").strip().lower()
-    return str(_SEMANTIC_FAMILY_ALIASES.get(normalized, normalized))
+    return _normalize_semantic_family_alias(normalized)
 
 
 @dataclass(frozen=True)

--- a/trellis/agent/family_lowering_ir.py
+++ b/trellis/agent/family_lowering_ir.py
@@ -15,6 +15,11 @@ if TYPE_CHECKING:
     from trellis.agent.backend_bindings import ResolvedBackendBindingSpec
 
 
+_SEMANTIC_FAMILY_ALIASES = {
+    "rate_cap_floor_strip": "period_rate_option_strip",
+}
+
+
 def _tuple_unique(values) -> tuple[str, ...]:
     """Return a deduplicated tuple of non-empty string values."""
     result: list[str] = []
@@ -23,6 +28,12 @@ def _tuple_unique(values) -> tuple[str, ...]:
         if text and text not in result:
             result.append(text)
     return tuple(result)
+
+
+def _canonical_semantic_family(value: str | None) -> str:
+    """Normalize one family alias onto its canonical semantic identifier."""
+    normalized = str(value or "").strip().lower()
+    return str(_SEMANTIC_FAMILY_ALIASES.get(normalized, normalized))
 
 
 @dataclass(frozen=True)
@@ -700,11 +711,11 @@ _FAMILY_IR_MATCH_PROFILES = {
     ),
     "period_rate_option_strip": FamilyIRMatchProfile(
         semantic_id="period_rate_option_strip",
-        allowed_semantic_ids=("period_rate_option_strip", "rate_cap_floor_strip"),
+        allowed_semantic_ids=("period_rate_option_strip",),
         allowed_instruments=("cap", "floor"),
-        allowed_payoff_families=("period_rate_option_strip", "rate_cap_floor_strip"),
+        allowed_payoff_families=("period_rate_option_strip",),
         allowed_product_instruments=("cap", "floor"),
-        allowed_product_payoff_families=("period_rate_option_strip", "rate_cap_floor_strip"),
+        allowed_product_payoff_families=("period_rate_option_strip",),
     ),
     "ranked_observation_basket": FamilyIRMatchProfile(
         semantic_id="ranked_observation_basket",
@@ -791,7 +802,6 @@ _TRANSFORM_MARKET_MAPPINGS = {
 _MC_MARKET_MAPPINGS = {
     ("hull_white_1f", "swaption"): "discount_curve_forward_curve_black_vol_to_short_rate_mc",
     ("hull_white_1f", "period_rate_option_strip"): "discount_curve_forward_curve_black_vol_to_rate_option_strip_mc",
-    ("hull_white_1f", "rate_cap_floor_strip"): "discount_curve_forward_curve_black_vol_to_rate_option_strip_mc",
     ("local_vol_1d", ""): "equity_spot_discount_local_vol_to_mc",
     ("gbm_1d", ""): "equity_spot_discount_black_vol_to_mc",
 }
@@ -800,7 +810,6 @@ _MC_MARKET_MAPPINGS = {
 _MC_HELPER_BINDINGS = {
     ("gbm_1d", "vanilla_option", "european"): "price_vanilla_equity_option_monte_carlo",
     ("hull_white_1f", "period_rate_option_strip", ""): "price_rate_cap_floor_strip_monte_carlo",
-    ("hull_white_1f", "rate_cap_floor_strip", ""): "price_rate_cap_floor_strip_monte_carlo",
     ("hull_white_1f", "swaption", ""): "price_swaption_monte_carlo",
 }
 
@@ -808,7 +817,6 @@ _MC_HELPER_BINDINGS = {
 _MC_REDUCER_BINDINGS = {
     "swaption": ("discounted_swap_pv",),
     "period_rate_option_strip": ("period_option_cashflow_strip",),
-    "rate_cap_floor_strip": ("period_option_cashflow_strip",),
     "vanilla_option": ("terminal_payoff",),
 }
 
@@ -823,8 +831,7 @@ _MC_TERMINAL_ONLY_FAMILY_EXERCISE = frozenset(
 _MC_PAYOFF_REDUCER_OUTPUTS = {
     "swaption": ("swaption_exercise_payoff", "swaption_exercise_payoff"),
     "vanilla_option": ("terminal_payoff", "vanilla_option_payoff"),
-    "period_rate_option_strip": ("period_option_cashflow_strip", "rate_cap_floor_strip_payoff"),
-    "rate_cap_floor_strip": ("period_option_cashflow_strip", "rate_cap_floor_strip_payoff"),
+    "period_rate_option_strip": ("period_option_cashflow_strip", "period_rate_option_strip_payoff"),
 }
 
 
@@ -862,17 +869,20 @@ _PDE_HELPER_BINDINGS = {
 def _matches_family_ir_profile(contract, product_ir, profile: FamilyIRMatchProfile) -> bool:
     """Return whether one semantic contract fits a declarative lowering profile."""
     instrument = str(getattr(product_ir, "instrument", "") or "").strip().lower()
-    payoff_family = str(getattr(product_ir, "payoff_family", "") or "").strip().lower()
+    payoff_family = _canonical_semantic_family(getattr(product_ir, "payoff_family", ""))
     exercise_style = str(getattr(product_ir, "exercise_style", "") or "").strip().lower()
     product = getattr(contract, "product", None)
     product_instrument = str(getattr(product, "instrument_class", "") or "").strip().lower()
-    product_payoff_family = str(getattr(product, "payoff_family", "") or "").strip().lower()
+    product_payoff_family = _canonical_semantic_family(getattr(product, "payoff_family", ""))
     payoff_traits = {
         str(item).strip().lower()
         for item in getattr(product_ir, "payoff_traits", ()) or ()
     }
-    semantic_id = str(getattr(contract, "semantic_id", "") or "").strip()
-    allowed_semantic_ids = profile.allowed_semantic_ids or (profile.semantic_id,)
+    semantic_id = _canonical_semantic_family(getattr(contract, "semantic_id", ""))
+    allowed_semantic_ids = tuple(
+        _canonical_semantic_family(item)
+        for item in (profile.allowed_semantic_ids or (profile.semantic_id,))
+    )
     if semantic_id not in allowed_semantic_ids:
         return False
     if profile.allowed_instruments and instrument not in profile.allowed_instruments:
@@ -1319,7 +1329,7 @@ def _common_kwargs(
         route_id=route_id,
         route_family=route_family,
         product_instrument=str(getattr(product_ir, "instrument", "")),
-        payoff_family=str(getattr(product_ir, "payoff_family", "")),
+        payoff_family=_canonical_semantic_family(getattr(product_ir, "payoff_family", "")),
         required_input_ids=required_input_ids,
         market_data_requirements=frozenset(required_input_ids),
         timeline_roles=_timeline_roles_for_contract(contract),
@@ -1609,7 +1619,7 @@ def _transform_characteristic_spec_for_product(
 
 def _transform_terminal_payoff_kind_for_product(product) -> str:
     """Return the bounded terminal payoff kind for one transform family IR."""
-    payoff_family = str(getattr(product, "payoff_family", "") or "").strip().lower()
+    payoff_family = _canonical_semantic_family(getattr(product, "payoff_family", ""))
     return _TRANSFORM_TERMINAL_PAYOFF_KIND_BY_FAMILY.get(
         payoff_family,
         "compiled_terminal_payoff",
@@ -1632,7 +1642,7 @@ def _transform_helper_symbol_for_product(
     characteristic_spec: TransformCharacteristicSpec,
 ) -> str:
     """Return the bounded helper symbol for transform routes when one exists."""
-    payoff_family = str(getattr(product, "payoff_family", "") or "").strip().lower()
+    payoff_family = _canonical_semantic_family(getattr(product, "payoff_family", ""))
     return _lookup_by_composite_key(
         _TRANSFORM_HELPER_BINDINGS,
         payoff_family,
@@ -1645,7 +1655,7 @@ def _transform_market_mapping_for_product(
     characteristic_spec: TransformCharacteristicSpec,
 ) -> str:
     """Return a readable market-binding label for one transform family IR."""
-    payoff_family = str(getattr(product, "payoff_family", "") or "").strip().lower()
+    payoff_family = _canonical_semantic_family(getattr(product, "payoff_family", ""))
     mapping = _lookup_by_composite_key(
         _TRANSFORM_MARKET_MAPPINGS,
         payoff_family,
@@ -1739,7 +1749,7 @@ def _build_event_aware_monte_carlo_ir(
 
 def _mc_uses_terminal_only_contract(product) -> bool:
     """Return whether the product should lower onto a terminal-only MC contract."""
-    payoff_family = str(getattr(product, "payoff_family", "") or "").strip().lower()
+    payoff_family = _canonical_semantic_family(getattr(product, "payoff_family", ""))
     exercise_style = str(getattr(product, "exercise_style", "") or "").strip().lower()
     return (payoff_family, exercise_style) in _MC_TERMINAL_ONLY_FAMILY_EXERCISE
 
@@ -1824,7 +1834,7 @@ def _mc_process_spec_for_product(
 
 def _mc_market_mapping_for_product(product, process_spec: MCProcessSpec) -> str:
     """Return a readable market-binding label for the bounded MC family IR."""
-    payoff_family = str(getattr(product, "payoff_family", "") or "").strip().lower()
+    payoff_family = _canonical_semantic_family(getattr(product, "payoff_family", ""))
     mapping = _lookup_by_composite_key(
         _MC_MARKET_MAPPINGS,
         process_spec.process_family,
@@ -1835,7 +1845,7 @@ def _mc_market_mapping_for_product(product, process_spec: MCProcessSpec) -> str:
 
 def _mc_helper_symbol_for_product(product, process_spec: MCProcessSpec) -> str:
     """Return a family-level helper symbol when one comprehensive kit exists."""
-    payoff_family = str(getattr(product, "payoff_family", "") or "").strip().lower()
+    payoff_family = _canonical_semantic_family(getattr(product, "payoff_family", ""))
     exercise_style = str(getattr(product, "exercise_style", "") or "").strip().lower()
     return _lookup_by_composite_key(
         _MC_HELPER_BINDINGS,
@@ -2027,7 +2037,7 @@ def _mc_path_requirement_spec_for_product(
 
 def _mc_reducer_kinds_for_product(product) -> tuple[str, ...]:
     """Return bounded reduced-state helper names for one semantic product."""
-    payoff_family = str(getattr(product, "payoff_family", "") or "").strip().lower()
+    payoff_family = _canonical_semantic_family(getattr(product, "payoff_family", ""))
     return _MC_REDUCER_BINDINGS.get(payoff_family, ())
 
 
@@ -2037,11 +2047,11 @@ def _mc_payoff_reducer_spec_for_product(
     event_timeline: tuple[MCEventTimeSpec, ...],
 ) -> MCPayoffReducerSpec:
     """Infer the payoff-reducer contract for one bounded MC family instance."""
-    payoff_family = str(getattr(product, "payoff_family", "") or "").strip().lower()
+    payoff_family = _canonical_semantic_family(getattr(product, "payoff_family", ""))
     reducer_profile = _MC_PAYOFF_REDUCER_OUTPUTS.get(payoff_family)
     if reducer_profile is not None:
         reducer_kind, output_semantics = reducer_profile
-        if payoff_family in {"swaption", "rate_cap_floor_strip", "period_rate_option_strip"}:
+        if payoff_family in {"swaption", "period_rate_option_strip"}:
             dependencies = tuple(
                 event.event_name
                 for bucket in event_timeline
@@ -2064,7 +2074,7 @@ def _mc_payoff_reducer_spec_for_product(
 
 def _pde_boundary_spec_for_product(product) -> PDEBoundarySpec:
     """Infer the bounded terminal/boundary contract for one PDE family IR."""
-    payoff_family = str(getattr(product, "payoff_family", "") or "").strip().lower()
+    payoff_family = _canonical_semantic_family(getattr(product, "payoff_family", ""))
     return _PDE_BOUNDARY_BINDINGS.get(
         payoff_family,
         PDEBoundarySpec(
@@ -2077,7 +2087,7 @@ def _pde_boundary_spec_for_product(product) -> PDEBoundarySpec:
 
 def _pde_market_mapping_for_product(product, operator_spec: PDEOperatorSpec) -> str:
     """Return a readable market-binding label for the bounded PDE family IR."""
-    payoff_family = str(getattr(product, "payoff_family", "") or "").strip().lower()
+    payoff_family = _canonical_semantic_family(getattr(product, "payoff_family", ""))
     mapping = _lookup_by_composite_key(
         _PDE_MARKET_MAPPINGS,
         operator_spec.operator_family,
@@ -2092,7 +2102,7 @@ def _pde_helper_symbol_for_product(
     control_style: str,
 ) -> str:
     """Return a bounded helper symbol for migrated event-aware PDE proof slices."""
-    payoff_family = str(getattr(product, "payoff_family", "") or "").strip().lower()
+    payoff_family = _canonical_semantic_family(getattr(product, "payoff_family", ""))
     return _lookup_by_composite_key(
         _PDE_HELPER_BINDINGS,
         payoff_family,

--- a/trellis/agent/semantic_contracts.py
+++ b/trellis/agent/semantic_contracts.py
@@ -454,7 +454,7 @@ def _build_semantic_family_registry() -> MappingProxyType:
                         "build_caplet_or_floorlet_schedule",
                         "map_period_option_strip_to_black_kernel",
                     ),
-                    spec_schema_hints=("period_rate_option_strip", "rate_cap_floor_strip"),
+                    spec_schema_hints=("period_rate_option_strip",),
                 ),
                 _method_surface_definition(
                     "monte_carlo",
@@ -469,7 +469,7 @@ def _build_semantic_family_registry() -> MappingProxyType:
                         "compile_period_option_strip_into_mc_timeline",
                         "reduce_period_option_strip_cashflows",
                     ),
-                    spec_schema_hints=("period_rate_option_strip", "rate_cap_floor_strip"),
+                    spec_schema_hints=("period_rate_option_strip",),
                 ),
             ),
         ),
@@ -2826,7 +2826,7 @@ def make_period_rate_option_strip_contract(
         required_inputs=required_inputs,
         candidate_methods=definition.candidate_methods,
         preferred_method=normalized_method,
-        bundle_hints=("rate_cap_floor_strip_contract",),
+        bundle_hints=("period_rate_option_strip_contract",),
         universal_checks=(
             "observation_schedule_present",
             "forward_curve_present",
@@ -2843,7 +2843,7 @@ def make_period_rate_option_strip_contract(
         adapter_obligations=surface.adapter_obligations,
         proving_tasks=(
             "compile_request_to_product_ir",
-            "validate_rate_cap_floor_strip_contract",
+            "validate_period_rate_option_strip_contract",
             "emit_bounded_semantic_blueprint",
         ),
         spec_schema_hints=surface.spec_schema_hints,

--- a/trellis/models/rate_cap_floor.py
+++ b/trellis/models/rate_cap_floor.py
@@ -103,9 +103,8 @@ def _option_expiry_years_for_observation_date(
     fixing_years: float,
     use_date_aware: bool,
 ) -> float:
-    if not use_date_aware:
-        return max(fixing_years, 0.0)
-    return max(year_fraction(spec.start_date, observation_date, DayCountConvention.ACT_365), 0.0)
+    del spec, observation_date, use_date_aware
+    return max(fixing_years, 0.0)
 
 
 def _cap_floor_model(spec: CapFloorSpec) -> str:
@@ -175,6 +174,7 @@ def _resolve_cap_floor_terms(
     forward_curve = _resolve_forward_curve(market_state, spec)
     use_date_aware = _uses_date_aware_curve_conventions(market_state, forward_curve)
 
+    timeline = ()
     if periods is None:
         timeline = build_payment_timeline(
             spec.start_date,
@@ -203,19 +203,33 @@ def _resolve_cap_floor_terms(
         if period.payment_date <= market_state.settlement:
             continue
         fixing_anchor = period.fixing_date or period.start_date
-        fixing_years = max(
-            year_fraction(market_state.settlement, fixing_anchor, DayCountConvention.ACT_365),
-            0.0,
-        )
-        accrual_fraction = float(year_fraction(period.start_date, period.end_date, spec.day_count))
-        payment_years = max(
-            year_fraction(market_state.settlement, period.payment_date, DayCountConvention.ACT_365),
-            fixing_years,
-        )
-        end_years = max(
-            year_fraction(market_state.settlement, period.end_date, DayCountConvention.ACT_365),
-            max(fixing_years, 1e-6),
-        )
+        schedule_period = timeline[index] if timeline else None
+        if schedule_period is not None and not use_date_aware:
+            fixing_years = max(float(schedule_period.t_start or 0.0), 0.0)
+            accrual_fraction = float(
+                schedule_period.accrual_fraction
+                if schedule_period.accrual_fraction is not None
+                else year_fraction(period.start_date, period.end_date, spec.day_count)
+            )
+            payment_years = max(float(schedule_period.t_payment or fixing_years), fixing_years)
+            end_years = max(
+                float(schedule_period.t_end or payment_years),
+                max(fixing_years, 1e-6),
+            )
+        else:
+            fixing_years = max(
+                year_fraction(market_state.settlement, fixing_anchor, DayCountConvention.ACT_365),
+                0.0,
+            )
+            accrual_fraction = float(year_fraction(period.start_date, period.end_date, spec.day_count))
+            payment_years = max(
+                year_fraction(market_state.settlement, period.payment_date, DayCountConvention.ACT_365),
+                fixing_years,
+            )
+            end_years = max(
+                year_fraction(market_state.settlement, period.end_date, DayCountConvention.ACT_365),
+                max(fixing_years, 1e-6),
+            )
         forward_rate = _forward_rate_for_period(
             forward_curve,
             period.start_date,

--- a/trellis/models/rate_cap_floor.py
+++ b/trellis/models/rate_cap_floor.py
@@ -74,14 +74,14 @@ def _discount_factor_for_period(market_state: MarketState, payment_date, payment
     return float(discount_curve.discount(payment_years))
 
 
-def _forward_rate_for_period(forward_curve, start_date, payment_date, fixing_years: float, payment_years: float, day_count) -> float:
+def _forward_rate_for_period(forward_curve, start_date, end_date, fixing_years: float, end_years: float, day_count) -> float:
     forward_rate_dates = getattr(forward_curve, "forward_rate_dates", None)
     if callable(forward_rate_dates):
         try:
-            return float(forward_rate_dates(start_date, payment_date, day_count=day_count))
+            return float(forward_rate_dates(start_date, end_date, day_count=day_count))
         except AttributeError:
             pass
-    return float(forward_curve.forward_rate(fixing_years, payment_years))
+    return float(forward_curve.forward_rate(fixing_years, end_years))
 
 
 def _uses_date_aware_curve_conventions(market_state: MarketState, forward_curve) -> bool:
@@ -94,17 +94,6 @@ def _uses_date_aware_curve_conventions(market_state: MarketState, forward_curve)
     return callable(getattr(underlying_curve, "discount_date", None)) or callable(
         getattr(underlying_curve, "forward_rate_dates", None)
     )
-
-
-def _option_expiry_years_for_observation_date(
-    spec: CapFloorSpec,
-    observation_date: date,
-    *,
-    fixing_years: float,
-    use_date_aware: bool,
-) -> float:
-    del spec, observation_date, use_date_aware
-    return max(fixing_years, 0.0)
 
 
 def _cap_floor_model(spec: CapFloorSpec) -> str:
@@ -244,12 +233,7 @@ def _resolve_cap_floor_terms(
             payment_years,
         )
         intrinsic_only = fixing_years <= 0.0
-        option_expiry_years = _option_expiry_years_for_observation_date(
-            spec,
-            fixing_anchor,
-            fixing_years=fixing_years,
-            use_date_aware=use_date_aware,
-        )
+        option_expiry_years = max(fixing_years, 0.0)
         volatility = 0.0 if intrinsic_only else float(
             market_state.vol_surface.black_vol(max(option_expiry_years, 1e-6), spec.strike)
         )


### PR DESCRIPTION
## What changed

This stacked slice normalizes the legacy `rate_cap_floor_strip` semantic name into a compatibility alias while preserving the canonical internal family as `period_rate_option_strip`.

- canonicalizes family identity inside `family_lowering_ir` so emitted lowering payloads use `period_rate_option_strip`
- removes legacy alias duplication from the cap/floor strip family-IR lookup tables and reducer metadata
- normalizes the benchmark fallback instrument family to `period_rate_option_strip` when no wrapper-side `cap_floor` discriminator is available
- updates semantic metadata hints so the registered surface advertises canonical schema and validation names
- updates docs and tests to defend canonical emission while keeping legacy alias compatibility coverage

## Why

The static-leg closure work already made `period_rate_option_strip` the real semantic home, but a few semantic and lowering surfaces still leaked `rate_cap_floor_strip` as if it were a first-class internal family. That kept the compatibility alias alive deeper in the compiler than intended.

This slice tightens the boundary:

- ingress may still say `rate_cap_floor_strip`
- internal semantic metadata and emitted lowering IR now normalize to `period_rate_option_strip`

## Validation

- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_benchmark_contracts.py tests/test_agent/test_semantic_contracts.py tests/test_agent/test_family_lowering_ir.py -q`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_backend_bindings.py tests/test_agent/test_route_registry.py tests/test_agent/test_platform_requests.py tests/test_agent/test_route_retirement_readiness.py tests/test_agent/test_decompose_static_and_dynamic_contracts.py tests/test_agent/test_semantic_track_classifier.py tests/test_agent/test_static_leg_admission.py tests/test_models/test_rate_cap_floor.py -q`

## Notes

This PR is intentionally stacked on top of #641 and should be merged after that branch lands or rebased once #641 merges.
