### PR TITLE
QUA-985: Add executable critic and arbiter claim verdicts

### DIFF
--- a/doc/plan/draft__agent-review-cycle-roadmap.md
+++ b/doc/plan/draft__agent-review-cycle-roadmap.md
@@ -47,7 +47,7 @@ Implementation queue:
 | --- | --- | --- | --- | --- |
 | 1 | `QUA-983` | Done | ARC.0 - explicit cycle report contract | none |
 | 2 | `QUA-984` | Done | ARC.1 - quant challenger packet | `QUA-983` |
-| 3 | `QUA-985` | Backlog | ARC.2 - executable critic and arbiter claims | `QUA-984` |
+| 3 | `QUA-985` | In Progress | ARC.2 - executable critic and arbiter claims | `QUA-984` |
 | 4 | `QUA-986` | Backlog | ARC.3 - residual-risk model validation | `QUA-985` |
 | 5 | `QUA-987` | Backlog | ARC.4 - promotion and adoption governance | `QUA-986` |
 | 6 | `QUA-988` | Backlog | ARC.5 - product-grade cycle result surface | `QUA-987` |

--- a/docs/developer/audit_and_observability.rst
+++ b/docs/developer/audit_and_observability.rst
@@ -258,6 +258,28 @@ It should treat the packet as the method-selection contract and focus on
 residual conceptual risk rather than rebuilding quant's method-choice rationale
 from loose prose.
 
+Executable Critic And Arbiter Claims
+------------------------------------
+
+Compiled validation contracts now own the admitted executable-claim surface for
+the critic and arbiter loop. Each ``ValidationCheckSpec`` that can be reviewed
+by critic and executed by arbiter is projected into an ``ExecutableClaimSpec``.
+The critic menu is derived from those claim specs when a validation contract is
+present; it does not fall back to instrument heuristics if the contract admits
+no executable claims.
+
+This makes an empty critic menu meaningful: it means the route has no admitted
+critic-selectable deterministic claims for this pass, not wildcard permission.
+If the LLM critic still emits an unavailable ``check_id``, the concern is
+marked ``invalid_selection`` and the arbiter records a failed, non-executed
+verdict rather than silently dropping or executing an unsupported check.
+
+Arbiter verdicts are now structured records with ``check_id``, ``status``,
+``reason``, ``executed``, ``detail``, and compatible failure-message fields.
+The ``arbiter_completed`` trace event and the derived ``cycle_report`` preserve
+those verdicts so operators can distinguish deterministic failures from
+fail-closed invalid critic selections.
+
 Governed Provider Provenance
 ----------------------------
 

--- a/tests/test_agent/test_build_loop.py
+++ b/tests/test_agent/test_build_loop.py
@@ -863,10 +863,7 @@ def test_validate_build_critic_path_uses_stage_helpers_without_nameerror(monkeyp
     assert failures == []
     assert captured["stage"] == "critic"
     assert captured["metadata"]["model"] == "critic-model"
-    assert critic_call["available_checks"] == [
-        "price_non_negative",
-        "volatility_input_usage",
-    ]
+    assert critic_call["available_checks"] == []
     assert critic_call["json_max_retries"] is None
     assert critic_call["allow_text_fallback"] is True
     assert "get_model_for_stage" not in caplog.text

--- a/tests/test_agent/test_critic.py
+++ b/tests/test_agent/test_critic.py
@@ -3,7 +3,7 @@
 from datetime import date
 import pytest
 
-from trellis.agent.arbiter import run_critic_tests
+from trellis.agent.arbiter import run_critic_check_verdicts, run_critic_tests
 from trellis.agent.critic import CriticConcern, available_critic_checks
 from trellis.core.market_state import MarketState
 from trellis.core.payoff import DeterministicCashflowPayoff
@@ -226,6 +226,25 @@ def test_available_critic_checks_can_be_restricted_by_validation_contract():
     ]
 
 
