### PR TITLE
QUA-970: Add autograd gradient support matrix

### DIFF
--- a/docs/benchmarks/pod_risk_workflows.json
+++ b/docs/benchmarks/pod_risk_workflows.json
@@ -4,14 +4,14 @@
     {
       "cold": {
         "label": "twist_cube",
-        "max_seconds": 0.036746,
-        "mean_seconds": 0.036345,
-        "median_seconds": 0.036345,
+        "max_seconds": 0.045087,
+        "mean_seconds": 0.044221,
+        "median_seconds": 0.044221,
         "metadata": {
           "position_count": 2,
           "scenario_count": 2
         },
-        "min_seconds": 0.035944,
+        "min_seconds": 0.043355,
         "mode": "cold",
         "notes": [
           "scenario_cube",
@@ -19,10 +19,10 @@
         ],
         "repeats": 2,
         "run_seconds": [
-          0.036746,
-          0.035944
+          0.045087,
+          0.043355
         ],
-        "runs_per_second": 27.514,
+        "runs_per_second": 22.614,
         "warmups": 1
       },
       "label": "twist_cube",
@@ -36,14 +36,14 @@
       ],
       "steady": {
         "label": "twist_cube",
-        "max_seconds": 0.034429,
-        "mean_seconds": 0.033873,
-        "median_seconds": 0.033873,
+        "max_seconds": 0.042119,
+        "mean_seconds": 0.042102,
+        "median_seconds": 0.042102,
         "metadata": {
           "position_count": 2,
           "scenario_count": 2
         },
-        "min_seconds": 0.033318,
+        "min_seconds": 0.042085,
         "mode": "steady_state",
         "notes": [
           "scenario_cube",
@@ -51,26 +51,26 @@
         ],
         "repeats": 2,
         "run_seconds": [
-          0.034429,
-          0.033318
+          0.042085,
+          0.042119
         ],
-        "runs_per_second": 29.522,
+        "runs_per_second": 23.752,
         "warmups": 1
       },
-      "steady_speedup": 1.073,
+      "steady_speedup": 1.05,
       "workflow": "pipeline_scenarios"
     },
     {
       "cold": {
         "label": "curve_rebuild_buckets",
-        "max_seconds": 1.604299,
-        "mean_seconds": 1.553535,
-        "median_seconds": 1.553535,
+        "max_seconds": 1.641834,
+        "mean_seconds": 1.62714,
+        "median_seconds": 1.62714,
         "metadata": {
           "bucket_count": 4,
           "methodology": "curve_rebuild"
         },
-        "min_seconds": 1.50277,
+        "min_seconds": 1.612445,
         "mode": "cold",
         "notes": [
           "curve_rebuild",
@@ -78,10 +78,10 @@
         ],
         "repeats": 2,
         "run_seconds": [
-          1.604299,
-          1.50277
+          1.612445,
+          1.641834
         ],
-        "runs_per_second": 0.644,
+        "runs_per_second": 0.615,
         "warmups": 1
       },
       "label": "curve_rebuild_buckets",
@@ -95,14 +95,14 @@
       ],
       "steady": {
         "label": "curve_rebuild_buckets",
-        "max_seconds": 1.350307,
-        "mean_seconds": 1.35,
-        "median_seconds": 1.35,
+        "max_seconds": 1.44564,
+        "mean_seconds": 1.434231,
+        "median_seconds": 1.434231,
         "metadata": {
           "bucket_count": 4,
           "methodology": "curve_rebuild"
         },
-        "min_seconds": 1.349694,
+        "min_seconds": 1.422822,
         "mode": "steady_state",
         "notes": [
           "curve_rebuild",
@@ -110,26 +110,91 @@
         ],
         "repeats": 2,
         "run_seconds": [
-          1.350307,
-          1.349694
+          1.44564,
+          1.422822
         ],
-        "runs_per_second": 0.741,
+        "runs_per_second": 0.697,
         "warmups": 1
       },
