### PR TITLE
QUA-986: Add residual-risk model validation handoff

### DIFF
--- a/docs/developer/audit_and_observability.rst
+++ b/docs/developer/audit_and_observability.rst
@@ -280,6 +280,40 @@ The ``arbiter_completed`` trace event and the derived ``cycle_report`` preserve
 those verdicts so operators can distinguish deterministic failures from
 fail-closed invalid critic selections.
 
+Residual-Risk Model Validation
+------------------------------
+
+Model validation is the final residual review layer, not a second generic
+reviewer. When the thorough path reaches model validation, the executor passes a
+structured deterministic evidence packet containing:
+
+- the compiled validation-contract checks, relations, blockers, and residual
+  risk ids
+- validation-bundle executed checks, skipped checks, and failure diagnostics
+- reference-oracle identity, relation, tolerance, sampled deviations, and pass
+  status when an oracle ran
+- structured arbiter verdicts for critic-selected executable claims
+
+The model-validator prompt renders this packet as ``Executed Deterministic
+Evidence`` and explicitly asks the reviewer not to convert passed deterministic
+evidence into prose findings. If the validation bundle, reference oracle, or
+arbiter has already produced a deterministic failure, the executor records a
+model-validator skip event instead of running residual prose review.
+
+The persisted ``cycle_report`` also separates outcome buckets:
+
+- ``deterministic_blockers`` for validation-contract, bundle, oracle, and arbiter
+  failures
+- ``conceptual_blockers`` for high/critical residual conceptual findings
+- ``calibration_blockers`` for high/critical residual calibration findings
+- ``residual_limitations`` for validation-contract or quant residual risks and
+  non-blocking model-validator limitation findings
+- ``residual_risks`` for the stable residual-risk ids handed forward by the
+  validation contract and quant challenger packet
+
+Downstream promotion and adoption logic should consume these separated buckets
+rather than parsing free-form model-validator text.
+
 Governed Provider Provenance
 ----------------------------
 