+def test_available_critic_checks_do_not_fall_back_when_contract_admits_no_claims():
+    from trellis.agent.validation_contract import CompiledValidationContract, ValidationCheckSpec
+
+    checks = available_critic_checks(
+        instrument_type="callable_bond",
+        validation_contract=CompiledValidationContract(
+            contract_id="rate_tree:callable_bond",
+            instrument_type="callable_bond",
+            method="rate_tree",
+            bundle_id="rate_tree:callable_bond",
+            deterministic_checks=(
+                ValidationCheckSpec("coupon_periods_settle_in_schedule_order", "route_specific"),
+            ),
+        ),
+    )
+
+    assert checks == []
+
+
 def test_run_critic_tests_respects_allowed_check_ids():
     concerns = [
         CriticConcern(
@@ -244,7 +263,59 @@ def test_run_critic_tests_respects_allowed_check_ids():
         allowed_check_ids={"volatility_input_usage"},
     )
 
-    assert failures == []
+    assert len(failures) == 1
+    assert "did not admit that executable claim" in failures[0]
+
+
+def test_run_critic_check_verdicts_fail_closed_on_unadmitted_checks():
+    concerns = [
+        CriticConcern(
+            "price_non_negative",
+            "price should stay non-negative",
+            "error",
+        ),
+    ]
+    bond = Bond(face=100, coupon=0.05, maturity_date=date(2034, 11, 15),
+                 maturity=10, frequency=2)
+    payoff = DeterministicCashflowPayoff(bond)
+
+    verdicts = run_critic_check_verdicts(
+        concerns,
+        payoff,
+        allowed_check_ids={"volatility_input_usage"},
+    )
+
+    assert len(verdicts) == 1
+    assert verdicts[0].check_id == "price_non_negative"
+    assert verdicts[0].status == "failed"
+    assert verdicts[0].reason == "check_not_admitted"
+    assert verdicts[0].executed is False
+
+
+def test_critique_marks_unadmitted_checks_invalid_when_menu_empty(monkeypatch):
+    from trellis.agent.critic import critique
+
+    def fake_llm_generate_json(*args, **kwargs):
+        return [
+            {
+                "check_id": "price_non_negative",
+                "description": "invented concern",
+                "severity": "error",
+            }
+        ]
+
+    monkeypatch.setattr("trellis.agent.critic.llm_generate_json", fake_llm_generate_json)
+
+    concerns = critique(
+        "class Demo: pass",
+        "Demo product",
+        available_checks=[],
+    )
+
+    assert len(concerns) == 1
+    assert concerns[0].check_id == "price_non_negative"
+    assert concerns[0].status == "invalid_selection"
+    assert concerns[0].severity == "error"
 
 
 class TestInvariantExpanded:

--- a/tests/test_agent/test_platform_traces.py
+++ b/tests/test_agent/test_platform_traces.py
@@ -244,7 +244,17 @@ def test_platform_trace_persists_cycle_report_from_lifecycle_events(tmp_path):
         compiled,
         "arbiter_completed",
         status="ok",
-        details={"failure_count": 0},
+        details={
+            "failure_count": 0,
+            "verdicts": [
+                {
+                    "check_id": "price_non_negative",
+                    "status": "passed",
+                    "reason": "",
+                    "executed": True,
+                }
+            ],
+        },
         root=tmp_path,
     )
     append_platform_trace_event(
@@ -294,6 +304,11 @@ def test_platform_trace_persists_cycle_report_from_lifecycle_events(tmp_path):
     assert quant_stage["details"]["challenger_packet"]["candidate_methods"][1][
         "method"
     ] == "monte_carlo"
+    arbiter_stage = next(
+        stage for stage in cycle_report["stages"] if stage["stage"] == "arbiter"
+    )
+    assert arbiter_stage["details"]["verdicts"][0]["check_id"] == "price_non_negative"
+    assert arbiter_stage["details"]["verdicts"][0]["status"] == "passed"
 
 
 def test_platform_trace_cycle_report_marks_failed_stage(tmp_path):

--- a/tests/test_agent/test_validation_contract.py
+++ b/tests/test_agent/test_validation_contract.py
@@ -75,6 +75,7 @@ def test_compile_build_request_attaches_validation_contract_summary():
 
 def test_callable_bond_validation_contract_carries_reference_bound_relation():
     from trellis.agent.platform_requests import compile_build_request
+    from trellis.agent.validation_contract import executable_claim_specs_for_contract
 
     compiled = compile_build_request(
         "Callable bond with annual coupons and issuer call dates 2026-01-15, 2027-01-15",
@@ -103,6 +104,18 @@ def test_callable_bond_validation_contract_carries_reference_bound_relation():
         "reference_factory",
         "market_state_factory",
     )
+    claim_specs = executable_claim_specs_for_contract(contract)
+    claim_ids = {claim.claim_id for claim in claim_specs}
+    assert "price_non_negative" in claim_ids
+    assert "volatility_input_usage" in claim_ids
+    callable_claim = next(
+        claim
+        for claim in claim_specs
+        if claim.claim_id == "callable_bound_vs_straight_bond"
+    )
+    assert callable_claim.validation_check_id == "check_bounded_by_reference"
+    assert callable_claim.relation == "<="
+    assert callable_claim.executable is True
 
 
 def test_puttable_bond_validation_contract_uses_lower_bound_relation():

--- a/trellis/agent/arbiter.py
+++ b/trellis/agent/arbiter.py
@@ -19,6 +19,20 @@ from trellis.models.vol_surface import FlatVol
 SETTLE = date(2024, 11, 15)
 
 
+@dataclass(frozen=True)
+class CriticCheckVerdict:
+    """Structured arbiter verdict for one critic-selected executable claim."""
+
+    check_id: str
+    status: str
+    reason: str
+    executed: bool
+    severity: str
+    description: str
+    message: str = ""
+    detail: str = ""
+
+
 @dataclass
 class ValidationResult:
     """Aggregate outcome of invariant checks plus critic-authored test cases."""
@@ -43,7 +57,26 @@ def run_critic_tests(
 
     Returns list of failure messages (empty = all passed).
     """
-    failures = []
+    return [
+        verdict.message
+        for verdict in run_critic_check_verdicts(
+            concerns,
+            payoff,
+            spec_kwargs=spec_kwargs,
+            allowed_check_ids=allowed_check_ids,
+        )
+        if verdict.status == "failed" and verdict.message
+    ]
+
+
+def run_critic_check_verdicts(
+    concerns: list,
+    payoff,
+    spec_kwargs: dict | None = None,
+    *,
+    allowed_check_ids: set[str] | None = None,
+) -> tuple[CriticCheckVerdict, ...]:
+    """Execute critic-selected checks and return structured arbiter verdicts."""
 
     # Build test environment
     ms = MarketState(
@@ -99,19 +132,93 @@ def run_critic_tests(
         "Bond": Bond,
     }
 
+    verdicts: list[CriticCheckVerdict] = []
     for concern in concerns:
-        if concern.severity != "error":
-            continue
         check_id = str(getattr(concern, "check_id", "") or "").strip()
+        severity = str(getattr(concern, "severity", "") or "").strip()
+        if severity != "error":
+            verdicts.append(
+                _critic_verdict(
+                    concern,
+                    status="skipped",
+                    reason="non_error_severity",
+                    executed=False,
+                    detail="Only error-severity critic concerns are executable.",
+                )
+            )
+            continue
         if allowed_check_ids is not None and check_id not in allowed_check_ids:
+            verdicts.append(
+                _critic_verdict(
+                    concern,
+                    status="failed",
+                    reason="check_not_admitted",
+                    executed=False,
+                    detail=(
+                        f"Critic selected `{check_id}`, but the validation contract "
+                        "did not admit that executable claim."
+                    ),
+                )
+            )
             continue
-        dispatched = _run_structured_critic_check(concern, namespace)
-        if dispatched is not None:
-            if dispatched:
-                failures.append(_format_structured_failure(concern, dispatched))
+        checker = _CRITIC_CHECK_DISPATCH.get(check_id)
+        if checker is None:
+            verdicts.append(
+                _critic_verdict(
+                    concern,
+                    status="failed",
+                    reason="unsupported_check",
+                    executed=False,
+                    detail=f"No deterministic arbiter dispatch is registered for `{check_id}`.",
+                )
+            )
             continue
+        try:
+            detail = checker(namespace)
+        except Exception as exc:
+            verdicts.append(
+                _critic_verdict(
+                    concern,
+                    status="failed",
+                    reason="checker_exception",
+                    executed=True,
+                    detail=f"{type(exc).__name__}: {exc}",
+                )
+            )
+            continue
+        verdicts.append(
+            _critic_verdict(
+                concern,
+                status="failed" if detail else "passed",
+                reason="deterministic_check_failed" if detail else "",
+                executed=True,
+                detail=detail,
+            )
+        )
 
-    return failures
+    return tuple(verdicts)
+
+
+def _critic_verdict(
+    concern,
+    *,
+    status: str,
+    reason: str,
+    executed: bool,
+    detail: str = "",
+) -> CriticCheckVerdict:
+    """Build one structured arbiter verdict and compatible failure message."""
+    message = _format_structured_failure(concern, detail) if status == "failed" else ""
+    return CriticCheckVerdict(
+        check_id=str(getattr(concern, "check_id", "") or "").strip(),
+        status=status,
+        reason=reason,
+        executed=executed,
+        severity=str(getattr(concern, "severity", "") or "").strip(),
+        description=str(getattr(concern, "description", "") or "").strip(),
+        message=message,
+        detail=detail,
+    )
 
 
 def _format_structured_failure(concern, detail: str) -> str:

--- a/trellis/agent/critic.py
+++ b/trellis/agent/critic.py
@@ -132,7 +132,7 @@ def available_critic_checks(
         instrument=instrument,
         validation_contract=validation_contract,
     )
-    if contract_checks:
+    if validation_contract is not None:
         return contract_checks
 
     checks: list[CriticCheck] = []
@@ -167,32 +167,14 @@ def _checks_from_validation_contract(
     if validation_contract is None:
         return []
 
-    deterministic_checks = tuple(getattr(validation_contract, "deterministic_checks", ()) or ())
-    deterministic_ids = {
-        str(getattr(item, "check_id", "") or "").strip()
-        for item in deterministic_checks
-        if str(getattr(item, "check_id", "") or "").strip()
-    }
-    bound_relation = None
-    for item in deterministic_checks:
-        if str(getattr(item, "check_id", "") or "").strip() == "check_bounded_by_reference":
-            relation = str(getattr(item, "relation", "") or "").strip()
-            if relation:
-                bound_relation = relation
-                break
+    from trellis.agent.validation_contract import executable_claim_specs_for_contract
 
+    claim_specs = executable_claim_specs_for_contract(validation_contract)
     checks: list[CriticCheck] = []
-    if "check_non_negativity" in deterministic_ids:
-        checks.append(_CHECK_LIBRARY["price_non_negative"])
-    if {"check_vol_sensitivity", "check_vol_monotonicity"} & deterministic_ids:
-        checks.append(_CHECK_LIBRARY["volatility_input_usage"])
-    if "check_rate_monotonicity" in deterministic_ids:
-        checks.append(_CHECK_LIBRARY["rate_sensitivity_present"])
-    if "check_bounded_by_reference" in deterministic_ids:
-        if instrument == "puttable_bond" or bound_relation == ">=":
-            checks.append(_CHECK_LIBRARY["puttable_bound_vs_straight_bond"])
-        elif instrument == "callable_bond" or bound_relation == "<=":
-            checks.append(_CHECK_LIBRARY["callable_bound_vs_straight_bond"])
+    for claim in claim_specs:
+        check = _CHECK_LIBRARY.get(claim.claim_id)
+        if check is not None:
+            checks.append(check)
 
     seen: set[str] = set()
     deduped: list[CriticCheck] = []
@@ -319,6 +301,7 @@ def critique(
         data = json.loads(data)
 
     concerns = []
+    enforce_allowed_checks = available_checks is not None
     allowed_check_ids = {
         check.check_id
         for check in (available_checks or ())
@@ -330,7 +313,19 @@ def critique(
             check_id = str(item.get("check_id", "") or "").strip()
             if not check_id:
                 continue
-            if allowed_check_ids and check_id not in allowed_check_ids:
+            if enforce_allowed_checks and check_id not in allowed_check_ids:
+                concerns.append(
+                    CriticConcern(
+                        check_id=check_id,
+                        description=str(item.get("description", "") or "").strip(),
+                        severity="error",
+                        evidence=str(item.get("evidence", "") or "").strip(),
+                        remediation=(
+                            "Select only validation-contract-admitted executable checks."
+                        ),
+                        status="invalid_selection",
+                    )
+                )
                 continue
             concerns.append(
                 CriticConcern(

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -2127,6 +2127,7 @@ def _validate_build(
     critic_text_max_retries = getattr(review_policy, "critic_text_max_retries", None)
 
     # Standard: run critic
+    arbiter_verdicts = ()
     if (
         validation in ("standard", "thorough")
         and getattr(review_policy, "run_critic", False)
@@ -2148,7 +2149,7 @@ def _validate_build(
         review_prompt_surface = review_context.knowledge_surface
         try:
             from trellis.agent.critic import available_critic_checks, critique
-            from trellis.agent.arbiter import run_critic_tests
+            from trellis.agent.arbiter import run_critic_check_verdicts
             critic_checks = available_critic_checks(
                 instrument_type=itype,
                 method=getattr(pricing_plan, "method", None),
@@ -2210,11 +2211,16 @@ def _validate_build(
                         "remediation": concern.remediation,
                     },
                 )
-            critic_failures = run_critic_tests(
+            arbiter_verdicts = run_critic_check_verdicts(
                 concerns,
                 test_payoff,
                 allowed_check_ids={check.check_id for check in critic_checks},
             )
+            critic_failures = [
+                verdict.message
+                for verdict in arbiter_verdicts
+                if verdict.status == "failed" and verdict.message
+            ]
             failures.extend(critic_failures)
             for failure in critic_failures:
                 _append_agent_observation(
@@ -2280,6 +2286,7 @@ def _validate_build(
         details={
             "validation": validation,
             "failure_count": len(failures),
+            "verdicts": [asdict(verdict) for verdict in arbiter_verdicts],
         },
     )
 

--- a/trellis/agent/platform_traces.py
+++ b/trellis/agent/platform_traces.py
@@ -1026,7 +1026,7 @@ def _cycle_stage_details(stage: str, details: dict[str, Any]) -> dict[str, Any]:
             "available_check_ids",
             "reason",
         ),
-        "arbiter": ("validation", "failure_count"),
+        "arbiter": ("validation", "failure_count", "verdicts"),
         "model_validator": (
             "finding_count",
             "blocker_count",

--- a/trellis/agent/validation_contract.py
+++ b/trellis/agent/validation_contract.py
@@ -58,6 +58,17 @@ class ValidationRelationSpec:
 
 
 @dataclass(frozen=True)
+class ExecutableClaimSpec:
+    """One validation-admitted claim that critic may select and arbiter may run."""
+
+    claim_id: str
+    validation_check_id: str
+    category: str
+    relation: str | None = None
+    executable: bool = True
+
+
+@dataclass(frozen=True)
 class CompiledValidationContract:
     """Compiled validation state derived from route, lowering, and semantics."""
 
@@ -245,6 +256,16 @@ def validation_contract_summary(
             }
             for relation in contract.comparison_relations
         ],
+        "executable_claims": [
+            {
+                "claim_id": claim.claim_id,
+                "validation_check_id": claim.validation_check_id,
+                "category": claim.category,
+                "relation": claim.relation,
+                "executable": claim.executable,
+            }
+            for claim in executable_claim_specs_for_contract(contract)
+        ],
         "lowering_errors": list(contract.lowering_errors),
         "admissibility_failures": list(contract.admissibility_failures),
         "residual_risks": list(contract.residual_risks),
@@ -259,6 +280,63 @@ def _has_quant_alternatives(packet: Mapping[str, object]) -> bool:
         if isinstance(candidate, Mapping) and candidate.get("status") == "rejected":
             return True
     return False
+
+
+def executable_claim_specs_for_contract(
+    contract: CompiledValidationContract | None,
+) -> tuple[ExecutableClaimSpec, ...]:
+    """Return critic/arbiter executable claims admitted by validation."""
+    if contract is None:
+        return ()
+
+    instrument = str(getattr(contract, "instrument_type", "") or "").strip().lower()
+    specs: list[ExecutableClaimSpec] = []
+    seen: set[str] = set()
+    for check in getattr(contract, "deterministic_checks", ()) or ():
+        check_id = str(getattr(check, "check_id", "") or "").strip()
+        if not check_id:
+            continue
+        category = str(getattr(check, "category", "") or "").strip()
+        relation = getattr(check, "relation", None)
+        claim_id = _claim_id_for_validation_check(
+            check_id,
+            instrument=instrument,
+            relation=None if relation is None else str(relation),
+        )
+        if claim_id is None or claim_id in seen:
+            continue
+        seen.add(claim_id)
+        specs.append(
+            ExecutableClaimSpec(
+                claim_id=claim_id,
+                validation_check_id=check_id,
+                category=category,
+                relation=relation,
+                executable=True,
+            )
+        )
+    return tuple(specs)
+
+
+def _claim_id_for_validation_check(
+    check_id: str,
+    *,
+    instrument: str,
+    relation: str | None,
+) -> str | None:
+    """Map validation check ids onto bounded critic/arbiter claim ids."""
+    if check_id == "check_non_negativity":
+        return "price_non_negative"
+    if check_id in {"check_vol_sensitivity", "check_vol_monotonicity"}:
+        return "volatility_input_usage"
+    if check_id == "check_rate_monotonicity":
+        return "rate_sensitivity_present"
+    if check_id == "check_bounded_by_reference":
+        if instrument == "puttable_bond" or relation == ">=":
+            return "puttable_bound_vs_straight_bond"
+        if instrument == "callable_bond" or relation == "<=":
+            return "callable_bound_vs_straight_bond"
+    return None
 
 
 def _resolve_instrument_type(


### PR DESCRIPTION
## Summary
- add validation-contract-owned executable claim specs for critic/arbiter admitted checks
- make a present validation contract authoritative for critic menus, including empty menus
- add structured arbiter verdicts and persist them through executor traces/cycle reports
- fail closed on unavailable critic-selected check ids instead of treating an empty menu as wildcard permission

## Tests
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_validation_contract.py::test_callable_bond_validation_contract_carries_reference_bound_relation tests/test_agent/test_critic.py::test_available_critic_checks_do_not_fall_back_when_contract_admits_no_claims tests/test_agent/test_critic.py::test_run_critic_check_verdicts_fail_closed_on_unadmitted_checks tests/test_agent/test_critic.py::test_critique_marks_unadmitted_checks_invalid_when_menu_empty tests/test_agent/test_platform_traces.py -q`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_critic.py tests/test_agent/test_validation_contract.py tests/test_agent/test_build_loop.py tests/test_agent/test_validation_bundles.py tests/test_agent/test_model_validator.py -q`
- `/Users/steveyang/miniforge3/bin/python3 -m compileall -q trellis/agent/validation_contract.py trellis/agent/critic.py trellis/agent/arbiter.py trellis/agent/executor.py trellis/agent/platform_traces.py`

Linear: QUA-985
