### PR TITLE
knowledge: curate F001-F015 evaluation lessons

### DIFF
--- a/trellis/agent/knowledge/lessons/entries/cal_016.yaml
+++ b/trellis/agent/knowledge/lessons/entries/cal_016.yaml
@@ -1,0 +1,35 @@
+category: calibration
+title: Use public cap-strip period APIs
+severity: high
+status: validated
+confidence: 0.6
+created: '2026-04-21T00:00:26.893715'
+version: ''
+source_trace: null
+applies_when:
+  method:
+  - analytical
+  features:
+  - floating_coupons
+  - vol_surface_dependence
+  instrument: []
+  error_signature: null
+symptom: The implementation assumed `CapFloorPeriod` was exported from `trellis.instruments.cap`,
+  causing the analytical pricer to fail during import and build.
+root_cause: 'This is an API boundary mistake: internal or non-exported types may exist
+  in the codebase but are not guaranteed to be available from the package interface.
+  The mental model failure is treating a private implementation detail as a stable
+  dependency.'
+fix: Import only documented/public symbols or construct the strip from exported leg/cashflow
+  interfaces, then keep the analytical logic isolated from internal types.
+validation: "Resolved during build of Build a pricer for: FinancePy parity: USD cap\
+  \ strip shifted Black\n\nPrice a cap strip under the declared benchmark rates surface.\n\
+  \nInstrument class: cap.\nStrike: 0.04.\nNotional: 1000000.0.\nStart date: 2024-11-15.\n\
+  End date: 2029-11-15.\nPayment frequency: quarterly.\nDay count: ACT/360.\nRate\
+  \ index: USD-SOFR-3M.\nPricing model: shifted_black.\nShift: 0.01.\n\nPreferred\
+  \ method family: analytical\nFinancePy binding: financepy.rates.cap_floor.shifted_black\n\
+  Benchmark product: rate_cap_floor_strip\n\nConstruct methods: analytical\nComparison\
+  \ targets: analytical (analytical)\nCross-validation harness:\n  external targets:\
+  \ financepy\n\nImplementation target: analytical"
+supersedes: []
+id: cal_016

--- a/trellis/agent/knowledge/lessons/entries/con_029.yaml
+++ b/trellis/agent/knowledge/lessons/entries/con_029.yaml
@@ -2,7 +2,7 @@ category: convention
 title: Missing payoff adapter using schedule primitive
 severity: critical
 status: promoted
-confidence: 0.8
+confidence: 1.0
 created: '2026-03-29T09:25:59.788063'
 version: ''
 source_trace: /Users/steveyang/Projects/steveya/trellis/trellis/agent/knowledge/traces/20260329_092600_barrier_option_analytical.yaml

--- a/trellis/agent/knowledge/lessons/entries/con_036.yaml
+++ b/trellis/agent/knowledge/lessons/entries/con_036.yaml
@@ -1,8 +1,8 @@
 category: convention
 title: Missing payoff schedule contract
 severity: critical
-status: validated
-confidence: 0.6
+status: promoted
+confidence: 0.9
 created: '2026-04-06T17:27:20.332248'
 version: ''
 source_trace: null

--- a/trellis/agent/knowledge/lessons/entries/fd_014.yaml
+++ b/trellis/agent/knowledge/lessons/entries/fd_014.yaml
@@ -1,8 +1,8 @@
 category: finite_differences
 title: Undefined symbol in dataclass defaults
 severity: critical
-status: validated
-confidence: 0.7
+status: promoted
+confidence: 1.0
 created: '2026-03-28T23:11:22.352553'
 version: ''
 source_trace: /Users/steveyang/Projects/steveya/trellis/trellis/agent/knowledge/traces/20260328_231123_barrier_option_analytical.yaml
