### PR TITLE
QUA-987: Gate promotion on cycle governance

### DIFF
--- a/docs/developer/audit_and_observability.rst
+++ b/docs/developer/audit_and_observability.rst
@@ -314,6 +314,35 @@ The persisted ``cycle_report`` also separates outcome buckets:
 Downstream promotion and adoption logic should consume these separated buckets
 rather than parsing free-form model-validator text.
 
+Cycle-Governed Promotion And Adoption
+-------------------------------------
+
+Promotion and adoption gates now use the stable ``cycle_report`` as a governed
+input. ``trellis.agent.cycle_governance.evaluate_cycle_promotion_governance``
+is the shared deterministic evaluator for this handoff.
+
+For ``_agent`` adapter promotion:
+
+- promotion-candidate YAML records the cycle report from the source platform
+  trace or FinancePy benchmark cold-agent run
+- promotion review artifacts persist ``cycle_promotion_governance`` next to the
+  existing deterministic checks and adapter lifecycle snapshot
+- adoption requires the review to contain an eligible cycle-governance artifact
+  and persists the refreshed governance result in the adoption artifact
+- stale, deprecated, and archived adapter lifecycle counts are surfaced as
+  governance warnings rather than hidden prompt-only state
+
+For governed MCP model lifecycle work, transition to ``approved`` now requires
+an eligible cycle report in the transition metadata. ``validated`` still means
+the deterministic model-version validation passed; ``approved`` means the
+version also has a clean agent-cycle governance record suitable for production
+execution eligibility.
+
+Audit and Linear/GitHub lifecycle comments render a compact ``Cycle Report``
+section when trace or event details contain ``cycle_report`` or
+``cycle_promotion_governance``. Comments should cite those stable fields rather
+than embedding full nested event payloads.
+
 Governed Provider Provenance
 ----------------------------
 

--- a/docs/user_guide/pricing.rst
+++ b/docs/user_guide/pricing.rst
@@ -708,6 +708,9 @@ Important constraints:
 
 - draft generation does not make a model execution-eligible
 - deterministic validation does not auto-approve a model
+- approval requires an eligible agent-cycle report in the promotion metadata,
+  so production eligibility depends on both deterministic validation and the
+  quant/critic/arbiter/model-validator cycle outcome
 - production pricing still requires an explicitly approved model version
 - deprecation removes execution eligibility without deleting the stored
   contract, code, validation, or lineage artifacts
@@ -744,6 +747,8 @@ Versioning constraints matter here:
 
 - every governed model version needs its own validation result before it can be
   promoted
+- every approved version needs its own cycle-governance evidence; a clean cycle
+  from a parent or previous implementation is not reused automatically
 - promotion uses the latest validation for that exact version, not any
   historical pass from an earlier validation run or parent version
 - metadata-only revisions still keep a version-specific code resource so later

