### PR TITLE
[codex] Align calibration architecture with Trellis-native layers

### DIFF
--- a/doc/plan/draft__calibration-documentation-and-architecture-alignment.md
+++ b/doc/plan/draft__calibration-documentation-and-architecture-alignment.md
@@ -39,7 +39,7 @@ Rules for coding agents:
 
 | Ticket | Status | Scope |
 | --- | --- | --- |
-| `QUA-947` | Backlog | Trellis-native architecture framing, market-object-first vocabulary, and calibration-doc alignment |
+| `QUA-947` | In Review | Trellis-native architecture framing, market-object-first vocabulary, and calibration-doc alignment |
 
 ## Purpose
 

--- a/doc/plan/draft__calibration-documentation-and-architecture-alignment.md
+++ b/doc/plan/draft__calibration-documentation-and-architecture-alignment.md
@@ -1,0 +1,294 @@
+# Calibration Documentation And Architecture Alignment Plan
+
+## Status
+
+Active execution mirror for the filed calibration-documentation alignment
+slice.
+
+The architecture-alignment work is tracked primarily by `QUA-947` under the
+calibration-sleeve umbrella `QUA-946`. This document remains the repo-local
+spec for that ticket and should stay synchronized with both Linear and the main
+calibration hardening plan.
+
+Status mirror last synced: `2026-04-21`
+
+## Linked Context
+
+- `QUA-946` Calibration sleeve: Trellis-native industrial hardening program
+- `QUA-947` Calibration architecture: align Trellis-native docs, runtime
+  vocabulary, and plan mirror
+- `doc/plan/draft__calibration-sleeve-industrial-hardening-program.md`
+
+## Linear Ticket Mirror
+
+Rules for coding agents:
+
+- Linear is the source of truth for ticket state.
+- This file is the repo-local mirror for the documentation-alignment slice.
+- Do not mark the row `Done` here before `QUA-947` is actually closed.
+- Keep the vocabulary in this file, the main calibration hardening plan, and
+  the calibration docs synchronized in the same closeout.
+
+### Workstream Ticket
+
+| Ticket | Status |
+| --- | --- |
+| `QUA-946` Calibration sleeve: Trellis-native industrial hardening program | Backlog |
+
+### Documentation Slice
+
+| Ticket | Status | Scope |
+| --- | --- | --- |
+| `QUA-947` | Backlog | Trellis-native architecture framing, market-object-first vocabulary, and calibration-doc alignment |
+
+## Purpose
+
+This document aligns the calibration documentation with the desired end state
+of the Trellis calibration sleeve.
+
+The immediate problem is not that the current mathematical framework is weak.
+It is that the strongest current ideas are spread across multiple documents and
+can easily be summarized in a misleading way as "a general multivariate SDE
+framework." That shorthand is too narrow and does not reflect the Trellis
+architecture we actually want.
+
+The calibration sleeve is not a separate library. It is part of Trellis and
+should leverage Trellis abstractions end to end.
+
+## Reviewed Source Documents
+
+This alignment plan is grounded in the following checked-in docs:
+
+- `docs/mathematical/calibration.rst`
+- `docs/unified_pricing_engine_model_grammar.md`
+- `docs/developer/composition_calibration_design.md`
+- `doc/plan/draft__calibration-sleeve-industrial-hardening-program.md`
+
+## Decision Summary
+
+The documentation should present the calibration sleeve as:
+
+1. a Trellis-native market inference layer
+2. organized into market reconstruction, model compression, and hybrid
+   composition
+3. using quote maps, market binding, solve requests, and runtime
+   materialization as first-class Trellis abstractions
+4. treating generic multivariate SDEs as one latent-state representation family
+   inside the model layer, not as the top-level unifier of the sleeve
+
+## What The Current Docs Already Get Right
+
+### 1. The mathematical note rejects the "one master SDE" framing
+
+`docs/unified_pricing_engine_model_grammar.md` already says the right unifier
+is not one master SDE and instead identifies the pricing operator, latent
+state, generator, contract family, quote map, and calibration objective as the
+reusable abstraction.
+
+This is the strongest current mathematical framing and should be preserved.
+
+### 2. Quote-space semantics are already treated as first-class
+
+Both the mathematical note and the calibration docs correctly emphasize that:
+
+- prices are core
+- quotes are transforms
+- the calibration layer needs both forward and inverse quote maps
+
+This is an excellent foundation for a desk-grade calibration sleeve.
+
+### 3. The developer design already anchors calibration onto Trellis runtime objects
+
+`docs/developer/composition_calibration_design.md` correctly connects
+calibration to:
+
+- `MarketState`
+- quote-map semantics
+- runtime materialization
+- generated and reused Trellis workflows
+
+This is the right architectural direction.
+
+## Main Documentation Gaps
+
+### A. The layered end state is not stated explicitly enough
+
+The docs do not yet clearly separate:
+
+- market reconstruction
+- model compression
+- hybrid composition
+
+Without that layering, readers can wrongly infer that every calibration should
+end in one reduced-form stochastic model.
+
+### B. The market-object-first view is underemphasized
+
+The current calibration docs still read primarily as "fit model parameters to
+market quotes." That is true for some workflows, but for liquid products the
+authoritative calibrated result is often a Trellis market object:
+
+- curve
+- vol surface or cube
+- credit curve
+- correlation surface
+
+The docs should say that directly.
+
+### C. The mathematical framework is easy to mislabel
+
+The mathematical note is broader than a multivariate SDE note:
+
+- it starts from the pricing operator
+- uses quote maps explicitly
+- treats calibration as an inverse problem in quote space
+- allows generators, SPDEs, lifted states, and non-diffusion structure
+
+The docs should make that broader framing more obvious.
+
+### D. The Trellis-native integration should be more explicit
+
+The docs should more clearly state that the calibration sleeve works through
+existing Trellis abstractions:
+
+- `SemanticContract`
+- `ValuationContext`
+- `MarketBindingSpec`
+- `MarketState`
+- `quote_maps`
+- `solve_request`
+- `materialization`
+
+This would prevent the calibration workstream from being interpreted as a
+parallel engine.
+
+### E. The current docs do not yet map product families to authoritative outputs
+
+The docs should have one explicit product-family table showing:
+
+- calibration instruments
+- authoritative calibrated output
+- optional reduced-model output
+- downstream Trellis consumers
+
+Without this, the architecture remains too implicit.
+
+## Documentation Target Shape
+
+### 1. `docs/mathematical/calibration.rst`
+
+This should become the practical and user-facing calibration architecture
+document.
+
+It should lead with:
+
+- the three-layer stack
+- the market-object-first rule
+- the relationship between quote maps, solve requests, and materialized runtime
+  objects
+
+Then it can describe the current shipped workflows.
+
+### 2. `docs/unified_pricing_engine_model_grammar.md`
+
+This should remain the deep mathematical reference for latent-state and
+generator-based models, but the opening should be interpreted as:
+
+- a model-layer and hybrid-layer framework
+- not the sole top-level description of the sleeve
+- not a separate engine outside Trellis
+
+It should explicitly point readers back to the calibration architecture and
+runtime materialization docs.
+
+### 3. `docs/developer/composition_calibration_design.md`
+
+This should stay the Trellis implementation bridge.
+
+It should explicitly connect:
+
+- calibration contracts
+- quote maps
+- `MarketState` capability materialization
+- chained calibrations
+- Trellis planner and compiler surfaces
+
+to the three-layer end-state architecture.
+
+## Required Documentation Changes
+
+### Phase 1: Calibration architecture framing
+
+1. Add a front section to `docs/mathematical/calibration.rst` defining:
+   - market reconstruction
+   - model compression
+   - hybrid composition
+2. Add an explicit statement that simple liquid products often calibrate
+   directly to Trellis market objects rather than to reduced-model parameters.
+3. Add a product-family mapping table.
+
+### Phase 2: Mathematical note alignment
+
+1. Add a short framing note near the top of
+   `docs/unified_pricing_engine_model_grammar.md` explaining that this is the
+   latent-state and generator framework within the broader Trellis calibration
+   sleeve.
+2. State explicitly that the document is not proposing a separate calibration
+   library or one master-SDE abstraction for all workflow layers.
+3. Cross-link to `docs/mathematical/calibration.rst` and
+   `docs/developer/composition_calibration_design.md`.
+
+### Phase 3: Trellis-native developer integration
+
+1. Expand `docs/developer/composition_calibration_design.md` with a short
+   section mapping the three calibration layers onto Trellis abstractions.
+2. Show where market reconstruction outputs land on `MarketState`.
+3. Show how later model compression and hybrid composition steps depend on
+   those materialized outputs.
+
+### Phase 4: Runtime and plan alignment
+
+1. Keep the canonical plan doc
+   `doc/plan/draft__calibration-sleeve-industrial-hardening-program.md`
+   synchronized with the doc wording.
+2. Ensure planner and canonical model-grammar registry language use the same
+   distinctions between priced-only, reconstructed-market-object, and
+   reduced-model workflows.
+
+## Recommended Product-Family Mapping Table
+
+The docs should include a table close to this form.
+
+| Product family | Liquid inputs | Primary calibrated output | Optional reduced-model output |
+| --- | --- | --- | --- |
+| OIS / IRS / FX swap | deposits, OIS, IRS, FX swaps, basis swaps | discount and forecast curves, basis structures | short-rate or curve-dynamics factors |
+| Vanilla equity / FX options | option prices or quoted vols | implied-vol surface or cube | local vol, Heston, stochastic-vol models |
+| Caps/floors / swaptions | option prices or quoted vols | caplet strips, swaption cubes | SABR, Hull-White, G2++, LMM |
+| CDS | running and upfront CDS quotes | credit curve | reduced-form factor model |
+| Basket credit tranches | tranche spreads | base-correlation or correlation surface | copula or factor correlation model |
+| Hybrid liquid sets | linked single-asset objects | cross-asset binding and correlation objects | hybrid state model |
+
+## Acceptance Criteria
+
+The documentation alignment work is complete when:
+
+- the docs no longer encourage the shorthand "general multivariate SDE
+  framework" as the top-level description of the sleeve
+- `docs/mathematical/calibration.rst` clearly presents the three-layer Trellis
+  calibration stack
+- the mathematical note is clearly positioned as a latent-state and
+  generator-layer reference inside Trellis
+- the developer docs explicitly connect calibration to Trellis abstractions and
+  runtime materialization
+- the plan docs and docs use the same end-state vocabulary
+
+## Non-Goals
+
+This alignment plan does not by itself:
+
+- widen the shipped numerical coverage
+- claim that the current workflows already meet the end state
+- turn the mathematical note into the only source of calibration truth
+
+The goal is alignment of architecture and documentation so later implementation
+work lands on a clear target.