@@ -28,3 +28,4 @@ fix: Use string literals or defined constants/Enums for dataclass defaults (e.g.
   check to catch undefined names at import time.
 validation: Discovered during build (attempt 2)
 id: fd_014
+supersedes: []

--- a/trellis/agent/knowledge/lessons/entries/mc_036.yaml
+++ b/trellis/agent/knowledge/lessons/entries/mc_036.yaml
@@ -2,8 +2,8 @@ id: mc_036
 title: Analytical Himalaya pricer must wrap required primitives explicitly
 severity: critical
 category: monte_carlo
-status: validated
-confidence: 0.7
+status: promoted
+confidence: 0.8
 created: '2026-03-28T15:16:49.135160'
 version: ''
 source_trace: /Users/steveyang/Projects/steveya/trellis/trellis/agent/knowledge/traces/20260328_151649_basket_option_analytical.yaml
@@ -31,3 +31,4 @@ fix: 'Structure the Himalaya evaluate() as a thin adapter: always call generate_
   period''s contribution, and aggregate results; do not import or call any substitute
   pricing functions.'
 validation: Discovered during build (attempt 3)
+supersedes: []

--- a/trellis/agent/knowledge/lessons/entries/mc_082.yaml
+++ b/trellis/agent/knowledge/lessons/entries/mc_082.yaml
@@ -1,8 +1,8 @@
 category: monte_carlo
 title: Require payoff shape contract
 severity: critical
-status: candidate
-confidence: 0.4
+status: validated
+confidence: 0.6
 created: '2026-04-06T17:26:07.630563'
 version: ''
 source_trace: null

--- a/trellis/agent/knowledge/lessons/entries/md_033.yaml
+++ b/trellis/agent/knowledge/lessons/entries/md_033.yaml
@@ -2,7 +2,7 @@ category: market_data
 title: Missing credit_curve and CDS spec
 severity: critical
 status: promoted
-confidence: 0.9
+confidence: 1.0
 created: '2026-03-30T08:34:54.488252'
 version: ''
 source_trace: /Users/steveyang/Projects/steveya/trellis/trellis/agent/knowledge/traces/20260330_083455_nth_to_default_analytical.yaml

--- a/trellis/agent/knowledge/lessons/entries/num_029.yaml
+++ b/trellis/agent/knowledge/lessons/entries/num_029.yaml
@@ -2,7 +2,7 @@ category: numerical
 title: Undefined method identifier in spec default
 severity: high
 status: promoted
-confidence: 0.9
+confidence: 1.0
 created: '2026-03-29T08:36:29.297101'
 version: ''
 source_trace: /Users/steveyang/Projects/steveya/trellis/trellis/agent/knowledge/traces/20260329_083630_barrier_option_analytical.yaml

--- a/trellis/agent/knowledge/lessons/entries/vol_026.yaml
+++ b/trellis/agent/knowledge/lessons/entries/vol_026.yaml
@@ -5,7 +5,7 @@ status: promoted
 confidence: 1.0
 created: '2026-04-20T16:13:06.826577'
 version: ''
-source_trace: /Users/steveyang/Projects/steveya/trellis/trellis/agent/knowledge/traces/20260420_161309_cap_analytical.yaml
+source_trace: trellis/agent/knowledge/traces/20260420_161309_cap_analytical.yaml
 applies_when:
   method:
   - analytical

--- a/trellis/agent/knowledge/lessons/entries/vol_026.yaml
+++ b/trellis/agent/knowledge/lessons/entries/vol_026.yaml
@@ -1,0 +1,31 @@
+category: volatility
+title: Missing Black76 Call Primitive
+severity: critical
+status: promoted
+confidence: 1.0
+created: '2026-04-20T16:13:06.826577'
+version: ''
+source_trace: /Users/steveyang/Projects/steveya/trellis/trellis/agent/knowledge/traces/20260420_161309_cap_analytical.yaml
+applies_when:
+  method:
+  - analytical
+  features:
+  - floating_coupons
+  - vol_surface_dependence
+  - forward_rate
+  - discounting
+  instrument: []
+  error_signature: null
+symptom: Build gate fails before code generation with an unresolved primitive error
+  stating that pricing kernel primitive 'black76_call' is missing.
+root_cause: The analytical cap-strip route depends on a Black76 caplet/call pricing
+  kernel, but the binding only declared the higher-level cap_floor route without registering
+  the required primitive adapter. As a result, the compiler cannot assemble the product
+  IR into an executable pricing path.
+fix: Add or map the missing `black76_call` primitive in the analytical rates model
+  and ensure the cap-strip route resolves each caplet to that kernel. Verify the binding
+  exports the primitive under the exact symbol name expected by the route compiler
+  before generation.
+validation: Discovered during build (attempt 0)
+supersedes: []
+id: vol_026

--- a/trellis/agent/knowledge/lessons/entries/vol_028.yaml
+++ b/trellis/agent/knowledge/lessons/entries/vol_028.yaml
@@ -1,0 +1,30 @@
+category: volatility
+title: Enforce non-zero vega
+severity: critical
+status: validated
+confidence: 0.6
+created: '2026-04-20T16:16:07.630391'
+version: ''
+source_trace: /Users/steveyang/Projects/steveya/trellis/trellis/agent/knowledge/traces/20260420_161610_basket_option_analytical.yaml
+applies_when:
+  method:
+  - analytical
+  features:
+  - discounting
+  - multi_asset
+  - maturity_settlement
+  - vol_surface_dependence
+  instrument: []
+  error_signature: null
+symptom: Repricing the option with vol bumped from 5% to 40% produced no price change,
+  with vega measured as 0.0000.
+root_cause: The analytical payoff/pricer path was assembled without correctly wiring
+  volatility dependence into the pricing kernel. As a result, the output was effectively
+  insensitive to the supplied volatility surface or vol input fields.
+fix: Ensure the analytical routine consumes the model volatilities/correlation in
+  the final pricing formula and that the resolved market-data object exposes the expected
+  volatility attribute. Add a sanity check that embedded-option products show non-zero
+  price sensitivity to a volatility bump before approving the build.
+validation: Discovered during build (attempt 0)
+supersedes: []
+id: vol_028

--- a/trellis/agent/knowledge/lessons/entries/vol_028.yaml
+++ b/trellis/agent/knowledge/lessons/entries/vol_028.yaml
@@ -5,7 +5,7 @@ status: validated
 confidence: 0.6
 created: '2026-04-20T16:16:07.630391'
 version: ''
-source_trace: /Users/steveyang/Projects/steveya/trellis/trellis/agent/knowledge/traces/20260420_161610_basket_option_analytical.yaml
+source_trace: trellis/agent/knowledge/traces/20260420_161610_basket_option_analytical.yaml
 applies_when:
   method:
   - analytical

--- a/trellis/agent/knowledge/lessons/entries/vol_029.yaml
+++ b/trellis/agent/knowledge/lessons/entries/vol_029.yaml
@@ -1,0 +1,35 @@
+category: volatility
+title: Ignored SABR vol dependence
+severity: high
+status: validated
+confidence: 0.6
+created: '2026-04-21T00:06:23.953330'
+version: ''
+source_trace: null
+applies_when:
+  method:
+  - analytical
+  features:
+  - floating_coupons
+  - vol_surface_dependence
+  instrument: []
+  error_signature: null
+symptom: The cap strip price did not change when SABR volatility inputs were varied,
+  so the embedded optionality had effectively zero vega.
+root_cause: This usually happens when the pricer uses a fixed discounting or forward
+  rate only, but never feeds the SABR-implied volatility into the caplet valuation.
+  The mental model error is treating an option as if it were a deterministic cashflow
+  instead of a volatility-sensitive payoff.
+fix: Wire the SABR surface into each caplet’s option formula so the strike-dependent
+  implied vol affects the premium.
+validation: "Resolved during build of Build a pricer for: FinancePy parity: USD cap\
+  \ strip SABR\n\nPrice a cap strip under the declared benchmark rates surface.\n\n\
+  Instrument class: cap.\nStrike: 0.04.\nNotional: 1000000.0.\nStart date: 2024-11-15.\n\
+  End date: 2029-11-15.\nPayment frequency: quarterly.\nDay count: ACT/360.\nRate\
+  \ index: USD-SOFR-3M.\nPricing model: sabr.\nSABR parameters: alpha=0.025, beta=0.5,\
+  \ nu=0.35, rho=-0.2.\n\nPreferred method family: analytical\nFinancePy binding:\
+  \ financepy.rates.cap_floor.sabr\nBenchmark product: rate_cap_floor_strip\n\nConstruct\
+  \ methods: analytical\nComparison targets: analytical (analytical)\nCross-validation\
+  \ harness:\n  external targets: financepy\n\nImplementation target: analytical"
+supersedes: []
+id: vol_029

--- a/trellis/agent/knowledge/lessons/index.yaml
+++ b/trellis/agent/knowledge/lessons/index.yaml
@@ -694,6 +694,20 @@ entries:
     - vol_surface_dependence
     instrument: []
     error_signature: null
+- id: cal_016
+  title: Use public cap-strip period APIs
+  severity: high
+  category: calibration
+  status: validated
+  supersedes: []
+  applies_when:
+    method:
+    - analytical
+    features:
+    - floating_coupons
+    - vol_surface_dependence
+    instrument: []
+    error_signature: null
 - id: con_001
   title: Use exact trellis import paths — never guess module names
   severity: critical
@@ -1249,7 +1263,7 @@ entries:
   title: Missing payoff schedule contract
   severity: critical
   category: convention
-  status: validated
+  status: promoted
   supersedes: []
   applies_when:
     method:
@@ -1682,7 +1696,7 @@ entries:
   title: Undefined symbol in dataclass defaults
   severity: critical
   category: finite_differences
-  status: validated
+  status: promoted
   supersedes: []
   applies_when:
     method:
@@ -2814,7 +2828,7 @@ entries:
   title: Analytical Himalaya pricer must wrap required primitives explicitly
   severity: critical
   category: monte_carlo
-  status: validated
+  status: promoted
   supersedes: []
   applies_when:
     method:
@@ -3554,7 +3568,7 @@ entries:
   title: Require payoff shape contract
   severity: critical
   category: monte_carlo
-  status: candidate
+  status: validated
   supersedes: []
   applies_when:
     method:
@@ -8110,6 +8124,52 @@ entries:
     - analytical
     features:
     - discounting
+    - vol_surface_dependence
+    instrument: []
+    error_signature: null
+- id: vol_026
+  title: Missing Black76 Call Primitive
+  severity: critical
+  category: volatility
+  status: promoted
+  supersedes: []
+  applies_when:
+    method:
+    - analytical
+    features:
+    - floating_coupons
+    - vol_surface_dependence
+    - forward_rate
+    - discounting
+    instrument: []
+    error_signature: null
+- id: vol_028
+  title: Enforce non-zero vega
+  severity: critical
+  category: volatility
+  status: validated
+  supersedes: []
+  applies_when:
+    method:
+    - analytical
+    features:
+    - discounting
+    - multi_asset
+    - maturity_settlement
+    - vol_surface_dependence
+    instrument: []
+    error_signature: null
+- id: vol_029
+  title: Ignored SABR vol dependence
+  severity: high
+  category: volatility
+  status: validated
+  supersedes: []
+  applies_when:
+    method:
+    - analytical
+    features:
+    - floating_coupons
     - vol_surface_dependence
     instrument: []
     error_signature: null


### PR DESCRIPTION
## Summary
- curate the useful lesson-store deltas from the F001-F015 evaluation pass
- keep the validated volatility and calibration lessons and promotion/confidence updates
- drop run artifacts, noisy semantic debris, and duplicate lesson candidates from the working tree

## Validation
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_knowledge_store.py -x -q