-      "steady_speedup": 1.151,
+      "steady_speedup": 1.135,
       "workflow": "key_rate_durations"
     },
     {
       "cold": {
+        "label": "bond_book_reverse_mode",
+        "max_seconds": 0.035902,
+        "mean_seconds": 0.035875,
+        "median_seconds": 0.035875,
+        "metadata": {
+          "curve_nodes": 5,
+          "position_count": 2,
+          "supported_route": "bond_only"
+        },
+        "min_seconds": 0.035848,
+        "mode": "cold",
+        "notes": [
+          "bond_book",
+          "reverse_mode",
+          "supported_curve"
+        ],
+        "repeats": 2,
+        "run_seconds": [
+          0.035902,
+          0.035848
+        ],
+        "runs_per_second": 27.875,
+        "warmups": 1
+      },
+      "label": "bond_book_reverse_mode",
+      "metadata": {
+        "curve_nodes": 5,
+        "position_count": 2,
+        "supported_route": "bond_only"
+      },
+      "notes": [
+        "bond_book",
+        "reverse_mode",
+        "supported_curve"
+      ],
+      "steady": {
+        "label": "bond_book_reverse_mode",
+        "max_seconds": 0.002515,
+        "mean_seconds": 0.002494,
+        "median_seconds": 0.002494,
+        "metadata": {
+          "curve_nodes": 5,
+          "position_count": 2,
+          "supported_route": "bond_only"
+        },
+        "min_seconds": 0.002473,
+        "mode": "steady_state",
+        "notes": [
+          "bond_book",
+          "reverse_mode",
+          "supported_curve"
+        ],
+        "repeats": 2,
+        "run_seconds": [
+          0.002473,
+          0.002515
+        ],
+        "runs_per_second": 400.946,
+        "warmups": 1
+      },
+      "steady_speedup": 14.384,
+      "workflow": "portfolio_aad"
+    },
+    {
+      "cold": {
         "label": "rebuild_pack",
-        "max_seconds": 0.862396,
-        "mean_seconds": 0.846134,
-        "median_seconds": 0.846134,
+        "max_seconds": 0.930823,
+        "mean_seconds": 0.912669,
+        "median_seconds": 0.912669,
         "metadata": {
           "methodology": "curve_rebuild",
           "scenario_count": 4
         },
-        "min_seconds": 0.829871,
+        "min_seconds": 0.894515,
         "mode": "cold",
         "notes": [
           "curve_rebuild",
@@ -137,10 +202,10 @@
         ],
         "repeats": 2,
         "run_seconds": [
-          0.862396,
-          0.829871
+          0.894515,
+          0.930823
         ],
-        "runs_per_second": 1.182,
+        "runs_per_second": 1.096,
         "warmups": 1
       },
       "label": "rebuild_pack",
@@ -154,14 +219,14 @@
       ],
       "steady": {
         "label": "rebuild_pack",
-        "max_seconds": 0.684988,
-        "mean_seconds": 0.675639,
-        "median_seconds": 0.675639,
+        "max_seconds": 0.743495,
+        "mean_seconds": 0.732731,
+        "median_seconds": 0.732731,
         "metadata": {
           "methodology": "curve_rebuild",
           "scenario_count": 4
         },
-        "min_seconds": 0.66629,
+        "min_seconds": 0.721966,
         "mode": "steady_state",
         "notes": [
           "curve_rebuild",
@@ -169,28 +234,28 @@
         ],
         "repeats": 2,
         "run_seconds": [
-          0.684988,
-          0.66629
+          0.721966,
+          0.743495
         ],
-        "runs_per_second": 1.48,
+        "runs_per_second": 1.365,
         "warmups": 1
       },
-      "steady_speedup": 1.252,
+      "steady_speedup": 1.246,
       "workflow": "scenario_pnl"
     },
     {
       "cold": {
         "label": "bucketed_surface",
-        "max_seconds": 0.018225,
-        "mean_seconds": 0.018114,
-        "median_seconds": 0.018114,
+        "max_seconds": 0.022764,
+        "mean_seconds": 0.022658,
+        "median_seconds": 0.022658,
         "metadata": {
           "grid_shape": [
             3,
             3
           ]
         },
-        "min_seconds": 0.018003,
+        "min_seconds": 0.022551,
         "mode": "cold",
         "notes": [
           "vol_surface",
@@ -198,10 +263,10 @@
         ],
         "repeats": 2,
         "run_seconds": [
-          0.018225,
-          0.018003
+          0.022764,
+          0.022551
         ],
-        "runs_per_second": 55.205,
+        "runs_per_second": 44.135,
         "warmups": 1
       },
       "label": "bucketed_surface",
@@ -217,16 +282,16 @@
       ],
       "steady": {
         "label": "bucketed_surface",
-        "max_seconds": 0.018091,
-        "mean_seconds": 0.017966,
-        "median_seconds": 0.017966,
+        "max_seconds": 0.023395,
+        "mean_seconds": 0.023035,
+        "median_seconds": 0.023035,
         "metadata": {
           "grid_shape": [
             3,
             3
           ]
         },
-        "min_seconds": 0.01784,
+        "min_seconds": 0.022676,
         "mode": "steady_state",
         "notes": [
           "vol_surface",
@@ -234,25 +299,25 @@
         ],
         "repeats": 2,
         "run_seconds": [
-          0.018091,
-          0.01784
+          0.023395,
+          0.022676
         ],
-        "runs_per_second": 55.662,
+        "runs_per_second": 43.412,
         "warmups": 1
       },
