### PR TITLE
Calibration plan: mark merged stack done

### DIFF
--- a/doc/plan/draft__calibration-sleeve-industrial-hardening-program.md
+++ b/doc/plan/draft__calibration-sleeve-industrial-hardening-program.md
@@ -68,10 +68,10 @@ Rules for coding agents:
 | --- | --- | --- | --- | --- |
 | `CAL.0A` | `QUA-947` | Done | Trellis-native architecture and documentation alignment | none |
 | `CAL.0B` | `QUA-948` | Done | equity-vol carry consistency across pricing and implied-vol inversion | none |
-| `CAL.0C` | `QUA-949` | In Review | CDS-pricer-backed single-name credit objective and diagnostics | none |
-| `CAL.1` | `QUA-950` | In Review | industrial equity-vol surface foundation and staged model fits | `CAL.0B` |
-| `CAL.2` | `QUA-951` | In Review | dated-instrument multi-curve hardening and calibration dependency DAG | none; ordered after the Phase 0 slices |
-| `CAL.3` | `QUA-952` | In Review | caplet stripping, swaption cube assembly, and rates-vol model diagnostics | `CAL.2` |
+| `CAL.0C` | `QUA-949` | Done | CDS-pricer-backed single-name credit objective and diagnostics | none |
+| `CAL.1` | `QUA-950` | Done | industrial equity-vol surface foundation and staged model fits | `CAL.0B` |
+| `CAL.2` | `QUA-951` | Done | dated-instrument multi-curve hardening and calibration dependency DAG | none; ordered after the Phase 0 slices |
+| `CAL.3` | `QUA-952` | Done | caplet stripping, swaption cube assembly, and rates-vol model diagnostics | `CAL.2` |
 | `CAL.4` | `QUA-953` | Backlog | schedule-aware single-name credit curve calibration | `CAL.0C` |
 | `CAL.5` | `QUA-954` | Backlog | basket-credit base-correlation workflow and tranche-surface governance | `CAL.4` |
 | `CAL.6` | `QUA-955` | Backlog | first cross-asset calibration slice on explicit dependency DAGs | set the concrete upstream blockers during implementation once the first supported slice is chosen |


### PR DESCRIPTION
## Summary
- Mark QUA-949 through QUA-952 Done in the calibration hardening plan mirror after REST merges completed.

## Validation
- git diff --check

## Notes
- This is bookkeeping only; implementation PRs were #654, #659, #660, and #661.