### PR TITLE
QUA-946: close the calibration sleeve implementation mirror

### DIFF
--- a/doc/plan/draft__calibration-sleeve-industrial-hardening-program.md
+++ b/doc/plan/draft__calibration-sleeve-industrial-hardening-program.md
@@ -8,9 +8,9 @@ portfolio AAD and derivative governance.
 
 The umbrella `QUA-946`, child tickets `QUA-947` through `QUA-956`, adjacent
 Autograd Phase 2 tickets `QUA-966` through `QUA-971`, and post-`QUA-955`
-hybrid follow-ons `QUA-972` / `QUA-973` are now filed in Linear. This
-document is the ordered repo-local mirror for that queue and should stay
-aligned with the live issue graph.
+hybrid follow-ons `QUA-972` / `QUA-973` were all filed and completed in
+Linear. This document is now the closeout mirror for that queue and should
+remain aligned with the landed issue graph.
 
 The adjacent Autograd Phase 2 plan is tracked by `QUA-966` through `QUA-971`.
 It should not duplicate calibration curve, surface, or cube plants. It should
@@ -83,7 +83,7 @@ Rules for coding agents:
 
 | Ticket | Status |
 | --- | --- |
-| `QUA-946` Calibration sleeve: Trellis-native industrial hardening program | In Progress |
+| `QUA-946` Calibration sleeve: Trellis-native industrial hardening program | Done |
 | `QUA-966` Autograd Phase 2: portfolio AAD and gradient governance | Done |
 
 ### Ordered Queue
@@ -129,9 +129,9 @@ and runtime reporting that consume those objects.
 | `INT.6` | `QUA-970` | Autograd | Done | product-family derivative matrix covering analytical, curve, surface, MC, and calibration representatives | `QUA-957`; consume `INT.2` / `INT.5` outcomes |
 | `INT.7` | `QUA-971` | Autograd | Done | unified runtime derivative-method reporting across analytical, AD, AAD, JVP/VJP/HVP, bump, smoothed/custom-adjoint, and unsupported lanes | `INT.2`, `INT.6`; coordinate with `INT.4` / `INT.5` |
 | `INT.8` | `QUA-955` | Calibration | Done | bounded rates + equity/FX quanto-correlation slice on explicit dependency DAGs, using calibrated market objects and existing derivative provenance where useful | `QUA-950`, `QUA-951`, `QUA-971` |
-| `INT.9` | `QUA-972` | Validation | Backlog | desk-like bounded quanto calibration fixtures, perturbation diagnostics, replay coverage, and latency envelopes for the shipped hybrid slice | `INT.8` |
-| `INT.10` | `QUA-973` | Autograd | Backlog | bounded hybrid derivative-matrix row and runtime/reporting governance for the shipped quanto slice | `INT.8`; consume `INT.4`, `INT.6`, `INT.7` |
-| `INT.11` | `QUA-946` | Closeout | In Progress | umbrella cleanup, docs maintenance, plan reconciliation, and follow-on ticket split | `INT.9`, `INT.10` landed or explicitly deferred in closeout |
+| `INT.9` | `QUA-972` | Validation | Done | desk-like bounded quanto calibration fixtures, perturbation diagnostics, replay coverage, and latency envelopes for the shipped hybrid slice | `INT.8` |
+| `INT.10` | `QUA-973` | Autograd | Done | bounded hybrid derivative-matrix row and runtime/reporting governance for the shipped quanto slice | `INT.8`; consume `INT.4`, `INT.6`, `INT.7` |
+| `INT.11` | `QUA-946` | Closeout | Done | umbrella cleanup, docs maintenance, plan reconciliation, and follow-on ticket split | `INT.9`, `INT.10` landed or explicitly deferred in closeout |
 
 ### Pickup Rule
 
@@ -142,11 +142,12 @@ and runtime reporting that consume those objects.
 - do not start `CAL.5` before `CAL.4` closes
 - do not start `CAL.6` until the first supported hybrid slice and its concrete
   upstream blockers are explicit in the ticket
-- after `CAL.6` closes, start `INT.9` / `QUA-972` and `INT.10` / `QUA-973`
-  next; they may run in parallel once the bounded hybrid input and reporting
-  surfaces from `QUA-955` are stable
-- do not close `INT.11` / `QUA-946` until `INT.9` and `INT.10` are either
-  landed or explicitly deferred in the umbrella closeout note
+- `INT.9` / `QUA-972` and `INT.10` / `QUA-973` both landed after `INT.8`
+  and completed the bounded hybrid validation and derivative-governance
+  follow-ons
+- `INT.11` / `QUA-946` closes only after those follow-ons land and the
+  umbrella closeout restores the persisted benchmark artifact to the default
+  smoothed baseline (`repeats=3`, `warmups=1`)
 - keep `CAL.7` moving alongside the active implementation slices so validation
   does not become a deferred cleanup bucket
 - do not start `AD2.2` before `AD2.1` lands a truthful backend operator
@@ -780,12 +781,12 @@ validation and derivative-governance slices, was:
 9. Unified runtime derivative-method taxonomy and reporting
 10. First bounded hybrid cross-asset calibration slice
 
