### PR TITLE
QUA-984: Add quant challenger packet handoff

### DIFF
--- a/doc/plan/draft__agent-review-cycle-roadmap.md
+++ b/doc/plan/draft__agent-review-cycle-roadmap.md
@@ -46,7 +46,7 @@ Implementation queue:
 | Order | Ticket | Status | Objective | Hard blocker |
 | --- | --- | --- | --- | --- |
 | 1 | `QUA-983` | Done | ARC.0 - explicit cycle report contract | none |
-| 2 | `QUA-984` | Backlog | ARC.1 - quant challenger packet | `QUA-983` |
+| 2 | `QUA-984` | In Progress | ARC.1 - quant challenger packet | `QUA-983` |
 | 3 | `QUA-985` | Backlog | ARC.2 - executable critic and arbiter claims | `QUA-984` |
 | 4 | `QUA-986` | Backlog | ARC.3 - residual-risk model validation | `QUA-985` |
 | 5 | `QUA-987` | Backlog | ARC.4 - promotion and adoption governance | `QUA-986` |

--- a/docs/developer/audit_and_observability.rst
+++ b/docs/developer/audit_and_observability.rst
@@ -228,6 +228,36 @@ model-validator findings. The cycle report makes those stage outcomes stable
 and inspectable so downstream tooling no longer has to infer governance state
 from ad hoc event strings.
 
+Quant Challenger Packet
+-----------------------
+
+The quant stage now emits a structured ``quant_challenger_packet`` alongside
+the selected pricing method. The packet is the stable method-selection handoff
+for downstream validation, critic, arbiter, and model-validator stages.
+
+The packet records:
+
+- the normalized selected method and route-family identity
+- the ranked candidate methods considered by quant
+- rejection reason codes for non-selected alternatives
+- the assumption basis used by method selection
+- required market-data capabilities and requested sensitivity measures
+- expected executable checks that downstream validation should cover
+- residual risk ids that model validation can review without reconstructing
+  quant reasoning from prompt text
+
+Compiled validation contracts persist the same packet under
+``quant_challenger_packet`` and enrich it with the validation contract id and
+actual deterministic check ids selected for the route. Platform request
+metadata carries the same summary, and ``quant_selected_method`` trace events
+include the packet so ``cycle_report`` consumers can read the quant hypothesis
+directly from stage details.
+
+Model-validator LLM review receives the packet as structured JSON when it runs.
+It should treat the packet as the method-selection contract and focus on
+residual conceptual risk rather than rebuilding quant's method-choice rationale
+from loose prose.
+
 Governed Provider Provenance
 ----------------------------
 

--- a/tests/test_agent/test_lite_review.py
+++ b/tests/test_agent/test_lite_review.py
@@ -903,6 +903,100 @@ def test_validate_build_supports_quanto_monte_carlo_market_inputs():
     assert failures == []
 
 
+def test_validate_build_passes_quant_selected_method_to_model_validator(monkeypatch):
+    from trellis.agent.executor import _validate_build
+    from trellis.agent.quant import PricingPlan
+    from trellis.agent.validation_report import ValidationReport
+
+    class DummyPayoff:
+        pass
+
+    spec_schema = SimpleNamespace(
+        class_name="DummyPayoff",
+        spec_name="DummySpec",
+        requirements=["discount_curve", "black_vol_surface"],
+        fields=[],
+    )
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        "trellis.agent.executor._make_test_payoff",
+        lambda *args, **kwargs: object(),
+    )
+    monkeypatch.setattr(
+        "trellis.agent.executor._record_platform_event",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "trellis.agent.executor._should_run_reference_oracle",
+        lambda *args, **kwargs: False,
+    )
+    monkeypatch.setattr(
+        "trellis.agent.validation_bundles.select_validation_bundle",
+        lambda *args, **kwargs: SimpleNamespace(
+            bundle_id="analytical:european_option",
+            checks=(),
+            categories={},
+        ),
+    )
+    monkeypatch.setattr(
+        "trellis.agent.validation_bundles.execute_validation_bundle",
+        lambda *args, **kwargs: SimpleNamespace(
+            failures=[],
+            failure_details=[],
+            executed_checks=(),
+            skipped_checks=(),
+        ),
+    )
+
+    def fake_validate_model(*, method, run_llm_review, **kwargs):
+        captured["method"] = method
+        captured["run_llm_review"] = run_llm_review
+        return ValidationReport(instrument="european_option", method=str(method))
+
+    monkeypatch.setattr(
+        "trellis.agent.model_validator.validate_model",
+        fake_validate_model,
+    )
+
+    failures = _validate_build(
+        DummyPayoff,
+        code="def evaluate(self, market_state):\n    return 0.0\n",
+        description="European call option on equity",
+        spec_schema=spec_schema,
+        validation="thorough",
+        compiled_request=SimpleNamespace(
+            request=SimpleNamespace(metadata={}, request_id="validate_build_method_surface"),
+            generation_plan=None,
+            semantic_blueprint=None,
+            comparison_spec=None,
+            execution_plan=SimpleNamespace(route_method="direct_existing"),
+        ),
+        pricing_plan=PricingPlan(
+            method="analytical",
+            method_modules=["trellis.models.black"],
+            required_market_data={"discount_curve", "black_vol_surface"},
+            model_to_build="european_option",
+            reasoning="test",
+        ),
+        product_ir=SimpleNamespace(
+            instrument="european_option",
+            payoff_traits=(),
+            exercise_style="european",
+            state_dependence="terminal_markov",
+            schedule_dependence=False,
+            model_family="equity_diffusion",
+            unresolved_primitives=(),
+            supported=True,
+        ),
+        attempt_number=1,
+    )
+
+    assert failures == []
+    assert captured["method"] == "analytical"
+    assert captured["run_llm_review"] is False
+
+
 def test_format_validation_failure_feedback_includes_structured_diagnostics():
     from trellis.agent.executor import _format_validation_failure_feedback
     from trellis.agent.invariants import InvariantFailure