--- a/tests/test_agent/test_lite_review.py
+++ b/tests/test_agent/test_lite_review.py
@@ -812,6 +812,128 @@ def test_validate_build_skips_llm_reviewer_stages_after_deterministic_failures(m
     assert failures == ["deterministic gate failure"]
 
 
+def test_validate_build_skips_model_validator_after_arbiter_deterministic_failure(monkeypatch):
+    from trellis.agent.arbiter import CriticCheckVerdict
+    from trellis.agent.critic import CriticCheck, CriticConcern
+    from trellis.agent.executor import _validate_build
+    from trellis.agent.quant import PricingPlan
+
+    class DummyPayoff:
+        pass
+
+    spec_schema = SimpleNamespace(
+        class_name="DummyPayoff",
+        spec_name="DummySpec",
+        requirements=["discount_curve", "black_vol_surface"],
+        fields=[],
+    )
+
+    monkeypatch.setattr(
+        "trellis.agent.executor._make_test_payoff",
+        lambda *args, **kwargs: object(),
+    )
+    monkeypatch.setattr(
+        "trellis.agent.executor._record_platform_event",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "trellis.agent.executor._should_run_reference_oracle",
+        lambda *args, **kwargs: False,
+    )
+    monkeypatch.setattr(
+        "trellis.agent.validation_bundles.select_validation_bundle",
+        lambda *args, **kwargs: SimpleNamespace(
+            bundle_id="rate_tree:callable_bond",
+            checks=(),
+            categories={},
+        ),
+    )
+    monkeypatch.setattr(
+        "trellis.agent.validation_bundles.execute_validation_bundle",
+        lambda *args, **kwargs: SimpleNamespace(
+            failures=[],
+            failure_details=[],
+            executed_checks=(),
+            skipped_checks=(),
+        ),
+    )
+    monkeypatch.setattr(
+        "trellis.agent.critic.available_critic_checks",
+        lambda *args, **kwargs: [
+            CriticCheck(
+                check_id="price_non_negative",
+                title="Price should remain non-negative",
+                when_to_use="test",
+                deterministic_contract="test",
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        "trellis.agent.critic.critique",
+        lambda *args, **kwargs: [
+            CriticConcern(
+                check_id="price_non_negative",
+                description="Price could be negative",
+                severity="error",
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        "trellis.agent.arbiter.run_critic_check_verdicts",
+        lambda *args, **kwargs: (
+            CriticCheckVerdict(
+                check_id="price_non_negative",
+                status="failed",
+                reason="deterministic_check_failed",
+                executed=True,
+                severity="error",
+                description="Price could be negative",
+                message="arbiter deterministic failure",
+                detail="price=-1.0",
+            ),
+        ),
+    )
+
+    calls = {"model_validator": 0}
+
+    def fake_validate_model(*args, **kwargs):
+        from trellis.agent.validation_report import ValidationReport
+
+        calls["model_validator"] += 1
+        return ValidationReport(instrument="callable_bond", method="rate_tree")
+
+    monkeypatch.setattr("trellis.agent.model_validator.validate_model", fake_validate_model)
+
+    failures = _validate_build(
+        DummyPayoff,
+        code="def evaluate(self, market_state):\n    return -1.0\n",
+        description="Callable bond with issuer call",
+        spec_schema=spec_schema,
+        validation="thorough",
+        pricing_plan=PricingPlan(
+            method="rate_tree",
+            method_modules=["trellis.models.trees.lattice"],
+            required_market_data={"discount_curve", "black_vol_surface"},
+            model_to_build="callable_bond",
+            reasoning="test",
+        ),
+        product_ir=SimpleNamespace(
+            instrument="callable_bond",
+            payoff_traits=("callable",),
+            exercise_style="issuer_call",
+            state_dependence="schedule_dependent",
+            schedule_dependence=True,
+            model_family="interest_rate",
+            unresolved_primitives=(),
+            supported=True,
+        ),
+        attempt_number=1,
+    )
+
+    assert failures == ["arbiter deterministic failure"]
+    assert calls["model_validator"] == 0
+
+
 def test_validate_build_uses_quanto_family_validation_bundle(monkeypatch):
     from trellis.agent.executor import _validate_build
     from trellis.agent.platform_requests import compile_build_request

--- a/tests/test_agent/test_model_validator.py
+++ b/tests/test_agent/test_model_validator.py
@@ -296,6 +296,56 @@ def test_llm_conceptual_review_includes_residual_risk_focus(monkeypatch):
     assert "Do not repeat deterministic checks" in captured["prompt"]
 
 
+def test_llm_conceptual_review_includes_executed_deterministic_evidence(monkeypatch):
+    from trellis.agent.model_validator import _llm_conceptual_review
+
+    captured = {}
+
+    monkeypatch.setattr(
+        "trellis.agent.config.get_default_model",
+        lambda: "fake-model",
+    )
+
+    def fake_llm_generate_json(prompt, model=None):
+        captured["prompt"] = prompt
+        return []
+
+    monkeypatch.setattr("trellis.agent.config.llm_generate_json", fake_llm_generate_json)
+
+    findings = _llm_conceptual_review(
+        code="def price():\n    return 0.0",
+        instrument_type="swaption",
+        method="analytical",
+        deterministic_evidence_packet={
+            "validation_bundle": {
+                "executed_checks": ["check_non_negativity"],
+                "failure_count": 0,
+            },
+            "reference_oracle": {
+                "oracle_id": "swaption_black76_exact",
+                "passed": True,
+            },
+            "arbiter": {
+                "verdicts": [
+                    {
+                        "check_id": "price_non_negative",
+                        "status": "passed",
+                        "executed": True,
+                    }
+                ]
+            },
+        },
+        model="fake-model",
+    )
+
+    assert findings == []
+    assert "Executed Deterministic Evidence" in captured["prompt"]
+    assert "check_non_negativity" in captured["prompt"]
+    assert "swaption_black76_exact" in captured["prompt"]
+    assert "price_non_negative" in captured["prompt"]
+    assert "Do not convert passed deterministic evidence into prose findings" in captured["prompt"]
+
+
 def test_determine_review_policy_skips_llm_for_low_risk_supported_vanilla():
     from trellis.agent.review_policy import determine_review_policy
 
@@ -601,6 +651,47 @@ def test_validate_model_threads_validation_contract_residual_risks(monkeypatch):
         == "insufficient_contract_features"
     )
     assert captured["review_reason"] is None
+
+
+def test_validate_model_threads_deterministic_evidence_packet(monkeypatch):
+    from trellis.agent.model_validator import validate_model
+
+    monkeypatch.setattr(
+        "trellis.agent.model_validator.check_sensitivity_signs",
+        lambda *args, **kwargs: [],
+    )
+    monkeypatch.setattr(
+        "trellis.agent.model_validator.check_benchmark",
+        lambda *args, **kwargs: [],
+    )
+
+    captured = {}
+
+    def fake_llm_review(*args, deterministic_evidence_packet=None, **kwargs):
+        captured["deterministic_evidence_packet"] = deterministic_evidence_packet
+        return []
+
+    monkeypatch.setattr(
+        "trellis.agent.model_validator._llm_conceptual_review",
+        fake_llm_review,
+    )
+
+    packet = {
+        "validation_bundle": {"executed_checks": ["check_price_sanity"]},
+        "arbiter": {"verdicts": [{"check_id": "price_non_negative", "status": "passed"}]},
+    }
+    report = validate_model(
+        payoff_factory=lambda: object(),
+        market_state_factory=lambda rate, vol: object(),
+        code="def price():\n    return 1.0",
+        instrument_type="callable_bond",
+        method="rate_tree",
+        deterministic_evidence_packet=packet,
+        run_llm_review=True,
+    )
+
+    assert report.findings == []
+    assert captured["deterministic_evidence_packet"] == packet
 
 
 def test_validate_model_for_request_threads_generation_plan(monkeypatch):

--- a/tests/test_agent/test_platform_traces.py
+++ b/tests/test_agent/test_platform_traces.py
@@ -311,6 +311,112 @@ def test_platform_trace_persists_cycle_report_from_lifecycle_events(tmp_path):
     assert arbiter_stage["details"]["verdicts"][0]["status"] == "passed"
 
 
+def test_platform_trace_cycle_report_classifies_residual_risk_buckets(tmp_path):
+    from trellis.agent.platform_traces import (
+        append_platform_trace_event,
+        load_platform_trace_cycle_report,
+    )
+
+    compiled = SimpleNamespace(
+        request=SimpleNamespace(
+            request_id="executor_cycle_report_risk_buckets",
+            request_type="build",
+            entry_point="executor",
+            instrument_type="callable_bond",
+            metadata={},
+        ),
+        execution_plan=SimpleNamespace(
+            action="build_then_price",
+            route_method="rate_tree",
+            measures=(),
+            requires_build=True,
+        ),
+        pricing_plan=SimpleNamespace(sensitivity_support=None),
+        product_ir=SimpleNamespace(instrument="callable_bond"),
+        blocker_report=None,
+        knowledge_summary={},
+    )
+
+    trace_path = append_platform_trace_event(
+        compiled,
+        "validation_bundle_executed",
+        status="ok",
+        details={
+            "bundle_id": "rate_tree:callable_bond",
+            "executed_checks": ["check_bounded_by_reference"],
+            "failure_count": 0,
+            "validation_contract": {
+                "contract_id": "rate_tree:callable_bond",
+                "residual_risks": ["unsupported_paths_declared"],
+            },
+        },
+        root=tmp_path,
+    )
+    append_platform_trace_event(
+        compiled,
+        "arbiter_completed",
+        status="error",
+        details={
+            "failure_count": 1,
+            "verdicts": [
+                {
+                    "check_id": "callable_bound_vs_straight_bond",
+                    "status": "failed",
+                    "reason": "deterministic_check_failed",
+                    "executed": True,
+                    "detail": "price exceeded straight-bond bound",
+                }
+            ],
+        },
+        root=tmp_path,
+    )
+    append_platform_trace_event(
+        compiled,
+        "model_validator_completed",
+        status="error",
+        details={
+            "finding_count": 3,
+            "blocker_count": 2,
+            "approved": False,
+            "llm_review": True,
+            "risk_level": "high",
+            "residual_risks": ["unsupported_paths_declared"],
+            "findings": [
+                {
+                    "id": "MV-L001",
+                    "severity": "high",
+                    "category": "conceptual",
+                    "description": "exercise model omits notice-period state",
+                },
+                {
+                    "id": "MV-L002",
+                    "severity": "critical",
+                    "category": "calibration",
+                    "description": "tree is not calibrated to the curve",
+                },
+                {
+                    "id": "MV-L003",
+                    "severity": "medium",
+                    "category": "limitation",
+                    "description": "single-factor curve limitation",
+                },
+            ],
+        },
+        root=tmp_path,
+    )
+
+    report = load_platform_trace_cycle_report(trace_path)
+
+    assert report.residual_risks == ("unsupported_paths_declared",)
+    assert report.deterministic_blockers[0]["check_id"] == "callable_bound_vs_straight_bond"
+    assert report.conceptual_blockers[0]["id"] == "MV-L001"
+    assert report.calibration_blockers[0]["id"] == "MV-L002"
+    assert {item["source"] for item in report.residual_limitations} == {
+        "validation_contract",
+        "model_validator",
+    }
+
+
 def test_platform_trace_cycle_report_marks_failed_stage(tmp_path):
     from trellis.agent.platform_traces import (
         append_platform_trace_event,

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -2290,10 +2290,28 @@ def _validate_build(
         },
     )
 
+    deterministic_review_blocked = bool(failures)
+    deterministic_review_block_reason = (
+        "deterministic_validation_failed" if deterministic_review_blocked else None
+    )
+    model_validation_evidence_packet = {}
+    if validation == "thorough":
+        from trellis.agent.model_validator import build_model_validation_evidence_packet
+
+        model_validation_evidence_packet = build_model_validation_evidence_packet(
+            validation_contract=validation_contract,
+            validation_bundle_execution=bundle_execution,
+            reference_oracle=oracle_summary if oracle_execution is not None else None,
+            arbiter_verdicts=arbiter_verdicts,
+        )
+
     # Thorough: run model validator (MRM-style)
-    if validation == "thorough" and not deterministic_gate_failed:
+    if validation == "thorough" and not deterministic_review_blocked:
         try:
-            from trellis.agent.model_validator import validate_model
+            from trellis.agent.model_validator import (
+                classify_model_validation_findings,
+                validate_model,
+            )
 
             if review_policy.run_model_validator_llm and not review_knowledge_text:
                 review_context = _resolve_knowledge_context_for_attempt(
@@ -2333,6 +2351,7 @@ def _validate_build(
                         product_ir=product_ir,
                         generation_plan=getattr(compiled_request, "generation_plan", None),
                         validation_contract=validation_contract,
+                        deterministic_evidence_packet=model_validation_evidence_packet,
                         review_reason=review_policy.model_validator_reason,
                         run_llm_review=True,
                     )
@@ -2367,6 +2386,7 @@ def _validate_build(
                     product_ir=product_ir,
                     generation_plan=getattr(compiled_request, "generation_plan", None),
                     validation_contract=validation_contract,
+                    deterministic_evidence_packet=model_validation_evidence_packet,
                     review_reason=review_policy.model_validator_reason,
                     run_llm_review=False,
                 )
@@ -2396,6 +2416,7 @@ def _validate_build(
                 finding for finding in report.findings
                 if finding.severity in ("critical", "high")
             ]
+            finding_classification = classify_model_validation_findings(report.findings)
             _record_platform_event(
                 compiled_request,
                 "model_validator_completed",
@@ -2417,6 +2438,15 @@ def _validate_build(
                     "approved": report.approved,
                     "llm_review": review_policy.run_model_validator_llm,
                     "risk_level": review_policy.risk_level,
+                    "residual_risks": list(
+                        dict(model_validation_evidence_packet.get("validation_contract") or {}).get(
+                            "residual_risks",
+                            (),
+                        )
+                    ),
+                    "deterministic_evidence": model_validation_evidence_packet,
+                    "findings": [asdict(finding) for finding in report.findings],
+                    "finding_classification": finding_classification,
                     "skip_reason": (
                         None if review_policy.run_model_validator_llm
                         else review_policy.model_validator_reason
@@ -2443,8 +2473,9 @@ def _validate_build(
             status="info",
             details={
                 "risk_level": review_policy.risk_level,
-                "reason": deterministic_gate_reason,
+                "reason": deterministic_review_block_reason,
                 "failure_count": len(failures),
+                "deterministic_evidence": model_validation_evidence_packet,
             },
         )
 

--- a/trellis/agent/model_validator.py
+++ b/trellis/agent/model_validator.py
@@ -12,7 +12,9 @@ Issues formal findings (Critical/High/Medium/Low) that the builder must remediat
 
 from __future__ import annotations
 
+from dataclasses import asdict, is_dataclass
 import json
+from typing import Any, Mapping
 
 from trellis.agent.review_policy import determine_review_policy
 from trellis.agent.validation_report import ValidationFinding, ValidationReport
@@ -34,6 +36,7 @@ def validate_model(
     product_ir=None,
     generation_plan=None,
     validation_contract=None,
+    deterministic_evidence_packet: Mapping[str, object] | None = None,
     review_reason: str | None = None,
     run_llm_review: bool | None = None,
 ) -> ValidationReport:
@@ -91,6 +94,7 @@ def validate_model(
             quant_challenger_packet=_model_validator_quant_challenger_packet(
                 validation_contract
             ),
+            deterministic_evidence_packet=deterministic_evidence_packet,
             review_reason=review_reason,
             model=model,
         )
@@ -132,6 +136,11 @@ def validate_model_for_request(
         product_ir=compiled_request.product_ir,
         generation_plan=getattr(compiled_request, "generation_plan", None),
         validation_contract=getattr(compiled_request, "validation_contract", None),
+        deterministic_evidence_packet=getattr(
+            compiled_request,
+            "deterministic_evidence_packet",
+            None,
+        ),
         review_reason=None,
     )
 
@@ -144,6 +153,7 @@ def _llm_conceptual_review(
     generation_plan=None,
     residual_risks: tuple[str, ...] = (),
     quant_challenger_packet: dict[str, object] | None = None,
+    deterministic_evidence_packet: Mapping[str, object] | None = None,
     review_reason: str | None = None,
     model: str | None = None,
 ) -> list[ValidationFinding]:
@@ -171,6 +181,15 @@ def _llm_conceptual_review(
             "quant reasoning from prose when these fields are present.\n"
             f"```json\n{json.dumps(quant_challenger_packet, indent=2, sort_keys=True)}\n```\n"
         )
+    deterministic_evidence_section = ""
+    if deterministic_evidence_packet:
+        deterministic_evidence_section = (
+            "\n## Executed Deterministic Evidence\n"
+            "These checks already own deterministic validation claims. "
+            "Do not convert passed deterministic evidence into prose findings. "
+            "Only review residual conceptual and calibration risks left after this evidence.\n"
+            f"```json\n{json.dumps(dict(deterministic_evidence_packet), indent=2, sort_keys=True)}\n```\n"
+        )
     review_reason_section = ""
     if review_reason:
         review_reason_section = f"\n## Review Trigger\n- `{review_reason}`\n"
@@ -195,6 +214,7 @@ reference bounds, or other validations already covered by the validation contrac
 {route_contract_section}
 {residual_risk_section}
 {quant_packet_section}
+{deterministic_evidence_section}
 {review_reason_section}
 
 ## Code to validate
@@ -278,3 +298,232 @@ def _model_validator_quant_challenger_packet(validation_contract) -> dict[str, o
     if validation_contract is None:
         return {}
     return dict(getattr(validation_contract, "quant_challenger_packet", {}) or {})
+
+
+def build_model_validation_evidence_packet(
+    *,
+    validation_contract=None,
+    validation_bundle_execution=None,
+    reference_oracle=None,
+    arbiter_verdicts=(),
+) -> dict[str, object]:
+    """Build the deterministic evidence packet handed to model validation."""
+    contract_summary = _validation_contract_evidence_summary(validation_contract)
+    bundle_summary = _validation_bundle_execution_summary(validation_bundle_execution)
+    oracle_summary = _summary_dict(reference_oracle)
+    arbiter_summary = _arbiter_evidence_summary(arbiter_verdicts)
+    packet: dict[str, object] = {}
+    if contract_summary:
+        packet["validation_contract"] = contract_summary
+    if bundle_summary:
+        packet["validation_bundle"] = bundle_summary
+    if oracle_summary:
+        packet["reference_oracle"] = oracle_summary
+    if arbiter_summary:
+        packet["arbiter"] = arbiter_summary
+    deterministic_blockers = _deterministic_blockers_from_packet(packet)
+    if deterministic_blockers:
+        packet["deterministic_blockers"] = deterministic_blockers
+    return packet
+
+
+def classify_model_validation_findings(
+    findings,
+) -> dict[str, list[dict[str, object]]]:
+    """Classify model-validator findings into residual report buckets."""
+    classification = {
+        "conceptual_blockers": [],
+        "calibration_blockers": [],
+        "residual_limitations": [],
+    }
+    for finding in findings or ():
+        summary = _finding_summary(finding)
+        severity = str(summary.get("severity", "") or "").strip().lower()
+        category = str(summary.get("category", "") or "").strip().lower()
+        is_blocker = severity in {"critical", "high"}
+        if category == "calibration" and is_blocker:
+            classification["calibration_blockers"].append(summary)
+        elif category == "conceptual" and is_blocker:
+            classification["conceptual_blockers"].append(summary)
+        elif category in {"limitation", "residual_limitation"} or not is_blocker:
+            classification["residual_limitations"].append(summary)
+        elif is_blocker:
+            classification["conceptual_blockers"].append(summary)
+    return classification
+
+
+def _validation_contract_evidence_summary(validation_contract) -> dict[str, object]:
+    """Project the validation contract fields relevant to residual review."""
+    if validation_contract is None:
+        return {}
+    return {
+        "contract_id": getattr(validation_contract, "contract_id", ""),
+        "deterministic_checks": [
+            {
+                "check_id": getattr(check, "check_id", ""),
+                "category": getattr(check, "category", ""),
+                "relation": getattr(check, "relation", None),
+            }
+            for check in getattr(validation_contract, "deterministic_checks", ()) or ()
+        ],
+        "comparison_relations": [
+            {
+                "target_id": getattr(relation, "target_id", ""),
+                "relation": getattr(relation, "relation", ""),
+                "source": getattr(relation, "source", ""),
+            }
+            for relation in getattr(validation_contract, "comparison_relations", ()) or ()
+        ],
+        "lowering_errors": list(getattr(validation_contract, "lowering_errors", ()) or ()),
+        "admissibility_failures": list(
+            getattr(validation_contract, "admissibility_failures", ()) or ()
+        ),
+        "residual_risks": list(getattr(validation_contract, "residual_risks", ()) or ()),
+    }
+
+
+def _validation_bundle_execution_summary(execution) -> dict[str, object]:
+    """Project validation-bundle execution into prompt-safe primitives."""
+    if execution is None:
+        return {}
+    data = _summary_dict(execution)
+    failures = list(data.get("failures") or ())
+    failure_details = [
+        _summary_dict(item) for item in data.get("failure_details") or ()
+    ]
+    failure_count = len(failures)
+    if not failures and isinstance(data.get("failure_count"), (int, float)):
+        failure_count = max(int(data.get("failure_count") or 0), 0)
+    return {
+        "executed_checks": list(data.get("executed_checks") or ()),
+        "skipped_checks": list(data.get("skipped_checks") or ()),
+        "failure_count": failure_count,
+        "failures": failures,
+        "failure_details": failure_details,
+    }
+
+
+def _arbiter_evidence_summary(arbiter_verdicts) -> dict[str, object]:
+    """Project arbiter verdicts into prompt-safe primitives."""
+    verdicts = [_summary_dict(verdict) for verdict in arbiter_verdicts or ()]
+    if not verdicts:
+        return {}
+    return {
+        "verdicts": verdicts,
+        "failure_count": sum(
+            1 for verdict in verdicts if verdict.get("status") == "failed"
+        ),
+        "executed_count": sum(1 for verdict in verdicts if verdict.get("executed")),
+    }
+
+
+def _deterministic_blockers_from_packet(
+    packet: Mapping[str, object],
+) -> list[dict[str, object]]:
+    """Return deterministic blockers already owned outside model validation."""
+    blockers: list[dict[str, object]] = []
+    contract = dict(packet.get("validation_contract") or {})
+    for key in ("lowering_errors", "admissibility_failures"):
+        for item in contract.get(key) or ():
+            blockers.append({"source": "validation_contract", "kind": key, "message": item})
+
+    bundle = dict(packet.get("validation_bundle") or {})
+    for detail in bundle.get("failure_details") or ():
+        data = dict(detail or {})
+        blockers.append({
+            "source": "validation_bundle",
+            "check_id": data.get("check") or data.get("check_id"),
+            "message": data.get("message") or data.get("exception_message") or "",
+        })
+    if bundle.get("failure_count") and not bundle.get("failure_details"):
+        blockers.append({
+            "source": "validation_bundle",
+            "failure_count": bundle.get("failure_count"),
+        })
+
+    oracle = dict(packet.get("reference_oracle") or {})
+    if oracle and not bool(oracle.get("passed", True)):
+        blockers.append({
+            "source": "reference_oracle",
+            "oracle_id": oracle.get("oracle_id"),
+            "message": oracle.get("failure_message") or "",
+        })
+
+    arbiter = dict(packet.get("arbiter") or {})
+    for verdict in arbiter.get("verdicts") or ():
+        data = dict(verdict or {})
+        if data.get("status") == "failed":
+            blockers.append({
+                "source": "arbiter",
+                "check_id": data.get("check_id"),
+                "reason": data.get("reason"),
+                "message": data.get("message") or data.get("detail") or "",
+            })
+    return blockers
+
+
+def _finding_summary(finding) -> dict[str, object]:
+    """Project one ValidationFinding or finding-like mapping into primitives."""
+    if isinstance(finding, Mapping):
+        data = dict(finding)
+    elif is_dataclass(finding):
+        data = asdict(finding)
+    else:
+        data = {
+            "id": getattr(finding, "id", ""),
+            "severity": getattr(finding, "severity", ""),
+            "category": getattr(finding, "category", ""),
+            "description": getattr(finding, "description", ""),
+            "evidence": getattr(finding, "evidence", ""),
+            "remediation": getattr(finding, "remediation", ""),
+        }
+    return {
+        "source": "model_validator",
+        "id": data.get("id", ""),
+        "severity": data.get("severity", ""),
+        "category": data.get("category", ""),
+        "description": data.get("description", ""),
+        "evidence": data.get("evidence", ""),
+        "remediation": data.get("remediation", ""),
+    }
+
+
+def _summary_dict(value) -> dict[str, Any]:
+    """Return a shallow primitive dictionary for dataclasses and mappings."""
+    if value is None:
+        return {}
+    if isinstance(value, Mapping):
+        return dict(value)
+    if is_dataclass(value):
+        return asdict(value)
+    data: dict[str, Any] = {}
+    for key in (
+        "contract_id",
+        "executed_checks",
+        "skipped_checks",
+        "failures",
+        "failure_details",
+        "failure_count",
+        "oracle_id",
+        "instrument_type",
+        "method",
+        "source",
+        "relation",
+        "tolerance",
+        "passed",
+        "sampled_prices",
+        "max_abs_deviation",
+        "max_rel_deviation",
+        "failure_message",
+        "check_id",
+        "status",
+        "reason",
+        "executed",
+        "severity",
+        "description",
+        "message",
+        "detail",
+    ):
+        if hasattr(value, key):
+            data[key] = getattr(value, key)
+    return data

--- a/trellis/agent/platform_traces.py
+++ b/trellis/agent/platform_traces.py
@@ -64,6 +64,11 @@ class CycleReport:
     stage_statuses: dict[str, str]
     stages: tuple[CycleStageReport, ...]
     failure_count: int
+    deterministic_blockers: tuple[dict[str, Any], ...] = ()
+    conceptual_blockers: tuple[dict[str, Any], ...] = ()
+    calibration_blockers: tuple[dict[str, Any], ...] = ()
+    residual_limitations: tuple[dict[str, Any], ...] = ()
+    residual_risks: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -886,6 +891,13 @@ def _cycle_report_summary(
             for stage in report.stages
         ],
         "failure_count": report.failure_count,
+        "deterministic_blockers": [
+            dict(item) for item in report.deterministic_blockers
+        ],
+        "conceptual_blockers": [dict(item) for item in report.conceptual_blockers],
+        "calibration_blockers": [dict(item) for item in report.calibration_blockers],
+        "residual_limitations": [dict(item) for item in report.residual_limitations],
+        "residual_risks": list(report.residual_risks),
     }
 
 
@@ -900,6 +912,11 @@ def _build_cycle_report(
         trace.get("validation_contract")
     )
     failure_count = 0
+    deterministic_blockers: list[dict[str, Any]] = []
+    conceptual_blockers: list[dict[str, Any]] = []
+    calibration_blockers: list[dict[str, Any]] = []
+    residual_limitations: list[dict[str, Any]] = []
+    residual_risks: list[str] = []
 
     for event_record in events:
         event_name = str(event_record.get("event", "") or "")
@@ -908,6 +925,7 @@ def _build_cycle_report(
             continue
 
         details = dict(event_record.get("details") or {})
+        event_status = str(event_record.get("status", "info") or "info")
         if stage == "quant":
             pricing_method = _first_non_empty(details.get("method"), pricing_method)
         event_contract_id = _validation_contract_id_from_payload(
@@ -917,10 +935,29 @@ def _build_cycle_report(
             event_contract_id,
             validation_contract_id,
         )
+        _extend_unique_strings(residual_risks, _residual_risks_from_details(details))
+        _extend_unique_dicts(
+            deterministic_blockers,
+            _deterministic_blockers_from_event(event_name, event_status, details),
+        )
+        if stage == "model_validator":
+            classification = _model_validator_classification_from_details(details)
+            _extend_unique_dicts(
+                conceptual_blockers,
+                classification.get("conceptual_blockers", ()),
+            )
+            _extend_unique_dicts(
+                calibration_blockers,
+                classification.get("calibration_blockers", ()),
+            )
+            _extend_unique_dicts(
+                residual_limitations,
+                classification.get("residual_limitations", ()),
+            )
 
         stage_status = _cycle_stage_status(
             event_name,
-            str(event_record.get("status", "info") or "info"),
+            event_status,
             details,
         )
         failure_count += _failure_count_from_details(details)
@@ -940,6 +977,20 @@ def _build_cycle_report(
         )
     )
     stage_statuses = {stage.stage: stage.status for stage in ordered_stages}
+    for risk in residual_risks:
+        risk_source = (
+            "quant_challenger_packet"
+            if str(risk).startswith("quant:")
+            else "validation_contract"
+        )
+        _extend_unique_dicts(
+            residual_limitations,
+            [{
+                "source": risk_source,
+                "risk_id": risk,
+                "category": "residual_limitation",
+            }],
+        )
     return CycleReport(
         request_id=str(trace.get("request_id", "") or ""),
         status=str(trace.get("status", "running") or "running"),
@@ -950,6 +1001,11 @@ def _build_cycle_report(
         stage_statuses=stage_statuses,
         stages=ordered_stages,
         failure_count=failure_count,
+        deterministic_blockers=tuple(deterministic_blockers),
+        conceptual_blockers=tuple(conceptual_blockers),
+        calibration_blockers=tuple(calibration_blockers),
+        residual_limitations=tuple(residual_limitations),
+        residual_risks=tuple(residual_risks),
     )
 
 
@@ -1033,6 +1089,8 @@ def _cycle_stage_details(stage: str, details: dict[str, Any]) -> dict[str, Any]:
             "approved",
             "llm_review",
             "risk_level",
+            "residual_risks",
+            "finding_classification",
             "reason",
             "skip_reason",
         ),
@@ -1057,6 +1115,164 @@ def _failure_count_from_details(details: dict[str, Any]) -> int:
     if isinstance(failures, list):
         return len(failures)
     return 0
+
+
+def _residual_risks_from_details(details: dict[str, Any]) -> tuple[str, ...]:
+    """Extract residual risk ids from lifecycle details."""
+    risks: list[str] = []
+    for value in details.get("residual_risks") or ():
+        _append_unique_string(risks, value)
+    contract = details.get("validation_contract")
+    if isinstance(contract, dict):
+        for value in contract.get("residual_risks") or ():
+            _append_unique_string(risks, value)
+    quant_packet = details.get("challenger_packet")
+    if isinstance(quant_packet, dict):
+        for value in quant_packet.get("residual_risk_handoff") or ():
+            _append_unique_string(risks, value)
+    return tuple(risks)
+
+
+def _deterministic_blockers_from_event(
+    event_name: str,
+    event_status: str,
+    details: dict[str, Any],
+) -> tuple[dict[str, Any], ...]:
+    """Return deterministic blockers already owned by non-LLM validation layers."""
+    blockers: list[dict[str, Any]] = []
+    contract = details.get("validation_contract")
+    if isinstance(contract, dict):
+        for key in ("lowering_errors", "admissibility_failures"):
+            for item in contract.get(key) or ():
+                blockers.append({
+                    "source": "validation_contract",
+                    "kind": key,
+                    "message": str(item),
+                })
+
+    if event_name == "validation_bundle_executed" and _failure_count_from_details(details) > 0:
+        failure_details = details.get("failure_details")
+        if isinstance(failure_details, list) and failure_details:
+            for item in failure_details:
+                data = dict(item or {}) if isinstance(item, dict) else {"message": str(item)}
+                blockers.append({
+                    "source": "validation_bundle",
+                    "check_id": data.get("check") or data.get("check_id"),
+                    "message": data.get("message") or data.get("exception_message") or "",
+                })
+        else:
+            blockers.append({
+                "source": "validation_bundle",
+                "failure_count": _failure_count_from_details(details),
+            })
+
+    if event_name == "reference_oracle_executed":
+        oracle = details.get("oracle")
+        oracle_data = dict(oracle or {}) if isinstance(oracle, dict) else {}
+        if event_status == "error" or not bool(oracle_data.get("passed", True)):
+            blockers.append({
+                "source": "reference_oracle",
+                "oracle_id": oracle_data.get("oracle_id"),
+                "message": oracle_data.get("failure_message") or "",
+            })
+
+    if event_name == "arbiter_completed":
+        for verdict in details.get("verdicts") or ():
+            data = dict(verdict or {}) if isinstance(verdict, dict) else {}
+            if data.get("status") == "failed":
+                blockers.append({
+                    "source": "arbiter",
+                    "check_id": data.get("check_id"),
+                    "reason": data.get("reason"),
+                    "message": data.get("message") or data.get("detail") or "",
+                })
+    return tuple(blockers)
+
+
+def _model_validator_classification_from_details(
+    details: dict[str, Any],
+) -> dict[str, list[dict[str, Any]]]:
+    """Classify model-validator details into cycle-report risk buckets."""
+    existing = details.get("finding_classification")
+    if isinstance(existing, dict):
+        return {
+            "conceptual_blockers": [
+                _model_validator_finding_summary(item)
+                for item in existing.get("conceptual_blockers") or ()
+            ],
+            "calibration_blockers": [
+                _model_validator_finding_summary(item)
+                for item in existing.get("calibration_blockers") or ()
+            ],
+            "residual_limitations": [
+                _model_validator_finding_summary(item)
+                for item in existing.get("residual_limitations") or ()
+            ],
+        }
+
+    classification = {
+        "conceptual_blockers": [],
+        "calibration_blockers": [],
+        "residual_limitations": [],
+    }
+    for item in details.get("findings") or ():
+        finding = _model_validator_finding_summary(item)
+        severity = str(finding.get("severity", "") or "").strip().lower()
+        category = str(finding.get("category", "") or "").strip().lower()
+        is_blocker = severity in {"critical", "high"}
+        if category == "calibration" and is_blocker:
+            classification["calibration_blockers"].append(finding)
+        elif category == "conceptual" and is_blocker:
+            classification["conceptual_blockers"].append(finding)
+        elif category in {"limitation", "residual_limitation"} or not is_blocker:
+            classification["residual_limitations"].append(finding)
+        elif is_blocker:
+            classification["conceptual_blockers"].append(finding)
+    return classification
+
+
+def _model_validator_finding_summary(item: object) -> dict[str, Any]:
+    """Normalize one model-validator finding-like object."""
+    data = dict(item or {}) if isinstance(item, dict) else {"description": str(item)}
+    data.setdefault("source", "model_validator")
+    return {
+        key: _normalize_yaml_value(value)
+        for key, value in data.items()
+        if key in {
+            "source",
+            "id",
+            "severity",
+            "category",
+            "description",
+            "evidence",
+            "remediation",
+            "risk_id",
+        }
+    }
+
+
+def _append_unique_string(target: list[str], value: object) -> None:
+    """Append a normalized string if it is not already present."""
+    text = str(value or "").strip()
+    if text and text not in target:
+        target.append(text)
+
+
+def _extend_unique_strings(target: list[str], values) -> None:
+    """Append normalized strings while preserving order."""
+    for value in values or ():
+        _append_unique_string(target, value)
+
+
+def _extend_unique_dicts(target: list[dict[str, Any]], values) -> None:
+    """Append dictionaries while preserving first occurrence."""
+    seen = {json.dumps(item, sort_keys=True, default=str) for item in target}
+    for value in values or ():
+        item = _normalize_yaml_value(dict(value or {}))
+        marker = json.dumps(item, sort_keys=True, default=str)
+        if marker not in seen:
+            target.append(item)
+            seen.add(marker)
 
 
 def _validation_contract_id_from_payload(payload: object) -> str | None:


### PR DESCRIPTION
## Summary
- add a deterministic evidence packet for residual model validation
- skip model-validator prose review after deterministic/arbiter failures
- classify cycle-report outcomes into deterministic, conceptual, calibration, residual-limitation buckets
- document the residual-risk model-validation audit contract

## Validation
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_model_validator.py tests/test_agent/test_platform_traces.py tests/test_agent/test_lite_review.py tests/test_agent/test_validation_contract.py -q`
- `/Users/steveyang/miniforge3/bin/python3 -m compileall trellis/agent/model_validator.py trellis/agent/platform_traces.py trellis/agent/executor.py`
- `make gate-pr`

Linear: QUA-986