--- a/scripts/run_financepy_benchmark.py
+++ b/scripts/run_financepy_benchmark.py
@@ -294,6 +294,10 @@ def _execute_single_benchmark_task(
         "status": status,
         "cold_agent_elapsed_seconds": round(float(cold_result.get("elapsed_seconds") or 0.0), 6),
         "cold_agent_token_usage": dict(cold_result.get("token_usage_summary") or {}),
+        "cold_agent_platform_trace_path": str(cold_result.get("platform_trace_path") or ""),
+        "cold_agent_cycle_report": dict(
+            (cold_result.get("build_observability") or {}).get("cycle_report") or {}
+        ),
         "warm_agent_mean_seconds": None if warm_result is None else warm_result.get("mean_seconds"),
         "warm_agent_last_price": None if warm_result is None else warm_result.get("last_price"),
         "warm_agent_execution_mode": (

--- a/tests/test_agent/test_promote_benchmark_candidate.py
+++ b/tests/test_agent/test_promote_benchmark_candidate.py
@@ -32,6 +32,30 @@ def _patch_promotion_paths(monkeypatch, knowledge_root: Path) -> None:
     monkeypatch.setattr(promotion_mod, "_REPO_ROOT", repo_root)
 
 
+def _cycle_report() -> dict[str, object]:
+    return {
+        "request_id": "executor_benchmark_candidate",
+        "status": "succeeded",
+        "outcome": "build_completed",
+        "success": True,
+        "pricing_method": "analytical",
+        "validation_contract_id": "validation:barrier_option:analytical",
+        "stage_statuses": {
+            "quant": "passed",
+            "validation_bundle": "passed",
+            "critic": "passed",
+            "arbiter": "passed",
+            "model_validator": "skipped",
+        },
+        "failure_count": 0,
+        "deterministic_blockers": [],
+        "conceptual_blockers": [],
+        "calibration_blockers": [],
+        "residual_limitations": [],
+        "residual_risks": [],
+    }
+
+
 def _prepare_record_and_candidate(
     tmp_path: Path,
     monkeypatch,
@@ -76,6 +100,7 @@ def _prepare_record_and_candidate(
             "compared_outputs": ("price",),
             "output_deviation_pct": {"price": 0.1},
         },
+        "cold_agent_cycle_report": _cycle_report(),
         "generated_artifact": {
             "module_name": f"trellis_benchmarks._fresh.{task_id.lower()}.analytical.barrieroption",
             "class_name": "BarrierOptionPayoff",
@@ -134,6 +159,10 @@ def test_promote_benchmark_candidate_writes_agent_adapter_with_admission_log(
         "trellis.instruments._agent.barrieroption"
     )
     assert payload["code_hash"] == hashlib.sha256(target_path.read_bytes()).hexdigest()
+    assert payload["cycle_promotion_governance"]["eligible"] is True
+    assert payload["cycle_promotion_governance"]["cycle_report"]["request_id"] == (
+        "executor_benchmark_candidate"
+    )
 
 
 def test_promote_benchmark_candidate_dry_run_leaves_filesystem_untouched(
@@ -171,6 +200,26 @@ def test_promote_benchmark_candidate_fails_closed_on_hash_mismatch(tmp_path, mon
         promote_benchmark_candidate(candidate_path, repo_root=tmp_path)
 
     assert "hash" in str(exc_info.value).lower()
+    target_path = tmp_path / "trellis" / "instruments" / "_agent" / "barrieroption.py"
+    assert not target_path.exists()
+
+
+def test_promote_benchmark_candidate_fails_closed_without_cycle_report(tmp_path, monkeypatch):
+    from trellis.agent.knowledge.promotion import (
+        PromotionAdmissionError,
+        promote_benchmark_candidate,
+    )
+
+    candidate_path, _record = _prepare_record_and_candidate(tmp_path, monkeypatch)
+    candidate = yaml.safe_load(candidate_path.read_text())
+    candidate.pop("cycle_report", None)
+    candidate["benchmark_provenance"].pop("cycle_report", None)
+    candidate_path.write_text(yaml.safe_dump(candidate, sort_keys=False))
+
+    with pytest.raises(PromotionAdmissionError) as exc_info:
+        promote_benchmark_candidate(candidate_path, repo_root=tmp_path)
+
+    assert "cycle_promotion_governance" in str(exc_info.value)
     target_path = tmp_path / "trellis" / "instruments" / "_agent" / "barrieroption.py"
     assert not target_path.exists()
 

--- a/tests/test_agent/test_promotion_candidates.py
+++ b/tests/test_agent/test_promotion_candidates.py
@@ -17,6 +17,39 @@ def _patch_promotion_paths(monkeypatch, root: Path) -> None:
     monkeypatch.setattr(promotion_mod, "_REPO_ROOT", root.parents[2])
 
 
+def _cycle_report(*, success: bool = True, failed_stage: str | None = None) -> dict[str, object]:
+    stage_statuses = {
+        "quant": "passed",
+        "validation_bundle": "passed",
+        "critic": "passed",
+        "arbiter": "passed",
+        "model_validator": "skipped",
+    }
+    if failed_stage is not None:
+        stage_statuses[failed_stage] = "failed"
+    return {
+        "request_id": "executor_build_demo",
+        "status": "succeeded" if success and failed_stage is None else "failed",
+        "outcome": "build_completed" if success and failed_stage is None else "request_failed",
+        "success": success and failed_stage is None,
+        "pricing_method": "analytical",
+        "validation_contract_id": "validation:demo:analytical",
+        "stage_statuses": stage_statuses,
+        "failure_count": 0 if success and failed_stage is None else 1,
+        "deterministic_blockers": [] if failed_stage is None else [
+            {
+                "source": "arbiter",
+                "check_id": "demo_bound",
+                "reason": "deterministic_check_failed",
+            }
+        ],
+        "conceptual_blockers": [],
+        "calibration_blockers": [],
+        "residual_limitations": [],
+        "residual_risks": ["comparison_relations_unspecified"],
+    }
+
+
 def _write_candidate(
     root: Path,
     name: str,
@@ -26,6 +59,7 @@ def _write_candidate(
     cross_status: str = "passed",
     deviation: float = 0.2,
     code: str | None = None,
+    cycle_report: dict[str, object] | None = None,
 ) -> Path:
     traces = root / "traces"
     candidate_dir = traces / "promotion_candidates"
@@ -58,6 +92,7 @@ def _write_candidate(
         "platform_request_id": "executor_build_demo",
         "platform_trace_path": str(platform_trace),
         "market_context": {"source": "mock"},
+        "cycle_report": cycle_report or _cycle_report(),
         "cross_validation": {
             "status": cross_status,
             "prices": {comparison_target: 101.0},
@@ -83,6 +118,7 @@ def _write_benchmark_record(
     preferred_method: str = "analytical",
     module_name: str = "trellis_benchmarks._fresh.f009.analytical.barrieroption",
     admission_target_module_name: str = "trellis.instruments._agent.barrieroption",
+    cycle_report: dict[str, object] | None = None,
 ) -> dict[str, object]:
     report_root = root.parents[2] / "task_runs" / "financepy_benchmarks"
     generated_dir = report_root / "generated" / task_id.lower() / preferred_method
@@ -115,6 +151,7 @@ def _write_benchmark_record(
             "compared_outputs": ("price",),
             "output_deviation_pct": {"price": 0.1},
         },
+        "cold_agent_cycle_report": cycle_report or _cycle_report(),
         "generated_artifact": {
             "module_name": module_name,
             "class_name": "BarrierOptionPayoff",
@@ -229,6 +266,7 @@ def test_record_benchmark_promotion_candidate_captures_run_and_artifact_provenan
     assert payload["validation_source"] == "financepy_benchmark"
     assert payload["benchmark_provenance"]["benchmark_run_id"] == record["run_id"]
     assert payload["benchmark_provenance"]["benchmark_record_path"] == record["history_path"]
+    assert payload["cycle_report"]["request_id"] == "executor_build_demo"
     assert payload["generated_artifact"]["module_name"] == record["generated_artifact"]["module_name"]
     assert payload["admission_target_module_name"] == "trellis.instruments._agent.barrieroption"
 
@@ -249,7 +287,30 @@ def test_review_promotion_candidate_approves_financepy_benchmark_candidate(monke
     assert review["status"] == "approved"
     assert review["validation_source"] == "financepy_benchmark"
     assert review["recommended_module_path"] == "trellis.instruments._agent.barrieroption"
+    assert review["cycle_promotion_governance"]["eligible"] is True
+    assert review["cycle_promotion_governance"]["cycle_report"]["request_id"] == "executor_build_demo"
     assert all(check["passed"] for check in review["checks"] if check["blocking"])
+
+
+def test_review_promotion_candidate_rejects_failed_cycle_report(monkeypatch, tmp_path):
+    from trellis.agent.knowledge.promotion import review_promotion_candidate
+
+    knowledge_root = tmp_path / "trellis" / "agent" / "knowledge"
+    _patch_promotion_paths(monkeypatch, knowledge_root)
+    candidate_path = _write_candidate(
+        knowledge_root,
+        "candidate_failed_cycle.yaml",
+        cycle_report=_cycle_report(success=False, failed_stage="arbiter"),
+    )
+
+    review = review_promotion_candidate(candidate_path)
+
+    assert review["status"] == "rejected"
+    governance = review["cycle_promotion_governance"]
+    assert governance["eligible"] is False
+    assert "cycle_stage_failed:arbiter" in governance["blockers"]
+    failed = {check["name"] for check in review["checks"] if not check["passed"] and check["blocking"]}
+    assert "cycle_promotion_governance" in failed
 
 
 def test_review_promotion_candidate_rejects_benchmark_hash_mismatch(monkeypatch, tmp_path):
@@ -320,6 +381,7 @@ def test_adopt_promotion_candidate_writes_financepy_benchmark_candidate_to_admis
     adoption = adopt_promotion_candidate(review["review_path"])
 
     assert adoption["status"] == "adopted"
+    assert adoption["cycle_promotion_governance"]["eligible"] is True
     assert target_path.read_text() == (yaml.safe_load(Path(candidate_path).read_text())["code"]).rstrip() + "\n"
 
 
@@ -355,6 +417,7 @@ def test_adopt_promotion_candidate_writes_approved_candidate_to_target(monkeypat
     assert adoption["status"] == "adopted"
     assert adoption["adopted"] is True
     assert adoption["changed"] is True
+    assert adoption["cycle_promotion_governance"]["eligible"] is True
     assert target_path.read_text() == (yaml.safe_load(candidate_path.read_text())["code"]).rstrip() + "\n"
     assert Path(adoption["adoption_path"]).exists()
 
@@ -481,6 +544,7 @@ def test_review_and_adopt_promotion_candidate_propagate_adapter_lifecycle_state(
     assert review_lifecycle["raw"]["summary"]["stale_adapter_count"] == 1
     assert review_lifecycle["resolved"]["summary"]["deprecated_adapter_count"] == 1
     assert review_lifecycle["resolved"]["summary"]["stale_adapter_count"] == 0
+    assert review["cycle_promotion_governance"]["adapter_lifecycle"]["status_counts"]["deprecated"] == 1
 
     review_payload = build_shared_knowledge_payload({})
     assert review_payload["summary"]["deprecated_adapter_count"] == 1
@@ -496,6 +560,7 @@ def test_review_and_adopt_promotion_candidate_propagate_adapter_lifecycle_state(
     assert adoption_lifecycle["raw"]["summary"]["stale_adapter_count"] == 1
     assert adoption_lifecycle["resolved"]["summary"]["archived_adapter_count"] == 1
     assert adoption_lifecycle["resolved"]["summary"]["stale_adapter_count"] == 0
+    assert adoption["cycle_promotion_governance"]["adapter_lifecycle"]["status_counts"]["archived"] == 1
 
     adoption_payload = build_shared_knowledge_payload({})
     assert adoption_payload["summary"]["archived_adapter_count"] == 1

--- a/tests/test_agent/test_request_issue_format.py
+++ b/tests/test_agent/test_request_issue_format.py
@@ -73,6 +73,77 @@ def test_issue_format_includes_task_and_target_context():
     assert "- ownership_role: `quant`" in comment
 
 
+def test_issue_format_includes_cycle_report_and_promotion_governance():
+    from trellis.agent.platform_requests import PlatformRequest
+    from trellis.agent.request_issue_format import build_event_comment, build_issue_body
+
+    request = PlatformRequest(
+        request_id="executor_build_cycle",
+        request_type="build",
+        entry_point="executor",
+        description="Build a callable bond pricer",
+        instrument_type="callable_bond",
+        metadata={"task_id": "F099", "task_title": "Callable bond cycle gate"},
+    )
+    compiled = SimpleNamespace(request=request)
+    cycle_report = {
+        "request_id": "executor_build_cycle",
+        "status": "failed",
+        "outcome": "request_failed",
+        "success": False,
+        "pricing_method": "rate_tree",
+        "validation_contract_id": "validation:callable_bond:rate_tree",
+        "stage_statuses": {
+            "quant": "passed",
+            "validation_bundle": "passed",
+            "arbiter": "failed",
+            "model_validator": "skipped",
+        },
+        "deterministic_blockers": [{"check_id": "callable_bound"}],
+        "conceptual_blockers": [],
+        "calibration_blockers": [],
+        "residual_limitations": [{"risk_id": "single_factor_curve"}],
+        "residual_risks": ["unsupported_paths_declared"],
+    }
+    governance = {
+        "eligible": False,
+        "decision": "blocked",
+        "blockers": ["cycle_stage_failed:arbiter"],
+        "warnings": ["residual_risks_present"],
+    }
+    trace = {
+        "action": "build_then_price",
+        "route_method": "rate_tree",
+        "requires_build": True,
+        "outcome": "request_failed",
+        "cycle_report": cycle_report,
+        "cycle_promotion_governance": governance,
+        "request_metadata": dict(request.metadata),
+    }
+    event = {
+        "event": "request_failed",
+        "status": "error",
+        "details": {
+            "reason": "arbiter_failed",
+            "cycle_report": cycle_report,
+            "cycle_promotion_governance": governance,
+        },
+    }
+
+    body = build_issue_body(trace, compiled, event)
+    comment = build_event_comment(trace, event)
+
+    assert "## Cycle Report" in body
+    assert "- cycle_success: `False`" in body
+    assert "- cycle_stage_statuses: `arbiter=failed, model_validator=skipped, quant=passed, validation_bundle=passed`" in body
+    assert "- deterministic_blockers: `1`" in body
+    assert "- residual_risks: `unsupported_paths_declared`" in body
+    assert "- promotion_eligible: `False`" in body
+    assert "- promotion_blockers: `cycle_stage_failed:arbiter`" in body
+    assert "## Cycle Report" in comment
+    assert "- promotion_eligible: `False`" in comment
+
+
 def test_stress_follow_on_format_includes_repeat_context_and_artifacts():
     from trellis.agent.request_issue_format import (
         build_stress_follow_on_body,

--- a/tests/test_mcp/test_model_lifecycle_tools.py
+++ b/tests/test_mcp/test_model_lifecycle_tools.py
@@ -81,6 +81,30 @@ def _candidate_payload() -> dict[str, object]:
     }
 
 
+def _cycle_report() -> dict[str, object]:
+    return {
+        "request_id": "executor_mcp_candidate",
+        "status": "succeeded",
+        "outcome": "build_completed",
+        "success": True,
+        "pricing_method": "analytical",
+        "validation_contract_id": "validation:vanilla_option:analytical",
+        "stage_statuses": {
+            "quant": "passed",
+            "validation_bundle": "passed",
+            "critic": "passed",
+            "arbiter": "passed",
+            "model_validator": "skipped",
+        },
+        "failure_count": 0,
+        "deterministic_blockers": [],
+        "conceptual_blockers": [],
+        "calibration_blockers": [],
+        "residual_limitations": [],
+        "residual_risks": [],
+    }
+
+
 def test_generate_candidate_creates_draft_version_and_persists_artifacts(tmp_path):
     from trellis.mcp.server import bootstrap_mcp_server
 
@@ -220,6 +244,7 @@ def test_promote_controls_execution_eligibility_and_deprecation(tmp_path):
             "to_status": "approved",
             "actor": "reviewer",
             "reason": "manual_approval",
+            "metadata": {"cycle_report": _cycle_report()},
         },
     )
     assert approved["version"]["status"] == "approved"

--- a/tests/test_mcp/test_model_store_tools.py
+++ b/tests/test_mcp/test_model_store_tools.py
@@ -75,6 +75,30 @@ def _candidate_payload() -> dict[str, object]:
     }
 
 
+def _cycle_report() -> dict[str, object]:
+    return {
+        "request_id": "executor_model_store_candidate",
+        "status": "succeeded",
+        "outcome": "build_completed",
+        "success": True,
+        "pricing_method": "analytical",
+        "validation_contract_id": "validation:vanilla_option:analytical",
+        "stage_statuses": {
+            "quant": "passed",
+            "validation_bundle": "passed",
+            "critic": "passed",
+            "arbiter": "passed",
+            "model_validator": "skipped",
+        },
+        "failure_count": 0,
+        "deterministic_blockers": [],
+        "conceptual_blockers": [],
+        "calibration_blockers": [],
+        "residual_limitations": [],
+        "residual_risks": [],
+    }
+
+
 def test_persist_versions_list_history_and_diff(tmp_path):
     from trellis.mcp.server import bootstrap_mcp_server
 
@@ -206,6 +230,7 @@ def test_persist_run_creates_reproducibility_bundle_and_attaches_it_to_run(tmp_p
             "to_status": "approved",
             "actor": "reviewer",
             "reason": "manual_approval",
+            "metadata": {"cycle_report": _cycle_report()},
         },
     )
     server.call_tool(
@@ -290,6 +315,7 @@ def test_persist_run_embeds_concrete_market_snapshot_for_live_provider_run(tmp_p
             "to_status": "approved",
             "actor": "reviewer",
             "reason": "manual_approval",
+            "metadata": {"cycle_report": _cycle_report()},
         },
     )
     server.call_tool(

--- a/tests/test_mcp/test_resources.py
+++ b/tests/test_mcp/test_resources.py
@@ -75,6 +75,30 @@ def _candidate_payload() -> dict[str, object]:
     }
 
 
+def _cycle_report() -> dict[str, object]:
+    return {
+        "request_id": "executor_resource_candidate",
+        "status": "succeeded",
+        "outcome": "build_completed",
+        "success": True,
+        "pricing_method": "analytical",
+        "validation_contract_id": "validation:vanilla_option:analytical",
+        "stage_statuses": {
+            "quant": "passed",
+            "validation_bundle": "passed",
+            "critic": "passed",
+            "arbiter": "passed",
+            "model_validator": "skipped",
+        },
+        "failure_count": 0,
+        "deterministic_blockers": [],
+        "conceptual_blockers": [],
+        "calibration_blockers": [],
+        "residual_limitations": [],
+        "residual_risks": [],
+    }
+
+
 def test_resource_templates_and_model_policy_resources(tmp_path):
     from trellis.mcp.server import bootstrap_mcp_server
 
@@ -153,6 +177,7 @@ def test_run_and_snapshot_resources_resolve_from_persisted_state(tmp_path):
             "to_status": "approved",
             "actor": "reviewer",
             "reason": "manual_approval",
+            "metadata": {"cycle_report": _cycle_report()},
         },
     )
     server.call_tool(

--- a/tests/test_platform/test_model_service.py
+++ b/tests/test_platform/test_model_service.py
@@ -45,6 +45,30 @@ def _seed_registry(tmp_path):
     return registry
 
 
+def _cycle_report(*, success: bool = True) -> dict[str, object]:
+    return {
+        "request_id": "executor_model_candidate",
+        "status": "succeeded" if success else "failed",
+        "outcome": "build_completed" if success else "request_failed",
+        "success": success,
+        "pricing_method": "analytical",
+        "validation_contract_id": "validation:vanilla_option:analytical",
+        "stage_statuses": {
+            "quant": "passed",
+            "validation_bundle": "passed",
+            "critic": "passed",
+            "arbiter": "passed" if success else "failed",
+            "model_validator": "skipped",
+        },
+        "failure_count": 0 if success else 1,
+        "deterministic_blockers": [] if success else [{"check_id": "call_bound"}],
+        "conceptual_blockers": [],
+        "calibration_blockers": [],
+        "residual_limitations": [],
+        "residual_risks": [],
+    }
+
+
 def test_promote_requires_latest_validation_to_pass(tmp_path):
     from trellis.mcp.errors import TrellisMcpError
     from trellis.platform.services.model_service import ModelService
@@ -92,3 +116,60 @@ def test_promote_requires_latest_validation_to_pass(tmp_path):
             validation_store=validation_store,
         )
     assert excinfo.value.code == "validation_required"
+
+
+def test_approval_requires_cycle_promotion_governance(tmp_path):
+    from trellis.mcp.errors import TrellisMcpError
+    from trellis.platform.services.model_service import ModelService
+    from trellis.platform.services.validation_service import ValidationService
+    from trellis.platform.storage import ValidationStore
+
+    registry = _seed_registry(tmp_path)
+    validation_store = ValidationStore(tmp_path / "validations")
+    validation_service = ValidationService(
+        registry=registry,
+        validation_store=validation_store,
+    )
+    model_service = ModelService(registry=registry)
+    validation_service.validate_model(
+        model_id="vanilla_option_candidate",
+        version="v1",
+        actor="validator",
+        reason="initial_validation",
+    )
+    model_service.promote_version(
+        model_id="vanilla_option_candidate",
+        version="v1",
+        to_status="validated",
+        actor="reviewer",
+        reason="validation_review_complete",
+        validation_store=validation_store,
+    )
+
+    with pytest.raises(TrellisMcpError) as excinfo:
+        model_service.promote_version(
+            model_id="vanilla_option_candidate",
+            version="v1",
+            to_status="approved",
+            actor="reviewer",
+            reason="manual_approval_without_cycle",
+            validation_store=validation_store,
+        )
+
+    assert excinfo.value.code == "cycle_governance_required"
+
+    approved = model_service.promote_version(
+        model_id="vanilla_option_candidate",
+        version="v1",
+        to_status="approved",
+        actor="reviewer",
+        reason="manual_approval",
+        metadata={"cycle_report": _cycle_report()},
+        validation_store=validation_store,
+    )
+
+    transition = approved["version"]["transitions"][-1]
+    governance = transition["metadata"]["cycle_promotion_governance"]
+    assert approved["version"]["status"] == "approved"
+    assert governance["eligible"] is True
+    assert governance["cycle_report"]["request_id"] == "executor_model_candidate"

--- a/trellis/agent/cycle_governance.py
+++ b/trellis/agent/cycle_governance.py
@@ -1,0 +1,219 @@
+"""Promotion/adoption governance derived from stable agent cycle reports."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+_BLOCKING_BUCKETS = (
+    "deterministic_blockers",
+    "conceptual_blockers",
+    "calibration_blockers",
+)
+
+
+@dataclass(frozen=True)
+class CyclePromotionGovernance:
+    """Serializable promotion/adoption gate result for one cycle report."""
+
+    eligible: bool
+    decision: str
+    prerequisites: tuple[str, ...]
+    blockers: tuple[str, ...]
+    warnings: tuple[str, ...]
+    cycle_report: Mapping[str, Any]
+    adapter_lifecycle: Mapping[str, Any]
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON/YAML-safe governance artifact."""
+        return {
+            "eligible": self.eligible,
+            "decision": self.decision,
+            "prerequisites": list(self.prerequisites),
+            "blockers": list(self.blockers),
+            "warnings": list(self.warnings),
+            "cycle_report": dict(self.cycle_report),
+            "adapter_lifecycle": dict(self.adapter_lifecycle),
+        }
+
+
+def evaluate_cycle_promotion_governance(
+    cycle_report: Mapping[str, Any] | None,
+    *,
+    adapter_lifecycle: Mapping[str, Any] | None = None,
+    require_cycle_report: bool = True,
+) -> CyclePromotionGovernance:
+    """Evaluate whether a build cycle is eligible for promotion/adoption.
+
+    The function is deliberately deterministic and low-cardinality. It consumes
+    the stable ``cycle_report`` projection produced by platform traces rather
+    than parsing critic/model-validator prose.
+    """
+    report = dict(cycle_report or {}) if isinstance(cycle_report, Mapping) else {}
+    lifecycle_summary = _adapter_lifecycle_summary(adapter_lifecycle)
+    blockers: list[str] = []
+    warnings: list[str] = []
+    prerequisites = [
+        "cycle_report_present",
+        "cycle_success_true",
+        "no_failed_cycle_stages",
+        "no_blocking_cycle_buckets",
+    ]
+
+    if not report:
+        if require_cycle_report:
+            blockers.append("cycle_report_missing")
+        else:
+            warnings.append("cycle_report_missing")
+        return CyclePromotionGovernance(
+            eligible=not blockers,
+            decision="blocked" if blockers else "advisory",
+            prerequisites=tuple(prerequisites),
+            blockers=tuple(blockers),
+            warnings=tuple(warnings),
+            cycle_report={},
+            adapter_lifecycle=lifecycle_summary,
+        )
+
+    if report.get("success") is not True:
+        blockers.append("cycle_success_not_true")
+
+    stage_statuses = report.get("stage_statuses") or {}
+    if isinstance(stage_statuses, Mapping):
+        for stage, status in sorted(stage_statuses.items()):
+            if str(status or "").strip().lower() == "failed":
+                blockers.append(f"cycle_stage_failed:{stage}")
+    else:
+        warnings.append("cycle_stage_statuses_missing")
+
+    failure_count = _int_value(report.get("failure_count"))
+    if failure_count > 0:
+        blockers.append("cycle_failure_count_nonzero")
+
+    for bucket in _BLOCKING_BUCKETS:
+        count = _item_count(report.get(bucket))
+        if count:
+            blockers.append(f"{bucket}_present")
+
+    residual_risks = _string_list(report.get("residual_risks"))
+    if residual_risks:
+        warnings.append("residual_risks_present")
+    if _item_count(report.get("residual_limitations")):
+        warnings.append("residual_limitations_present")
+
+    lifecycle_counts = lifecycle_summary.get("status_counts") or {}
+    if isinstance(lifecycle_counts, Mapping):
+        for status in ("stale", "deprecated", "archived"):
+            count = _int_value(lifecycle_counts.get(status))
+            if count:
+                warnings.append(f"adapter_lifecycle_{status}:{count}")
+
+    blockers = _unique(blockers)
+    warnings = _unique(warnings)
+    return CyclePromotionGovernance(
+        eligible=not blockers,
+        decision="eligible" if not blockers else "blocked",
+        prerequisites=tuple(prerequisites),
+        blockers=tuple(blockers),
+        warnings=tuple(warnings),
+        cycle_report=_cycle_report_summary(report),
+        adapter_lifecycle=lifecycle_summary,
+    )
+
+
+def _cycle_report_summary(report: Mapping[str, Any]) -> dict[str, object]:
+    """Return the compact cycle fields promotion/adoption artifacts need."""
+    stage_statuses = report.get("stage_statuses") or {}
+    if not isinstance(stage_statuses, Mapping):
+        stage_statuses = {}
+    return {
+        "request_id": str(report.get("request_id") or ""),
+        "status": str(report.get("status") or ""),
+        "outcome": str(report.get("outcome") or ""),
+        "success": report.get("success"),
+        "pricing_method": str(report.get("pricing_method") or ""),
+        "validation_contract_id": str(report.get("validation_contract_id") or ""),
+        "stage_statuses": {str(key): str(value) for key, value in stage_statuses.items()},
+        "failure_count": _int_value(report.get("failure_count")),
+        "blocker_counts": {
+            bucket: _item_count(report.get(bucket))
+            for bucket in _BLOCKING_BUCKETS
+        },
+        "residual_limitations_count": _item_count(report.get("residual_limitations")),
+        "residual_risks": _string_list(report.get("residual_risks")),
+    }
+
+
+def _adapter_lifecycle_summary(lifecycle: Mapping[str, Any] | None) -> dict[str, object]:
+    """Extract low-cardinality adapter lifecycle state from review/adoption payloads."""
+    if not isinstance(lifecycle, Mapping):
+        return {
+            "status_counts": {},
+            "stale_adapter_ids": [],
+            "deprecated_adapter_ids": [],
+            "archived_adapter_ids": [],
+        }
+
+    summary = lifecycle.get("summary")
+    if not isinstance(summary, Mapping):
+        resolved = lifecycle.get("resolved")
+        if isinstance(resolved, Mapping):
+            summary = resolved.get("summary")
+    if not isinstance(summary, Mapping):
+        summary = lifecycle
+
+    status_counts = summary.get("status_counts") if isinstance(summary, Mapping) else {}
+    if not isinstance(status_counts, Mapping):
+        status_counts = {}
+    return {
+        "status_counts": {
+            str(key): _int_value(value)
+            for key, value in status_counts.items()
+        },
+        "stale_adapter_ids": _string_list(summary.get("stale_adapter_ids")),
+        "deprecated_adapter_ids": _string_list(summary.get("deprecated_adapter_ids")),
+        "archived_adapter_ids": _string_list(summary.get("archived_adapter_ids")),
+    }
+
+
+def _item_count(value: object) -> int:
+    if isinstance(value, Mapping):
+        return len(value)
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return len(value)
+    return 0
+
+
+def _int_value(value: object) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _string_list(value: object) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        values = [value]
+    elif isinstance(value, (list, tuple, set, frozenset)):
+        values = list(value)
+    else:
+        values = [value]
+    return _unique(str(item).strip() for item in values if str(item).strip())
+
+
+def _unique(values) -> list[str]:
+    result: list[str] = []
+    for value in values:
+        text = str(value or "").strip()
+        if text and text not in result:
+            result.append(text)
+    return result
+
+
+__all__ = [
+    "CyclePromotionGovernance",
+    "evaluate_cycle_promotion_governance",
+]

--- a/trellis/agent/knowledge/promotion.py
+++ b/trellis/agent/knowledge/promotion.py
@@ -21,6 +21,7 @@ from collections.abc import Mapping
 
 import yaml
 
+from trellis.agent.cycle_governance import evaluate_cycle_promotion_governance
 from trellis.agent.knowledge.import_registry import get_repo_revision
 from trellis.agent.knowledge.schema import (
     AdapterLifecycleRecord,
@@ -1246,6 +1247,58 @@ def summarize_adapter_lifecycle_records(
     return _serialize_adapter_lifecycle_summary(list(records))
 
 
+def _load_cycle_report_from_trace_path(trace_path: object) -> dict[str, object]:
+    """Load a persisted platform trace's cycle report when available."""
+    path_text = str(trace_path or "").strip()
+    if not path_text:
+        return {}
+    path = Path(path_text)
+    if not path.is_absolute():
+        path = _REPO_ROOT / path
+    if not path.is_file():
+        return {}
+    try:
+        payload = yaml.safe_load(path.read_text()) or {}
+    except Exception:
+        return {}
+    if not isinstance(payload, Mapping):
+        return {}
+    cycle_report = payload.get("cycle_report") or {}
+    return dict(cycle_report) if isinstance(cycle_report, Mapping) else {}
+
+
+def _cycle_report_from_candidate_data(data: Mapping[str, object]) -> dict[str, object]:
+    """Return the candidate's persisted cycle report, if any."""
+    for key in ("cycle_report", "cold_agent_cycle_report"):
+        value = data.get(key)
+        if isinstance(value, Mapping):
+            return dict(value)
+    benchmark_provenance = data.get("benchmark_provenance")
+    if isinstance(benchmark_provenance, Mapping):
+        value = benchmark_provenance.get("cycle_report") or benchmark_provenance.get(
+            "cold_agent_cycle_report"
+        )
+        if isinstance(value, Mapping):
+            return dict(value)
+    return {}
+
+
+def _cycle_report_from_benchmark_record(
+    benchmark_record: Mapping[str, object],
+) -> dict[str, object]:
+    """Return the benchmark run's agent cycle report, if the runner persisted it."""
+    for key in ("cold_agent_cycle_report", "cycle_report"):
+        value = benchmark_record.get(key)
+        if isinstance(value, Mapping):
+            return dict(value)
+    build_observability = benchmark_record.get("build_observability")
+    if isinstance(build_observability, Mapping):
+        value = build_observability.get("cycle_report")
+        if isinstance(value, Mapping):
+            return dict(value)
+    return {}
+
+
 def record_promotion_candidate(
     *,
     task_id: str,
@@ -1262,6 +1315,7 @@ def record_promotion_candidate(
     market_context: dict | None = None,
     cross_validation: dict | None = None,
     reference_target: bool = False,
+    cycle_report: Mapping[str, object] | None = None,
 ) -> str | None:
     """Persist a fresh-build candidate snapshot for later promotion review."""
     source = (code or "").strip()
@@ -1274,6 +1328,11 @@ def record_promotion_candidate(
     suffix = _safe_filename_fragment(comparison_target or preferred_method or "candidate")
     filename = f"{timestamp.strftime('%Y%m%d_%H%M%S')}_{task_id.lower()}_{suffix}.yaml"
     path = candidate_dir / filename
+    persisted_cycle_report = (
+        dict(cycle_report)
+        if isinstance(cycle_report, Mapping)
+        else _load_cycle_report_from_trace_path(platform_trace_path)
+    )
     payload = {
         "timestamp": timestamp.isoformat(),
         "task_id": task_id,
@@ -1288,6 +1347,7 @@ def record_promotion_candidate(
         "platform_request_id": platform_request_id,
         "platform_trace_path": platform_trace_path,
         "market_context": market_context or {},
+        "cycle_report": persisted_cycle_report,
         "cross_validation": cross_validation or {},
         "code_hash": hashlib.sha256(source.encode()).hexdigest()[:12],
         "code": source,
@@ -1352,6 +1412,7 @@ def record_benchmark_promotion_candidate(
         code_hash = record_artifact_hash
     else:
         code_hash = hashlib.sha256(source_bytes).hexdigest()
+    cycle_report = _cycle_report_from_benchmark_record(benchmark_record)
 
     # Dedup: if a previously emitted candidate for the same task already
     # carries the same `code_hash`, the generated artifact is byte-identical
@@ -1367,6 +1428,28 @@ def record_benchmark_promotion_candidate(
         if not isinstance(existing_payload, Mapping):
             continue
         if _hashes_equivalent(existing_payload.get("code_hash"), code_hash):
+            existing_cycle_report = existing_payload.get("cycle_report")
+            if cycle_report and (
+                not isinstance(existing_cycle_report, Mapping)
+                or not existing_cycle_report
+            ):
+                updated_payload = dict(existing_payload)
+                updated_payload["cycle_report"] = cycle_report
+                provenance = updated_payload.get("benchmark_provenance") or {}
+                if isinstance(provenance, Mapping):
+                    provenance = dict(provenance)
+                else:
+                    provenance = {}
+                provenance["cycle_report"] = cycle_report
+                updated_payload["benchmark_provenance"] = provenance
+                with open(existing_path, "w") as handle:
+                    yaml.safe_dump(
+                        _yaml_safe_data(updated_payload),
+                        handle,
+                        default_flow_style=False,
+                        sort_keys=False,
+                        allow_unicode=True,
+                    )
             return str(existing_path)
 
     filename = (
@@ -1404,6 +1487,7 @@ def record_benchmark_promotion_candidate(
         "market_context": {
             "market_scenario_id": str(benchmark_record.get("market_scenario_id") or ""),
         },
+        "cycle_report": cycle_report,
         "generated_artifact": generated_artifact,
         "benchmark_provenance": {
             "benchmark_kind": "financepy",
@@ -1416,6 +1500,7 @@ def record_benchmark_promotion_candidate(
             "status": str(benchmark_record.get("status") or ""),
             "comparison_summary": dict(benchmark_record.get("comparison_summary") or {}),
             "generated_artifact": generated_artifact,
+            "cycle_report": cycle_report,
         },
         "code_hash": code_hash,
         "code": source,
@@ -1747,6 +1832,9 @@ def promote_benchmark_candidate(
         "code_hash": computed_hash,
         "review_status": str(review.get("status") or ""),
         "review_path": str(review.get("review_path") or ""),
+        "cycle_promotion_governance": dict(
+            review.get("cycle_promotion_governance") or {}
+        ),
     }
 
     if not dry_run:
@@ -2141,8 +2229,44 @@ def review_promotion_candidate(
                 ),
             ]
         )
+    base_approved = all(check["passed"] for check in checks if check["blocking"])
+    adapter_lifecycle_stage = "deprecated" if base_approved else "stale"
+    adapter_lifecycle_snapshot = _adapter_lifecycle_snapshot(
+        adapter_records,
+        stage=adapter_lifecycle_stage,
+        adapter_id=recommended_module_path,
+        replacement=module_path,
+        repo_revision=adapter_repo_revision,
+    )
+    cycle_governance = evaluate_cycle_promotion_governance(
+        _cycle_report_from_candidate_data(data),
+        adapter_lifecycle=adapter_lifecycle_snapshot,
+    ).to_dict()
+    checks.append(
+        _review_check(
+            "cycle_promotion_governance",
+            bool(cycle_governance.get("eligible")),
+            "agent cycle report is promotion-eligible",
+            failure_detail=(
+                "agent cycle report is not promotion-eligible: "
+                + ", ".join(str(item) for item in cycle_governance.get("blockers", ()))
+            ),
+        )
+    )
     approved = all(check["passed"] for check in checks if check["blocking"])
-    adapter_lifecycle_stage = "deprecated" if approved else "stale"
+    if not approved and adapter_lifecycle_stage != "stale":
+        adapter_lifecycle_stage = "stale"
+        adapter_lifecycle_snapshot = _adapter_lifecycle_snapshot(
+            adapter_records,
+            stage=adapter_lifecycle_stage,
+            adapter_id=recommended_module_path,
+            replacement=module_path,
+            repo_revision=adapter_repo_revision,
+        )
+        cycle_governance = evaluate_cycle_promotion_governance(
+            _cycle_report_from_candidate_data(data),
+            adapter_lifecycle=adapter_lifecycle_snapshot,
+        ).to_dict()
     review = {
         "timestamp": datetime.now().isoformat(),
         "candidate_path": str(path),
@@ -2159,13 +2283,8 @@ def review_promotion_candidate(
         "status": "approved" if approved else "rejected",
         "approved": approved,
         "checks": checks,
-        "adapter_lifecycle": _adapter_lifecycle_snapshot(
-            adapter_records,
-            stage=adapter_lifecycle_stage,
-            adapter_id=recommended_module_path,
-            replacement=module_path,
-            repo_revision=adapter_repo_revision,
-        ),
+        "adapter_lifecycle": adapter_lifecycle_snapshot,
+        "cycle_promotion_governance": cycle_governance,
     }
     if persist:
         review["review_path"] = _record_promotion_review(review)
@@ -2213,6 +2332,9 @@ def adopt_promotion_candidate(
     existing_text = recommended_file.read_text() if recommended_file.exists() else ""
     existing_hash = hashlib.sha256(existing_text.encode()).hexdigest()[:12] if existing_text else ""
     previous_exists = recommended_file.exists()
+    review_cycle_governance = review.get("cycle_promotion_governance") or {}
+    if not isinstance(review_cycle_governance, Mapping):
+        review_cycle_governance = {}
     checks = [
         _review_check(
             "review_exists",
@@ -2225,6 +2347,12 @@ def adopt_promotion_candidate(
             bool(review.get("approved")),
             "review approved the candidate for adoption",
             failure_detail="review is not approved",
+        ),
+        _review_check(
+            "cycle_promotion_governance_eligible",
+            bool(review_cycle_governance.get("eligible")),
+            "review includes an eligible agent-cycle promotion governance artifact",
+            failure_detail="review is missing an eligible agent-cycle promotion governance artifact",
         ),
         _review_check(
             "candidate_exists",
@@ -2277,6 +2405,18 @@ def adopt_promotion_candidate(
     if adopted:
         recommended_file.parent.mkdir(parents=True, exist_ok=True)
         recommended_file.write_text(normalized_source)
+    adapter_lifecycle_snapshot = _adapter_lifecycle_snapshot(
+        adapter_raw_records,
+        stage=adapter_lifecycle_stage,
+        adapter_id=str(review.get("recommended_module_path") or ""),
+        replacement=str(review.get("module_path") or ""),
+        repo_revision=adapter_repo_revision,
+    )
+    adoption_cycle_governance = evaluate_cycle_promotion_governance(
+        _cycle_report_from_candidate_data(candidate)
+        or review_cycle_governance.get("cycle_report"),
+        adapter_lifecycle=adapter_lifecycle_snapshot,
+    ).to_dict()
     adoption = {
         "timestamp": datetime.now().isoformat(),
         "review_path": str(path),
@@ -2293,13 +2433,8 @@ def adopt_promotion_candidate(
         "previous_code_hash": existing_hash or None,
         "adopted_code_hash": snapshot_hash or None,
         "checks": checks,
-        "adapter_lifecycle": _adapter_lifecycle_snapshot(
-            adapter_raw_records,
-            stage=adapter_lifecycle_stage,
-            adapter_id=str(review.get("recommended_module_path") or ""),
-            replacement=str(review.get("module_path") or ""),
-            repo_revision=adapter_repo_revision,
-        ),
+        "adapter_lifecycle": adapter_lifecycle_snapshot,
+        "cycle_promotion_governance": adoption_cycle_governance,
     }
     if persist:
         adoption["adoption_path"] = _record_promotion_adoption(adoption)

--- a/trellis/agent/request_issue_format.py
+++ b/trellis/agent/request_issue_format.py
@@ -101,7 +101,14 @@ def build_issue_body(
         if details:
             lines.extend(["", "## Trigger Details"])
             for key in sorted(details):
+                if key in {"cycle_report", "cycle_promotion_governance"}:
+                    continue
                 lines.append(f"- {key}: `{details[key]}`")
+
+    cycle_lines = _cycle_report_lines(trace, event_record)
+    if cycle_lines:
+        lines.extend(["", "## Cycle Report"])
+        lines.extend(cycle_lines)
 
     description = (request.description or "").strip()
     if description:
@@ -160,7 +167,14 @@ def build_event_comment(
 
     details = event_record.get("details") or {}
     for key in sorted(details):
+        if key in {"cycle_report", "cycle_promotion_governance"}:
+            continue
         lines.append(f"- {key}: `{details[key]}`")
+
+    cycle_lines = _cycle_report_lines(trace, event_record)
+    if cycle_lines:
+        lines.extend(["", "## Cycle Report"])
+        lines.extend(cycle_lines)
 
     outcome = trace.get("outcome")
     if outcome:
@@ -272,6 +286,100 @@ def _metadata_value(compiled_request, trace: dict[str, Any] | None, key: str) ->
         if isinstance(metadata, Mapping):
             return metadata.get(key)
     return None
+
+
+def _cycle_report_lines(
+    trace: dict[str, Any],
+    event_record: dict[str, Any] | None,
+) -> list[str]:
+    cycle_report = _nested_mapping(trace, event_record, "cycle_report")
+    governance = _nested_mapping(trace, event_record, "cycle_promotion_governance")
+    if not cycle_report and not governance:
+        return []
+
+    lines: list[str] = []
+    if cycle_report:
+        lines.append(f"- cycle_success: `{cycle_report.get('success')}`")
+        if cycle_report.get("status"):
+            lines.append(f"- cycle_status: `{cycle_report.get('status')}`")
+        if cycle_report.get("outcome"):
+            lines.append(f"- cycle_outcome: `{cycle_report.get('outcome')}`")
+        if cycle_report.get("pricing_method"):
+            lines.append(f"- pricing_method: `{cycle_report.get('pricing_method')}`")
+        if cycle_report.get("validation_contract_id"):
+            lines.append(
+                f"- validation_contract_id: `{cycle_report.get('validation_contract_id')}`"
+            )
+        stage_statuses = cycle_report.get("stage_statuses") or {}
+        if isinstance(stage_statuses, Mapping) and stage_statuses:
+            rendered = ", ".join(
+                f"{key}={stage_statuses[key]}" for key in sorted(stage_statuses)
+            )
+            lines.append(f"- cycle_stage_statuses: `{rendered}`")
+        for bucket in (
+            "deterministic_blockers",
+            "conceptual_blockers",
+            "calibration_blockers",
+            "residual_limitations",
+        ):
+            count = _count_items(cycle_report.get(bucket))
+            if count:
+                lines.append(f"- {bucket}: `{count}`")
+        residual_risks = _string_values(cycle_report.get("residual_risks"))
+        if residual_risks:
+            lines.append(f"- residual_risks: `{', '.join(residual_risks)}`")
+
+    if governance:
+        if "eligible" in governance:
+            lines.append(f"- promotion_eligible: `{governance.get('eligible')}`")
+        if governance.get("decision"):
+            lines.append(f"- promotion_decision: `{governance.get('decision')}`")
+        blockers = _string_values(governance.get("blockers"))
+        if blockers:
+            lines.append(f"- promotion_blockers: `{', '.join(blockers)}`")
+        warnings = _string_values(governance.get("warnings"))
+        if warnings:
+            lines.append(f"- promotion_warnings: `{', '.join(warnings)}`")
+    return lines
+
+
+def _nested_mapping(
+    trace: dict[str, Any],
+    event_record: dict[str, Any] | None,
+    key: str,
+) -> dict[str, Any]:
+    details = {}
+    if event_record is not None:
+        raw_details = event_record.get("details") or {}
+        if isinstance(raw_details, Mapping):
+            details = raw_details
+    value = details.get(key)
+    if isinstance(value, Mapping):
+        return dict(value)
+    value = trace.get(key)
+    if isinstance(value, Mapping):
+        return dict(value)
+    return {}
+
+
+def _count_items(value: object) -> int:
+    if isinstance(value, Mapping):
+        return len(value)
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return len(value)
+    return 0
+
+
+def _string_values(value: object) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        values = [value]
+    elif isinstance(value, (list, tuple, set, frozenset)):
+        values = list(value)
+    else:
+        values = [value]
+    return [str(item).strip() for item in values if str(item).strip()]
 
 
 def _compact(text: object, limit: int) -> str:

--- a/trellis/agent/task_runtime.py
+++ b/trellis/agent/task_runtime.py
@@ -1028,6 +1028,9 @@ def _trace_observability(trace_path: str | None) -> dict[str, Any]:
         "trace_status": trace.get("status"),
         "trace_outcome": trace.get("outcome"),
     }
+    cycle_report = trace.get("cycle_report")
+    if isinstance(cycle_report, dict):
+        observability["cycle_report"] = cycle_report
     details = dict(trace.get("details") or {})
     candidates: list[dict[str, Any]] = [details]
     for item in trace.get("events", []):

--- a/trellis/platform/services/model_service.py
+++ b/trellis/platform/services/model_service.py
@@ -228,6 +228,7 @@ class ModelService:
         validation_store=None,
     ) -> dict[str, object]:
         """Apply one explicit governed lifecycle transition to a stored version."""
+        from trellis.agent.cycle_governance import evaluate_cycle_promotion_governance
         from trellis.mcp.errors import TrellisMcpError
 
         current = self.registry.get_version(model_id, version)
@@ -268,6 +269,41 @@ class ModelService:
                     details={"model_id": model_id, "version": version, "to_status": normalized_status.value},
                 )
 
+        transition_metadata = dict(metadata or {})
+        if normalized_status is ModelLifecycleStatus.APPROVED:
+            supplied_governance = transition_metadata.get("cycle_promotion_governance")
+            supplied_report = transition_metadata.get("cycle_report")
+            if isinstance(supplied_governance, Mapping) and not isinstance(supplied_report, Mapping):
+                maybe_report = supplied_governance.get("cycle_report")
+                if isinstance(maybe_report, Mapping):
+                    supplied_report = maybe_report
+            governance = evaluate_cycle_promotion_governance(
+                supplied_report if isinstance(supplied_report, Mapping) else None,
+            ).to_dict()
+            if not bool(governance.get("eligible")):
+                raise TrellisMcpError(
+                    code="cycle_governance_required",
+                    message=(
+                        "Lifecycle transition to 'approved' requires an eligible "
+                        "agent cycle report with no blocking deterministic, "
+                        "conceptual, or calibration outcomes."
+                    ),
+                    details={
+                        "model_id": model_id,
+                        "version": version,
+                        "to_status": normalized_status.value,
+                        "cycle_promotion_governance": governance,
+                    },
+                )
+            transition_metadata["cycle_promotion_governance"] = governance
+        elif isinstance(transition_metadata.get("cycle_report"), Mapping):
+            transition_metadata["cycle_promotion_governance"] = (
+                evaluate_cycle_promotion_governance(
+                    transition_metadata.get("cycle_report"),
+                    require_cycle_report=False,
+                ).to_dict()
+            )
+
         try:
             updated = self.registry.transition_version(
                 model_id,
@@ -276,7 +312,7 @@ class ModelService:
                 actor=actor,
                 reason=reason,
                 notes=notes,
-                metadata=metadata,
+                metadata=transition_metadata,
             )
         except Exception as exc:
             raise TrellisMcpError(


### PR DESCRIPTION
## Summary
- add shared cycle promotion-governance evaluator over stable cycle reports
- persist cycle-governance artifacts through adapter promotion review, benchmark admission, and adoption
- require eligible cycle governance before governed MCP model approval
- render compact cycle-report/governance fields in audit comments

## Validation
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_promotion_candidates.py tests/test_agent/test_promote_benchmark_candidate.py tests/test_agent/test_request_issue_format.py tests/test_platform/test_model_service.py tests/test_mcp/test_model_lifecycle_tools.py tests/test_mcp/test_model_store_tools.py tests/test_mcp/test_resources.py -q`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_promotion_candidates.py tests/test_agent/test_promote_benchmark_candidate.py tests/test_agent/test_request_issue_format.py tests/test_agent/test_platform_traces.py tests/test_platform/test_model_service.py tests/test_platform/test_model_execution_gate.py tests/test_mcp/test_model_lifecycle_tools.py tests/test_mcp/test_model_store_tools.py tests/test_mcp/test_resources.py tests/test_mcp/test_model_match_service.py -q`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_knowledge_store.py -q`
- `/Users/steveyang/miniforge3/bin/python3 scripts/remediate.py --analyze-only`
- `PYTHON=/Users/steveyang/miniforge3/bin/python3 make gate-pr`