### PR TITLE
QUA-964 Align generated payoffs with trace-safe PV contract

### DIFF
--- a/cassettes/full_task/T13.yaml
+++ b/cassettes/full_task/T13.yaml
@@ -8,7 +8,7 @@ calls:
 - seq: 0
   function: llm_generate
   stage: code_generation
-  prompt_hash: 5fa50ca87ea96ed8bb5e405b3b3fb4afbdca317b1f974aa2cae499ab7c2fb6aa
+  prompt_hash: fd1cb0f1627c23ef746e61731ab935d8b86dd70227503a008daf4708a9b19db9
   response_text: "from trellis.models.equity_option_pde import price_vanilla_equity_option_pde\n\
     \n        return float(price_vanilla_equity_option_pde(market_state, spec, theta=0.5))"
   prompt_text: "You are implementing the evaluate() method for `EuropeanOptionAnalyticalPayoff`\
@@ -345,7 +345,7 @@ calls:
 - seq: 1
   function: llm_generate_json
   stage: critic
-  prompt_hash: fe671a56ecc1364b3ebb176ba0dd8b5ac37ed6b3d0be4cb554d34debee8fcbba
+  prompt_hash: 6f4eb17def00ed87bf1c574ef64c9eebbf08277aadc318914d7cd145e258f711
   response_text: '{"check_id": "volatility_input_usage", "description": "PDE pricer
     may ignore required market volatility inputs because the route helper is called
     with only market_state and spec, with no explicit evidence that the spec/state
@@ -468,7 +468,7 @@ calls:
 - seq: 2
   function: llm_generate
   stage: code_generation
-  prompt_hash: 98aff0cb866b289bcf0d947921287c1dfd46034805385d86efd78ea7bdf3c87d
+  prompt_hash: 419b595dfb473ebb72c719338807a6744b8d43228a784ef69b6bcf75a9fa5456
   response_text: "spec = self._spec\n\n        if self._spec.option_type not in {\"\
     call\", \"put\"}:\n            raise ValueError(f\"Unsupported option_type: {spec.option_type!r}\"\
     )\n\n        if market_state.vol_surface is None:\n            raise ValueError(\"\
@@ -810,7 +810,7 @@ calls:
 - seq: 3
   function: llm_generate_json
   stage: critic
-  prompt_hash: 617b204bcb1afbc1172c835990216e0c0e84ca02513ecee63c6d3f8cf0df3ac7
+  prompt_hash: 697ed0854accac1e8905527d002146f6c550e3d7f9af3c23a68c6a2f8f79a05d
   response_text: '{"check_id": "volatility_input_usage", "description": "Volatility
     likely bypassed or flattened because the implementation hard-codes a route helper
     call without passing any explicit grid controls or validating expiry-vol input,

--- a/docs/quant/analytical_route_cookbook.rst
+++ b/docs/quant/analytical_route_cookbook.rst
@@ -101,10 +101,10 @@ Here is a stripped-down template for a new analytical route:
         domestic_rate: float,
         carry_rate: float,
         T: float,
-    ) -> float:
+    ):
         """Price MyProduct. Public adapter — handles market inputs."""
         if T <= 0.0:
-            return float(terminal_intrinsic(option_type, spot=S, strike=K))
+            return terminal_intrinsic(option_type, spot=S, strike=K)
         resolved = ResolvedMyProductInputs(
             option_type=option_type,
             spot=S,
@@ -113,7 +113,7 @@ Here is a stripped-down template for a new analytical route:
             carry_rate=carry_rate,
             T=T,
         )
-        return float(my_product_raw(resolved))
+        return my_product_raw(resolved)
 
 
 Rules for Raw Kernels
@@ -128,8 +128,9 @@ Rules for Raw Kernels
    open-ended ``**kwargs`` plumbing.
 
 3. Keep the raw kernel trace-friendly. Do not wrap the final value in
-   ``float(...)`` inside the traced region; let the public adapter cast if it
-   needs a plain Python float.
+   ``float(...)`` inside the traced region, and do not cast the final
+   present value solely because the public adapter is public. Reserve
+   ``float(...)`` for explicit reporting or solver boundaries.
 
 4. Keep market resolution, date parsing, and hard route selection outside the
    raw kernel. Small semantic branches such as call vs put are fine; traced
@@ -220,6 +221,9 @@ Recent analytical routes in Trellis follow the same resolver-to-raw split:
 When a checked-in helper already owns market binding plus a raw kernel, agent
 generated adapters should delegate to that helper-backed surface instead of
 reconstructing annuity, forward, or strike-normalization logic inline.
+The public adapter should preserve the same present-value scalar as the raw
+kernel; the raw helper exists for reuse and verification, not because the
+public route must collapse the trace.
 
 
 Gradient Verification

--- a/docs/quant/differentiable_pricing.rst
+++ b/docs/quant/differentiable_pricing.rst
@@ -93,6 +93,8 @@ Implementation Rules
 - keep the public pricing adapter trace-safe and reserve ``float(...)`` for
   explicit reporting or solver boundaries; expose raw resolved-input kernels as
   ``*_raw`` helpers when they improve reuse
+- keep generator prompts, cookbook templates, and payoff skeletons aligned to
+  that same public contract so learned routes preserve traced PVs by default
 - for piecewise-linear curves and surfaces, target node-value derivatives as
   the supported contract and treat query-location derivatives as piecewise only
   away from knot boundaries

--- a/docs/quant/extending_trellis.rst
+++ b/docs/quant/extending_trellis.rst
@@ -26,7 +26,9 @@ The core checklist is:
 2. Implement a payoff class with explicit ``requirements`` and ``evaluate()`` semantics.
    If the payoff has a resolved-input pricing kernel, expose it as ``*_raw``
    or ``evaluate_raw(...)`` and keep ``evaluate()`` as the public trace-safe
-   adapter boundary.
+   adapter boundary. Generated payoff skeletons should annotate the public
+   return as ``PricingValue`` and preserve the final present-value scalar
+   through the adapter.
 3. Return the present-value scalar directly. Legacy ``Cashflows`` and
    ``PresentValue`` wrappers remain for backward compatibility only.
 4. Add targeted pricing and capability tests.

