### PR TITLE
Update QUA-977 execution plan mirror

### DIFF
--- a/doc/plan/draft__contract-execution-ir-and-visitor-framework.md
+++ b/doc/plan/draft__contract-execution-ir-and-visitor-framework.md
@@ -39,7 +39,7 @@ implementation sequencing.
 
 ## Linear Ticket Mirror
 
-Status mirror last synced: `2026-04-28`.
+Status mirror last synced: `2026-05-01`.
 
 Umbrella:
 
@@ -52,7 +52,7 @@ Implementation queue:
 | Order | Ticket | Status | Objective | Hard blocker |
 | --- | --- | --- | --- | --- |
 | 1 | `QUA-976` | Done | XIR.0 - execution seam and authority boundary | none |
-| 2 | `QUA-977` | Backlog | XIR.1 - static-leg execution visitors and repricing slice | `QUA-976` |
+| 2 | `QUA-977` | Done | XIR.1 - static-leg execution visitors and repricing slice | `QUA-976` |
 | 3 | `QUA-978` | Backlog | XIR.2 - execution-backed payoff and adapter migration | `QUA-977` |
 | 4 | `QUA-979` | Backlog | XIR.3 - dynamic execution bridge for callable structures | `QUA-978` |
 | 5 | `QUA-980` | Backlog | XIR.4 - simulation and future-value bridge | `QUA-979` |


### PR DESCRIPTION
## Summary
- mark QUA-977 Done in the execution IR plan mirror after Linear closeout
- update the mirror sync date to 2026-05-01

## Validation
- Documentation mirror only; QUA-977 implementation validation is in PR #703.