-The remaining integrated implementation order is:
+The final integrated implementation order was:
 
 1. `QUA-972` bounded hybrid validation tranche over the shipped quanto slice
 2. `QUA-973` bounded hybrid derivative-governance tranche over the same route
 3. `QUA-946` umbrella closeout and documentation maintenance once those
-   follow-ons land or are explicitly deferred
+   follow-ons landed
 
 `QUA-967` landed early as `AD2.1` / `INT.2`, and `QUA-968` consumed that
 checked VJP/HVP surface for the first bounded bond-book reverse-mode lane.
@@ -830,17 +831,18 @@ This plan does not propose immediately building:
 The right first industrialization move is to harden a few narrow slices until
 they are actually desk-grade, then widen.
 
-## Immediate Follow-On Execution Slice
+## Closeout Result
 
-The next execution slice after the `CAL.6` / `QUA-955` closeout should be:
+The final execution slice after the `CAL.6` / `QUA-955` closeout was:
 
-1. `QUA-972`: add the first desk-like bounded hybrid fixture pack, replay
+1. `QUA-972`: the first desk-like bounded hybrid fixture pack, replay
    coverage, perturbation diagnostics, and latency envelopes for the shipped
    quanto-correlation route
-2. `QUA-973`: extend the finished derivative-matrix and runtime-reporting
-   contract onto the bounded hybrid slice without overstating AD/AAD support
-3. `QUA-946`: close the umbrella only after those two follow-ons land or are
-   explicitly deferred in the closeout note
+2. `QUA-973`: the bounded hybrid derivative-matrix and runtime-reporting
+   contract on the same shipped route without overstating AD/AAD support
+3. `QUA-946`: umbrella closeout once those two follow-ons landed, including
+   benchmark-artifact stabilization back to the default smoothed baseline
 
-`QUA-972` and `QUA-973` may run in parallel once the `QUA-955` input schema,
-materialization payload, and runtime-reporting surface are treated as stable.
+`QUA-972` and `QUA-973` ran in parallel once the `QUA-955` input schema,
+materialization payload, and runtime-reporting surface were stable enough to
+treat as the shipped bounded hybrid contract.