--- a/tests/test_agent/test_build_loop.py
+++ b/tests/test_agent/test_build_loop.py
@@ -12,6 +12,7 @@ import pytest
 from trellis.agent.planner import FieldDef, SpecSchema
 from trellis.core.date_utils import year_fraction
 from trellis.core.market_state import MarketState
+from trellis.core.payoff import PricingValue
 from trellis.curves.yield_curve import YieldCurve
 from trellis.engine.payoff_pricer import price_payoff
 from trellis.instruments.fx import FXRate
@@ -31,6 +32,7 @@ from dataclasses import dataclass
 from datetime import date
 
 from trellis.core.market_state import MarketState
+from trellis.core.payoff import PricingValue
 from trellis.core.types import DayCountConvention, Frequency
 from trellis.models.rate_style_swaption import (
     price_swaption_black76_raw,
@@ -66,9 +68,9 @@ class SwaptionPayoff:
     def requirements(self) -> set[str]:
         return {"black_vol_surface", "discount_curve", "forward_curve"}
 
-    def evaluate(self, market_state: MarketState) -> float:
+    def evaluate(self, market_state: MarketState) -> PricingValue:
         resolved = resolve_swaption_black76_inputs(market_state, self._spec)
-        return float(price_swaption_black76_raw(resolved))
+        return price_swaption_black76_raw(resolved)
 '''
 
 BAD_IMPORT_MODULE_CODE = MOCK_MODULE_CODE.replace(
@@ -90,6 +92,7 @@ from dataclasses import dataclass
 from datetime import date
 
 from trellis.core.market_state import MarketState
+from trellis.core.payoff import PricingValue
 from trellis.core.types import DayCountConvention
 from trellis.models.quanto_option import price_quanto_option_analytical_from_market_state
 
@@ -135,8 +138,8 @@ class QuantoOptionAnalyticalPayoff:
     def requirements(self) -> set[str]:
         return REQUIREMENTS
 
-    def evaluate(self, market_state: MarketState) -> float:
-        return float(price_quanto_option_analytical_from_market_state(market_state, self._spec))
+    def evaluate(self, market_state: MarketState) -> PricingValue:
+        return price_quanto_option_analytical_from_market_state(market_state, self._spec)
 '''
 
 UNAPPROVED_QUANTO_IMPORT_MODULE_CODE = GOOD_QUANTO_MODULE_CODE.replace(
@@ -404,7 +407,9 @@ def test_generate_quanto_monte_carlo_skeleton_uses_family_helper_surface():
     )
 
     assert "from trellis.models.quanto_option import price_quanto_option_monte_carlo_from_market_state" in skeleton
-    assert "return float(price_quanto_option_monte_carlo_from_market_state(market_state, spec))" in skeleton
+    assert "from trellis.core.payoff import PricingValue" in skeleton
+    assert "def evaluate(self, market_state: MarketState) -> PricingValue:" in skeleton
+    assert "return price_quanto_option_monte_carlo_from_market_state(market_state, spec)" in skeleton
 def test_generate_module_reports_syntax_error_context(monkeypatch):
     from types import SimpleNamespace
 

--- a/tests/test_agent/test_cookbooks.py
+++ b/tests/test_agent/test_cookbooks.py
@@ -65,6 +65,15 @@ class TestCookbooks:
         assert "return pv" in cb
         assert "spec.spot" in cb
         assert "black76_call" in cb
+        assert "PV (float)" not in cb
+        assert "return float(price_swaption_black76_raw(resolved))" not in cb
+        assert "return price_swaption_black76_raw(resolved)" in cb
+
+    def test_analytical_cookbook_teaches_trace_safe_public_contract(self):
+        cb = get_cookbook("analytical")
+        assert "present-value scalar" in cb
+        assert "Do not wrap the final present value in `float(...)` solely because `evaluate()` is public." in cb
+        assert "solver or reporting boundary" in cb
 
     def test_analytical_cookbook_includes_fx_garman_kohlhagen_pattern(self):
         cb = get_cookbook("analytical")

--- a/tests/test_agent/test_executor.py
+++ b/tests/test_agent/test_executor.py
@@ -490,7 +490,7 @@ def test_deterministic_exact_binding_module_materializes_swaption_helper_wrapper
     )
 
     assert generated is not None
-    assert "return float(price_swaption_black76(market_state, spec))" in generated.code
+    assert "return price_swaption_black76(market_state, spec)" in generated.code
     assert "sigma=0.01" not in generated.code
     assert EVALUATE_SENTINEL not in generated.code
 
@@ -588,7 +588,7 @@ def test_deterministic_exact_binding_module_materializes_callable_bond_tree_wrap
     )
 
     assert generated is not None
-    assert 'return float(price_callable_bond_tree(market_state, spec, model="hull_white"))' in generated.code
+    assert 'return price_callable_bond_tree(market_state, spec, model="hull_white")' in generated.code
     assert EVALUATE_SENTINEL not in generated.code
 
 
@@ -618,7 +618,7 @@ def test_deterministic_exact_binding_module_materializes_callable_bond_pde_wrapp
     )
 
     assert generated is not None
-    assert "return float(price_callable_bond_pde(market_state, spec))" in generated.code
+    assert "return price_callable_bond_pde(market_state, spec)" in generated.code
     assert EVALUATE_SENTINEL not in generated.code
 
 
@@ -799,7 +799,7 @@ def test_deterministic_exact_binding_module_materializes_route_free_vanilla_blac
     assert "black76_call(forward, strike, sigma, T)" in generated.code
     assert "black76_put(forward, strike, sigma, T)" in generated.code
     assert "year_fraction(market_state.settlement, spec.expiry_date, spec.day_count)" in generated.code
-    assert "return float(spec.notional) * df * float(undiscounted)" in generated.code
+    assert "return spec.notional * df * undiscounted" in generated.code
     assert EVALUATE_SENTINEL not in generated.code
 
 