--- a/doc/plan/draft__calibration-sleeve-industrial-hardening-program.md
+++ b/doc/plan/draft__calibration-sleeve-industrial-hardening-program.md
@@ -66,7 +66,7 @@ Rules for coding agents:
 
 | Queue ID | Linear | Status | Scope | Hard prerequisites |
 | --- | --- | --- | --- | --- |
-| `CAL.0A` | `QUA-947` | Backlog | Trellis-native architecture and documentation alignment | none |
+| `CAL.0A` | `QUA-947` | In Review | Trellis-native architecture and documentation alignment | none |
 | `CAL.0B` | `QUA-948` | Backlog | equity-vol carry consistency across pricing and implied-vol inversion | none |
 | `CAL.0C` | `QUA-949` | Backlog | CDS-pricer-backed single-name credit objective and diagnostics | none |
 | `CAL.1` | `QUA-950` | Backlog | industrial equity-vol surface foundation and staged model fits | `CAL.0B` |

--- a/doc/plan/draft__calibration-sleeve-industrial-hardening-program.md
+++ b/doc/plan/draft__calibration-sleeve-industrial-hardening-program.md
@@ -1,0 +1,719 @@
+# Calibration Sleeve Industrial Hardening Program
+
+## Status
+
+Active execution mirror for the filed calibration-sleeve industrialization
+queue.
+
+The umbrella `QUA-946` and child tickets `QUA-947` through `QUA-956` are now
+filed in Linear. This document is the ordered repo-local mirror for that queue
+and should stay aligned with the live issue graph.
+
+Status mirror last synced: `2026-04-21`
+
+## Linked Context
+
+- `QUA-590` Calibration and market realism
+- `QUA-663` Calibration review: rates, local vol, SABR, Heston, and solve
+  requests
+- `QUA-686` Semantic model grammar: calibration-layer unification for model
+  specs, quote maps, and bindings
+- `QUA-946` Calibration sleeve: Trellis-native industrial hardening program
+- `QUA-947` Calibration architecture: align Trellis-native docs, runtime
+  vocabulary, and plan mirror
+- `QUA-948` Equity-vol calibration: carry-consistent pricing and implied-vol
+  inversion
+- `QUA-949` Credit calibration: CDS-pricer-backed single-name objective and
+  diagnostics
+- `QUA-950` Equity-vol calibration: industrial surface foundation and staged
+  model fits
+- `QUA-951` Rates calibration: dated-instrument multi-curve hardening and
+  dependency DAG
+- `QUA-952` Rates-vol calibration: caplet stripping, swaption cube assembly,
+  and model diagnostics
+- `QUA-953` Credit curve calibration: schedule-aware CDS workflow, quote
+  normalization, and hazard governance
+- `QUA-954` Basket credit calibration: base-correlation workflow and
+  tranche-surface governance
+- `QUA-955` Hybrid calibration: dependency DAG and first cross-asset slice
+- `QUA-956` Calibration validation: desk-like fixtures, perturbation
+  diagnostics, and latency envelopes
+- `doc/plan/draft__calibration-documentation-and-architecture-alignment.md`
+
+## Linear Ticket Mirror
+
+Rules for coding agents:
+
+- Linear is the source of truth for ticket state.
+- This file is the repo-local mirror for subsequent agents.
+- Implement the earliest ticket in the ordered queue below whose status is not
+  `Done` and whose hard prerequisites are satisfied.
+- `CAL.0A`, `CAL.0B`, `CAL.0C`, and `CAL.7` may run in parallel when their
+  write scopes do not conflict.
+- Do not mark a row `Done` here before the corresponding Linear issue is
+  actually closed.
+- When a ticket changes behavior, APIs, runtime workflow, or operator
+  expectations, update the relevant docs and `LIMITATIONS.md` in the same
+  closeout unless the ticket explicitly records why not.
+
+### Workstream Ticket
+
+| Ticket | Status |
+| --- | --- |
+| `QUA-946` Calibration sleeve: Trellis-native industrial hardening program | Backlog |
+
+### Ordered Queue
+
+| Queue ID | Linear | Status | Scope | Hard prerequisites |
+| --- | --- | --- | --- | --- |
+| `CAL.0A` | `QUA-947` | Backlog | Trellis-native architecture and documentation alignment | none |
+| `CAL.0B` | `QUA-948` | Backlog | equity-vol carry consistency across pricing and implied-vol inversion | none |
+| `CAL.0C` | `QUA-949` | Backlog | CDS-pricer-backed single-name credit objective and diagnostics | none |
+| `CAL.1` | `QUA-950` | Backlog | industrial equity-vol surface foundation and staged model fits | `CAL.0B` |
+| `CAL.2` | `QUA-951` | Backlog | dated-instrument multi-curve hardening and calibration dependency DAG | none; ordered after the Phase 0 slices |
+| `CAL.3` | `QUA-952` | Backlog | caplet stripping, swaption cube assembly, and rates-vol model diagnostics | `CAL.2` |
+| `CAL.4` | `QUA-953` | Backlog | schedule-aware single-name credit curve calibration | `CAL.0C` |
+| `CAL.5` | `QUA-954` | Backlog | basket-credit base-correlation workflow and tranche-surface governance | `CAL.4` |
+| `CAL.6` | `QUA-955` | Backlog | first cross-asset calibration slice on explicit dependency DAGs | set the concrete upstream blockers during implementation once the first supported slice is chosen |
+| `CAL.7` | `QUA-956` | Backlog | desk-like fixtures, perturbation diagnostics, and latency envelopes | none; extend alongside the active implementation slices |
+
+### Pickup Rule
+
+- start with `CAL.0A`, `CAL.0B`, or `CAL.0C`
+- do not start `CAL.1` before `CAL.0B` closes
+- do not start `CAL.3` before `CAL.2` closes
+- do not start `CAL.4` before `CAL.0C` closes
+- do not start `CAL.5` before `CAL.4` closes
+- do not start `CAL.6` until the first supported hybrid slice and its concrete
+  upstream blockers are explicit in the ticket
+- keep `CAL.7` moving alongside the active implementation slices so validation
+  does not become a deferred cleanup bucket
+
+## Purpose
+
+This document defines a bounded plan for upgrading the Trellis calibration
+sleeve from its current proving-and-replay grade into something closer to a
+mature industrial desk standard.
+
+The calibration sleeve is treated here as a Trellis subsystem, not as a
+separate library. It must work through and strengthen existing Trellis
+abstractions such as:
+
+- `SemanticContract` and `ValuationContext`
+- `MarketBindingSpec` and `RequiredDataSpec`
+- `MarketState`
+- `trellis.models.calibration.quote_maps`
+- `trellis.models.calibration.solve_request`
+- `trellis.models.calibration.materialization`
+- canonical model-grammar and planner surfaces
+
+The plan starts with the current checked calibration layer and then widens the
+scan in the order requested:
+
+1. equity volatility
+2. yield curve and multi-curve rates
+3. yield-vol models such as SABR and short-rate fits
+4. credit curve
+5. basket credit and correlation
+6. higher-order and cross-asset calibration
+
+This is a planning document, not a claim that the repo already supports the
+full industrial target.
+
+## Repo-Grounded Decision Summary
+
+The current repo has a real typed calibration substrate:
+
+- `trellis/models/calibration/solve_request.py`
+- `trellis/models/calibration/quote_maps.py`
+- `trellis/models/calibration/materialization.py`
+- `docs/mathematical/calibration.rst`
+
+That substrate is good enough for bounded replayable workflows, but the
+calibration sleeve is still narrow by desk standards.
+
+The main current-state split is:
+
+- shipped calibration workflows exist for bootstrap, flat rates vol, SABR
+  single smile, Heston single smile, Dupire local vol, and bounded single-name
+  credit
+- pricing and market-resolution helpers exist for basket credit, quanto, FX,
+  and some exotic/hybrid runtime surfaces
+- joint or higher-order calibration workflows are mostly absent
+- several of the shipped workflows are still proving-grade approximations
+  rather than production-grade market calibrators
+
+The plan should therefore focus on two things at once:
+
+1. fixing correctness and contract weaknesses inside the shipped workflows
+2. widening the calibration inventory in the order that a desk would actually
+   need it
+
+## End-State Architecture
+
+The target calibration sleeve should be organized as one Trellis-native
+three-layer stack.
+
+### Layer 1: Market reconstruction
+
+The first job of the sleeve is to reconstruct liquid, arbitrage-aware market
+objects from elementary products.
+
+Representative outputs:
+
+- discount and forecast curves
+- basis and collateral-aware rates structures
+- equity, FX, cap/floor, and swaption vol surfaces or cubes
+- single-name credit curves
+- basket-credit correlation or base-correlation surfaces
+
+For many liquid products, this layer is the authoritative result. The
+calibration does not need to end in a reduced-form model parameter vector if
+the calibrated curve or surface is already the market object that downstream
+pricing should consume.
+
+### Layer 2: Model compression
+
+The second job of the sleeve is to fit tractable pricing models to the market
+objects from Layer 1 when Trellis needs reduced models for pricing, simulation,
+or risk.
+
+Representative outputs:
+
+- SABR parameter packs fitted to rates-vol surfaces
+- short-rate parameter sets fitted to rates curve and vol objects
+- local-vol or Heston parameterizations fitted to equity-vol objects
+- reduced-form credit parameter packs fitted to credit curves
+- copula or factor model parameters fitted to correlation objects
+
+This layer should prefer fitting to Trellis-calibrated market objects where the
+market standard supports that decomposition, instead of forcing every workflow
+to jump directly from raw quotes to final reduced-model parameters.
+
+### Layer 3: Hybrid composition
+
+The third job of the sleeve is to combine already-calibrated single-asset
+objects into cross-asset or higher-order systems.
+
+Representative outputs:
+
+- SPX plus variance or SPX plus VIX state models
+- FX plus rates domestic/foreign joint setups
+- rates plus equity quanto or hybrid discounting setups
+- credit plus equity or credit plus rates hybrids
+
+This layer should be dependency-aware. It must consume calibrated curves,
+surfaces, credit objects, and correlation objects produced by the first two
+layers rather than bypassing them with one monolithic direct fit.
+
+## Trellis-Native Design Constraints
+
+The calibration sleeve should not evolve into an independent sidecar engine.
+The end-state design must satisfy these constraints.
+
+### 1. Calibration outputs are Trellis runtime capabilities
+
+Calibrated curves, surfaces, and parameter packs must materialize back onto
+`MarketState` and be consumed through existing runtime capability lookups
+instead of through route-local payloads.
+
+### 2. Quote semantics remain first-class
+
+Quote families and conventions must continue to flow through
+`trellis.models.calibration.quote_maps`, not through per-model custom logic.
+
+### 3. Calibration planning reuses Trellis semantic and binding layers
+
+Where calibration is required before pricing, the planning surface should use
+the same Trellis contract and binding abstractions rather than inventing a
+parallel calibration DSL.
+
+### 4. Chained calibrations are explicit
+
+Curve builds, surface builds, model fits, and hybrid fits should form explicit
+calibration dependency chains or DAGs rather than being hidden in helper-local
+control flow.
+
+### 5. Market reconstruction is not second-class
+
+Curve, surface, and correlation object reconstruction should be treated as a
+core calibration product of Trellis, not only as a precursor to later model
+fits.
+
+## Relationship To Existing Calibration Work
+
+This plan extends, rather than replaces, the completed model-grammar and typed
+materialization work captured in:
+
+- `doc/plan/done__calibration-layer-model-grammar-unification.md`
+- `doc/plan/draft__calibration-documentation-and-architecture-alignment.md`
+
+That earlier work made calibration routes typed and replayable. This plan is
+about raising the numerical, market-data, and cross-asset standard of those
+routes.
+
+## Repo-Grounded Current State
+
+### 1. Equity volatility
+
+Current checked workflow surface:
+
+- `trellis/models/calibration/heston_fit.py`
+- `trellis/models/calibration/local_vol.py`
+- `trellis/models/calibration/implied_vol.py`
+- synthetic benchmark inputs in `trellis/models/calibration/benchmarking.py`
+
+What is actually shipped:
+
+- single-expiry Heston smile calibration
+- Dupire local-vol extraction from an implied-vol grid
+- typed solve-request, provenance, replay, and materialization support
+
+What is not yet at desk standard:
+
+- Heston is calibrated smile-by-smile, not across a term structure or full
+  surface
+- the implied-vol inversion used by the Heston workflow is Black-Scholes in
+  `(S, K, T, r)` space and does not carry dividend or carry inputs
+- the Heston objective uses a large sentinel vol on pricing/inversion failure
+  instead of a governed failure surface or robust loss
+- the local-vol workflow interpolates implied vol directly and falls back to
+  implied vol when Dupire is unstable; it does not build an arbitrage-repaired
+  price surface first
+- no evident SVI or SSVI-style surface parameterization is present
+- no stochastic-local-vol bridge is present
+- no joint SPX plus variance or SPX plus VIX calibration workflow is present
+- equity variance swap pricing exists, but no variance-surface or VIX-style
+  calibration workflow was found under `trellis/models/calibration/`
+
+Industrial implication:
+
+- Trellis currently has a real single-underlier equity-vol proving slice
+- it does not yet have a production smile-surface plant
+
+### 2. Yield curve and multi-curve rates
+
+Current checked workflow surface:
+
+- `trellis/curves/bootstrap.py`
+- `trellis/models/calibration/rates.py`
+- `trellis/core/market_state.py`
+
+What is actually shipped:
+
+- typed bootstrap inputs for deposit, future, and swap quotes
+- explicit multi-curve role provenance through selected discount and forecast
+  curve names
+- typed rates quote maps and materialization onto `MarketState`
+
+What is not yet at desk standard:
+
+- bootstrap still works on year-fraction tenors rather than fully dated
+  schedule construction
+- no evidence of production calendars, business-day rules, stubs, IMM logic,
+  or turn handling in the bootstrap itself
+- futures are handled as simplified contracts rather than with exchange-grade
+  convexity and date logic
+- there is no visible chained OIS then forecast then basis calibration DAG in
+  the bootstrap layer itself
+- no explicit smoothing or regularized curve family is present beyond the
+  current differentiable least-squares setup
+- no cross-currency or collateral-aware multi-curve calibration program was
+  found in the calibration sleeve
+
+Industrial implication:
+
+- Trellis preserves multi-curve role metadata better than many toy libraries
+- the actual bootstrap engine remains materially simplified versus desk curve
+  construction
+
+### 3. Yield-vol models
+
+Current checked workflow surface:
+
+- `trellis/models/calibration/rates.py`
+- `trellis/models/calibration/sabr_fit.py`
+
+What is actually shipped:
+
+- cap/floor flat Black-vol inversion
+- swaption flat Black-vol inversion
+- SABR single-smile fit
+- one strip-level Hull-White fit for a constant `(mean_reversion, sigma)` pair
+
+What is not yet at desk standard:
+
+- cap/floor and swaption workflows are one-flat-vol-per-quote helpers, not a
+  caplet strip or swaption cube plant
+- SABR is a single-smile workflow rather than an expiry-tenor cube with smooth
+  arbitrage-aware interpolation
+- the supported Hull-White fit is constant-parameter across the strip, not a
+  time-dependent short-rate calibration
+- no G2++, LMM, displaced-diffusion, or normal-vol calibration workflow was
+  found as a first-class checked route
+- no evident co-calibration loop ties the rates vol surface to the lattice or
+  short-rate model used downstream
+
+Industrial implication:
+
+- the rates-vol sleeve currently covers bounded inversion and one simple model
+  fit
+- it does not yet cover the cube, stripping, model-selection, or term-structure
+  problems that matter on a desk
+
+### 4. Credit curve
+
+Current checked workflow surface:
+
+- `trellis/models/calibration/credit.py`
+- `trellis/curves/credit_curve.py`
+- `docs/mathematical/calibration.rst`
+
+What is actually shipped:
+
+- typed single-name reduced-form credit calibration inputs
+- spread and hazard quote maps
+- credit-curve materialization back onto `MarketState`
+
+What is not yet at desk standard:
+
+- the current spread workflow normalizes spread to hazard using
+  `hazard ~= spread / (1 - recovery)` rather than calibrating through a CDS PV
+  engine
+- the solve objective is effectively the identity map over the hazard vector,
+  so the solver reproduces transformed hazards instead of fitting priced CDS
+  quotes
+- no schedule-aware CDS bootstrap with accrual-on-default, upfront plus running
+  conventions, standard coupon handling, or recovery sensitivity was found
+- no index credit, bond/CDS basis, structural credit, or hybrid credit-equity
+  workflow was found
+
+Industrial implication:
+
+- this is a typed reduced-form placeholder surface with good provenance
+- it is not yet a production CDS calibration engine
+
+### 5. Basket credit and correlation
+
+Current checked pricing and helper surface:
+
+- `trellis/models/credit_basket_copula.py`
+- `trellis/instruments/nth_to_default.py`
+- `docs/mathematical/copulas.rst`
+
+What is actually shipped:
+
+- Gaussian and Student-t copula pricing helpers
+- nth-to-default and tranche-style pricing support
+- correlation-aware runtime helper surfaces
+- documentation that explains tranche loss and mentions base correlation
+
+What was not found:
+
+- no basket-credit calibration workflow under `trellis/models/calibration/`
+- no base-correlation surface calibration routine
+- no tranche-implied correlation or factor-loading calibrator
+- no joint calibration tying single-name curves to tranche quotes
+- no calibration governance for loss-surface smoothing or tranche arbitrage
+
+Industrial implication:
+
+- Trellis can price bounded basket-credit structures
+- Trellis does not yet calibrate basket-credit correlation surfaces
+
+### 6. Higher-order and cross-asset calibration
+
+Current checked pricing and resolver surface:
+
+- `trellis/models/resolution/quanto.py`
+- `trellis/models/quanto_option.py`
+- `trellis/models/fx_vanilla.py`
+- correlation-resolution logic in `trellis/data/resolver.py`
+- design notes in `docs/design_quanto_runtime_contract.md`
+
+What is actually shipped:
+
+- a narrow single-underlier quanto pricing slice
+- explicit runtime binding for FX vol and underlier/FX correlation
+- FX vanilla pricing helpers
+- correlation provenance and empirical-correlation resolution support
+
+What was not found as first-class calibration workflows:
+
+- no SPX plus VIX calibration route
+- no FX plus rates hybrid calibration route
+- no rates plus equity hybrid calibration route
+- no generic joint-factor or cross-asset calibration DAG
+- no stochastic-local-vol or hybrid affine workflow under
+  `trellis/models/calibration/`
+
+Industrial implication:
+
+- Trellis has some good runtime ingredients for cross-asset pricing
+- it does not yet have a real hybrid calibration sleeve
+
+## Gap Taxonomy Against A Mature Industrial Standard
+
+### A. Market-data conditioning is too thin
+
+Industrial sleeves normally include:
+
+- quote cleaning
+- stale or crossed quote detection
+- arbitrage repair
+- robust weighting and liquidity weighting
+- convention-specific normalization
+
+Trellis currently emphasizes typed quote semantics and replayability, but not
+yet a strong market-data conditioning layer.
+
+### B. The calibration inventory is too narrow
+
+The repo contains several bounded workflows, but a mature stack needs:
+
+- equity smile and surface parameterizations
+- rates curve ladders and basis dependencies
+- rates-vol cube handling
+- true CDS curve bootstrap
+- basket-credit correlation surfaces
+- hybrid and cross-asset linkage
+
+### C. The solver layer is typed but still shallow
+
+The current solve substrate is useful, but industrial desks typically need:
+
+- constraints beyond box bounds
+- regularization terms
+- robust losses
+- multi-start or global-search support
+- calibration dependency graphs
+- parameter freezing and staged solves
+
+### D. Diagnostics are good for replay, weaker for desk review
+
+The repo records provenance and residuals well, but a mature sleeve also needs:
+
+- parameter stability diagnostics
+- sensitivity to quote perturbations
+- condition and identifiability diagnostics at the model level
+- bad-point attribution and quote exclusion policy
+- comparative model-fit reporting across candidate models
+
+### E. Validation remains synthetic-heavy
+
+The current replay and benchmark surface is useful, but industrial standards
+usually require:
+
+- noisy and imperfect fixtures
+- historical backfill or golden-market snapshots
+- stress calibration cases
+- comparative model-to-model and model-to-market regression packs
+- latency budgets on realistic instrument counts
+
+### F. Documentation occasionally overstates the typed workflow relative to the numerical depth
+
+The repo documents the bounded workflows clearly in many places, but there are
+still areas where the typed calibration surface looks stronger than the actual
+mathematical content. The credit slice is the clearest example.
+
+### G. Documentation and architecture framing are not yet fully aligned
+
+The mathematical framework is already broader and better than the shorthand
+"general multivariate SDE setup" suggests, but that framing is still loose in
+practice.
+
+The end-state docs should say clearly that:
+
+- the top-level unifier is not one master SDE
+- the sleeve is Trellis-native rather than a separate calibration engine
+- market reconstruction, model compression, and hybrid composition are distinct
+  layers
+- quote maps, market binding, and materialization are core Trellis abstractions
+  rather than implementation details
+
+## Ordered Work Program
+
+### Phase 0: Architectural and correctness alignment
+
+1. Reframe the calibration sleeve explicitly as a Trellis-native market
+   inference layer organized into market reconstruction, model compression, and
+   hybrid composition.
+2. Update the documentation plan so the mathematical framework, calibration
+   docs, and developer docs all describe the same end state.
+3. Fix equity-vol carry consistency across pricing and implied-vol inversion.
+4. Replace the single-name credit identity solve with a real CDS pricer-backed
+   objective.
+5. Tighten docs and model-grammar registry language so pricing support is not
+   mistaken for calibration support.
+
+Acceptance bar:
+
+- the end-state architecture is documented as Trellis-native rather than as a
+  separate library or one master-SDE engine
+- Heston and local-vol carry assumptions are internally consistent
+- credit calibration reprices CDS-style quotes through a pricing engine rather
+  than a direct transform
+- docs and benchmark notes clearly distinguish priced-only from calibrated
+  surfaces
+
+### Phase 1: Industrial equity-vol foundation
+
+1. Add a governed surface-cleaning layer for equity option quotes.
+2. Add an arbitrage-aware parameterized smile or surface family, likely SVI or
+   SSVI, as the first production surface authority.
+3. Rebuild local-vol extraction off an arbitrage-repaired price or total-variance
+   surface rather than raw implied-vol spline interpolation.
+4. Widen Heston from single-smile to a controlled term-structure or surface fit.
+5. Add staged calibration support so surface-fit and model-fit layers can be
+   compared instead of conflated.
+
+Acceptance bar:
+
+- one desk-style SPX surface fixture with stable no-arb diagnostics
+- stable parameter fits under small quote perturbations
+- explicit comparison between surface-only and model-based fits
+
+### Phase 2: Rates curve and multi-curve hardening
+
+1. Upgrade bootstrap inputs from tenor-only abstractions toward dated
+   instrument schedules.
+2. Add explicit OIS-discount then forecast then basis dependency handling.
+3. Add schedule-aware futures and swap conventions, including business-day and
+   stub handling where required.
+4. Add regularized curve families or smoothing choices where the current raw
+   least-squares formulation is too unstable.
+5. Make chained calibration dependencies a first-class contract.
+
+Acceptance bar:
+
+- one realistic USD OIS plus SOFR forecast calibration fixture
+- explicit dependency graph and replay artifact for chained curve builds
+- stable repricing under realistic quoted instruments and conventions
+
+### Phase 3: Rates-vol surface and model program
+
+1. Add caplet stripping and swaption-cube support.
+2. Widen SABR from single smile to expiry-tenor cube with interpolation policy.
+3. Add time-dependent short-rate calibration or a second rates model family
+   beyond constant-parameter Hull-White.
+4. Support model-to-surface and surface-to-model comparison diagnostics.
+
+Acceptance bar:
+
+- one checked swaption cube fixture
+- clear fit diagnostics by expiry and tenor
+- downstream rates models consume calibrated outputs without hidden
+  reconvention
+
+### Phase 4: Real single-name credit calibration
+
+1. Implement schedule-aware CDS quote normalization and pricing.
+2. Support standard running plus upfront quote styles.
+3. Add hazard smoothing or bootstrap policy with diagnostics on survival and
+   forward hazard behavior.
+4. Surface recovery assumptions and sensitivity in the calibration result.
+
+Acceptance bar:
+
+- one realistic CDS tenor strip fixture repriced through the CDS pricer
+- quote-style coverage for spread and upfront conventions
+- diagnostics on survival monotonicity and hazard reasonableness
+
+### Phase 5: Basket credit and correlation calibration
+
+1. Add base-correlation or tranche-implied correlation workflow support.
+2. Add a calibration contract that ties single-name curves, tranche quotes, and
+   correlation surface outputs together.
+3. Add smoothing and monotonicity governance for tranche or base-correlation
+   surfaces.
+4. Separate homogeneous proving cases from heterogeneous portfolio cases.
+
+Acceptance bar:
+
+- one tranche surface fixture with reproducible implied-correlation outputs
+- explicit linkage from single-name curve inputs to basket-correlation outputs
+- diagnostics on tranche arbitrage and surface smoothness
+
+### Phase 6: Higher-order and cross-asset calibration
+
+1. Introduce a calibration dependency DAG for chained or joint calibrations.
+2. Start with one narrow but real hybrid slice rather than a universal hybrid
+   engine.
+3. Candidate first slices:
+   - SPX plus variance or SPX plus VIX
+   - FX plus rates with consistent domestic and foreign curve plus vol binding
+   - rates plus equity quanto or hybrid discounting cases
+4. Add explicit cross-asset state and correlation parameter materialization.
+
+Acceptance bar:
+
+- one checked cross-asset calibration slice with replay
+- explicit dependency and provenance packet across all linked calibrations
+- honest failure semantics when required hybrid inputs are missing
+
+### Phase 7: Validation and benchmark hardening
+
+1. Keep the current typed replay pack, but add noisy and desk-like fixtures.
+2. Add latency benchmarks at realistic instrument counts.
+3. Add perturbation tests so parameter instability is measured rather than
+   guessed.
+4. Add comparative model packs for at least one asset class per quarter.
+5. Keep the doc, plan, and runtime surfaces aligned as the calibration sleeve
+   widens so architectural drift does not reappear.
+
+Acceptance bar:
+
+- benchmark pack includes realistic and synthetic fixtures
+- replay captures numerical drift and model-instability regressions
+- calibration latency and convergence envelopes are explicit
+
+## Recommended Build Order
+
+The practical implementation order should be:
+
+1. Phase 0 correctness fixes
+2. Phase 1 equity-vol foundation
+3. Phase 2 rates curve and multi-curve hardening
+4. Phase 3 rates-vol program
+5. Phase 4 real single-name credit calibration
+6. Phase 5 basket-credit correlation calibration
+7. Phase 6 one narrow cross-asset slice
+8. Phase 7 benchmark hardening throughout
+
+Reason:
+
+- equity vol is the fastest path to a visibly stronger desk-standard slice
+- rates and rates-vol need deeper infrastructure but are central to the broader
+  stack
+- credit should not widen into basket and hybrid work until the single-name
+  slice is mathematically real
+- cross-asset calibration should be introduced only after at least one strong
+  surface exists in each linked asset class
+
+## Explicit Non-Goals For The First Tranche
+
+This plan does not propose immediately building:
+
+- a universal calibration engine for all models
+- rough-vol calibration
+- generic HJM or SPDE calibration
+- all hybrid models at once
+- every correlation product family simultaneously
+
+The right first industrialization move is to harden a few narrow slices until
+they are actually desk-grade, then widen.
+
+## Immediate Follow-On Execution Slice
+
+The first execution slice after this plan should be:
+
+1. architecture and documentation alignment for the Trellis-native calibration
+   sleeve
+2. equity-vol correctness audit and hardening
+3. single-name credit rework from transform-based hazard mapping to pricer-based
+   CDS calibration
+4. curve bootstrap dependency and dated-instrument design for multi-curve rates
+
+Those three slices give the fastest improvement in actual calibration quality
+while preserving the typed calibration and replay substrate already in the
+repo.