-      "steady_speedup": 1.008,
+      "steady_speedup": 0.984,
       "workflow": "vega"
     },
     {
       "cold": {
         "label": "delta_gamma_theta_bundle",
-        "max_seconds": 0.013554,
-        "mean_seconds": 0.013524,
-        "median_seconds": 0.013524,
+        "max_seconds": 0.018577,
+        "mean_seconds": 0.018363,
+        "median_seconds": 0.018363,
         "metadata": {
           "measure_count": 3
         },
-        "min_seconds": 0.013495,
+        "min_seconds": 0.01815,
         "mode": "cold",
         "notes": [
           "spot_risk",
@@ -260,10 +325,10 @@
         ],
         "repeats": 2,
         "run_seconds": [
-          0.013554,
-          0.013495
+          0.01815,
+          0.018577
         ],
-        "runs_per_second": 73.942,
+        "runs_per_second": 54.456,
         "warmups": 1
       },
       "label": "delta_gamma_theta_bundle",
@@ -276,13 +341,13 @@
       ],
       "steady": {
         "label": "delta_gamma_theta_bundle",
-        "max_seconds": 0.013885,
-        "mean_seconds": 0.013805,
-        "median_seconds": 0.013805,
+        "max_seconds": 0.018754,
+        "mean_seconds": 0.018316,
+        "median_seconds": 0.018316,
         "metadata": {
           "measure_count": 3
         },
-        "min_seconds": 0.013724,
+        "min_seconds": 0.017878,
         "mode": "steady_state",
         "notes": [
           "spot_risk",
@@ -290,17 +355,17 @@
         ],
         "repeats": 2,
         "run_seconds": [
-          0.013885,
-          0.013724
+          0.018754,
+          0.017878
         ],
-        "runs_per_second": 72.44,
+        "runs_per_second": 54.597,
         "warmups": 1
       },
-      "steady_speedup": 0.98,
+      "steady_speedup": 1.003,
       "workflow": "spot_greeks"
     }
   ],
-  "created_at": "2026-04-05T19:51:03Z",
+  "created_at": "2026-04-23T12:52:58Z",
   "environment": {
     "platform": "macOS-26.3.1-arm64-arm-64bit",
     "python_version": "3.10.6"
@@ -310,10 +375,10 @@
     "Coverage includes shared scenario-result cube execution plus supported rates, volatility, and spot-risk analytics."
   ],
   "summary": {
-    "average_steady_speedup": 1.093,
-    "cold_mean_seconds": 0.49353,
-    "steady_mean_seconds": 0.418257,
-    "steady_state_workflow_count": 5,
-    "workflow_count": 5
+    "average_steady_speedup": 3.3,
+    "cold_mean_seconds": 0.443488,
+    "steady_mean_seconds": 0.375485,
+    "steady_state_workflow_count": 6,
+    "workflow_count": 6
   }
 }

--- a/docs/benchmarks/pod_risk_workflows.md
+++ b/docs/benchmarks/pod_risk_workflows.md
@@ -1,10 +1,10 @@
 # Pod Risk Benchmark: `pod_risk_workflows`
-- Created at: `2026-04-05T19:51:03Z`
-- Workflows: `5`
-- Steady-state workflows: `5`
-- Avg cold mean seconds: `0.49353`
-- Avg steady mean seconds: `0.418257`
-- Avg steady speedup: `1.093`x
+- Created at: `2026-04-23T12:52:58Z`
+- Workflows: `6`
+- Steady-state workflows: `6`
+- Avg cold mean seconds: `0.443488`
+- Avg steady mean seconds: `0.375485`
+- Avg steady speedup: `3.3`x
 
 ## Environment
 - Python: `3.10.6`
@@ -17,51 +17,62 @@
 ## Workflow Results
 
 ### `pipeline_scenarios` twist_cube
-- Cold mean: `0.036345` s
-- Cold throughput: `27.514` runs/s
-- Steady mean: `0.033873` s
-- Steady throughput: `29.522` runs/s
-- Steady speedup: `1.073`x
+- Cold mean: `0.044221` s
+- Cold throughput: `22.614` runs/s
+- Steady mean: `0.042102` s
+- Steady throughput: `23.752` runs/s
+- Steady speedup: `1.05`x
 - Metadata: `position_count`=2, `scenario_count`=2
 - Note: scenario_cube
 - Note: twist_pack
 
 ### `key_rate_durations` curve_rebuild_buckets
-- Cold mean: `1.553535` s
-- Cold throughput: `0.644` runs/s
-- Steady mean: `1.35` s
-- Steady throughput: `0.741` runs/s
-- Steady speedup: `1.151`x
+- Cold mean: `1.62714` s
+- Cold throughput: `0.615` runs/s
+- Steady mean: `1.434231` s
+- Steady throughput: `0.697` runs/s
+- Steady speedup: `1.135`x
 - Metadata: `bucket_count`=4, `methodology`='curve_rebuild'
 - Note: curve_rebuild
 - Note: rates_risk
 