--- a/tests/test_agent/test_model_validator.py
+++ b/tests/test_agent/test_model_validator.py
@@ -545,8 +545,15 @@ def test_validate_model_threads_validation_contract_residual_risks(monkeypatch):
 
     captured = {}
 
-    def fake_llm_review(*args, residual_risks=(), review_reason=None, **kwargs):
+    def fake_llm_review(
+        *args,
+        residual_risks=(),
+        quant_challenger_packet=None,
+        review_reason=None,
+        **kwargs,
+    ):
         captured["residual_risks"] = residual_risks
+        captured["quant_challenger_packet"] = quant_challenger_packet
         captured["review_reason"] = review_reason
         return []
 
@@ -567,12 +574,32 @@ def test_validate_model_threads_validation_contract_residual_risks(monkeypatch):
             method="rate_tree",
             bundle_id="rate_tree:callable_bond",
             residual_risks=("unsupported_paths_declared",),
+            quant_challenger_packet={
+                "selected_method": "rate_tree",
+                "candidate_methods": [
+                    {"method": "rate_tree", "status": "selected"},
+                    {
+                        "method": "analytical",
+                        "status": "rejected",
+                        "rejection_reason": "insufficient_contract_features",
+                    },
+                ],
+                "expected_executable_checks": ["deterministic_validation_bundle"],
+                "residual_risk_handoff": ["quant:early_exercise_sensitive_product"],
+            },
         ),
         run_llm_review=True,
     )
 
     assert report.findings == []
     assert captured["residual_risks"] == ("unsupported_paths_declared",)
+    assert captured["quant_challenger_packet"]["selected_method"] == "rate_tree"
+    assert (
+        captured["quant_challenger_packet"]["candidate_methods"][1][
+            "rejection_reason"
+        ]
+        == "insufficient_contract_features"
+    )
     assert captured["review_reason"] is None
 
 

--- a/tests/test_agent/test_platform_traces.py
+++ b/tests/test_agent/test_platform_traces.py
@@ -195,7 +195,27 @@ def test_platform_trace_persists_cycle_report_from_lifecycle_events(tmp_path):
         compiled,
         "quant_selected_method",
         status="ok",
-        details={"method": "analytical", "selection_reason": "exact_binding"},
+        details={
+            "method": "analytical",
+            "selection_reason": "exact_binding",
+            "challenger_packet": {
+                "selected_method": "analytical",
+                "method_identity": "analytical",
+                "candidate_methods": [
+                    {"method": "analytical", "status": "selected"},
+                    {
+                        "method": "monte_carlo",
+                        "status": "rejected",
+                        "rejection_reason": "higher_complexity_than_selected_default",
+                    },
+                ],
+                "expected_executable_checks": [
+                    "market_data_capability_check",
+                    "deterministic_validation_bundle",
+                ],
+                "residual_risk_handoff": ["quant:multiple_valid_methods_available"],
+            },
+        },
         root=tmp_path,
     )
     append_platform_trace_event(
@@ -267,6 +287,13 @@ def test_platform_trace_persists_cycle_report_from_lifecycle_events(tmp_path):
         "arbiter": "passed",
         "model_validator": "skipped",
     }
+    quant_stage = next(
+        stage for stage in cycle_report["stages"] if stage["stage"] == "quant"
+    )
+    assert quant_stage["details"]["challenger_packet"]["selected_method"] == "analytical"
+    assert quant_stage["details"]["challenger_packet"]["candidate_methods"][1][
+        "method"
+    ] == "monte_carlo"
 
 
 def test_platform_trace_cycle_report_marks_failed_stage(tmp_path):

--- a/tests/test_agent/test_quant.py
+++ b/tests/test_agent/test_quant.py
@@ -9,6 +9,7 @@ from trellis.agent.quant import (
     PricingPlan,
     STATIC_PLANS,
     check_data_availability,
+    quant_challenger_packet_summary,
     select_pricing_method,
     select_pricing_method_for_product_ir,
 )
@@ -246,6 +247,45 @@ class TestPricingPlan:
             "no_path_sampling_required",
         )
         assert "multiple_valid_methods_available" in plan.assumption_summary