--- a/docs/developer/composition_calibration_design.md
+++ b/docs/developer/composition_calibration_design.md
@@ -277,14 +277,14 @@ otherwise uses flat `payoff_family` matching (existing behavior).
 ```python
 @dataclass(frozen=True)
 class CalibrationTarget:
-    """What parameter to calibrate."""
+    """What market object or parameter family to calibrate."""
     parameter: str        # "hw_mean_reversion", "sabr_alpha", "local_vol_surface"
-    output_capability: str  # MarketState capability name for the result
+    output_capability: str  # MarketState capability name for the authoritative runtime result
     quote_map: QuoteMapSpec | None = None  # "Price", "ImpliedVol(Black)", "Spread", ...
 
 @dataclass(frozen=True)
 class CalibrationContract:
-    """Typed calibration step executed before pricing."""
+    """Typed calibration step executed before pricing or before later calibration steps."""
 
     calibration_id: str
     target: CalibrationTarget
@@ -302,6 +302,26 @@ class CalibrationAcceptanceCriteria:
     stability_check: bool = True
     max_fitting_error_bps: float = 5.0
 ```
+
+### Trellis-native calibration layers
+
+The current Trellis calibration sleeve treats a `CalibrationContract` as one
+typed market-inference step inside a broader three-layer architecture:
+
+| Layer | Typical authoritative output | Trellis authority surface |
+| --- | --- | --- |
+| Market reconstruction | discount curves, forecast curves, vol surfaces, credit curves, correlation objects | `output_binding` plus `trellis.models.calibration.materialization` onto `MarketState` |
+| Model compression | reduced-form parameter packs such as Hull-White, SABR, Heston, or other model parameters | `output_binding` for reusable model-parameter capabilities on `MarketState` |
+| Hybrid composition | cross-asset state, connector, or correlation outputs built from earlier calibrated single-asset objects | later calibration steps that consume already-materialized `MarketState` capabilities |
+
+This is intentionally Trellis-native rather than a sidecar calibration DSL:
+
+- quote semantics flow through `trellis.models.calibration.quote_maps`
+- runtime outputs land back on `MarketState`
+- later calibration steps should consume already-materialized outputs rather
+  than reconstructing them route-locally
+- calibration chains belong in explicit `calibration_steps` or later
+  dependency-DAG surfaces rather than hidden helper control flow
 
 ### Quote maps as first-class calibration semantics
 