+### `portfolio_aad` bond_book_reverse_mode
+- Cold mean: `0.035875` s
+- Cold throughput: `27.875` runs/s
+- Steady mean: `0.002494` s
+- Steady throughput: `400.946` runs/s
+- Steady speedup: `14.384`x
+- Metadata: `curve_nodes`=5, `position_count`=2, `supported_route`='bond_only'
+- Note: bond_book
+- Note: reverse_mode
+- Note: supported_curve
+
 ### `scenario_pnl` rebuild_pack
-- Cold mean: `0.846134` s
-- Cold throughput: `1.182` runs/s
-- Steady mean: `0.675639` s
-- Steady throughput: `1.48` runs/s
-- Steady speedup: `1.252`x
+- Cold mean: `0.912669` s
+- Cold throughput: `1.096` runs/s
+- Steady mean: `0.732731` s
+- Steady throughput: `1.365` runs/s
+- Steady speedup: `1.246`x
 - Metadata: `methodology`='curve_rebuild', `scenario_count`=4
 - Note: curve_rebuild
 - Note: named_scenarios
 
 ### `vega` bucketed_surface
-- Cold mean: `0.018114` s
-- Cold throughput: `55.205` runs/s
-- Steady mean: `0.017966` s
-- Steady throughput: `55.662` runs/s
-- Steady speedup: `1.008`x
+- Cold mean: `0.022658` s
+- Cold throughput: `44.135` runs/s
+- Steady mean: `0.023035` s
+- Steady throughput: `43.412` runs/s
+- Steady speedup: `0.984`x
 - Metadata: `grid_shape`=[3, 3]
 - Note: vol_surface
 - Note: bucketed_vega
 
 ### `spot_greeks` delta_gamma_theta_bundle
-- Cold mean: `0.013524` s
-- Cold throughput: `73.942` runs/s
-- Steady mean: `0.013805` s
-- Steady throughput: `72.44` runs/s
-- Steady speedup: `0.98`x
+- Cold mean: `0.018363` s
+- Cold throughput: `54.456` runs/s
+- Steady mean: `0.018316` s
+- Steady throughput: `54.597` runs/s
+- Steady speedup: `1.003`x
 - Metadata: `measure_count`=3
 - Note: spot_risk
 - Note: bundle

--- a/docs/quant/differentiable_pricing.rst
+++ b/docs/quant/differentiable_pricing.rst
@@ -160,6 +160,59 @@ keeping today's ``autograd`` boundary honest.
 These paths now use autograd-friendly primitives and avoid scalarization inside
 the traced region.
 
+Product-Family Gradient Matrix
+------------------------------
+
+``tests/test_verification/test_autograd_gradient_matrix.py`` is the checked
+product-family gradient matrix for the public support contract. It is
+representative, not exhaustive: each row pins one product family, derivative
+method, fallback boundary, or unsupported lane that future generated routes and
+runtime reporting must not overstate.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Family id
+     - Product family
+     - Checked derivative method
+     - Support status and boundary
+   * - ``analytical_black76``
+     - Black76 closed-form route
+     - ``autodiff_scalar_gradient``
+     - supported on smooth interior inputs; compared against finite
+       differences
+   * - ``public_curve_nodes``
+     - public ``YieldCurve`` and ``CreditCurve`` node routes
+     - ``autodiff_public_curve``
+     - supported for node-value sensitivities; query-location derivatives are
+       only piecewise away from knots
+   * - ``grid_vol_surface_bucketed``
+     - ``GridVolSurface`` node sensitivities and runtime bucketed vega
+     - ``surface_bucket_bump``
+     - partial support: node values are traceable, while runtime surface risk is
+       explicit bucket bumping rather than scalar surface-native AD
+   * - ``smooth_monte_carlo_pathwise``
+     - smooth Monte Carlo route through ``simulate_with_shocks(...)`` /
+       ``MonteCarloEngine.price(..., shocks=..., differentiable=True)``
+     - ``autodiff_pathwise``
+     - supported only for deterministic explicit-shock paths and smooth payoff
+       contracts
+   * - ``rates_bootstrap_calibration``
+     - rates bootstrap calibration route
+     - ``autodiff_vector_jacobian``
+     - supported through the repricing Jacobian recorded in
+       ``solver_provenance``
+   * - ``quanto_generated_helper``
+     - route-generated quanto analytical helper route
+     - ``autodiff_scalar_gradient``
+     - supported through the semantic helper-facing raw pricing path, not a
+       claim that every generated adapter preserves traced values
+   * - ``barrier_mc_discontinuous_policy``
+     - barrier Monte Carlo discontinuous policy route
+     - ``unsupported_discontinuous_pathwise``
+     - unsupported for pathwise AD; the governed fallback is
+       ``finite_difference_bump_reprice`` with fail-closed policy metadata
+
 Where Trellis Still Stays Forward-Only
 --------------------------------------
 