--- a/tests/test_agent/test_prompts.py
+++ b/tests/test_agent/test_prompts.py
@@ -86,6 +86,32 @@ def test_evaluate_prompt_renders_selection_basis_and_assumptions():
     assert "closed_form_or_quasi_closed_form_route" in prompt
 
 
+def test_evaluate_prompt_teaches_trace_safe_public_value_contract():
+    from trellis.agent.prompts import evaluate_prompt
+    from trellis.agent.quant import PricingPlan
+
+    prompt = evaluate_prompt(
+        skeleton_code="class Demo:\n    def evaluate(self, market_state):\n        pass\n",
+        spec_schema=SimpleNamespace(class_name="Demo", fields=[]),
+        reference_sources={},
+        pricing_plan=PricingPlan(
+            method="analytical",
+            method_modules=["trellis.models.black"],
+            required_market_data={"discount_curve"},
+            model_to_build="european_option",
+            reasoning="Known vanilla route.",
+        ),
+        knowledge_context="",
+    )
+
+    assert "present-value scalar" in prompt
+    assert "Do not wrap the final present value in `float(...)`" in prompt
+    assert "raw-kernel-plus-wrapper pattern" in prompt
+    assert "explicit reporting or solver boundary" in prompt
+    assert "returns a FLOAT" not in prompt
+    assert "def evaluate(self, market_state: MarketState) -> float:" not in prompt
+
+
 def test_executor_knowledge_context_escalates_after_first_attempt(monkeypatch):
     from trellis.agent.executor import (
         _builder_knowledge_context_for_attempt,

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -3074,7 +3074,8 @@ def _generate_skeleton(
     fields_block = "\n".join(field_lines)
 
     requirements_str = ", ".join(f'"{r}"' for r in sorted(spec_schema.requirements))
-    import_lines = list(_skeleton_type_import_lines(spec_schema))
+    import_lines = ["from trellis.core.payoff import PricingValue"]
+    import_lines.extend(_skeleton_type_import_lines(spec_schema))
     import_lines.extend(_skeleton_exact_binding_import_lines(generation_plan))
     semantic_helper_imports, semantic_helper_lines = _skeleton_semantic_helper_hints(
         instrument_type,
@@ -3118,7 +3119,7 @@ class {spec_schema.class_name}:
     def requirements(self) -> set[str]:
         return {{{requirements_str}}}
 
-    def evaluate(self, market_state: MarketState) -> float:
+    def evaluate(self, market_state: MarketState) -> PricingValue:
 {evaluate_preamble}{EVALUATE_SENTINEL}
 '''
 
@@ -3144,11 +3145,11 @@ def _skeleton_semantic_helper_hints(
     helper_hints = {
         ("quanto_option", "analytical"): (
             ("from trellis.models.quanto_option import price_quanto_option_analytical_from_market_state",),
-            ("        # return float(price_quanto_option_analytical_from_market_state(market_state, spec))",),
+            ("        # return price_quanto_option_analytical_from_market_state(market_state, spec)",),
         ),
         ("quanto_option", "monte_carlo"): (
             ("from trellis.models.quanto_option import price_quanto_option_monte_carlo_from_market_state",),
-            ("        # return float(price_quanto_option_monte_carlo_from_market_state(market_state, spec))",),
+            ("        # return price_quanto_option_monte_carlo_from_market_state(market_state, spec)",),
         ),
     }
     return helper_hints.get((instrument_type, method), ((), ()))
@@ -3329,7 +3330,7 @@ def _deterministic_exact_binding_evaluate_body(
         return textwrap.dedent(
             f"""\
             spec = self._spec
-            return float(price_rate_cap_floor_strip_analytical(
+            return price_rate_cap_floor_strip_analytical(
                 market_state,
                 spec=spec,
                 instrument_class="{instrument_type}",
@@ -3343,7 +3344,7 @@ def _deterministic_exact_binding_evaluate_body(
                 model=getattr(spec, "model", None),
                 shift=getattr(spec, "shift", None),
                 sabr=getattr(spec, "sabr", None),
-            ))
+            )
             """
         ).rstrip()
     if (
@@ -3354,7 +3355,7 @@ def _deterministic_exact_binding_evaluate_body(
         return textwrap.dedent(
             f"""\
             spec = self._spec
-            return float(price_rate_cap_floor_strip_monte_carlo(
+            return price_rate_cap_floor_strip_monte_carlo(
                 market_state,
                 spec=spec,
                 instrument_class="{instrument_type}",
@@ -3367,7 +3368,7 @@ def _deterministic_exact_binding_evaluate_body(
                 rate_index=spec.rate_index,
                 n_paths=20000,
                 seed=42,
-            ))
+            )
             """
         ).rstrip()
     if (
@@ -3383,14 +3384,14 @@ def _deterministic_exact_binding_evaluate_body(
             if market_state.vol_surface is None:
                 raise ValueError("market_state.vol_surface is required for Black-Scholes comparison")
             T = max(float(year_fraction(market_state.settlement, spec.expiry_date, spec.day_count)), 0.0)
-            spot = float(spec.spot)
-            strike = float(spec.strike)
+            spot = spec.spot
+            strike = spec.strike
             option_type = str(spec.option_type or "call").strip().lower()
             if T <= 0.0:
                 intrinsic = max(spot - strike, 0.0) if option_type == "call" else max(strike - spot, 0.0)
-                return float(spec.notional) * intrinsic
-            df = float(market_state.discount.discount(T))
-            sigma = float(market_state.vol_surface.black_vol(max(T, 1e-6), strike))
+                return spec.notional * intrinsic
+            df = market_state.discount.discount(T)
+            sigma = market_state.vol_surface.black_vol(max(T, 1e-6), strike)
             forward = spot / max(df, 1e-12)
             if option_type == "call":
                 undiscounted = black76_call(forward, strike, sigma, T)
@@ -3398,7 +3399,7 @@ def _deterministic_exact_binding_evaluate_body(
                 undiscounted = black76_put(forward, strike, sigma, T)
             else:
                 raise ValueError(f"Unsupported option_type {spec.option_type!r}")
-            return float(spec.notional) * df * float(undiscounted)
+            return spec.notional * df * undiscounted
             """
         ).rstrip()
     if (
@@ -3416,14 +3417,14 @@ def _deterministic_exact_binding_evaluate_body(
             if market_state.vol_surface is None:
                 raise ValueError("market_state.vol_surface is required for exact Black-76 vanilla pricing")
             T = max(float(year_fraction(market_state.settlement, spec.expiry_date, spec.day_count)), 0.0)
-            spot = float(spec.spot)
-            strike = float(spec.strike)
+            spot = spec.spot
+            strike = spec.strike
             option_type = str(spec.option_type or "call").strip().lower()
             if T <= 0.0:
                 intrinsic = max(spot - strike, 0.0) if option_type == "call" else max(strike - spot, 0.0)
-                return float(spec.notional) * intrinsic
-            df = float(market_state.discount.discount(T))
-            sigma = float(market_state.vol_surface.black_vol(max(T, 1e-6), strike))
+                return spec.notional * intrinsic
+            df = market_state.discount.discount(T)
+            sigma = market_state.vol_surface.black_vol(max(T, 1e-6), strike)
             forward = spot / max(df, 1e-12)
             if option_type == "call":
                 undiscounted = black76_call(forward, strike, sigma, T)
@@ -3431,7 +3432,7 @@ def _deterministic_exact_binding_evaluate_body(
                 undiscounted = black76_put(forward, strike, sigma, T)
             else:
                 raise ValueError(f"Unsupported option_type {spec.option_type!r}")
-            return float(spec.notional) * df * float(undiscounted)
+            return spec.notional * df * undiscounted
             """
         ).rstrip()
     if comparison_target is None and route_free_exact_binding and instrument_type == "digital_option":
@@ -3450,8 +3451,8 @@ def _deterministic_exact_binding_evaluate_body(
                 if market_state.vol_surface is None:
                     raise ValueError("market_state.vol_surface is required for exact Black-76 digital pricing")
                 T = max(float(year_fraction(market_state.settlement, spec.expiry_date, spec.day_count)), 0.0)
-                spot = float(spec.spot)
-                strike = float(spec.strike)
+                spot = spec.spot
+                strike = spec.strike
                 option_type = str(spec.option_type or "call").strip().lower()
                 payout_type = str(getattr(spec, "payout_type", "cash_or_nothing") or "cash_or_nothing").strip().lower()
                 cash_payoff = float(getattr(spec, "cash_payoff", 1.0) or 1.0)
@@ -3460,114 +3461,114 @@ def _deterministic_exact_binding_evaluate_body(
                 if T <= 0.0:
                     in_the_money = spot > strike if option_type == "call" else spot < strike
                     if payout_type == "cash_or_nothing":
-                        return float(spec.notional) * cash_payoff * (1.0 if in_the_money else 0.0)
+                        return spec.notional * cash_payoff * (1.0 if in_the_money else 0.0)
                     if payout_type == "asset_or_nothing":
-                        return float(spec.notional) * (spot if in_the_money else 0.0)
+                        return spec.notional * (spot if in_the_money else 0.0)
                     raise ValueError(f"Unsupported payout_type {getattr(spec, 'payout_type', None)!r}")
-                df = float(market_state.discount.discount(T))
-                sigma = float(market_state.vol_surface.black_vol(max(T, 1e-6), strike))
+                df = market_state.discount.discount(T)
+                sigma = market_state.vol_surface.black_vol(max(T, 1e-6), strike)
                 forward = spot / max(df, 1e-12)
                 if payout_type == "cash_or_nothing":
                     if option_type == "call":
                         undiscounted = black76_cash_or_nothing_call(forward, strike, sigma, T)
                     else:
                         undiscounted = black76_cash_or_nothing_put(forward, strike, sigma, T)
-                    return float(spec.notional) * cash_payoff * df * float(undiscounted)
+                    return spec.notional * cash_payoff * df * undiscounted
                 if payout_type == "asset_or_nothing":
                     if option_type == "call":
                         undiscounted = black76_asset_or_nothing_call(forward, strike, sigma, T)
                     else:
                         undiscounted = black76_asset_or_nothing_put(forward, strike, sigma, T)
-                    return float(spec.notional) * df * float(undiscounted)
+                    return spec.notional * df * undiscounted
                 raise ValueError(f"Unsupported payout_type {getattr(spec, 'payout_type', None)!r}")
                 """
             ).rstrip()
     helper_bodies = {
         "trellis.models.quanto_option.price_quanto_option_analytical_from_market_state": (
-            "return float(price_quanto_option_analytical_from_market_state(market_state, spec))"
+            "return price_quanto_option_analytical_from_market_state(market_state, spec)"
         ),
         "trellis.models.quanto_option.price_quanto_option_monte_carlo_from_market_state": (
-            "return float(price_quanto_option_monte_carlo_from_market_state(market_state, spec))"
+            "return price_quanto_option_monte_carlo_from_market_state(market_state, spec)"
         ),
         "trellis.models.fx_vanilla.price_fx_vanilla_analytical": (
-            "return float(price_fx_vanilla_analytical(market_state, spec))"
+            "return price_fx_vanilla_analytical(market_state, spec)"
         ),
         "trellis.models.callable_bond_pde.price_callable_bond_pde": (
-            "return float(price_callable_bond_pde(market_state, spec))"
+            "return price_callable_bond_pde(market_state, spec)"
         ),
         "trellis.models.callable_bond_tree.price_callable_bond_tree": (
-            'return float(price_callable_bond_tree(market_state, spec, model="hull_white"))'
+            'return price_callable_bond_tree(market_state, spec, model="hull_white")'
         ),
         "trellis.models.rate_style_swaption.price_swaption_black76": (
-            "return float(price_swaption_black76(market_state, spec"
-            f"{swaption_comparison_kwargs}))"
+            "return price_swaption_black76(market_state, spec"
+            f"{swaption_comparison_kwargs})"
         ),
         "trellis.models.rate_style_swaption_tree.price_swaption_tree": (
-            "return float(price_swaption_tree(market_state, spec"
-            f"{swaption_comparison_kwargs}))"
+            "return price_swaption_tree(market_state, spec"
+            f"{swaption_comparison_kwargs})"
         ),
         "trellis.models.rate_style_swaption.price_swaption_monte_carlo": (
-            "return float(price_swaption_monte_carlo("
+            "return price_swaption_monte_carlo("
             "market_state, spec, n_paths=20000, seed=42"
-            f"{swaption_comparison_kwargs}))"
+            f"{swaption_comparison_kwargs})"
         ),
         "trellis.models.equity_option_monte_carlo.price_vanilla_equity_option_monte_carlo": (
-            "return float(price_vanilla_equity_option_monte_carlo("
-            f"market_state, spec{vanilla_equity_mc_kwargs}))"
+            "return price_vanilla_equity_option_monte_carlo("
+            f"market_state, spec{vanilla_equity_mc_kwargs})"
         ),
         "trellis.models.equity_option_transforms.price_vanilla_equity_option_transform": (
-            "return float(price_vanilla_equity_option_transform("
-            f"market_state, spec{vanilla_equity_transform_kwargs}))"
+            "return price_vanilla_equity_option_transform("
+            f"market_state, spec{vanilla_equity_transform_kwargs})"
         ),
         "trellis.models.zcb_option_tree.price_zcb_option_tree": (
-            "return float(price_zcb_option_tree("
-            f"market_state, spec{zcb_option_tree_kwargs}))"
+            "return price_zcb_option_tree("
+            f"market_state, spec{zcb_option_tree_kwargs})"
         ),
         "trellis.models.credit_basket_copula.price_credit_basket_tranche": (
-            "return float(price_credit_basket_tranche("
-            f"market_state, spec{credit_basket_tranche_kwargs}))"
+            "return price_credit_basket_tranche("
+            f"market_state, spec{credit_basket_tranche_kwargs})"
         ),
         "trellis.models.credit_basket_copula.price_credit_portfolio_loss_distribution_recursive": (
-            "return float(price_credit_portfolio_loss_distribution_recursive("
-            'market_state, spec, copula_family="gaussian"))'
+            "return price_credit_portfolio_loss_distribution_recursive("
+            'market_state, spec, copula_family="gaussian")'
         ),
         "trellis.models.credit_basket_copula.price_credit_portfolio_loss_distribution_transform_proxy": (
-            "return float(price_credit_portfolio_loss_distribution_transform_proxy("
-            'market_state, spec, copula_family="gaussian"))'
+            "return price_credit_portfolio_loss_distribution_transform_proxy("
+            'market_state, spec, copula_family="gaussian")'
         ),
         "trellis.models.credit_basket_copula.price_credit_portfolio_loss_distribution_monte_carlo": (
-            "return float(price_credit_portfolio_loss_distribution_monte_carlo("
-            'market_state, spec, copula_family="gaussian", n_paths=40000, seed=42))'
+            "return price_credit_portfolio_loss_distribution_monte_carlo("
+            'market_state, spec, copula_family="gaussian", n_paths=40000, seed=42)'
         ),
         "trellis.models.basket_option.price_basket_option_analytical": (
-            "return float(price_basket_option_analytical("
-            f"market_state, spec{basket_option_kwargs}))"
+            "return price_basket_option_analytical("
+            f"market_state, spec{basket_option_kwargs})"
         ),
         "trellis.models.basket_option.price_basket_option_monte_carlo": (
-            "return float(price_basket_option_monte_carlo("
-            f"market_state, spec{basket_option_kwargs}, seed=42))"
+            "return price_basket_option_monte_carlo("
+            f"market_state, spec{basket_option_kwargs}, seed=42)"
         ),
         "trellis.models.basket_option.price_basket_option_transform_proxy": (
-            "return float(price_basket_option_transform_proxy("
-            f"market_state, spec{basket_option_kwargs}))"
+            "return price_basket_option_transform_proxy("
+            f"market_state, spec{basket_option_kwargs})"
         ),
         "trellis.models.analytical.equity_exotics.price_equity_digital_option_analytical": (
-            "return float(price_equity_digital_option_analytical(market_state, spec))"
+            "return price_equity_digital_option_analytical(market_state, spec)"
         ),
         "trellis.models.analytical.equity_exotics.price_equity_fixed_lookback_option_analytical": (
-            "return float(price_equity_fixed_lookback_option_analytical(market_state, spec))"
+            "return price_equity_fixed_lookback_option_analytical(market_state, spec)"
         ),
         "trellis.models.analytical.equity_exotics.price_equity_chooser_option_analytical": (
-            "return float(price_equity_chooser_option_analytical(market_state, spec))"
+            "return price_equity_chooser_option_analytical(market_state, spec)"
         ),
         "trellis.models.analytical.equity_exotics.price_equity_compound_option_analytical": (
-            "return float(price_equity_compound_option_analytical(market_state, spec))"
+            "return price_equity_compound_option_analytical(market_state, spec)"
         ),
         "trellis.models.analytical.equity_exotics.price_equity_cliquet_option_analytical": (
-            "return float(price_equity_cliquet_option_analytical(market_state, spec))"
+            "return price_equity_cliquet_option_analytical(market_state, spec)"
         ),
         "trellis.models.analytical.equity_exotics.price_equity_variance_swap_analytical": (
-            "return float(price_equity_variance_swap_analytical(market_state, spec))"
+            "return price_equity_variance_swap_analytical(market_state, spec)"
         ),
         "trellis.models.analytical.barrier.barrier_option_price": (
             "if market_state.discount is None:\n"
@@ -3596,7 +3597,7 @@ def _deterministic_exact_binding_evaluate_body(
             "    q=carry_rate,\n"
             "    observations_per_year=getattr(spec, 'observations_per_year', None),\n"
             ")\n"
-            "return float(spec.notional) * float(price)"
+            "return spec.notional * price"
         ),
     }
     for ref, body in helper_bodies.items():

--- a/trellis/agent/knowledge/canonical/cookbooks.yaml
+++ b/trellis/agent/knowledge/canonical/cookbooks.yaml
@@ -118,29 +118,32 @@ analytical:
   template: "## Cookbook: Analytical\nThis family contains distinct solution contracts.\
     \ Each is valid only under\nits stated assumptions. See the `solution_contracts`\
     \ block above for the\nassumption sets. Do not mix assumptions across contracts.\n\
-    \nevaluate() returns the PV (float) and discounts each period internally.\n\n\
+    \nevaluate() returns the present-value scalar and discounts each period internally.\n\
+    Do not wrap the final present value in `float(...)` solely because `evaluate()` is public.\n\
+    Use `float(...)` only at an explicit solver or reporting boundary.\n\
+    Prefer the raw-kernel-plus-wrapper pattern when a resolved-input helper exists.\n\n\
     ### Black-Scholes equity European (solution contract: black_scholes_equity)\n\
     Assumptions: lognormal spot (GBM), deterministic rates, European exercise.\n```python\n\
     def evaluate(self, market_state):\n    from trellis.core.date_utils import year_fraction\n\
     \    from trellis.models.black import black76_call, black76_put\n\n    spec =\
     \ self._spec\n    T = year_fraction(market_state.settlement, spec.expiry_date,\
-    \ spec.day_count)\n    if T <= 0:\n        return 0.0\n\n    df = float(market_state.discount.discount(T))\n\
-    \    sigma = float(market_state.vol_surface.black_vol(T, spec.strike))\n    forward\
+    \ spec.day_count)\n    if T <= 0:\n        return 0.0\n\n    df = market_state.discount.discount(T)\n\
+    \    sigma = market_state.vol_surface.black_vol(T, spec.strike)\n    forward\
     \ = spec.spot / max(df, 1e-12)\n\n    if spec.option_type == \"put\":\n      \
     \  undiscounted = black76_put(forward, spec.strike, sigma, T)\n    else:\n   \
     \     undiscounted = black76_call(forward, spec.strike, sigma, T)\n\n    return\
-    \ spec.notional * df * float(undiscounted)\n```\n\n### Black-Scholes cash-or-nothing\
+    \ spec.notional * df * undiscounted\n```\n\n### Black-Scholes cash-or-nothing\
     \ digital (solution contract: black_scholes_digital)\nAssumptions: lognormal spot\
     \ (GBM), deterministic rates, European exercise.\n```python\ndef evaluate(self,\
     \ market_state):\n    from trellis.core.date_utils import year_fraction\n    from\
     \ trellis.models.black import black76_cash_or_nothing_call, black76_cash_or_nothing_put\n\
     \n    spec = self._spec\n    T = year_fraction(market_state.settlement, spec.expiry_date,\
-    \ spec.day_count)\n    if T <= 0:\n        return 0.0\n\n    df = float(market_state.discount.discount(T))\n\
-    \    sigma = float(market_state.vol_surface.black_vol(T, spec.strike))\n    F\
+    \ spec.day_count)\n    if T <= 0:\n        return 0.0\n\n    df = market_state.discount.discount(T)\n\
+    \    sigma = market_state.vol_surface.black_vol(T, spec.strike)\n    F\
     \ = spec.spot / max(df, 1e-12)\n\n    if spec.option_type == \"put\":\n      \
     \  undiscounted = black76_cash_or_nothing_put(F, spec.strike, sigma, T)\n    else:\n\
     \        undiscounted = black76_cash_or_nothing_call(F, spec.strike, sigma, T)\n\
-    \n    pv = spec.notional * float(undiscounted) * df\n    return pv\n```\n\n###\
+    \n    pv = spec.notional * undiscounted * df\n    return pv\n```\n\n###\
     \ Garman-Kohlhagen FX European (helper-backed resolved-input route; solution contract:\
     \ garman_kohlhagen_fx)\nAssumptions: lognormal FX spot, deterministic domestic/foreign\
     \ rates,\ncovered interest parity.\n```python\ndef evaluate(self, market_state):\n\
@@ -149,13 +152,13 @@ analytical:
     \    )\n\n    spec = self._spec\n    T = year_fraction(market_state.settlement,\
     \ spec.expiry_date, spec.day_count)\n\n    fx_quote = market_state.fx_rates[spec.fx_pair]\n\
     \    foreign_curve = market_state.forecast_curves[spec.foreign_discount_key]\n\
-    \n    spot = float(fx_quote.spot)\n    df_domestic = float(market_state.discount.discount(T))\n\
-    \    df_foreign = float(foreign_curve.discount(T))\n    sigma = 0.0 if T <= 0\
-    \ else float(market_state.vol_surface.black_vol(T, spec.strike))\n    resolved\
+    \n    spot = float(fx_quote.spot)\n    df_domestic = market_state.discount.discount(T)\n\
+    \    df_foreign = foreign_curve.discount(T)\n    sigma = 0.0 if T <= 0\
+    \ else market_state.vol_surface.black_vol(T, spec.strike)\n    resolved\
     \ = ResolvedGarmanKohlhagenInputs(\n        spot=spot,\n        strike=spec.strike,\n\
     \        sigma=sigma,\n        T=T,\n        df_domestic=df_domestic,\n      \
-    \  df_foreign=df_foreign,\n    )\n\n    return spec.notional * float(garman_kohlhagen_price_raw(spec.option_type,\
-    \ resolved))\n```\n\nFor FX tasks, the selected foreign curve is usually bridged\
+    \  df_foreign=df_foreign,\n    )\n\n    return spec.notional * garman_kohlhagen_price_raw(spec.option_type,\
+    \ resolved)\n```\n\nFor FX tasks, the selected foreign curve is usually bridged\
     \ into\n`market_state.forward_curve` for routing and capability checks, while\
     \ the\nexplicit foreign discount factors still come from\n`market_state.forecast_curves[spec.foreign_discount_key]`.\n\
     \n### Black76 forward-rate (solution contract: black76_forward_rate)\nAssumptions:\
@@ -173,7 +176,7 @@ analytical:
     \n        # >>> INSTRUMENT-SPECIFIC: choose black76_call or black76_put <<<\n\
     \        undiscounted = spec.notional * tau * black76_call(F, spec.strike, sigma,\
     \ t_start)\n        df = market_state.discount.discount(t_end)\n        pv +=\
-    \ float(undiscounted) * float(df)\n\n    return pv\n```\n\nFor European rate-style\
+    \ undiscounted * df\n\n    return pv\n```\n\nFor European rate-style\
     \ swaptions, prefer the checked helper-backed path\nover rebuilding annuity, forward-swap-rate,\
     \ and expiry binding inline.\n\n### Rate-style swaption Black76 (helper-backed\
     \ resolved-input route; solution contract: black76_forward_rate)\nAssumptions:\
@@ -182,7 +185,7 @@ analytical:
     \ import (\n        ResolvedSwaptionBlack76Inputs,\n        price_swaption_black76_raw,\n\
     \        resolve_swaption_black76_inputs,\n    )\n\n    spec = self._spec\n  \
     \  resolved = resolve_swaption_black76_inputs(market_state, spec)\n    assert\
-    \ isinstance(resolved, ResolvedSwaptionBlack76Inputs)\n    return float(price_swaption_black76_raw(resolved))\n\
+    \ isinstance(resolved, ResolvedSwaptionBlack76Inputs)\n    return price_swaption_black76_raw(resolved)\n\
     ```\n\n### Jamshidian zero-coupon bond option (helper-backed resolved-input route;\
     \ solution contract: jamshidian_zcb_option)\nAssumptions: one-factor Hull-White\
     \ / Jamshidian closed form, European\nexercise, option on a zero-coupon bond.\n\
@@ -197,8 +200,8 @@ analytical:
     \ resolved.jamshidian.discount_factor_bond,\n                0.0,\n          \
     \  )\n        else:\n            intrinsic = max(\n                resolved.jamshidian.discount_factor_bond\
     \ - resolved.jamshidian.strike,\n                0.0,\n            )\n       \
-    \ return float(resolved.notional * intrinsic)\n\n    raw = zcb_option_hw_raw(resolved.jamshidian)\n\
-    \    return float(resolved.notional * raw[resolved.option_type])\n```\n\n### Credit\
+    \ return resolved.notional * intrinsic\n\n    raw = zcb_option_hw_raw(resolved.jamshidian)\n\
+    \    return resolved.notional * raw[resolved.option_type]\n```\n\n### Credit\
     \ default swap (single-name) (solution contract: credit_default_swap)\nAssumptions:\
     \ deterministic discounting, credit survival probabilities from\na credit curve,\
     \ one reference entity, premium leg on a schedule, protection\nleg triggered by\
@@ -426,9 +429,9 @@ monte_carlo:
     \ T)\n    dt = T / engine.n_steps\n    exercise_dates = list(range(1, engine.n_steps\
     \ + 1))\n    basis = LaguerreBasis()  # example continuation basis, not mandatory\n\
     \n    def exercise_payoff(spots):\n        return np.maximum(spec.strike - spots,\
-    \ 0.0)\n\n    return float(\n        longstaff_schwartz(\n            paths,\n\
+    \ 0.0)\n\n    return longstaff_schwartz(\n            paths,\n\
     \            exercise_dates,\n            exercise_payoff,\n            discount_rate=r,\n\
-    \            dt=dt,\n            basis_fn=basis,\n        )\n    )\n```\n"
+    \            dt=dt,\n            basis_fn=basis,\n        )\n```\n"
 qmc:
   description: Low-discrepancy Monte Carlo accelerators built on Sobol sampling and
     optional Brownian-bridge path construction
@@ -455,7 +458,7 @@ qmc:
     \    spots = spec.spot * np.exp(\n        np.concatenate([np.zeros((n_paths, 1)),\
     \ log_paths], axis=1)\n    )\n\n    # >>> INSTRUMENT-SPECIFIC: compute payoff\
     \ from full paths <<<\n    payoffs = np.maximum(spots[:, -1] - spec.strike, 0.0)\
-    \ * spec.notional\n    discounted = np.exp(-r * T) * payoffs\n    return float(np.mean(discounted))\n\
+    \ * spec.notional\n    discounted = np.exp(-r * T) * payoffs\n    return np.mean(discounted)\n\
     ```\n"
 copula:
   description: Correlated-default pricing for basket credit and tranche products
@@ -556,7 +559,7 @@ fft_pricing:
     \        return process.characteristic_function(u, T)\n\n    price = cos_price(\n\
     \        char_fn=char_fn,\n        S0=spec.spot,\n        K=spec.strike,\n   \
     \     T=T,\n        r=r,\n        option_type=\"call\",  # >>> INSTRUMENT-SPECIFIC:\
-    \ choose call or put <<<\n    )\n    return float(price) * spec.notional\n```\n"
+    \ choose call or put <<<\n    )\n    return price * spec.notional\n```\n"
 credit:
   template: "class CDSPricer:\n    def __init__(self, spec):\n        self._spec =\
     \ spec\n\n    @property\n    def requirements(self) -> set[str]:\n        return\

--- a/trellis/agent/knowledge/import_registry.py
+++ b/trellis/agent/knowledge/import_registry.py
@@ -492,6 +492,7 @@ If a module or symbol is not listed below, it does NOT exist.
 ### Core
 from trellis.core.date_utils import generate_schedule, year_fraction, add_months
 from trellis.core.market_state import MarketState
+from trellis.core.payoff import PricingValue
 from trellis.core.types import DayCountConvention, Frequency
 
 ### Curves

--- a/trellis/agent/prompts.py
+++ b/trellis/agent/prompts.py
@@ -309,9 +309,8 @@ Reasoning: {pricing_plan.reasoning}
 ```
 
 ## Your task
-Write ONLY the body of the `evaluate()` method. The signature is already defined:
-
-    def evaluate(self, market_state: MarketState) -> float:
+Write ONLY the body of the `evaluate()` method. The signature is already
+defined in the skeleton.
 
 ## Spec fields available via self._spec
 {field_descs}
@@ -320,7 +319,11 @@ Write ONLY the body of the `evaluate()` method. The signature is already defined
 {assembly_context}
 {family_route_guidance}
 ## Conventions
-- evaluate() returns a FLOAT — the present value (PV) of the instrument
+- evaluate() returns the present-value scalar (PV) of the instrument
+- On smooth autodiff-compatible routes that scalar may be traced by the active differentiable backend
+- Do not wrap the final present value in `float(...)` solely because `evaluate()` is public
+- Prefer the raw-kernel-plus-wrapper pattern when the route has a reusable resolved-input kernel: keep market resolution in `evaluate()`, keep reusable math in the raw helper, and preserve the same traced PV through both surfaces
+- If a plain Python `float` is required, convert only at an explicit reporting or solver boundary, not at the payoff adapter boundary
 - You MUST handle all discounting internally — use `market_state.discount.discount(t)`
 - For forward rates: `market_state.forecast_forward_curve(self._spec.rate_index)`
 - For vol: `market_state.vol_surface.black_vol(T, strike)`

--- a/trellis/instruments/_agent/_fresh/quantooptionanalytical.py
+++ b/trellis/instruments/_agent/_fresh/quantooptionanalytical.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from datetime import date
 
 from trellis.core.market_state import MarketState
+from trellis.core.payoff import PricingValue
 from trellis.core.types import DayCountConvention
 from trellis.models.quanto_option import price_quanto_option_analytical_from_market_state
 
@@ -51,5 +52,5 @@ class QuantoOptionAnalyticalPayoff:
     def requirements(self) -> set[str]:
         return REQUIREMENTS
 
-    def evaluate(self, market_state: MarketState) -> float:
-        return float(price_quanto_option_analytical_from_market_state(market_state, self._spec))
+    def evaluate(self, market_state: MarketState) -> PricingValue:
+        return price_quanto_option_analytical_from_market_state(market_state, self._spec)

--- a/trellis/instruments/_agent/europeanoptionanalytical.py
+++ b/trellis/instruments/_agent/europeanoptionanalytical.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass
 from datetime import date
 
 from trellis.core.market_state import MarketState
+from trellis.core.payoff import PricingValue
 from trellis.core.types import DayCountConvention
 from trellis.core.date_utils import year_fraction
 from trellis.models.black import black76_call, black76_put, black76_asset_or_nothing_call, black76_asset_or_nothing_put, black76_cash_or_nothing_call, black76_cash_or_nothing_put
@@ -77,7 +78,7 @@ Implementation target: black_scholes."""
     def requirements(self) -> set[str]:
         return {"black_vol_surface", "discount_curve"}
 
-    def evaluate(self, market_state: MarketState) -> float:
+    def evaluate(self, market_state: MarketState) -> PricingValue:
         spec = self._spec
         spec = self._spec
         if market_state.discount is None:
@@ -85,14 +86,14 @@ Implementation target: black_scholes."""
         if market_state.vol_surface is None:
             raise ValueError("market_state.vol_surface is required for Black-Scholes comparison")
         T = max(float(year_fraction(market_state.settlement, spec.expiry_date, spec.day_count)), 0.0)
-        spot = float(spec.spot)
-        strike = float(spec.strike)
+        spot = spec.spot
+        strike = spec.strike
         option_type = str(spec.option_type or "call").strip().lower()
         if T <= 0.0:
             intrinsic = max(spot - strike, 0.0) if option_type == "call" else max(strike - spot, 0.0)
-            return float(spec.notional) * intrinsic
-        df = float(market_state.discount.discount(T))
-        sigma = float(market_state.vol_surface.black_vol(max(T, 1e-6), strike))
+            return spec.notional * intrinsic
+        df = market_state.discount.discount(T)
+        sigma = market_state.vol_surface.black_vol(max(T, 1e-6), strike)
         forward = spot / max(df, 1e-12)
         if option_type == "call":
             undiscounted = black76_call(forward, strike, sigma, T)
@@ -100,7 +101,7 @@ Implementation target: black_scholes."""
             undiscounted = black76_put(forward, strike, sigma, T)
         else:
             raise ValueError(f"Unsupported option_type {spec.option_type!r}")
-        return float(spec.notional) * df * float(undiscounted)
+        return spec.notional * df * undiscounted
 
     def benchmark_outputs(self, market_state: MarketState) -> dict[str, float]:
         return dict(equity_vanilla_bs_outputs(market_state, self._spec))

--- a/trellis/instruments/_agent/quantooptionanalytical.py
+++ b/trellis/instruments/_agent/quantooptionanalytical.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from datetime import date
 
 from trellis.core.market_state import MarketState
+from trellis.core.payoff import PricingValue
 from trellis.core.types import DayCountConvention
 from trellis.models.quanto_option import price_quanto_option_analytical_from_market_state
 
@@ -51,5 +52,5 @@ class QuantoOptionAnalyticalPayoff:
     def requirements(self) -> set[str]:
         return REQUIREMENTS
 
-    def evaluate(self, market_state: MarketState) -> float:
-        return float(price_quanto_option_analytical_from_market_state(market_state, self._spec))
+    def evaluate(self, market_state: MarketState) -> PricingValue:
+        return price_quanto_option_analytical_from_market_state(market_state, self._spec)

--- a/trellis/instruments/_agent/swaption.py
+++ b/trellis/instruments/_agent/swaption.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from datetime import date
 
 from trellis.core.market_state import MarketState
+from trellis.core.payoff import PricingValue
 from trellis.core.types import DayCountConvention, Frequency
 from trellis.models.rate_style_swaption import price_swaption_black76
 
@@ -39,6 +40,6 @@ class SwaptionPayoff:
     def requirements(self) -> set[str]:
         return {"black_vol_surface", "discount_curve", "forward_curve"}
 
-    def evaluate(self, market_state: MarketState) -> float:
+    def evaluate(self, market_state: MarketState) -> PricingValue:
         spec = self._spec
-        return float(price_swaption_black76(market_state, spec))
+        return price_swaption_black76(market_state, spec)


### PR DESCRIPTION
Summary:
- align generated payoff and builder prompt surfaces with the trace-safe public PV contract
- update executor, prompt, and cookbook guidance so learned routes preserve differentiable kernels instead of collapsing them at evaluate
- refresh the checked generated artifacts and related docs for the autograd-native route pattern

Testing:
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_build_loop.py tests/test_agent/test_cookbooks.py tests/test_agent/test_executor.py tests/test_agent/test_prompts.py -q