@@ -334,7 +354,8 @@ role, and the risky-discount contract that combines discounting with survival.
 
 ### Output binding as MarketState capabilities
 
-Calibrated parameters are materialized as `MarketState` capabilities:
+Calibrated market objects and parameter packs are materialized as
+`MarketState` capabilities:
 
 ```python
 # Before pricing:
@@ -348,7 +369,7 @@ hw_params = market_state.hw_short_rate_params
 ```
 
 This is consistent with how `market_state.discount`, `market_state.vol_surface`,
-etc. already work. No new infrastructure needed.
+and similar runtime lookups already work. No new infrastructure needed.
 
 For the migrated workflow surface, that handoff is now explicit in
 `trellis.models.calibration.materialization`. Those helpers still populate the
@@ -366,6 +387,15 @@ inspect:
 
 The supported lookup surface is
 `MarketState.materialized_calibrated_object(object_kind=..., object_name=...)`.
+
+That split matters architecturally:
+
+- market-reconstruction steps should materialize the calibrated runtime object
+  that later pricing consumes directly
+- model-compression steps should materialize reusable parameter packs without
+  pretending they replaced the underlying market object
+- hybrid steps should reuse those already-materialized objects instead of
+  rebuilding them implicitly
 
 ### Canonical model-grammar registry
 