--- a/tests/test_verification/test_autograd_gradient_matrix.py
+++ b/tests/test_verification/test_autograd_gradient_matrix.py
@@ -1,0 +1,406 @@
+"""Product-family gradient matrix for the public autograd support contract."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+
+import numpy as raw_np
+import pytest
+
+from trellis.conventions.day_count import DayCountConvention
+from trellis.core.differentiable import get_numpy, gradient
+from trellis.core.market_state import MarketState
+from trellis.core.payoff import ResolvedInputPayoff
+from trellis.core.types import Frequency
+from trellis.curves.bootstrap import (
+    BootstrapConventionBundle,
+    BootstrapCurveInputBundle,
+    BootstrapInstrument,
+    bootstrap_curve_result,
+)
+from trellis.curves.credit_curve import CreditCurve
+from trellis.curves.yield_curve import YieldCurve
+from trellis.instruments.fx import FXRate
+from trellis.models.analytical.quanto import price_quanto_option_analytical
+from trellis.models.black import black76_call
+from trellis.models.monte_carlo.engine import (
+    MonteCarloEngine,
+    describe_monte_carlo_derivative_policy,
+)
+from trellis.models.monte_carlo.path_state import barrier_payoff
+from trellis.models.processes.gbm import GBM
+from trellis.models.resolution.quanto import resolve_quanto_inputs
+from trellis.models.vol_surface import FlatVol, GridVolSurface
+from trellis.session import Session
+
+
+anp = get_numpy()
+SETTLE = date(2024, 11, 15)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@dataclass(frozen=True)
+class GradientMatrixRow:
+    """One checked row in the product-family derivative support matrix."""
+
+    family_id: str
+    product_family: str
+    category: str
+    support_status: str
+    expected_derivative_method: str
+    fallback_derivative_method: str | None
+    documentation_terms: tuple[str, ...]
+
+
+GRADIENT_MATRIX: tuple[GradientMatrixRow, ...] = (
+    GradientMatrixRow(
+        family_id="analytical_black76",
+        product_family="Black76 closed-form route",
+        category="analytical",
+        support_status="supported",
+        expected_derivative_method="autodiff_scalar_gradient",
+        fallback_derivative_method=None,
+        documentation_terms=("analytical_black76", "Black76", "autodiff_scalar_gradient"),
+    ),
+    GradientMatrixRow(
+        family_id="public_curve_nodes",
+        product_family="public yield and credit curve node routes",
+        category="public_curve",
+        support_status="supported",
+        expected_derivative_method="autodiff_public_curve",
+        fallback_derivative_method=None,
+        documentation_terms=("public_curve_nodes", "YieldCurve", "CreditCurve", "autodiff_public_curve"),
+    ),
+    GradientMatrixRow(
+        family_id="grid_vol_surface_bucketed",
+        product_family="grid volatility surface node and bucketed-vega route",
+        category="vol_surface",
+        support_status="partial",
+        expected_derivative_method="surface_bucket_bump",
+        fallback_derivative_method=None,
+        documentation_terms=("grid_vol_surface_bucketed", "GridVolSurface", "surface_bucket_bump"),
+    ),
+    GradientMatrixRow(
+        family_id="smooth_monte_carlo_pathwise",
+        product_family="smooth Monte Carlo pathwise route",
+        category="smooth_monte_carlo",
+        support_status="supported",
+        expected_derivative_method="autodiff_pathwise",
+        fallback_derivative_method=None,
+        documentation_terms=("smooth_monte_carlo_pathwise", "autodiff_pathwise", "simulate_with_shocks"),
+    ),
+    GradientMatrixRow(
+        family_id="rates_bootstrap_calibration",
+        product_family="rates bootstrap calibration route",
+        category="calibration",
+        support_status="supported",
+        expected_derivative_method="autodiff_vector_jacobian",
+        fallback_derivative_method=None,
+        documentation_terms=("rates_bootstrap_calibration", "autodiff_vector_jacobian", "solver_provenance"),
+    ),
+    GradientMatrixRow(
+        family_id="quanto_generated_helper",
+        product_family="route-generated quanto analytical helper route",
+        category="route_generated",
+        support_status="supported",
+        expected_derivative_method="autodiff_scalar_gradient",
+        fallback_derivative_method=None,
+        documentation_terms=("quanto_generated_helper", "route-generated", "autodiff_scalar_gradient"),
+    ),
+    GradientMatrixRow(
+        family_id="barrier_mc_discontinuous_policy",
+        product_family="barrier Monte Carlo discontinuous policy route",
+        category="unsupported_discontinuous",
+        support_status="unsupported_with_declared_fallback",
+        expected_derivative_method="unsupported_discontinuous_pathwise",
+        fallback_derivative_method="finite_difference_bump_reprice",
+        documentation_terms=(
+            "barrier_mc_discontinuous_policy",
+            "unsupported_discontinuous_pathwise",
+            "finite_difference_bump_reprice",
+        ),
+    ),
+)
+
+
+@dataclass(frozen=True)
+class _ResolvedVolProbe:
+    expiry: float
+    strike: float
+    vol: object
+
+
+class _VolProbePayoff(ResolvedInputPayoff[None, _ResolvedVolProbe]):
+    requirements = {"black_vol_surface"}
+
+    def __init__(self, *, expiry: float, strike: float):
+        super().__init__(None)
+        self.expiry = float(expiry)
+        self.strike = float(strike)
+
+    def resolve_inputs(self, market_state: MarketState) -> _ResolvedVolProbe:
+        return _ResolvedVolProbe(
+            expiry=self.expiry,
+            strike=self.strike,
+            vol=market_state.vol_surface.black_vol(self.expiry, self.strike),
+        )
+
+    def evaluate_from_resolved(self, resolved: _ResolvedVolProbe):
+        return resolved.vol
+
+
+def _finite_difference(fn, x: float, bump: float = 1e-4) -> float:
+    return float((fn(x + bump) - fn(x - bump)) / (2.0 * bump))
+
+
+def test_gradient_matrix_has_required_product_family_coverage():
+    required_categories = {
+        "analytical",
+        "public_curve",
+        "vol_surface",
+        "smooth_monte_carlo",
+        "calibration",
+        "route_generated",
+        "unsupported_discontinuous",
+    }
+    categories = {row.category for row in GRADIENT_MATRIX}
+    assert required_categories <= categories
+
+    family_ids = [row.family_id for row in GRADIENT_MATRIX]
+    assert len(family_ids) == len(set(family_ids))
+
+    for row in GRADIENT_MATRIX:
+        assert row.expected_derivative_method
+        assert row.support_status in {
+            "supported",
+            "partial",
+            "unsupported_with_declared_fallback",
+        }
+        if row.support_status.startswith("unsupported"):
+            assert row.fallback_derivative_method
+
+
+@pytest.mark.parametrize("row", GRADIENT_MATRIX, ids=lambda row: row.family_id)
+def test_gradient_matrix_row_matches_checked_runtime_or_governance(row: GradientMatrixRow):
+    check = _ROW_CHECKS[row.family_id]
+    check(row)
+
+
+def test_gradient_matrix_is_documented_and_prevents_stale_support_claims():
+    differentiable_pricing = (REPO_ROOT / "docs/quant/differentiable_pricing.rst").read_text()
+    limitations = (REPO_ROOT / "LIMITATIONS.md").read_text()
+
+    assert "Product-Family Gradient Matrix" in differentiable_pricing
+    for row in GRADIENT_MATRIX:
+        for term in row.documentation_terms:
+            assert term in differentiable_pricing
+        assert row.expected_derivative_method in differentiable_pricing
+        if row.fallback_derivative_method:
+            assert row.fallback_derivative_method in differentiable_pricing
+
+    stale_or_overbroad_claims = (
+        "jvp=True",
+        "portfolio_aad=True",
+        "supports universal portfolio AAD",
+        "automatic discontinuous Greeks are supported",
+        "all generated routes are differentiable by default",
+        "surface-native scalar vega for every smile surface is supported",
+    )
+    for claim in stale_or_overbroad_claims:
+        assert claim not in differentiable_pricing
+        assert claim not in limitations
+
+
+def _check_analytical_black76(row: GradientMatrixRow) -> None:
+    assert row.expected_derivative_method == "autodiff_scalar_gradient"
+    autodiff_vega = gradient(lambda sigma: black76_call(100.0, 100.0, sigma, 1.0))(0.20)
+    fd_vega = _finite_difference(lambda sigma: black76_call(100.0, 100.0, sigma, 1.0), 0.20)
+    assert autodiff_vega == pytest.approx(fd_vega, rel=1e-6, abs=1e-8)
+
+
+def _check_public_curve_nodes(row: GradientMatrixRow) -> None:
+    assert row.expected_derivative_method == "autodiff_public_curve"
+
+    curve_gradient = gradient(
+        lambda rates: YieldCurve((1.0, 2.0), rates).discount(1.5)
+    )(anp.array([0.04, 0.06]))
+    expected_discount = raw_np.exp(-0.05 * 1.5)
+    raw_np.testing.assert_allclose(
+        curve_gradient,
+        raw_np.array([-0.75 * expected_discount, -0.75 * expected_discount]),
+        atol=1e-12,
+    )
+
+    credit_gradient = gradient(
+        lambda hazards: CreditCurve((1.0, 3.0), hazards).survival_probability(2.0)
+    )(anp.array([0.01, 0.02]))
+    expected_survival = raw_np.exp(-0.03)
+    raw_np.testing.assert_allclose(
+        credit_gradient,
+        raw_np.array([-expected_survival, -expected_survival]),
+        atol=1e-12,
+    )
+
+
+def _check_grid_vol_surface_bucketed(row: GradientMatrixRow) -> None:
+    assert row.expected_derivative_method == "surface_bucket_bump"
+
+    surface_gradient = gradient(
+        lambda vols: GridVolSurface(
+            expiries=(1.0, 2.0),
+            strikes=(90.0, 110.0),
+            vols=vols,
+        ).black_vol(1.5, 100.0)
+    )(anp.array([[0.25, 0.22], [0.27, 0.24]]))
+    raw_np.testing.assert_allclose(surface_gradient, raw_np.full((2, 2), 0.25), atol=1e-12)
+
+    session = Session(
+        curve=YieldCurve.flat(0.04),
+        settlement=SETTLE,
+        vol_surface=GridVolSurface(
+            expiries=(1.0, 2.0),
+            strikes=(90.0, 110.0),
+            vols=((0.25, 0.22), (0.27, 0.24)),
+        ),
+    )
+    vega = session.analyze(
+        _VolProbePayoff(expiry=1.5, strike=100.0),
+        measures=[
+            {
+                "vega": {
+                    "expiries": (1.0, 2.0),
+                    "strikes": (90.0, 110.0),
+                    "bump_pct": 1.0,
+                }
+            }
+        ],
+    ).vega
+    assert vega.metadata["resolved_derivative_method"] == "surface_bucket_bump"
+
+
+def _check_smooth_monte_carlo_pathwise(row: GradientMatrixRow) -> None:
+    assert row.expected_derivative_method == "autodiff_pathwise"
+
+    engine = MonteCarloEngine(GBM(mu=0.05, sigma=0.20), n_paths=64, n_steps=8, seed=43, method="exact")
+    shocks = raw_np.random.default_rng(47).standard_normal((engine.n_paths, engine.n_steps))
+
+    def price_from_spot(spot):
+        return engine.price(
+            spot,
+            1.0,
+            lambda paths: anp.maximum(paths[:, -1] - 100.0, 0.0),
+            discount_rate=0.05,
+            shocks=shocks,
+            differentiable=True,
+            return_paths=False,
+        )["price"]
+
+    metadata = engine.price(
+        100.0,
+        1.0,
+        lambda paths: anp.maximum(paths[:, -1] - 100.0, 0.0),
+        discount_rate=0.05,
+        shocks=shocks,
+        differentiable=True,
+        return_paths=False,
+    )["derivative_metadata"]
+    assert metadata["resolved_derivative_method"] == "autodiff_pathwise"
+
+    autodiff_delta = gradient(price_from_spot)(100.0)
+    finite_difference_delta = (price_from_spot(100.01) - price_from_spot(99.99)) / 0.02
+    assert autodiff_delta == pytest.approx(finite_difference_delta, rel=1e-4, abs=1e-4)
+
+
+def _check_rates_bootstrap_calibration(row: GradientMatrixRow) -> None:
+    assert row.expected_derivative_method == "autodiff_vector_jacobian"
+
+    bundle = BootstrapCurveInputBundle(
+        curve_name="usd_ois_boot",
+        currency="USD",
+        rate_index="USD-SOFR-3M",
+        conventions=BootstrapConventionBundle(
+            deposit_day_count=DayCountConvention.ACT_360,
+            future_day_count=DayCountConvention.ACT_360,
+            swap_fixed_frequency=Frequency.ANNUAL,
+            swap_fixed_day_count=DayCountConvention.THIRTY_360_US,
+            swap_float_frequency=Frequency.QUARTERLY,
+            swap_float_day_count=DayCountConvention.ACT_360,
+        ),
+        instruments=(
+            BootstrapInstrument(tenor=0.25, quote=0.04, instrument_type="deposit", label="DEP3M"),
+            BootstrapInstrument(tenor=2.0, quote=0.045, instrument_type="swap", label="SWAP2Y"),
+            BootstrapInstrument(tenor=5.0, quote=0.048, instrument_type="swap", label="SWAP5Y"),
+        ),
+    )
+    result = bootstrap_curve_result(bundle, max_iter=75, tol=1e-12)
+
+    assert result.solve_result.metadata["derivative_method"] == "autodiff_vector_jacobian"
+    assert result.solver_provenance.backend["derivative_method"] == "autodiff_vector_jacobian"
+    assert result.diagnostics.max_abs_residual < 1e-8
+
+
+def _check_quanto_generated_helper(row: GradientMatrixRow) -> None:
+    assert row.expected_derivative_method == "autodiff_scalar_gradient"
+
+    from trellis.instruments._agent.quantooptionanalytical import QuantoOptionSpec
+
+    spec = QuantoOptionSpec(
+        notional=100_000.0,
+        strike=100.0,
+        expiry_date=date(2025, 11, 15),
+        fx_pair="EURUSD",
+        underlier_currency="EUR",
+        domestic_currency="USD",
+    )
+
+    def price_from_spot(spot):
+        market_state = MarketState(
+            as_of=SETTLE,
+            settlement=SETTLE,
+            discount=YieldCurve.flat(0.05),
+            forecast_curves={"EUR-DISC": YieldCurve.flat(0.03)},
+            fx_rates={"EURUSD": FXRate(spot=1.10, domestic="USD", foreign="EUR")},
+            spot=spot,
+            underlier_spots={"EUR": spot},
+            vol_surface=FlatVol(0.20),
+            model_parameters={"quanto_correlation": 0.35},
+        )
+        return price_quanto_option_analytical(spec, resolve_quanto_inputs(market_state, spec))
+
+    autodiff_delta = gradient(price_from_spot)(100.0)
+    finite_difference_delta = (price_from_spot(100.01) - price_from_spot(99.99)) / 0.02
+    assert autodiff_delta == pytest.approx(finite_difference_delta, rel=1e-6)
+
+
+def _check_barrier_mc_discontinuous_policy(row: GradientMatrixRow) -> None:
+    assert row.expected_derivative_method == "unsupported_discontinuous_pathwise"
+    assert row.fallback_derivative_method == "finite_difference_bump_reprice"
+
+    payoff = barrier_payoff(
+        barrier=95.0,
+        direction="down",
+        knock="out",
+        terminal_payoff_fn=lambda terminal: raw_np.maximum(terminal - 100.0, 0.0),
+    )
+    metadata = describe_monte_carlo_derivative_policy(
+        payoff.path_requirement,
+        differentiable=True,
+    )
+
+    assert metadata["resolved_derivative_method"] == "unsupported_discontinuous_pathwise"
+    assert metadata["pathwise_autodiff_supported"] is False
+    assert metadata["fallback_derivative_method"] == "finite_difference_bump_reprice"
+    assert metadata["discontinuous_derivative_policy"] == "fail_closed"
+
+
+_ROW_CHECKS = {
+    "analytical_black76": _check_analytical_black76,
+    "public_curve_nodes": _check_public_curve_nodes,
+    "grid_vol_surface_bucketed": _check_grid_vol_surface_bucketed,
+    "smooth_monte_carlo_pathwise": _check_smooth_monte_carlo_pathwise,
+    "rates_bootstrap_calibration": _check_rates_bootstrap_calibration,
+    "quanto_generated_helper": _check_quanto_generated_helper,
+    "barrier_mc_discontinuous_policy": _check_barrier_mc_discontinuous_policy,
+}

--- a/tests/test_verification/test_pod_risk_benchmarks.py
+++ b/tests/test_verification/test_pod_risk_benchmarks.py
@@ -15,12 +15,13 @@ def test_live_supported_pod_risk_benchmark_report_covers_workflow_shape():
     report = build_supported_pod_risk_benchmark_report(repeats=1, warmups=0)
 
     assert report["benchmark_name"] == "pod_risk_workflows"
-    assert report["summary"]["workflow_count"] == 5
-    assert report["summary"]["steady_state_workflow_count"] == 5
+    assert report["summary"]["workflow_count"] == 6
+    assert report["summary"]["steady_state_workflow_count"] == 6
     workflows = {case["workflow"] for case in report["cases"]}
     assert workflows == {
         "pipeline_scenarios",
         "key_rate_durations",
+        "portfolio_aad",
         "scenario_pnl",
         "vega",
         "spot_greeks",
@@ -31,11 +32,13 @@ def test_checked_pod_risk_benchmark_artifact_covers_supported_workflows():
     payload = json.loads((REPO_ROOT / "docs" / "benchmarks" / "pod_risk_workflows.json").read_text())
 
     assert payload["benchmark_name"] == "pod_risk_workflows"
-    assert payload["summary"]["workflow_count"] == 5
+    assert payload["summary"]["workflow_count"] == 6
+    assert payload["summary"]["steady_state_workflow_count"] == 6
     workflows = {case["workflow"] for case in payload["cases"]}
     assert workflows == {
         "pipeline_scenarios",
         "key_rate_durations",
+        "portfolio_aad",
         "scenario_pnl",
         "vega",
         "spot_greeks",


### PR DESCRIPTION
## Summary
- add a checked product-family autograd gradient matrix covering analytical, curve, vol-surface, smooth MC, calibration, route-generated helper, and unsupported discontinuous lanes
- document the matrix in `docs/quant/differentiable_pricing.rst` without broadening the support contract
- refresh the pod-risk benchmark artifact/test to include the landed `portfolio_aad` workflow

## Validation
- `PYTHONDONTWRITEBYTECODE=1 /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_verification/test_autograd_gradient_matrix.py tests/test_verification/test_autograd_support_contract.py -q -p no:cacheprovider`
- `PYTHONDONTWRITEBYTECODE=1 /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_verification/test_pod_risk_benchmarks.py -q -p no:cacheprovider`
- `PYTHONDONTWRITEBYTECODE=1 /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_verification -q -p no:cacheprovider`
- `git diff --check`

Linear: QUA-970