### PR TITLE
[codex] Mark QUA-971 plan mirror done

### DIFF
--- a/doc/plan/draft__autograd-phase-2-aad-and-gradient-governance.md
+++ b/doc/plan/draft__autograd-phase-2-aad-and-gradient-governance.md
@@ -48,7 +48,7 @@ Rules for coding agents:
 | `AD2.2` | `QUA-968` | Done | book-level reverse-mode / portfolio AAD substrate | `QUA-967` |
 | `AD2.3` | `QUA-969` | Done | smoothing and custom-adjoint policy for discontinuous products | `QUA-957` |
 | `AD2.4` | `QUA-970` | Done | product-family gradient matrix and support-contract cohort expansion | `QUA-957`; consume `QUA-967` / `QUA-969` outcomes as they land |
-| `AD2.5` | `QUA-971` | Backlog | runtime derivative-method taxonomy and reporting integration | `QUA-967`, `QUA-970` |
+| `AD2.5` | `QUA-971` | Done | runtime derivative-method taxonomy and reporting integration | `QUA-967`, `QUA-970` |
 
 ## Purpose
 

--- a/doc/plan/draft__calibration-sleeve-industrial-hardening-program.md
+++ b/doc/plan/draft__calibration-sleeve-industrial-hardening-program.md
@@ -104,7 +104,7 @@ Rules for coding agents:
 | `AD2.2` | `QUA-968` | Done | book-level reverse-mode / portfolio AAD substrate | `AD2.1` |
 | `AD2.3` | `QUA-969` | Done | smoothing and custom-adjoint policy for discontinuous products | `QUA-957` |
 | `AD2.4` | `QUA-970` | Done | product-family gradient matrix and support-contract cohort expansion | consume `AD2.1` / `AD2.3` outcomes as they land |
-| `AD2.5` | `QUA-971` | Backlog | runtime derivative-method taxonomy and reporting integration | `AD2.1`, `AD2.4` |
+| `AD2.5` | `QUA-971` | Done | runtime derivative-method taxonomy and reporting integration | `AD2.1`, `AD2.4` |
 
 ### Combined Implementation Queue
 
@@ -122,7 +122,7 @@ and runtime reporting that consume those objects.
 | `INT.4` | `QUA-968` | Autograd | Done | first bounded book-level reverse-mode / portfolio AAD substrate over supported smooth routes | `INT.2` |
 | `INT.5` | `QUA-969` | Autograd | Done | governed discontinuous-Greek policy for one bounded barrier, digital, or event/exercise family | `QUA-957`; coordinate with `INT.7` |
 | `INT.6` | `QUA-970` | Autograd | Done | product-family derivative matrix covering analytical, curve, surface, MC, and calibration representatives | `QUA-957`; consume `INT.2` / `INT.5` outcomes |
-| `INT.7` | `QUA-971` | Autograd | Backlog | unified runtime derivative-method reporting across analytical, AD, AAD, JVP/VJP/HVP, bump, smoothed/custom-adjoint, and unsupported lanes | `INT.2`, `INT.6`; coordinate with `INT.4` / `INT.5` |
+| `INT.7` | `QUA-971` | Autograd | Done | unified runtime derivative-method reporting across analytical, AD, AAD, JVP/VJP/HVP, bump, smoothed/custom-adjoint, and unsupported lanes | `INT.2`, `INT.6`; coordinate with `INT.4` / `INT.5` |
 | `INT.8` | `QUA-955` | Calibration | Backlog | first cross-asset calibration slice on explicit dependency DAGs, using calibrated market objects and derivative provenance where useful | concrete hybrid target chosen; upstream blockers set during audit |
 | `INT.9` | `QUA-946` | Closeout | Backlog | umbrella cleanup, docs maintenance, plan reconciliation, and follow-on ticket split | `CAL.5`, `CAL.6`, `CAL.7`, and relevant AD2 integration gates closed or explicitly deferred |
 
@@ -765,13 +765,13 @@ validation and derivative-governance slices, was:
 6. Phase 5 bounded homogeneous basket-credit tranche-correlation calibration
 7. First desk-like calibration validation tranche
 8. First bounded discontinuous Monte Carlo derivative policy
+9. Unified runtime derivative-method taxonomy and reporting
 
 The remaining integrated implementation order is:
 
-1. `QUA-971` unified runtime derivative reporting
-2. `QUA-955` one narrow cross-asset calibration slice once the concrete target
+1. `QUA-955` one narrow cross-asset calibration slice once the concrete target
    and blockers are explicit
-3. `QUA-946` umbrella closeout and documentation maintenance
+2. `QUA-946` umbrella closeout and documentation maintenance
 
 `QUA-967` landed early as `AD2.1` / `INT.2`, and `QUA-968` consumed that
 checked VJP/HVP surface for the first bounded bond-book reverse-mode lane.
@@ -781,7 +781,9 @@ first bounded discontinuous Monte Carlo derivative policy, keeping barrier and
 event discontinuities fail-closed for pathwise AD while reporting the fallback
 method explicitly. `QUA-970` added the checked product-family derivative matrix
 covering representative analytical, curve, surface, Monte Carlo, calibration,
-route-generated, and unsupported discontinuous lanes.
+route-generated, and unsupported discontinuous lanes. `QUA-971` normalized
+runtime derivative-method reporting across analytical, AD, AAD, VJP/HVP-backed,
+bump, fail-closed, and future smoothed/custom-adjoint lanes.
 
 Reason:
 
@@ -794,7 +796,9 @@ Reason:
   before they can claim throughput or method-selection support
 - discontinuous products need explicit policy before they can appear in a
   support matrix or runtime report as anything other than unsupported or bump
-  fallback
+- `QUA-971` normalized runtime derivative-method reporting across analytical,
+  AD, AAD, JVP/VJP/HVP, bump, fail-closed, and future smoothed/custom-adjoint
+  lanes
 - cross-asset calibration should be introduced only after at least one strong
   surface exists in each linked asset class and the first derivative-governance
   vocabulary is stable enough to report calibration and risk provenance
@@ -814,12 +818,7 @@ they are actually desk-grade, then widen.
 
 ## Immediate Follow-On Execution Slice
 
-The next execution slice after the `AD2.4` / `QUA-970` closeout should be:
+The next execution slice after the `AD2.5` / `QUA-971` closeout should be:
 
-1. `QUA-971`: normalize runtime derivative-method reporting across analytical,
-   AD, AAD, JVP/VJP/HVP, bump, fail-closed, and future smoothed/custom-adjoint
-   lanes.
-
-After that derivative-reporting slice, `QUA-955` should choose and
-implement one concrete hybrid calibration slice on the same dependency and
-provenance model.
+1. `QUA-955`: choose and implement one concrete hybrid calibration slice on the
+   same dependency and provenance model.


### PR DESCRIPTION
## Summary
- Mark QUA-971 / AD2.5 as Done in the Autograd Phase 2 plan mirror.
- Mark QUA-971 / INT.7 as Done in the combined calibration/autograd plan.
- Advance the remaining integrated queue to QUA-955, then QUA-946 closeout.

## Validation
- `git diff --check`

## Linear
- QUA-971