--- a/docs/mathematical/calibration.rst
+++ b/docs/mathematical/calibration.rst
@@ -1,7 +1,97 @@
 Calibration Methods
 ===================
 
-Calibration maps market-observed prices to model parameters.
+Trellis treats calibration as a market-inference layer inside the pricing
+stack. It is not a separate library, and it is not only "fit model parameters
+to market quotes." For many liquid products, the authoritative calibrated
+result is a Trellis market object such as a curve, vol surface, credit curve,
+or correlation surface that downstream pricing should consume directly.
+Reduced-form model parameters are a later layer used when Trellis needs model
+compression for pricing, simulation, or risk.
+
+Calibration Architecture
+------------------------
+
+The calibration sleeve has three Trellis-native layers:
+
+- **Market reconstruction** reconstructs liquid market objects from quoted
+  elementary products.
+- **Model compression** fits tractable pricing models to those calibrated
+  market objects when Trellis needs reusable reduced-form parameter packs.
+- **Hybrid composition** combines already-calibrated single-asset objects into
+  higher-order or cross-asset systems.
+
+Simple liquid products often use the same pricing engine for both pricing and
+calibration: the engine is the translation machine between observed quotes and
+the runtime object being reconstructed or fitted. Trellis still treats that as
+typed calibration work because it needs explicit quote maps, fitting
+instruments, acceptance criteria, runtime materialization, and provenance.
+
+Trellis-Native Runtime Outputs
+------------------------------
+
+Calibration outputs land back on ``MarketState`` through
+``trellis.models.calibration.materialization`` and related runtime binding
+surfaces. That makes calibrated curves, surfaces, credit objects, and model
+parameter packs first-class Trellis runtime capabilities instead of route-local
+payloads.
+
+The practical split is:
+
+- market reconstruction outputs are often the authoritative runtime result
+- model-compression outputs are optional follow-on fits that consume those
+  market objects
+- hybrid workflows should consume already-materialized single-asset outputs
+  rather than bypassing them with one opaque direct fit
+
+Representative Product-Family Mapping
+-------------------------------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Product family
+     - Liquid inputs
+     - Primary calibrated output
+     - Optional reduced-model output
+   * - OIS / IRS / FX swap
+     - deposits, OIS, IRS, FX swaps, basis swaps
+     - discount and forecast curves, basis structures
+     - short-rate or curve-dynamics factors
+   * - Vanilla equity / FX options
+     - option prices or quoted vols
+     - implied-vol surface or cube
+     - local vol, Heston, stochastic-vol parameter packs
+   * - Caps/floors / swaptions
+     - option prices or quoted vols
+     - caplet strips, swaption cubes
+     - SABR, Hull-White, G2++, or LMM parameter packs
+   * - CDS
+     - running and upfront CDS quotes
+     - credit curve
+     - reduced-form factor model
+   * - Basket credit tranches
+     - tranche spreads
+     - base-correlation or correlation surface
+     - copula or factor correlation model
+   * - Hybrid liquid sets
+     - linked single-asset objects
+     - cross-asset binding and correlation objects
+     - hybrid state model
+
+Current Bounded Workflow Boundary
+---------------------------------
+
+This note documents the currently shipped bounded calibration workflows. It
+does not claim that the repo already has a full industrial curve, surface, or
+correlation plant for every asset class. Where the current support boundary is
+still single-smile, quote-local, or proving-grade, that boundary is stated
+explicitly below.
+
+For the latent-state and generator grammar inside the broader sleeve, see
+``docs/unified_pricing_engine_model_grammar.md``. For the Trellis implementation
+bridge that maps calibration contracts onto runtime bindings, see
+``docs/developer/composition_calibration_design.md``.
 
 Solve-Request Substrate
 -----------------------