+
+    def test_product_ir_multiple_candidates_emits_challenger_packet(self):
+        product_ir = SimpleNamespace(
+            instrument="synthetic_option",
+            required_market_data={"discount_curve", "black_vol_surface"},
+            candidate_engine_families=("pde", "monte_carlo", "tree", "analytical"),
+            multi_asset=False,
+            schedule_dependence=False,
+            state_dependence="static",
+            exercise_style="",
+        )
+
+        plan = select_pricing_method_for_product_ir(product_ir)
+        packet = plan.challenger_packet
+        summary = quant_challenger_packet_summary(plan)
+
+        assert packet is not None
+        assert packet.selected_method == "analytical"
+        assert summary["selected_method"] == "analytical"
+        assert summary["method_identity"] == "analytical"
+        assert summary["route_family"] == "analytical"
+        assert summary["candidate_methods"][0]["method"] == "analytical"
+        assert summary["candidate_methods"][0]["status"] == "selected"
+        rejected = {
+            item["method"]: item["rejection_reason"]
+            for item in summary["candidate_methods"]
+            if item["status"] == "rejected"
+        }
+        assert rejected == {
+            "rate_tree": "higher_complexity_than_selected_default",
+            "pde_solver": "higher_complexity_than_selected_default",
+            "monte_carlo": "higher_complexity_than_selected_default",
+        }
+        assert summary["assumption_basis"] == list(plan.assumption_summary)
+        assert summary["required_market_data"] == ["black_vol_surface", "discount_curve"]
+        assert "market_data_capability_check" in summary["expected_executable_checks"]
+        assert "deterministic_validation_bundle" in summary["expected_executable_checks"]
+        assert "alternative_method_challenge" in summary["expected_executable_checks"]
+        assert "quant:multiple_valid_methods_available" in summary["residual_risk_handoff"]
 
     def test_product_ir_sensitivity_request_prefers_rate_tree_for_callable_bond(self):
         from trellis.agent.knowledge.decompose import decompose_to_ir

--- a/tests/test_agent/test_validation_contract.py
+++ b/tests/test_agent/test_validation_contract.py
@@ -59,6 +59,18 @@ def test_compile_build_request_attaches_validation_contract_summary():
         compiled.request.metadata["validation_contract"]["deterministic_checks"][0]["check_id"]
         == contract.deterministic_checks[0].check_id
     )
+    packet = contract.quant_challenger_packet
+    assert packet["selected_method"] == contract.method
+    assert packet["method_identity"] == contract.method
+    assert packet["route_family"] == contract.route_family
+    assert "deterministic_validation_bundle" in packet["expected_executable_checks"]
+    assert "check_non_negativity" in packet["expected_executable_checks"]
+    assert "check_price_sanity" in packet["expected_executable_checks"]
+    assert packet["validation_contract_id"] == contract.contract_id
+    assert (
+        compiled.request.metadata["validation_contract"]["quant_challenger_packet"]
+        == packet
+    )
 
 
 def test_callable_bond_validation_contract_carries_reference_bound_relation():

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -841,6 +841,7 @@ def build_payoff(
     from trellis.agent.planner import plan_build
     from trellis.agent.quant import (
         check_data_availability,
+        quant_challenger_packet_summary,
         select_pricing_method,
         select_pricing_method_for_product_ir,
     )
@@ -921,6 +922,7 @@ def build_payoff(
             model=model,
         )
     )