--- a/docs/benchmarks/calibration_workflows.json
+++ b/docs/benchmarks/calibration_workflows.json
@@ -3,11 +3,11 @@
   "cases": [
     {
       "cold": {
-        "calibrations_per_second": 0.368,
+        "calibrations_per_second": 0.365,
         "label": "swaption_strip",
-        "max_seconds": 2.718538,
-        "mean_seconds": 2.718538,
-        "median_seconds": 2.718538,
+        "max_seconds": 2.750142,
+        "mean_seconds": 2.736263,
+        "median_seconds": 2.732267,
         "metadata": {
           "instrument_count": 2,
           "multi_curve_roles": {
@@ -17,17 +17,19 @@
           },
           "warm_start": true
         },
-        "min_seconds": 2.718538,
+        "min_seconds": 2.726381,
         "mode": "cold",
         "notes": [
           "least_squares",
           "tree_pricing"
         ],
-        "repeats": 1,
+        "repeats": 3,
         "run_seconds": [
-          2.718538
+          2.750142,
+          2.726381,
+          2.732267
         ],
-        "warmups": 0
+        "warmups": 1
       },
       "label": "swaption_strip",
       "metadata": {
@@ -44,11 +46,11 @@
         "tree_pricing"
       ],
       "warm": {
-        "calibrations_per_second": 3.415,
+        "calibrations_per_second": 3.326,
         "label": "swaption_strip",
-        "max_seconds": 0.292813,
-        "mean_seconds": 0.292813,
-        "median_seconds": 0.292813,
+        "max_seconds": 0.302529,
+        "mean_seconds": 0.300682,
+        "median_seconds": 0.299851,
         "metadata": {
           "instrument_count": 2,
           "multi_curve_roles": {
@@ -58,28 +60,30 @@
           },
           "warm_start": true
         },
-        "min_seconds": 0.292813,
+        "min_seconds": 0.299667,
         "mode": "warm",
         "notes": [
           "least_squares",
           "tree_pricing"
         ],
-        "repeats": 1,
+        "repeats": 3,
         "run_seconds": [
-          0.292813
+          0.302529,
+          0.299667,
+          0.299851
         ],
-        "warmups": 0
+        "warmups": 1
       },
-      "warm_speedup": 9.284,
+      "warm_speedup": 9.1,
       "workflow": "hull_white"
     },
     {
       "cold": {
-        "calibrations_per_second": 56.386,
+        "calibrations_per_second": 55.855,
         "label": "price_bootstrap_surface",
-        "max_seconds": 0.017735,
-        "mean_seconds": 0.017735,
-        "median_seconds": 0.017735,
+        "max_seconds": 0.018175,
+        "mean_seconds": 0.017903,
+        "median_seconds": 0.01786,
         "metadata": {
           "grid_shape": [
             4,
@@ -89,18 +93,20 @@
           "surface_name": "usd_caplet_strip",
           "warm_start": false
         },
-        "min_seconds": 0.017735,
+        "min_seconds": 0.017675,
         "mode": "cold",
         "notes": [
           "bootstrap",
           "caplet_surface",
           "price_quotes"
         ],
-        "repeats": 1,
+        "repeats": 3,
         "run_seconds": [
-          0.017735
+          0.017675,
+          0.01786,
+          0.018175
         ],
-        "warmups": 0
+        "warmups": 1
       },
       "label": "price_bootstrap_surface",
       "metadata": {
@@ -123,29 +129,31 @@
     },
     {
       "cold": {
-        "calibrations_per_second": 10.808,
+        "calibrations_per_second": 12.776,
         "label": "single_smile",
-        "max_seconds": 0.092521,
-        "mean_seconds": 0.092521,
-        "median_seconds": 0.092521,
+        "max_seconds": 0.098016,
+        "mean_seconds": 0.078271,
+        "median_seconds": 0.068968,
         "metadata": {
           "point_count": 7,
           "surface_name": "usd_rates_smile",
           "synthetic_generation_contract_version": "v2",
           "warm_start": true
         },
-        "min_seconds": 0.092521,
+        "min_seconds": 0.067831,
         "mode": "cold",
         "notes": [
           "least_squares",
           "implied_vol_fit",
           "synthetic_generation_contract_fixture"
         ],
-        "repeats": 1,
+        "repeats": 3,
         "run_seconds": [
-          0.092521
+          0.067831,
+          0.068968,
+          0.098016
         ],
-        "warmups": 0
+        "warmups": 1
       },
       "label": "single_smile",
       "metadata": {
@@ -160,40 +168,42 @@
         "synthetic_generation_contract_fixture"
       ],
       "warm": {
-        "calibrations_per_second": 294.193,
+        "calibrations_per_second": 290.707,
         "label": "single_smile",
-        "max_seconds": 0.003399,
-        "mean_seconds": 0.003399,
-        "median_seconds": 0.003399,
+        "max_seconds": 0.003473,
+        "mean_seconds": 0.00344,
+        "median_seconds": 0.003458,
         "metadata": {
           "point_count": 7,
           "surface_name": "usd_rates_smile",
           "synthetic_generation_contract_version": "v2",
           "warm_start": true
         },
-        "min_seconds": 0.003399,
+        "min_seconds": 0.003389,
         "mode": "warm",
         "notes": [
           "least_squares",
           "implied_vol_fit",
           "synthetic_generation_contract_fixture"
         ],
-        "repeats": 1,
+        "repeats": 3,
         "run_seconds": [
-          0.003399
+          0.003473,
+          0.003389,
+          0.003458
         ],
-        "warmups": 0
+        "warmups": 1
       },
-      "warm_speedup": 27.219,
+      "warm_speedup": 22.754,
       "workflow": "sabr"
     },
     {
       "cold": {
-        "calibrations_per_second": 19.081,
+        "calibrations_per_second": 18.769,
         "label": "price_normalized_cube",
-        "max_seconds": 0.052409,
-        "mean_seconds": 0.052409,
-        "median_seconds": 0.052409,
+        "max_seconds": 0.054264,
+        "mean_seconds": 0.053278,
+        "median_seconds": 0.053217,
         "metadata": {
           "grid_shape": [
             2,
@@ -205,7 +215,7 @@
           "synthetic_generation_contract_version": "v2",
           "warm_start": false
         },
-        "min_seconds": 0.052409,
+        "min_seconds": 0.052354,
         "mode": "cold",
         "notes": [
           "cube_assembly",
@@ -213,11 +223,13 @@
           "price_quotes",
           "synthetic_generation_contract_fixture"
         ],
-        "repeats": 1,
+        "repeats": 3,
         "run_seconds": [
-          0.052409
+          0.054264,
+          0.053217,
+          0.052354
         ],
-        "warmups": 0
+        "warmups": 1
       },
       "label": "price_normalized_cube",
       "metadata": {
@@ -243,11 +255,11 @@
     },
     {
       "cold": {
-        "calibrations_per_second": 0.263,
+        "calibrations_per_second": 0.261,
         "label": "repaired_surface_authority",
-        "max_seconds": 3.804943,
-        "mean_seconds": 3.804943,
-        "median_seconds": 3.804943,
+        "max_seconds": 3.878549,
+        "mean_seconds": 3.83706,
+        "median_seconds": 3.868679,
         "metadata": {
           "grid_shape": [
             5,
@@ -257,18 +269,20 @@
           "synthetic_generation_contract_version": "v2",
           "warm_start": false
         },
-        "min_seconds": 3.804943,
+        "min_seconds": 3.763952,
         "mode": "cold",
         "notes": [
           "svi_surface",
           "quote_governance",
           "synthetic_generation_contract_fixture"
         ],
-        "repeats": 1,
+        "repeats": 3,
         "run_seconds": [
-          3.804943
+          3.868679,
+          3.878549,
+          3.763952
         ],
-        "warmups": 0
+        "warmups": 1
       },
       "label": "repaired_surface_authority",
       "metadata": {
@@ -291,29 +305,31 @@
     },
     {
       "cold": {
-        "calibrations_per_second": 1.161,
+        "calibrations_per_second": 1.177,
         "label": "single_smile",
-        "max_seconds": 0.861616,
-        "mean_seconds": 0.861616,
-        "median_seconds": 0.861616,
+        "max_seconds": 0.85473,
+        "mean_seconds": 0.849907,
+        "median_seconds": 0.84922,
         "metadata": {
           "point_count": 5,
           "surface_name": "spx_heston_implied_vol",
           "synthetic_generation_contract_version": "v2",
           "warm_start": true
         },
-        "min_seconds": 0.861616,
+        "min_seconds": 0.845769,
         "mode": "cold",
         "notes": [
           "least_squares",
           "fft_pricing",
           "synthetic_generation_contract_fixture"
         ],
-        "repeats": 1,
+        "repeats": 3,
         "run_seconds": [
-          0.861616
+          0.845769,
+          0.85473,
+          0.84922
         ],
-        "warmups": 0
+        "warmups": 1
       },
       "label": "single_smile",
       "metadata": {
@@ -328,40 +344,42 @@
         "synthetic_generation_contract_fixture"
       ],
       "warm": {
-        "calibrations_per_second": 14.65,
+        "calibrations_per_second": 14.517,
         "label": "single_smile",
-        "max_seconds": 0.068261,
-        "mean_seconds": 0.068261,
-        "median_seconds": 0.068261,
+        "max_seconds": 0.070622,
+        "mean_seconds": 0.068884,
+        "median_seconds": 0.068623,
         "metadata": {
           "point_count": 5,
           "surface_name": "spx_heston_implied_vol",
           "synthetic_generation_contract_version": "v2",
           "warm_start": true
         },
-        "min_seconds": 0.068261,
+        "min_seconds": 0.067407,
         "mode": "warm",
         "notes": [
           "least_squares",
           "fft_pricing",
           "synthetic_generation_contract_fixture"
         ],
-        "repeats": 1,
+        "repeats": 3,
         "run_seconds": [
-          0.068261
+          0.067407,
+          0.068623,
+          0.070622
         ],
-        "warmups": 0
+        "warmups": 1
       },
-      "warm_speedup": 12.622,
+      "warm_speedup": 12.338,
       "workflow": "heston"
     },
     {
       "cold": {
-        "calibrations_per_second": 0.984,
+        "calibrations_per_second": 0.989,
         "label": "surface_compression",
-        "max_seconds": 1.016551,
-        "mean_seconds": 1.016551,
-        "median_seconds": 1.016551,
+        "max_seconds": 1.011576,
+        "mean_seconds": 1.011428,
+        "median_seconds": 1.011357,
         "metadata": {
           "grid_shape": [
             5,
@@ -371,7 +389,7 @@
           "synthetic_generation_contract_version": "v2",
           "warm_start": true
         },
-        "min_seconds": 1.016551,
+        "min_seconds": 1.011351,
         "mode": "cold",
         "notes": [
           "least_squares",
@@ -379,11 +397,13 @@
           "surface_compression",
           "synthetic_generation_contract_fixture"
         ],
-        "repeats": 1,
+        "repeats": 3,
         "run_seconds": [
-          1.016551
+          1.011576,
+          1.011357,
+          1.011351
         ],
-        "warmups": 0
+        "warmups": 1
       },
       "label": "surface_compression",
       "metadata": {
@@ -402,11 +422,11 @@
         "synthetic_generation_contract_fixture"
       ],
       "warm": {
-        "calibrations_per_second": 2.753,
+        "calibrations_per_second": 2.802,
         "label": "surface_compression",
-        "max_seconds": 0.363279,
-        "mean_seconds": 0.363279,
-        "median_seconds": 0.363279,
+        "max_seconds": 0.358763,
+        "mean_seconds": 0.356915,
+        "median_seconds": 0.357088,
         "metadata": {
           "grid_shape": [
             5,
@@ -416,7 +436,7 @@
           "synthetic_generation_contract_version": "v2",
           "warm_start": true
         },
-        "min_seconds": 0.363279,
+        "min_seconds": 0.354894,
         "mode": "warm",
         "notes": [
           "least_squares",
@@ -424,22 +444,24 @@
           "surface_compression",
           "synthetic_generation_contract_fixture"
         ],
-        "repeats": 1,
+        "repeats": 3,
         "run_seconds": [
-          0.363279
+          0.354894,
+          0.357088,
+          0.358763
         ],
-        "warmups": 0
+        "warmups": 1
       },
-      "warm_speedup": 2.798,
+      "warm_speedup": 2.834,
       "workflow": "heston_surface"
     },
     {
       "cold": {
-        "calibrations_per_second": 2531.107,
+        "calibrations_per_second": 2926.709,
         "label": "dupire_surface",
-        "max_seconds": 0.000395,
-        "mean_seconds": 0.000395,
-        "median_seconds": 0.000395,
+        "max_seconds": 0.000347,
+        "mean_seconds": 0.000342,
+        "median_seconds": 0.000339,
         "metadata": {
           "grid_shape": [
             5,
@@ -450,18 +472,20 @@
           "synthetic_generation_contract_version": "v2",
           "warm_start": false
         },
-        "min_seconds": 0.000395,
+        "min_seconds": 0.000338,
         "mode": "cold",
         "notes": [
           "dupire",
           "workflow_surface",
           "synthetic_generation_contract_fixture"
         ],
-        "repeats": 1,
+        "repeats": 3,
         "run_seconds": [
-          0.000395
+          0.000347,
+          0.000338,
+          0.000339
         ],
-        "warmups": 0
+        "warmups": 1
       },
       "label": "dupire_surface",
       "metadata": {
@@ -485,11 +509,11 @@
     },
     {
       "cold": {
-        "calibrations_per_second": 1.407,
+        "calibrations_per_second": 1.426,
         "label": "single_name_curve",
-        "max_seconds": 0.710894,
-        "mean_seconds": 0.710894,
-        "median_seconds": 0.710894,
+        "max_seconds": 0.705981,
+        "mean_seconds": 0.701379,
+        "median_seconds": 0.699765,
         "metadata": {
           "curve_name": "usd_ig",
           "model_consistency_contract_version": "v1",
@@ -497,17 +521,19 @@
           "quote_family": "spread",
           "warm_start": false
         },
-        "min_seconds": 0.710894,
+        "min_seconds": 0.698392,
         "mode": "cold",
         "notes": [
           "least_squares",
           "model_consistency_contract_fixture"
         ],
-        "repeats": 1,
+        "repeats": 3,
         "run_seconds": [
-          0.710894
+          0.705981,
+          0.699765,
+          0.698392
         ],
-        "warmups": 0
+        "warmups": 1
       },
       "label": "single_name_curve",
       "metadata": {
@@ -527,11 +553,11 @@
     },
     {
       "cold": {
-        "calibrations_per_second": 0.329,
+        "calibrations_per_second": 0.327,
         "label": "desk_tranche_surface",
-        "max_seconds": 3.043611,
-        "mean_seconds": 3.043611,
-        "median_seconds": 3.043611,
+        "max_seconds": 3.063437,
+        "mean_seconds": 3.055233,
+        "median_seconds": 3.060854,
         "metadata": {
           "fixture_style": "desk_like",
           "latency_envelope": {
@@ -592,7 +618,7 @@
           "tranche_count": 3,
           "warm_start": false
         },
-        "min_seconds": 3.043611,
+        "min_seconds": 3.041407,
         "mode": "cold",
         "notes": [
           "brentq_root_scan",
@@ -600,19 +626,21 @@
           "desk_like_fixture",
           "linked_single_name_credit_curve"
         ],
-        "repeats": 1,
+        "repeats": 3,
         "run_seconds": [
-          3.043611
+          3.041407,
+          3.060854,
+          3.063437
         ],
-        "warmups": 0
+        "warmups": 1
       },
       "label": "desk_tranche_surface",
       "latency_envelope": {
         "breaches": {},
         "cold_max_limit_seconds": 8.0,
-        "cold_max_seconds": 3.043611,
+        "cold_max_seconds": 3.063437,
         "cold_mean_limit_seconds": 6.0,
-        "cold_mean_seconds": 3.043611,
+        "cold_mean_seconds": 3.055233,
         "fixture_style": "desk_like",
         "instrument_count": null,
         "label": "desk_tranche_surface",
@@ -694,11 +722,11 @@
     },
     {
       "cold": {
-        "calibrations_per_second": 103.952,
+        "calibrations_per_second": 107.21,
         "label": "desk_quanto_correlation",
-        "max_seconds": 0.00962,
-        "mean_seconds": 0.00962,
-        "median_seconds": 0.00962,
+        "max_seconds": 0.009612,
+        "mean_seconds": 0.009328,
+        "median_seconds": 0.00921,
         "metadata": {
           "correlation_keys": [
             "EURUSD_corr"
@@ -745,7 +773,7 @@
           "support_boundary": "bounded_quanto_correlation",
           "warm_start": true
         },
-        "min_seconds": 0.00962,
+        "min_seconds": 0.00916,
         "mode": "cold",
         "notes": [
           "least_squares",
@@ -753,26 +781,28 @@
           "bounded_quanto_correlation",
           "linked_market_state_materialization"
         ],
-        "repeats": 1,
+        "repeats": 3,
         "run_seconds": [
-          0.00962
+          0.00921,
+          0.009612,
+          0.00916
         ],
-        "warmups": 0
+        "warmups": 1
       },
       "label": "desk_quanto_correlation",
       "latency_envelope": {
         "breaches": {},
         "cold_max_limit_seconds": 2.0,
-        "cold_max_seconds": 0.00962,
+        "cold_max_seconds": 0.009612,
         "cold_mean_limit_seconds": 1.5,
-        "cold_mean_seconds": 0.00962,
+        "cold_mean_seconds": 0.009328,
         "fixture_style": "desk_like",
         "instrument_count": null,
         "label": "desk_quanto_correlation",
         "quote_count": 3,
         "status": "pass",
         "warm_mean_limit_seconds": 0.5,
-        "warm_mean_seconds": 0.002744,
+        "warm_mean_seconds": 0.002906,
         "workflow": "quanto_correlation"
       },
       "metadata": {
@@ -828,11 +858,11 @@
         "linked_market_state_materialization"
       ],
       "warm": {
-        "calibrations_per_second": 364.42,
+        "calibrations_per_second": 344.142,
         "label": "desk_quanto_correlation",
-        "max_seconds": 0.002744,
-        "mean_seconds": 0.002744,
-        "median_seconds": 0.002744,
+        "max_seconds": 0.002912,
+        "mean_seconds": 0.002906,
+        "median_seconds": 0.002906,
         "metadata": {
           "correlation_keys": [
             "EURUSD_corr"
@@ -879,7 +909,7 @@
           "support_boundary": "bounded_quanto_correlation",
           "warm_start": true
         },
-        "min_seconds": 0.002744,
+        "min_seconds": 0.002899,
         "mode": "warm",
         "notes": [
           "least_squares",
@@ -887,17 +917,19 @@
           "bounded_quanto_correlation",
           "linked_market_state_materialization"
         ],
-        "repeats": 1,
+        "repeats": 3,
         "run_seconds": [
-          0.002744
+          0.002899,
+          0.002912,
+          0.002906
         ],
-        "warmups": 0
+        "warmups": 1
       },
-      "warm_speedup": 3.506,
+      "warm_speedup": 3.21,
       "workflow": "quanto_correlation"
     }
   ],
-  "created_at": "2026-04-23T23:32:54Z",
+  "created_at": "2026-04-23T23:50:03Z",
   "environment": {
     "platform": "macOS-26.3.1-arm64-arm-64bit",
     "python_version": "3.10.6"
@@ -907,12 +939,12 @@
     "Warm-start baselines use workflow-native seed hooks where the workflow supports them."
   ],
   "summary": {
-    "average_warm_speedup": 11.086,
-    "cold_mean_seconds": 1.120803,
+    "average_warm_speedup": 10.047,
+    "cold_mean_seconds": 1.122763,
     "desk_like_workflow_count": 2,
     "latency_envelope_count": 2,
     "perturbation_diagnostic_count": 2,
-    "warm_mean_seconds": 0.146099,
+    "warm_mean_seconds": 0.146565,
     "warm_start_workflow_count": 5,
     "workflow_count": 11
   }

--- a/docs/benchmarks/calibration_workflows.md
+++ b/docs/benchmarks/calibration_workflows.md
@@ -1,13 +1,13 @@
 # Calibration Benchmark: `supported_calibration_workflows`
-- Created at: `2026-04-23T23:32:54Z`
+- Created at: `2026-04-23T23:50:03Z`
 - Workflows: `11`
 - Warm-start workflows: `5`
 - Desk-like workflows: `2`
 - Perturbation diagnostics: `2`
 - Latency envelopes: `2`
-- Avg cold mean seconds: `1.120803`
-- Avg warm mean seconds: `0.146099`
-- Avg warm speedup: `11.086`x
+- Avg cold mean seconds: `1.122763`
+- Avg warm mean seconds: `0.146565`
+- Avg warm speedup: `10.047`x
 
 ## Environment
 - Python: `3.10.6`
@@ -20,18 +20,18 @@
 ## Workflow Results
 
 ### `hull_white` swaption_strip
-- Cold mean: `2.718538` s
-- Cold throughput: `0.368` runs/s
-- Warm mean: `0.292813` s
-- Warm throughput: `3.415` runs/s
-- Warm speedup: `9.284`x
+- Cold mean: `2.736263` s
+- Cold throughput: `0.365` runs/s
+- Warm mean: `0.300682` s
+- Warm throughput: `3.326` runs/s
+- Warm speedup: `9.1`x
 - Metadata: `instrument_count`=2, `multi_curve_roles`={'discount_curve': 'usd_ois', 'forecast_curve': 'USD-SOFR-3M', 'rate_index': 'USD-SOFR-3M'}, `warm_start`=True
 - Note: least_squares
 - Note: tree_pricing
 
 ### `caplet_strip` price_bootstrap_surface
-- Cold mean: `0.017735` s
-- Cold throughput: `56.386` runs/s
+- Cold mean: `0.017903` s
+- Cold throughput: `55.855` runs/s
 - Warm start: `n/a`
 - Metadata: `grid_shape`=[4, 2], `quote_count`=8, `surface_name`='usd_caplet_strip', `warm_start`=False
 - Note: bootstrap
@@ -39,19 +39,19 @@
 - Note: price_quotes
 
 ### `sabr` single_smile
-- Cold mean: `0.092521` s
-- Cold throughput: `10.808` runs/s
-- Warm mean: `0.003399` s
-- Warm throughput: `294.193` runs/s
-- Warm speedup: `27.219`x
+- Cold mean: `0.078271` s
+- Cold throughput: `12.776` runs/s
+- Warm mean: `0.00344` s
+- Warm throughput: `290.707` runs/s
+- Warm speedup: `22.754`x
 - Metadata: `point_count`=7, `surface_name`='usd_rates_smile', `synthetic_generation_contract_version`='v2', `warm_start`=True
 - Note: least_squares
 - Note: implied_vol_fit
 - Note: synthetic_generation_contract_fixture
 
 ### `swaption_cube` price_normalized_cube
-- Cold mean: `0.052409` s
-- Cold throughput: `19.081` runs/s
+- Cold mean: `0.053278` s
+- Cold throughput: `18.769` runs/s
 - Warm start: `n/a`
 - Metadata: `grid_shape`=[2, 2, 3], `quote_count`=12, `surface_name`='usd_swaption_cube', `synthetic_generation_contract_version`='v2', `warm_start`=False
 - Note: cube_assembly
@@ -60,8 +60,8 @@
 - Note: synthetic_generation_contract_fixture
 
 ### `equity_vol_surface` repaired_surface_authority
-- Cold mean: `3.804943` s
-- Cold throughput: `0.263` runs/s
+- Cold mean: `3.83706` s
+- Cold throughput: `0.261` runs/s
 - Warm start: `n/a`
 - Metadata: `grid_shape`=[5, 5], `surface_name`='spx_surface_authority', `synthetic_generation_contract_version`='v2', `warm_start`=False
 - Note: svi_surface
@@ -69,22 +69,22 @@
 - Note: synthetic_generation_contract_fixture
 
 ### `heston` single_smile
-- Cold mean: `0.861616` s
-- Cold throughput: `1.161` runs/s
-- Warm mean: `0.068261` s
-- Warm throughput: `14.65` runs/s
-- Warm speedup: `12.622`x
+- Cold mean: `0.849907` s
+- Cold throughput: `1.177` runs/s
+- Warm mean: `0.068884` s
+- Warm throughput: `14.517` runs/s
+- Warm speedup: `12.338`x
 - Metadata: `point_count`=5, `surface_name`='spx_heston_implied_vol', `synthetic_generation_contract_version`='v2', `warm_start`=True
 - Note: least_squares
 - Note: fft_pricing
 - Note: synthetic_generation_contract_fixture
 
 ### `heston_surface` surface_compression
-- Cold mean: `1.016551` s
-- Cold throughput: `0.984` runs/s
-- Warm mean: `0.363279` s
-- Warm throughput: `2.753` runs/s
-- Warm speedup: `2.798`x
+- Cold mean: `1.011428` s
+- Cold throughput: `0.989` runs/s
+- Warm mean: `0.356915` s
+- Warm throughput: `2.802` runs/s
+- Warm speedup: `2.834`x
 - Metadata: `grid_shape`=[5, 5], `surface_name`='spx_surface_authority', `synthetic_generation_contract_version`='v2', `warm_start`=True
 - Note: least_squares
 - Note: fft_pricing
@@ -92,8 +92,8 @@
 - Note: synthetic_generation_contract_fixture
 
 ### `local_vol` dupire_surface
-- Cold mean: `0.000395` s
-- Cold throughput: `2531.107` runs/s
+- Cold mean: `0.000342` s
+- Cold throughput: `2926.709` runs/s
 - Warm start: `n/a`
 - Metadata: `grid_shape`=[5, 5], `source_surface_name`='spx_heston_implied_vol', `surface_name`='spx_local_vol', `synthetic_generation_contract_version`='v2', `warm_start`=False
 - Note: dupire
@@ -101,18 +101,18 @@
 - Note: synthetic_generation_contract_fixture
 
 ### `credit` single_name_curve
-- Cold mean: `0.710894` s
-- Cold throughput: `1.407` runs/s
+- Cold mean: `0.701379` s
+- Cold throughput: `1.426` runs/s
 - Warm start: `n/a`
 - Metadata: `curve_name`='usd_ig', `model_consistency_contract_version`='v1', `point_count`=4, `quote_family`='spread', `warm_start`=False
 - Note: least_squares
 - Note: model_consistency_contract_fixture
 
 ### `basket_credit` desk_tranche_surface
-- Cold mean: `3.043611` s
-- Cold throughput: `0.329` runs/s
+- Cold mean: `3.055233` s
+- Cold throughput: `0.327` runs/s
 - Warm start: `n/a`
-- Latency envelope: `pass` (cold mean `3.043611` s <= `6.0` s)
+- Latency envelope: `pass` (cold mean `3.055233` s <= `6.0` s)
 - Perturbation diagnostic: `pass` (max abs change `0.004268596412018488`)
 - Metadata: `fixture_style`='desk_like', `latency_envelope`={'workflow': 'basket_credit', 'label': 'desk_tranche_surface', 'fixture_style': 'desk_like', 'instrument_count': None, 'quote_count': 6, 'cold_mean_limit_seconds': 6.0, 'cold_max_limit_seconds': 8.0, 'warm_mean_limit_seconds': None}, `linked_credit_curve`='benchmark_single_name_credit', `maturity_count`=2, `perturbation_diagnostic`={'label': 'basket_credit_parallel_quote_up', 'perturbation_size': 0.0025, 'baseline_metrics': {'5y_0.00_0.03': 0.18000000000001112, '5y_0.03_0.07': 0.23999999999990046, '5y_0.07_0.10': 0.33999999999225816, '7y_0.00_0.03': 0.39, '7y_0.03_0.07': 0.48000000000000054, '7y_0.07_0.10': 0.5399999999999684}, 'perturbed_metrics': {'5y_0.00_0.03': 0.1781832312816442, '5y_0.03_0.07': 0.23573140358788197, '5y_0.07_0.10': 0.34400870869280414, '7y_0.00_0.03': 0.3880026451908997, '7y_0.03_0.07': 0.4774988971374956, '7y_0.07_0.10': 0.5361447035161097}, 'absolute_changes': {'5y_0.00_0.03': -0.0018167687183669179, '5y_0.03_0.07': -0.004268596412018488, '5y_0.07_0.10': 0.004008708700545982, '7y_0.00_0.03': -0.0019973548091002935, '7y_0.03_0.07': -0.0025011028625049336, '7y_0.07_0.10': -0.003855296483858739}, 'relative_changes': {'5y_0.00_0.03': -0.010093159546482253, '5y_0.03_0.07': -0.017785818383417744, '5y_0.07_0.10': 0.011790319707756649, '7y_0.00_0.03': -0.00512142258743665, '7y_0.03_0.07': -0.00521063096355194, '7y_0.07_0.10': -0.007139437933072156}, 'max_abs_change': 0.004268596412018488, 'max_relative_change': 0.017785818383417744, 'threshold_breaches': {}, 'status': 'pass'}, `quote_count`=6, `support_boundary`='homogeneous_representative_curve', `surface_name`='benchmark_tranche_correlation', `tranche_count`=3, `warm_start`=False
 - Note: brentq_root_scan
@@ -121,12 +121,12 @@
 - Note: linked_single_name_credit_curve
 
 ### `quanto_correlation` desk_quanto_correlation
-- Cold mean: `0.00962` s
-- Cold throughput: `103.952` runs/s
-- Warm mean: `0.002744` s
-- Warm throughput: `364.42` runs/s
-- Warm speedup: `3.506`x
-- Latency envelope: `pass` (cold mean `0.00962` s <= `1.5` s)
+- Cold mean: `0.009328` s
+- Cold throughput: `107.21` runs/s
+- Warm mean: `0.002906` s
+- Warm throughput: `344.142` runs/s
+- Warm speedup: `3.21`x
+- Latency envelope: `pass` (cold mean `0.009328` s <= `1.5` s)
 - Perturbation diagnostic: `pass` (max abs change `0.00741841223079881`)
 - Metadata: `correlation_keys`=['EURUSD_corr'], `fixture_style`='desk_like', `fx_pair`='EURUSD', `latency_envelope`={'workflow': 'quanto_correlation', 'label': 'desk_quanto_correlation', 'fixture_style': 'desk_like', 'instrument_count': None, 'quote_count': 3, 'cold_mean_limit_seconds': 1.5, 'cold_max_limit_seconds': 2.0, 'warm_mean_limit_seconds': 0.5}, `linked_curve_roles`={'discount_curve': 'usd_ois', 'forecast_curve': 'EUR-DISC'}, `linked_vol_surface`='quanto_flat_vol', `parameter_set_name`='benchmark_quanto_rho', `perturbation_diagnostic`={'label': 'quanto_correlation_parallel_quote_up', 'perturbation_size': 0.0025, 'baseline_metrics': {'quanto_correlation': 0.3499999999999991}, 'perturbed_metrics': {'quanto_correlation': 0.3425815877692003}, 'absolute_changes': {'quanto_correlation': -0.00741841223079881}, 'relative_changes': {'quanto_correlation': -0.021195463516568085}, 'max_abs_change': 0.00741841223079881, 'max_relative_change': 0.021195463516568085, 'threshold_breaches': {}, 'status': 'pass'}, `quote_count`=3, `support_boundary`='bounded_quanto_correlation', `warm_start`=True
 - Note: least_squares

--- a/tests/test_verification/test_calibration_replay.py
+++ b/tests/test_verification/test_calibration_replay.py
@@ -306,3 +306,9 @@ def test_checked_calibration_benchmark_artifact_covers_supported_workflows():
     assert cases["quanto_correlation"]["metadata"]["correlation_keys"] == ["EURUSD_corr"]
     assert cases["quanto_correlation"]["metadata"]["perturbation_diagnostic"]["threshold_breaches"] == {}
     assert cases["quanto_correlation"]["latency_envelope"]["status"] == "pass"
+    for case in cases.values():
+        assert case["cold"]["repeats"] == 3
+        assert case["cold"]["warmups"] == 1
+        if case["warm"] is not None:
+            assert case["warm"]["repeats"] == 3
+            assert case["warm"]["warmups"] == 1


### PR DESCRIPTION
## Summary
- restore the checked calibration benchmark artifact to the default smoothed baseline (`repeats=3`, `warmups=1`) and lock that contract into the replay test
- roll the closeout branch forward through the merged bounded quanto validation and derivative-governance slices
- mark the calibration-sleeve execution mirror as fully completed, including the bounded hybrid follow-ons and umbrella closeout

## Testing
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_verification/test_calibration_replay.py -k "live_supported_calibration_benchmark_report_covers_warm_start_shape or checked_calibration_benchmark_artifact_covers_supported_workflows" -q