@@ -138,6 +228,10 @@ Newton refinement. More robust than pure Newton for extreme strikes.
 SABR Calibration
 ----------------
 
+SABR fits live in the model-compression layer. The current shipped workflow is
+still bounded to one smile at a time rather than a full expiry-tenor surface or
+cube reconstruction plant.
+
 Given market implied vols :math:`\sigma_{\text{mkt}}(K_i)` at strikes
 :math:`K_i`, calibrate SABR parameters :math:`(\alpha, \rho, \nu)` with
 :math:`\beta` typically fixed:
@@ -189,6 +283,10 @@ The ATM vol provides a good initial guess for :math:`\alpha`:
 Heston Smile Calibration
 ------------------------
 
+The supported Heston path is also a model-compression workflow. It fits one
+single-expiry smile and then materializes a reusable parameter pack back onto
+``MarketState``; it is not yet a full equity-vol surface authority.
+
 The supported Heston workflow fits one single-expiry implied-vol smile onto
 the five runtime parameters :math:`(\kappa, \theta, \xi, \rho, v_0)`. Trellis
 packages that calibration as an explicit smile surface first:
@@ -214,6 +312,11 @@ replay, runtime reuse, and later performance benchmarking.
 
 Dupire Local Volatility
 ------------------------
+
+The local-vol path sits on the boundary between market reconstruction and model
+compression. In the current shipped workflow it remains a bounded local-vol
+extraction layer over a supplied implied-vol grid rather than a full
+arbitrage-repaired surface authority.
 
 Dupire's formula extracts the local volatility surface from the implied
 vol surface :math:`\sigma_{\text{impl}}(K, T)`:
@@ -294,6 +397,10 @@ synthetic market assumptions that task and proving workflows see at runtime.
 Curve Bootstrapping
 -------------------
 
+Curve bootstrapping is a market-reconstruction workflow. The calibrated curve
+is the authoritative runtime object; later short-rate or curve-dynamics fits
+are optional follow-on model-compression steps.
+
 Calibrate a zero-rate curve from market instruments (deposits, futures, swaps).
 
 The bootstrap input surface is now explicit:
@@ -335,6 +442,11 @@ thin compatibility wrappers over that richer result surface.
 
 Rates Option Calibration
 ------------------------
+
+The current shipped rates-vol slice is still primarily quote-local. It
+normalizes individual cap/floor or swaption quotes and preserves the selected
+curve roles, but it does not yet claim a full caplet-strip or swaption-cube
+reconstruction plant.
 
 Cap/floor and European swaption quotes are often calibrated as implied Black
 volatilities under a multi-curve environment. Trellis keeps the calibration
@@ -406,6 +518,10 @@ artifacts:
 Hull-White Strip Calibration
 ----------------------------
 
+The supported Hull-White strip fit is a model-compression workflow layered on
+top of rates curve and option calibration inputs. It materializes one reusable
+parameter pack, not a full time-dependent rates-model surface.
+
 The supported Hull-White workflow now calibrates one reusable
 ``(mean_reversion, sigma)`` parameter pair to a strip of swaption-style quotes
 instead of requiring helper routes to hard-code ``mean_reversion = 0.1``.