+    quant_challenger_packet = quant_challenger_packet_summary(pricing_plan)
     _record_platform_event(
         compiled_request,
         "quant_selected_method",
@@ -936,6 +938,7 @@ def build_payoff(
             "selection_reason": pricing_plan.selection_reason,
             "assumption_summary": list(pricing_plan.assumption_summary),
             "required_market_data": sorted(pricing_plan.required_market_data),
+            "challenger_packet": quant_challenger_packet,
             "sensitivity_support": (
                 pricing_plan.sensitivity_support.to_dict()
                 if pricing_plan.sensitivity_support is not None
@@ -960,6 +963,7 @@ def build_payoff(
             "reasoning": pricing_plan.reasoning,
             "selection_reason": pricing_plan.selection_reason,
             "assumption_summary": list(pricing_plan.assumption_summary),
+            "challenger_packet": quant_challenger_packet,
             "sensitivity_support": (
                 pricing_plan.sensitivity_support.to_dict()
                 if pricing_plan.sensitivity_support is not None
@@ -1859,9 +1863,14 @@ def _validate_build(
         route_binding_authority_data = dict(
             getattr(getattr(compiled_request, "request", None), "metadata", {}).get("route_binding_authority") or {}
         )
+    validation_method = (
+        getattr(pricing_plan, "method", None)
+        or getattr(getattr(compiled_request, "execution_plan", None), "route_method", None)
+        or "unknown"
+    )
     review_policy = determine_review_policy(
         validation=validation,
-        method=(pricing_plan.method if pricing_plan is not None else "unknown"),
+        method=validation_method,
         instrument_type=itype,
         product_ir=product_ir,
         validation_contract=validation_contract,
@@ -1991,7 +2000,7 @@ def _validate_build(
 
     validation_bundle = select_validation_bundle(
         instrument_type=itype,
-        method=(pricing_plan.method if pricing_plan is not None else "unknown"),
+        method=validation_method,
         product_ir=product_ir,
         semantic_blueprint=getattr(compiled_request, "semantic_blueprint", None),
     )
@@ -2059,7 +2068,7 @@ def _validate_build(
     if not failures and _should_run_reference_oracle(compiled_request):
         oracle_spec = select_reference_oracle(
             instrument_type=itype,
-            method=(pricing_plan.method if pricing_plan is not None else "unknown"),
+            method=validation_method,
             product_ir=product_ir,
             semantic_blueprint=getattr(compiled_request, "semantic_blueprint", None),
         )
@@ -2311,7 +2320,7 @@ def _validate_build(
                         market_state_factory=ms_factory,
                         code=code,
                         instrument_type=itype,
-                        method=spec_schema.requirements[0] if hasattr(spec_schema, 'requirements') else "unknown",
+                        method=validation_method,
                         knowledge_context=review_knowledge_text,
                         model=stage_model,
                         product_ir=product_ir,
@@ -2345,7 +2354,7 @@ def _validate_build(
                     market_state_factory=ms_factory,
                     code=code,
                     instrument_type=itype,
-                    method=spec_schema.requirements[0] if hasattr(spec_schema, 'requirements') else "unknown",
+                    method=validation_method,
                     knowledge_context="",
                     model=model,
                     product_ir=product_ir,

--- a/trellis/agent/model_validator.py
+++ b/trellis/agent/model_validator.py
@@ -88,6 +88,9 @@ def validate_model(
             knowledge_context=knowledge_context,
             generation_plan=generation_plan,
             residual_risks=_model_validator_residual_risks(validation_contract),
+            quant_challenger_packet=_model_validator_quant_challenger_packet(
+                validation_contract
+            ),
             review_reason=review_reason,
             model=model,
         )
@@ -140,6 +143,7 @@ def _llm_conceptual_review(
     knowledge_context: str = "",
     generation_plan=None,
     residual_risks: tuple[str, ...] = (),
+    quant_challenger_packet: dict[str, object] | None = None,
     review_reason: str | None = None,
     model: str | None = None,
 ) -> list[ValidationFinding]:
@@ -158,6 +162,14 @@ def _llm_conceptual_review(
             "\n## Residual Conceptual Risks\n"
             "Residual conceptual review only. Focus on the unresolved items below.\n"
             f"{residual_risk_lines}\n"
+        )
+    quant_packet_section = ""
+    if quant_challenger_packet:
+        quant_packet_section = (
+            "\n## Quant Challenger Packet\n"
+            "Use this as the method-selection contract. Do not reconstruct "
+            "quant reasoning from prose when these fields are present.\n"
+            f"```json\n{json.dumps(quant_challenger_packet, indent=2, sort_keys=True)}\n```\n"
         )
     review_reason_section = ""
     if review_reason:
@@ -182,6 +194,7 @@ reference bounds, or other validations already covered by the validation contrac
 {knowledge_section}
 {route_contract_section}
 {residual_risk_section}
+{quant_packet_section}
 {review_reason_section}
 
 ## Code to validate
@@ -258,3 +271,10 @@ def _model_validator_residual_risks(validation_contract) -> tuple[str, ...]:
     if validation_contract is None:
         return ()
     return tuple(getattr(validation_contract, "residual_risks", ()) or ())
+
+
+def _model_validator_quant_challenger_packet(validation_contract) -> dict[str, object]:
+    """Return the structured quant challenger packet attached to validation."""
+    if validation_contract is None:
+        return {}
+    return dict(getattr(validation_contract, "quant_challenger_packet", {}) or {})

--- a/trellis/agent/platform_requests.py
+++ b/trellis/agent/platform_requests.py
@@ -1096,6 +1096,12 @@ def _finalize_compiled_request(
             artifact_kind=route_artifact,
             semantic_contract=semantic_contract is not None,
         )
+    if pricing_plan is not None:
+        from trellis.agent.quant import quant_challenger_packet_summary
+
+        quant_summary = quant_challenger_packet_summary(pricing_plan)
+        if quant_summary:
+            request_metadata["quant_challenger_packet"] = quant_summary
     validation_contract = None
     if any(
         item is not None
@@ -1118,6 +1124,9 @@ def _finalize_compiled_request(
         validation_summary = validation_contract_summary(validation_contract)
         if validation_summary is not None:
             request_metadata["validation_contract"] = validation_summary
+            quant_summary = validation_summary.get("quant_challenger_packet")
+            if quant_summary:
+                request_metadata["quant_challenger_packet"] = quant_summary
     if generation_plan is not None and semantic_blueprint is not None:
         generation_plan = enrich_generation_plan(
             generation_plan,

--- a/trellis/agent/platform_traces.py
+++ b/trellis/agent/platform_traces.py
@@ -1011,6 +1011,7 @@ def _cycle_stage_details(stage: str, details: dict[str, Any]) -> dict[str, Any]:
             "selection_reason",
             "assumption_summary",
             "required_market_data",
+            "challenger_packet",
         ),
         "validation_bundle": (
             "bundle_id",

--- a/trellis/agent/quant.py
+++ b/trellis/agent/quant.py
@@ -10,6 +10,7 @@ products.
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
+from typing import Mapping
 import re
 
 from trellis.agent.knowledge import get_store
@@ -28,12 +29,41 @@ from trellis.core.capabilities import (
 
 
 @dataclass(frozen=True)
+class QuantMethodCandidate:
+    """One candidate method considered by the quant agent."""
+
+    method: str
+    status: str
+    rejection_reason: str = ""
+    priority_rank: int = 999
+    sensitivity_level: str | None = None
+    supported_measures: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class QuantChallengerPacket:
+    """Structured quant handoff for downstream review stages."""
+
+    selected_method: str
+    method_identity: str
+    route_family: str
+    selection_reason: str
+    candidate_methods: tuple[QuantMethodCandidate, ...]
+    assumption_basis: tuple[str, ...]
+    required_market_data: tuple[str, ...]
+    requested_measures: tuple[str, ...]
+    expected_executable_checks: tuple[str, ...]
+    residual_risk_handoff: tuple[str, ...]
+
+
+@dataclass(frozen=True)
 class PricingPlan:
     """Output of the quant agent's method selection step.
 
     Contains the chosen pricing method (e.g. 'analytical', 'monte_carlo'),
-    the modules that implement it, the market data it needs, and any
-    modeling constraints or assumptions.
+    the modules that implement it, the market data it needs, any modeling
+    constraints or assumptions, and the structured challenger packet consumed
+    by downstream validation stages.
     """
 
     method: str
@@ -45,6 +75,7 @@ class PricingPlan:
     sensitivity_support: SensitivitySupport | None = None
     selection_reason: str = ""
     assumption_summary: tuple[str, ...] = ()
+    challenger_packet: QuantChallengerPacket | Mapping[str, object] | None = None
 
 
 _DEFAULT_METHOD_MODULES = {
@@ -117,6 +148,18 @@ _METHOD_ASSUMPTION_SUMMARIES = {
 }
 
 
+def _normalize_string_tuple(values) -> tuple[str, ...]:
+    """Normalize arbitrary values into a deduplicated tuple of strings."""
+    if not values:
+        return ()
+    normalized: list[str] = []
+    for value in values:
+        text = str(getattr(value, "value", value)).strip()
+        if text and text not in normalized:
+            normalized.append(text)
+    return tuple(normalized)
+
+
 def _merge_unique_strings(*groups: tuple[str, ...] | list[str]) -> tuple[str, ...]:
     """Merge string collections while preserving order and dropping duplicates."""
     merged: list[str] = []
@@ -131,6 +174,300 @@ def _merge_unique_strings(*groups: tuple[str, ...] | list[str]) -> tuple[str, ..
 def _method_priority(method: str) -> int:
     """Return the default simplicity/latency rank for a method family."""
     return _METHOD_PRIORITY_ORDER.get(normalize_method(method), len(_METHOD_PRIORITY_ORDER))
+
+
+def _candidate_methods_from_packet(packet) -> tuple[str, ...]:
+    """Recover candidate method identities from an existing challenger packet."""
+    if packet is None:
+        return ()
+    if isinstance(packet, QuantChallengerPacket):
+        return tuple(candidate.method for candidate in packet.candidate_methods)
+    if isinstance(packet, Mapping):
+        candidates = packet.get("candidate_methods") or ()
+        methods: list[str] = []
+        for candidate in candidates:
+            if isinstance(candidate, Mapping):
+                method = normalize_method(candidate.get("method"))
+            else:
+                method = normalize_method(getattr(candidate, "method", None))
+            if method and method not in methods:
+                methods.append(method)
+        return tuple(methods)
+    return ()
+
+
+def _rejection_reason_for_candidate(
+    candidate_method: str,
+    selected_method: str,
+    *,
+    selection_reason: str,
+    requested_measures: tuple[str, ...],
+    selected_support: SensitivitySupport | None,
+) -> str:
+    """Return the stable reason a non-selected candidate lost."""
+    if candidate_method == selected_method:
+        return ""
+    if "explicit_preference" in selection_reason:
+        return "not_explicit_preference"
+    if requested_measures:
+        candidate_rank = rank_sensitivity_support(
+            support_for_method(candidate_method),
+            requested_measures,
+        )[:3]
+        selected_rank = rank_sensitivity_support(
+            selected_support or support_for_method(selected_method),
+            requested_measures,
+        )[:3]
+        if candidate_rank < selected_rank:
+            return "lower_requested_measure_support"
+        return "lower_measure_selection_rank"
+    return "higher_complexity_than_selected_default"
+
+
+def _candidate_summary_for_method(
+    method: str,
+    *,
+    selected_method: str,
+    selection_reason: str,
+    requested_measures: tuple[str, ...],
+    selected_support: SensitivitySupport | None,
+) -> QuantMethodCandidate:
+    """Build one structured candidate entry for the challenger packet."""
+    normalized = normalize_method(method)
+    support = support_for_method(normalized)
+    selected = normalized == selected_method
+    return QuantMethodCandidate(
+        method=normalized,
+        status="selected" if selected else "rejected",
+        rejection_reason="" if selected else _rejection_reason_for_candidate(
+            normalized,
+            selected_method,
+            selection_reason=selection_reason,
+            requested_measures=requested_measures,
+            selected_support=selected_support,
+        ),
+        priority_rank=_method_priority(normalized),
+        sensitivity_level=support.level,
+        supported_measures=tuple(support.supported_measures),
+    )
+
+
+def _ordered_candidate_methods(
+    selected_method: str,
+    candidate_methods: tuple[str, ...] | list[str] | None,
+) -> tuple[str, ...]:
+    """Return candidate methods with the selected method first, then simplicity order."""
+    methods: list[str] = []
+    for method in (selected_method, *(candidate_methods or ())):
+        normalized = normalize_method(method)
+        if normalized and normalized not in methods:
+            methods.append(normalized)
+    return tuple(
+        sorted(
+            methods,
+            key=lambda method: (
+                0 if method == selected_method else 1,
+                _method_priority(method),
+                method,
+            ),
+        )
+    )
+
+
+def _expected_executable_checks_for_packet(
+    *,
+    candidate_methods: tuple[str, ...],
+    requested_measures: tuple[str, ...],
+) -> tuple[str, ...]:
+    """Return quant-side executable checks expected downstream."""
+    checks = ["market_data_capability_check", "deterministic_validation_bundle"]
+    if len(candidate_methods) > 1:
+        checks.append("alternative_method_challenge")
+    if requested_measures:
+        checks.append("requested_measure_support_check")
+    return tuple(checks)
+
+
+def _residual_risk_handoff_for_packet(
+    *,
+    assumption_basis: tuple[str, ...],
+    sensitivity_support: SensitivitySupport | None,
+) -> tuple[str, ...]:
+    """Return quant-side residual risk ids for model-validation handoff."""
+    risk_assumptions = {
+        "multiple_valid_methods_available",
+        "multi_asset_context",
+        "schedule_dependent_product",
+        "path_dependent_product",
+        "early_exercise_sensitive_product",
+        "path_sampling_required",
+        "boundary_conditions_required",
+        "exercise_and_cashflow_discretization_acceptable",
+        "dependence_modeling_route",
+        "cashflow_schedule_required",
+        "local_vol_surface_driven_context",
+    }
+    risks = [
+        f"quant:{assumption}"
+        for assumption in assumption_basis
+        if assumption in risk_assumptions
+    ]
+    if sensitivity_support is not None and sensitivity_support.level == "experimental":
+        risks.append("quant:experimental_sensitivity_support")
+    return _merge_unique_strings(tuple(risks))
+
+
+def _build_challenger_packet(
+    *,
+    selected_method: str,
+    selection_reason: str,
+    assumption_basis: tuple[str, ...],
+    required_market_data,
+    candidate_methods: tuple[str, ...] | list[str] | None = None,
+    requested_measures: tuple[str, ...] | list[str] | None = None,
+    sensitivity_support: SensitivitySupport | None = None,
+) -> QuantChallengerPacket:
+    """Build the stable quant packet consumed by review and validation."""
+    method = normalize_method(selected_method)
+    requested = normalize_requested_measures(requested_measures)
+    ordered_candidates = _ordered_candidate_methods(method, candidate_methods)
+    normalized_assumptions = _normalize_string_tuple(assumption_basis)
+    return QuantChallengerPacket(
+        selected_method=method,
+        method_identity=method,
+        route_family=method,
+        selection_reason=selection_reason or "pricing_plan_selection",
+        candidate_methods=tuple(
+            _candidate_summary_for_method(
+                candidate,
+                selected_method=method,
+                selection_reason=selection_reason or "",
+                requested_measures=requested,
+                selected_support=sensitivity_support,
+            )
+            for candidate in ordered_candidates
+        ),
+        assumption_basis=normalized_assumptions,
+        required_market_data=_normalize_string_tuple(sorted(required_market_data or ())),
+        requested_measures=_normalize_string_tuple(requested),
+        expected_executable_checks=_expected_executable_checks_for_packet(
+            candidate_methods=ordered_candidates,
+            requested_measures=requested,
+        ),
+        residual_risk_handoff=_residual_risk_handoff_for_packet(
+            assumption_basis=normalized_assumptions,
+            sensitivity_support=sensitivity_support,
+        ),
+    )
+
+
+def _attach_challenger_packet(
+    plan: PricingPlan,
+    *,
+    candidate_methods: tuple[str, ...] | list[str] | None = None,
+    requested_measures: tuple[str, ...] | list[str] | None = None,
+) -> PricingPlan:
+    """Return ``plan`` with a fresh challenger packet matching its fields."""
+    candidates = tuple(candidate_methods or ()) or _candidate_methods_from_packet(
+        plan.challenger_packet
+    ) or (plan.method,)
+    packet = _build_challenger_packet(
+        selected_method=plan.method,
+        selection_reason=plan.selection_reason,
+        assumption_basis=plan.assumption_summary,
+        required_market_data=plan.required_market_data,
+        candidate_methods=candidates,
+        requested_measures=requested_measures,
+        sensitivity_support=plan.sensitivity_support,
+    )
+    return replace(plan, challenger_packet=packet)
+
+
+def quant_challenger_packet_summary(
+    pricing_plan: PricingPlan | None = None,
+    *,
+    packet: QuantChallengerPacket | Mapping[str, object] | None = None,
+    deterministic_check_ids: tuple[str, ...] | list[str] | None = None,
+    validation_contract_id: str | None = None,
+    route_family: str | None = None,
+    residual_risks: tuple[str, ...] | list[str] | None = None,
+) -> dict[str, object]:
+    """Return a YAML-safe quant challenger packet summary."""
+    raw_packet = packet or getattr(pricing_plan, "challenger_packet", None)
+    if raw_packet is None and pricing_plan is not None:
+        selected_method = getattr(pricing_plan, "method", "")
+        raw_packet = _build_challenger_packet(
+            selected_method=selected_method,
+            selection_reason=getattr(pricing_plan, "selection_reason", ""),
+            assumption_basis=tuple(getattr(pricing_plan, "assumption_summary", ()) or ()),
+            required_market_data=getattr(pricing_plan, "required_market_data", ()) or (),
+            candidate_methods=(selected_method,),
+            sensitivity_support=getattr(pricing_plan, "sensitivity_support", None),
+        )
+    if raw_packet is None:
+        return {}
+
+    if isinstance(raw_packet, QuantChallengerPacket):
+        payload = {
+            "selected_method": raw_packet.selected_method,
+            "method_identity": raw_packet.method_identity,
+            "route_family": raw_packet.route_family,
+            "selection_reason": raw_packet.selection_reason,
+            "candidate_methods": [
+                {
+                    "method": candidate.method,
+                    "status": candidate.status,
+                    "rejection_reason": candidate.rejection_reason,
+                    "priority_rank": candidate.priority_rank,
+                    "sensitivity_level": candidate.sensitivity_level,
+                    "supported_measures": list(candidate.supported_measures),
+                }
+                for candidate in raw_packet.candidate_methods
+            ],
+            "assumption_basis": list(raw_packet.assumption_basis),
+            "required_market_data": list(raw_packet.required_market_data),
+            "requested_measures": list(raw_packet.requested_measures),
+            "expected_executable_checks": list(raw_packet.expected_executable_checks),
+            "residual_risk_handoff": list(raw_packet.residual_risk_handoff),
+        }
+    else:
+        payload = dict(raw_packet)
+        payload["candidate_methods"] = [
+            dict(candidate) if isinstance(candidate, Mapping) else {
+                "method": getattr(candidate, "method", ""),
+                "status": getattr(candidate, "status", ""),
+                "rejection_reason": getattr(candidate, "rejection_reason", ""),
+            }
+            for candidate in payload.get("candidate_methods", ()) or ()
+        ]
+        for key in (
+            "assumption_basis",
+            "required_market_data",
+            "requested_measures",
+            "expected_executable_checks",
+            "residual_risk_handoff",
+        ):
+            payload[key] = list(payload.get(key) or ())
+
+    if route_family:
+        payload["route_family"] = route_family
+    if deterministic_check_ids:
+        payload["expected_executable_checks"] = list(
+            _merge_unique_strings(
+                tuple(payload.get("expected_executable_checks") or ()),
+                _normalize_string_tuple(deterministic_check_ids),
+            )
+        )
+    if residual_risks:
+        payload["residual_risk_handoff"] = list(
+            _merge_unique_strings(
+                tuple(payload.get("residual_risk_handoff") or ()),
+                tuple(f"validation:{risk}" for risk in _normalize_string_tuple(residual_risks)),
+            )
+        )
+    if validation_contract_id:
+        payload["validation_contract_id"] = validation_contract_id
+    return payload
 
 
 def _assumption_summary_for_method(
@@ -214,7 +551,7 @@ def _plan_from_decomposition(decomposition) -> PricingPlan:
     method = normalize_method(decomposition.method)
     selection_reason = "canonical_decomposition"
     assumption_summary = _assumption_summary_for_method(method)
-    return PricingPlan(
+    plan = PricingPlan(
         method=method,
         method_modules=list(decomposition.method_modules),
         required_market_data=normalize_market_data_requirements(
@@ -227,6 +564,7 @@ def _plan_from_decomposition(decomposition) -> PricingPlan:
         selection_reason=selection_reason,
         assumption_summary=assumption_summary,
     )
+    return _attach_challenger_packet(plan, candidate_methods=(method,))
 
 
 def _load_static_plans() -> dict[str, PricingPlan]:
@@ -354,6 +692,8 @@ def select_pricing_method_for_product_ir(
         plan,
         context_description,
         instrument_type=getattr(product_ir, "instrument", None),
+        candidate_methods=candidate_methods,
+        requested_measures=requested,
     )
 
 
@@ -454,20 +794,29 @@ def _prefer_transform_route_for_requested_sensitivities(
 def known_methods() -> tuple[str, ...]:
     """Return the canonical method-family labels understood by the quant agent."""
     return tuple(sorted(CANONICAL_METHODS))
+
+
 def _apply_contextual_overrides(
     plan: PricingPlan,
     description: str | None,
     *,
     instrument_type: str | None = None,
+    candidate_methods: tuple[str, ...] | list[str] | None = None,
+    requested_measures: tuple[str, ...] | list[str] | None = None,
 ) -> PricingPlan:
     """Apply conservative context-derived overrides without changing the core ontology."""
     plan = _apply_local_vol_overrides(
         plan,
         description,
         instrument_type=instrument_type,
+        requested_measures=requested_measures,
     )
     if not _looks_like_fx_option(description, instrument_type=instrument_type):
-        return plan
+        return _attach_challenger_packet(
+            plan,
+            candidate_methods=candidate_methods,
+            requested_measures=requested_measures,
+        )
 
     required_market_data = normalize_market_data_requirements(
         set(plan.required_market_data)
@@ -482,12 +831,16 @@ def _apply_contextual_overrides(
         plan.assumption_summary,
         ("fx_cross_currency_context", "garman_kohlhagen_or_equivalent_context"),
     )
-    return replace(
-        plan,
-        required_market_data=required_market_data,
-        reasoning=reasoning,
-        selection_reason=selection_reason,
-        assumption_summary=assumption_summary,
+    return _attach_challenger_packet(
+        replace(
+            plan,
+            required_market_data=required_market_data,
+            reasoning=reasoning,
+            selection_reason=selection_reason,
+            assumption_summary=assumption_summary,
+        ),
+        candidate_methods=candidate_methods,
+        requested_measures=requested_measures,
     )
 
 
@@ -505,6 +858,7 @@ def _apply_local_vol_overrides(
     description: str | None,
     *,
     instrument_type: str | None = None,
+    requested_measures: tuple[str, ...] | list[str] | None = None,
 ) -> PricingPlan:
     """Narrow vanilla local-vol requests onto the supported MC/PDE substrate."""
     if not _looks_like_local_vol_context(description, instrument_type=instrument_type):
@@ -554,15 +908,22 @@ def _apply_local_vol_overrides(
         ),
         preserved_context_tags,
     )
-    return replace(
-        plan,
-        method=method,
-        method_modules=method_modules,
-        required_market_data=required_market_data,
-        reasoning=reasoning,
-        sensitivity_support=support_for_method(method),
-        selection_reason=selection_reason,
-        assumption_summary=assumption_summary,
+    return _attach_challenger_packet(
+        replace(
+            plan,
+            method=method,
+            method_modules=method_modules,
+            required_market_data=required_market_data,
+            reasoning=reasoning,
+            sensitivity_support=support_for_method(method),
+            selection_reason=selection_reason,
+            assumption_summary=assumption_summary,
+        ),
+        candidate_methods=_merge_unique_strings(
+            _candidate_methods_from_packet(plan.challenger_packet),
+            (plan.method, method),
+        ),
+        requested_measures=requested_measures,
     )
 
 

--- a/trellis/agent/validation_contract.py
+++ b/trellis/agent/validation_contract.py
@@ -9,6 +9,7 @@ from typing import Mapping
 from trellis.agent.assembly_tools import normalize_comparison_relation
 from trellis.agent.instrument_identity import resolve_authoritative_instrument_type
 from trellis.agent.knowledge.methods import normalize_method
+from trellis.agent.quant import quant_challenger_packet_summary
 from trellis.agent import validation_bundles
 
 _VOL_CHECK_INPUTS = frozenset({"black_vol_surface", "local_vol_surface"})
@@ -75,10 +76,16 @@ class CompiledValidationContract:
     lowering_errors: tuple[str, ...] = ()
     admissibility_failures: tuple[str, ...] = ()
     residual_risks: tuple[str, ...] = ()
+    quant_challenger_packet: Mapping[str, object] = field(default_factory=dict)
     review_hints: Mapping[str, object] = field(default_factory=dict)
 
     def __post_init__(self):
         """Freeze mutable mapping fields for stability in traces and tests."""
+        object.__setattr__(
+            self,
+            "quant_challenger_packet",
+            _freeze_mapping(self.quant_challenger_packet),
+        )
         object.__setattr__(self, "review_hints", _freeze_mapping(self.review_hints))
 
 
@@ -164,6 +171,14 @@ def compile_validation_contract(
         for check_id in bundle.checks
         if _check_supported_by_market_data(check_id, required_market_data)
     )
+    contract_id = f"{method}:{resolved_instrument}"
+    quant_challenger_packet = quant_challenger_packet_summary(
+        pricing_plan,
+        deterministic_check_ids=tuple(check.check_id for check in deterministic_checks),
+        validation_contract_id=contract_id,
+        route_family=route_family or method,
+        residual_risks=residual_risks,
+    )
     review_hints = {
         "has_residual_risks": bool(residual_risks),
         "has_lowering_errors": bool(lowering_errors),
@@ -172,9 +187,11 @@ def compile_validation_contract(
             relation.relation == "unspecified" for relation in comparison_relations
         ),
         "has_exact_validation_identity": bool(exact_bundle_id),
+        "has_quant_challenger_packet": bool(quant_challenger_packet),
+        "has_quant_alternatives": _has_quant_alternatives(quant_challenger_packet),
     }
     return CompiledValidationContract(
-        contract_id=f"{method}:{resolved_instrument}",
+        contract_id=contract_id,
         instrument_type=resolved_instrument,
         method=method,
         bundle_id=bundle.bundle_id,
@@ -189,6 +206,7 @@ def compile_validation_contract(
         lowering_errors=lowering_errors,
         admissibility_failures=admissibility_failures,
         residual_risks=residual_risks,
+        quant_challenger_packet=quant_challenger_packet,
         review_hints=review_hints,
     )
 
@@ -230,8 +248,17 @@ def validation_contract_summary(
         "lowering_errors": list(contract.lowering_errors),
         "admissibility_failures": list(contract.admissibility_failures),
         "residual_risks": list(contract.residual_risks),
+        "quant_challenger_packet": dict(contract.quant_challenger_packet),
         "review_hints": dict(contract.review_hints),
     }
+
+
+def _has_quant_alternatives(packet: Mapping[str, object]) -> bool:
+    """Return whether a quant challenger packet contains rejected alternatives."""
+    for candidate in packet.get("candidate_methods", ()) or ():
+        if isinstance(candidate, Mapping) and candidate.get("status") == "rejected":
+            return True
+    return False
 
 
 def _resolve_instrument_type(


### PR DESCRIPTION
## Summary
- add structured quant challenger packet to `PricingPlan`
- persist packet through validation contracts, platform request metadata, trace cycle details, and model-validator review context
- normalize executor validation/model-validator method identity to the quant-selected method

## Tests
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_quant.py tests/test_agent/test_validation_contract.py::test_compile_build_request_attaches_validation_contract_summary tests/test_agent/test_platform_traces.py tests/test_agent/test_model_validator.py::test_validate_model_threads_validation_contract_residual_risks -q`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_validation_contract.py::test_compile_validation_contract_prefers_more_specific_product_family_over_generic_request_family tests/test_agent/test_validation_contract.py tests/test_agent/test_model_validator.py tests/test_agent/test_platform_requests.py tests/test_agent/test_lite_review.py::test_validate_build_passes_quant_selected_method_to_model_validator -q`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_executor.py tests/test_contracts/test_quant_contracts.py -q`
- `/Users/steveyang/miniforge3/bin/python3 -m compileall -q trellis/agent/quant.py trellis/agent/validation_contract.py trellis/agent/platform_requests.py trellis/agent/platform_traces.py trellis/agent/executor.py trellis/agent/model_validator.py`

Linear: QUA-984