@@ -453,6 +569,11 @@ Reduced-Form Credit Calibration
 The supported credit slice is intentionally bounded to single-name reduced-form
 hazard calibration for CDS-style quotes. Trellis now exposes
 ``calibrate_single_name_credit_curve_workflow(...)`` as the typed entry point.
+
+This remains a proving-grade single-name curve workflow rather than the later
+schedule-aware CDS industrialization path. In particular, the current
+``Spread`` quote handling is still a bounded normalization layer rather than a
+full instrument-by-instrument CDS repricing plant.
 
 The workflow accepts tenor-labeled quotes in either of the shipped credit quote
 families:

--- a/docs/unified_pricing_engine_model_grammar.md
+++ b/docs/unified_pricing_engine_model_grammar.md
@@ -2,11 +2,35 @@
 
 ## Purpose
 
-This note turns the earlier mathematical synthesis into a concrete design document for a cross-asset computational engine.
+This note turns the earlier mathematical synthesis into a concrete design
+document for Trellis's latent-state and generator grammar.
 
-The design goal is to avoid building separate conceptual engines for short-rate models, volatility models, credit models, and hybrids. Instead, the engine should be built around a **single abstraction layer** that can represent all of them and then dispatch to the right numerical backend for pricing, Greeks, and calibration.
+It is the model-layer mathematical reference inside the broader Trellis
+calibration architecture described in
+`docs/mathematical/calibration.rst` and
+`docs/developer/composition_calibration_design.md`.
 
-> **Working thesis:**  
+The design goal here is not to replace the full Trellis calibration sleeve with
+one separate master engine. The broader sleeve still includes market
+reconstruction, runtime materialization onto `MarketState`, and later hybrid
+composition. This note focuses on the common model-layer abstraction Trellis
+uses when it needs a latent-state representation for model compression or
+hybrid composition.
+
+Within that model layer, the goal is to avoid building separate conceptual
+engines for short-rate models, volatility models, credit models, and hybrids.
+Instead, the model grammar should be built around a **single model-layer
+abstraction** that can represent all of them and then dispatch to the right
+numerical backend for pricing, Greeks, and calibration.
+
+> **Framing note:**
+> This document does not propose a separate calibration library outside
+> Trellis. It also does not claim that every calibration workflow should end in
+> one latent-state model. Curves, vol surfaces, credit curves, and correlation
+> objects can be authoritative calibrated outputs in their own right and may
+> later feed this model layer.
+
+> **Working thesis:**
 > The right unifier is not one master SDE for “short rate / variance / hazard rate.”  
 > The right unifier is a **dynamic arbitrage-free pricing operator**, represented computationally by a latent stochastic state, its generator, a contract compiler, and a quote/calibration layer.
 


### PR DESCRIPTION
## What changed
- reframed `docs/mathematical/calibration.rst` as the practical Trellis calibration architecture note
- added the explicit three-layer split: market reconstruction, model compression, and hybrid composition
- added the market-object-first rule and a product-family mapping table
- reframed `docs/unified_pricing_engine_model_grammar.md` as the latent-state / generator reference inside the broader Trellis sleeve rather than a separate top-level engine
- expanded `docs/developer/composition_calibration_design.md` so `CalibrationContract` maps directly onto `MarketState`, quote maps, materialization, and later calibration chaining
- added the repo-local plan mirrors for the calibration industrialization queue and the documentation-alignment slice

## Why it changed
The calibration docs and plan language were not presenting one stable architecture. The strongest mathematical note was broader than the shorthand "general multivariate SDE framework" suggested, but the practical and developer docs did not yet anchor that note inside a Trellis-native market-inference stack.

## Impact
This is a documentation-only change. It does not widen numerical support, but it makes the current support boundary and the intended end-state architecture explicit so later calibration tickets can build against one consistent contract.

## Validation
- `git diff --check`
- targeted terminology review with `rg` across `docs/` and `doc/plan/`

## Root cause
The repo had the right ideas in multiple places, but they were split across documents and easy to summarize incorrectly as one master SDE-oriented calibration concept rather than a Trellis-native stack with runtime materialization and layered calibration outputs.
