### PR TITLE
Harden task evaluation loop persistence

### DIFF
--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -65,7 +65,7 @@ The repo ships a small task-operations toolchain:
 - ``scripts/run_financepy_benchmark.py``: run the FinancePy parity corpus with timestamped run-history persistence
 - ``scripts/run_negative_benchmark.py``: run the clarification / honest-block corpus with timestamped run-history persistence
 - ``scripts/run_benchmark_history_scorecard.py``: build a repeated-run scorecard from append-only FinancePy or negative benchmark history
-- ``scripts/remediate.py``: analyze failures, categorize knowledge gaps, and patch common knowledge issues
+- ``scripts/remediate.py``: analyze failures from the latest canonical task-run surface by default, or inspect root-level ``task_results_*.json`` tranches with ``--source tranches``
 - ``scripts/evaluate_shared_memory.py``: compare two task-result tranches and render a shared-memory improvement report
 - ``scripts/should_run_canary.py``: decide whether current local changes justify the focused core canary gate
 - ``scripts/test_hygiene.py``: report stale skip/xfail/quarantine markers for local test-hygiene triage
@@ -185,6 +185,10 @@ under ``task_runs/financepy_benchmarks/`` with explicit ``run_started_at`` and
 knowledge, and campaign revisions. The runner also emits a repeated-run
 scorecard from the matching append-only history slice.
 
+Those benchmark runs now keep any per-task run/diagnosis packets under an
+isolated local store at ``task_runs/financepy_benchmarks/task_run_records/``
+instead of rewriting the repo-wide canonical ``task_runs/latest`` surface.
+
 Those repeated-run scorecards now include an ``agent_cycle`` block derived from
 the same product-facing cycle surface returned by task results. The aggregate
 tracks cycle-report availability, pass/fail/incomplete counts, stage trigger
@@ -196,7 +200,9 @@ monitoring API.
 Negative-task benchmark runs do the same under
 ``task_runs/negative_benchmarks/`` so clarification and honest-block behavior
 can be tracked across repeated library and knowledge updates, again with a
-scorecard generated from append-only history.
+scorecard generated from append-only history. Their per-task run packets now
+live under ``task_runs/negative_benchmarks/task_run_records/`` for the same
+reason.
 
 Every canary batch now also writes a dedicated aggregate telemetry record under
 ``task_runs/canary_batches/``:
@@ -233,7 +239,9 @@ Use those loaders, not ad hoc scans over ``task_runs/history/``, when you want
 to compare canary latency, token, or attempt trends over time. The batch store
 excludes ordinary ad hoc task runs by construction and can filter replay-backed
 history out of the benchmark view. Root-level pytest runs are also marked as
-synthetic so they do not become accidental benchmark baselines.
+synthetic so they do not become accidental benchmark baselines, and synthetic
+pytest batches no longer rewrite the stable ``task_runs/canary_batches/latest``
+comparison files.
 
 To compare against the ``2026-04-09`` full curated rerun baseline, treat that
 date's documented ``14/14`` pass as the historical anchor and compare fresh
@@ -308,6 +316,8 @@ Each pass writes:
 - a raw task-result file under ``task_runs/learning_benchmarks/raw/``
 - a pass summary JSON beside that raw file
 - a Markdown plus JSON scorecard under ``task_runs/learning_benchmarks/reports/``
+- an isolated per-pass task-run ledger under
+  ``task_runs/learning_benchmarks/task_run_records/``
 
 The scorecard reports:
 

--- a/scripts/remediate.py
+++ b/scripts/remediate.py
@@ -2,11 +2,12 @@
 
 Usage:
     python scripts/remediate.py                   # analyze + fix + re-run
-    python scripts/remediate.py --analyze-only     # just show what's wrong
+    python scripts/remediate.py --analyze-only    # just show what's wrong
 """
 
 from __future__ import annotations
 
+import argparse
 import json
 import sys
 from collections import Counter
@@ -15,9 +16,34 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT))
 
+from trellis.agent.task_run_store import load_latest_task_run_records
 
-def load_all_results() -> list[dict]:
-    """Load all task result files."""
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--analyze-only", action="store_true")
+    parser.add_argument(
+        "--source",
+        choices=("latest", "tranches"),
+        default="latest",
+        help="Select canonical latest task runs or root-level task_results tranches.",
+    )
+    return parser.parse_args(argv)
+
+
+def load_all_results(*, source: str = "latest") -> list[dict]:
+    """Load concrete task results from the selected evidence source."""
+    if source == "latest":
+        results = []
+        for record in load_latest_task_run_records(root=ROOT):
+            payload = record.get("result")
+            if _is_result_record(payload):
+                results.append(dict(payload))
+        return results
+
+    if source != "tranches":
+        raise ValueError(f"Unsupported remediation results source: {source}")
+
     results = []
     for f in sorted(ROOT.glob("task_results_*.json")):
         with open(f) as fh:
@@ -524,10 +550,10 @@ def rerun_failed(results: list[dict], model: str = "gpt-5.4-mini"):
 
 
 def main():
-    analyze_only = "--analyze-only" in sys.argv
+    args = _parse_args(sys.argv[1:])
 
     print("Loading results...")
-    results = load_all_results()
+    results = load_all_results(source=args.source)
     if not results:
         print("No results found. Run tasks first.")
         return
@@ -538,7 +564,7 @@ def main():
     categories = analyze_failures(results)
     print_analysis(categories)
 
-    if analyze_only:
+    if args.analyze_only:
         return
 
     print(f"\n{'='*60}")

--- a/scripts/run_financepy_benchmark.py
+++ b/scripts/run_financepy_benchmark.py
@@ -155,6 +155,7 @@ def _execute_single_benchmark_task(
         requested_policy=args.execution_policy,
     )
     fresh_generated = execution_policy == "fresh_generated"
+    task_run_storage_root = output_root / "task_run_records"
     cold_result = run_task(
         task,
         market_state,
@@ -162,6 +163,8 @@ def _execute_single_benchmark_task(
         force_rebuild=args.force_rebuild,
         fresh_build=fresh_generated,
         validation=args.validation,
+        task_run_storage_root=task_run_storage_root,
+        task_run_storage_layout="standalone",
     )
     warm_result: dict[str, Any] | None = None
     financepy_result: dict[str, Any] | None = None

--- a/scripts/run_negative_benchmark.py
+++ b/scripts/run_negative_benchmark.py
@@ -94,6 +94,7 @@ def main(argv: list[str] | None = None) -> int:
     campaign_id = str(args.campaign_id or args.report_name).strip()
     market_state = build_market_state()
     benchmark_runs: list[dict[str, object]] = []
+    task_run_storage_root = output_root / "task_run_records"
 
     for task in tasks:
         run_started_at = datetime.now(timezone.utc).isoformat()
@@ -103,6 +104,8 @@ def main(argv: list[str] | None = None) -> int:
             model=args.model,
             force_rebuild=True,
             validation=args.validation,
+            task_run_storage_root=task_run_storage_root,
+            task_run_storage_layout="standalone",
         )
         evaluation = evaluate_negative_task_result(task, result)
         run_completed_at = datetime.now(timezone.utc).isoformat()

--- a/scripts/run_task_learning_benchmark.py
+++ b/scripts/run_task_learning_benchmark.py
@@ -171,6 +171,7 @@ def run_learning_benchmark(
             pass_number=pass_number,
             fresh_build=fresh_build,
             knowledge_light=knowledge_light,
+            task_run_storage_root=output_root / "task_run_records" / label,
         )
         output_path.write_text(json.dumps(results, indent=2, default=str))
         summary = summarize_task_results(results)
@@ -234,6 +235,7 @@ def _run_learning_pass(
     pass_number: int,
     fresh_build: bool,
     knowledge_light: bool,
+    task_run_storage_root: Path,
 ) -> list[dict[str, Any]]:
     market_state = build_market_state()
     results: list[dict[str, Any]] = []
@@ -248,6 +250,8 @@ def _run_learning_pass(
             fresh_build=fresh_build,
             knowledge_profile="knowledge_light" if knowledge_light else None,
             validation=validation,
+            task_run_storage_root=task_run_storage_root,
+            task_run_storage_layout="standalone",
         )
         payload = dict(result)
         payload["learning_benchmark_name"] = benchmark_name

--- a/tests/test_agent/test_remediate.py
+++ b/tests/test_agent/test_remediate.py
@@ -37,11 +37,37 @@ def test_load_all_results_handles_list_and_summary_index_formats(tmp_path, monke
 
     monkeypatch.setattr(remediate, "ROOT", tmp_path)
 
-    results = remediate.load_all_results()
+    results = remediate.load_all_results(source="tranches")
 
     assert [r["task_id"] for r in results] == ["T001", "T002", "T100", "T101"]
     assert all(isinstance(r, dict) for r in results)
     assert all("success" in r for r in results)
+
+
+def test_load_all_results_defaults_to_latest_canonical_runs(monkeypatch):
+    monkeypatch.setattr(
+        remediate,
+        "load_latest_task_run_records",
+        lambda *, root: [
+            {
+                "task_id": "T013",
+                "result": {"task_id": "T013", "success": True, "failures": []},
+            },
+            {
+                "task_id": "T014",
+                "result": {"task_id": "T014", "success": False, "failures": ["boom"]},
+            },
+            {
+                "task_id": "summary_only",
+                "result": {"note": "not a task result"},
+            },
+        ],
+    )
+
+    results = remediate.load_all_results()
+
+    assert [r["task_id"] for r in results] == ["T013", "T014"]
+    assert [r["success"] for r in results] == [True, False]
 
 
 def test_analyze_failures_uses_nested_method_failure_text():

--- a/tests/test_agent/test_task_run_store.py
+++ b/tests/test_agent/test_task_run_store.py
@@ -874,6 +874,81 @@ def test_persist_canary_batch_record_writes_history_and_latest_views(tmp_path):
     )
 
 
+def test_persist_task_run_record_appends_on_run_id_collision(tmp_path):
+    from trellis.agent.task_run_store import load_task_run_record, persist_task_run_record
+
+    task = {"id": "T13", "title": "European call: theta-method convergence order"}
+    first = persist_task_run_record(
+        task,
+        {
+            "task_id": "T13",
+            "title": task["title"],
+            "success": True,
+            "start_time": "2026-03-24T12:00:00",
+            "elapsed_seconds": 1.0,
+            "reflection": {},
+        },
+        root=tmp_path,
+        persisted_at=datetime(2026, 4, 10, 12, 0, tzinfo=timezone.utc),
+    )
+    second = persist_task_run_record(
+        task,
+        {
+            "task_id": "T13",
+            "title": task["title"],
+            "success": False,
+            "start_time": "2026-03-24T12:00:00",
+            "error": "rerun changed the outcome",
+            "elapsed_seconds": 2.0,
+            "reflection": {},
+        },
+        root=tmp_path,
+        persisted_at=datetime(2026, 4, 10, 12, 5, tzinfo=timezone.utc),
+    )
+
+    assert first["history_path"] != second["history_path"]
+    assert Path(first["history_path"]).exists()
+    assert Path(second["history_path"]).exists()
+
+    first_record = load_task_run_record(first["history_path"])
+    second_record = load_task_run_record(second["history_path"])
+    latest_record = load_task_run_record(second["latest_path"])
+
+    assert first_record["summary"]["success"] is True
+    assert second_record["summary"]["success"] is False
+    assert first_record["run_id"] == "20260324T120000"
+    assert second_record["run_id"].startswith("20260324T120000__")
+    assert latest_record["summary"]["success"] is False
+
+
+def test_persist_task_run_record_supports_standalone_storage_layout(tmp_path):
+    from trellis.agent.task_run_store import persist_task_run_record
+
+    persisted = persist_task_run_record(
+        {"id": "T13", "title": "European call: theta-method convergence order"},
+        {
+            "task_id": "T13",
+            "title": "European call: theta-method convergence order",
+            "success": True,
+            "start_time": "2026-03-24T12:00:00",
+            "reflection": {},
+        },
+        root=tmp_path,
+        storage_layout="standalone",
+        persisted_at=datetime(2026, 4, 10, 12, 0, tzinfo=timezone.utc),
+    )
+
+    assert persisted["history_path"] == str(tmp_path / "history" / "T13" / "20260324T120000.json")
+    assert persisted["latest_path"] == str(tmp_path / "latest" / "T13.json")
+    assert persisted["latest_index_path"] == str(tmp_path / "task_results_latest.json")
+    assert persisted["diagnosis_packet_path"] == str(tmp_path / "diagnostics" / "history" / "T13" / "20260324T120000.json")
+    assert persisted["latest_diagnosis_packet_path"] == str(tmp_path / "diagnostics" / "latest" / "T13.json")
+    assert Path(persisted["history_path"]).exists()
+    assert Path(persisted["latest_path"]).exists()
+    assert Path(persisted["diagnosis_packet_path"]).exists()
+    assert Path(persisted["latest_diagnosis_packet_path"]).exists()
+
+
 def test_load_canary_task_history_excludes_replay_runs_from_benchmark_view(tmp_path):
     from trellis.agent.task_run_store import (
         load_canary_task_history,
@@ -936,6 +1011,45 @@ def test_load_canary_task_history_excludes_replay_runs_from_benchmark_view(tmp_p
     assert len(benchmark_history) == 1
     assert benchmark_history[0]["execution_mode"] == "live"
     assert benchmark_history[0]["benchmark_eligible"] is True
+
+
+def test_persist_canary_batch_record_skips_latest_view_for_synthetic_batches(monkeypatch, tmp_path):
+    from trellis.agent.task_run_store import persist_canary_batch_record
+
+    monkeypatch.setattr(
+        "trellis.agent.task_run_store._synthetic_canary_source",
+        lambda root: "pytest",
+    )
+
+    persisted = persist_canary_batch_record(
+        canaries=[{"id": "T13", "engine_family": "pde", "complexity": "simple"}],
+        meta={"version": 3},
+        results=[
+            {
+                "task_id": "T13",
+                "canary_id": "T13",
+                "success": True,
+                "elapsed_seconds": 4.0,
+                "attempts": 2,
+                "token_usage_summary": {"total_tokens": 300},
+            }
+        ],
+        model="gpt-5.4-mini",
+        validation="standard",
+        knowledge_light=False,
+        replay=False,
+        requested_task_id=None,
+        requested_subset=None,
+        root=tmp_path,
+        started_at=datetime(2026, 4, 10, 12, 0, tzinfo=timezone.utc),
+        finished_at=datetime(2026, 4, 10, 12, 1, tzinfo=timezone.utc),
+    )
+
+    assert Path(persisted["history_path"]).exists()
+    assert persisted["latest_path"].endswith(
+        "/task_runs/canary_batches/latest/live__full_curated__standard__default__gpt-5.4-mini.json"
+    )
+    assert not Path(persisted["latest_path"]).exists()
 
 
 def test_collect_trace_summaries_reads_analytical_trace_json(tmp_path):

--- a/tests/test_agent/test_task_runtime.py
+++ b/tests/test_agent/test_task_runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import date, datetime
+from pathlib import Path
 from types import ModuleType, SimpleNamespace
 import sys
 
@@ -824,7 +825,7 @@ def test_run_task_persists_latest_record(monkeypatch):
     def fake_build(**kwargs):
         return FakeResult()
 
-    def fake_persist(task, result):
+    def fake_persist(task, result, *, root, storage_layout, persisted_at=None):
         persisted["task"] = task
         persisted["result"] = dict(result)
         return {
@@ -915,7 +916,7 @@ def test_run_task_marks_cassette_replay_runs_and_persists_metadata(monkeypatch, 
         seen["llm_text"] = critic.llm_generate(prompt)
         return FakeResult()
 
-    def fake_persist(task, result):
+    def fake_persist(task, result, *, root, storage_layout, persisted_at=None):
         persisted["task"] = task
         persisted["result"] = dict(result)
         return {
@@ -961,6 +962,64 @@ def test_run_task_marks_cassette_replay_runs_and_persists_metadata(monkeypatch, 
     assert persisted["result"]["llm_cassette"]["path"] == str(cassette_path)
     assert result["task_diagnosis_packet_path"] == "/tmp/task_runs/diagnostics/history/T13/run.json"
     assert result["task_diagnosis_dossier_path"] == "/tmp/task_runs/diagnostics/history/T13/run.md"
+
+
+def test_run_task_forwards_isolated_task_run_storage(monkeypatch):
+    from trellis.agent.task_runtime import run_task
+
+    persisted: dict[str, object] = {}
+
+    class FakeResult:
+        success = True
+        attempts = 1
+        gap_confidence = 0.8
+        knowledge_gaps = []
+        payoff_cls = type("FakePayoff", (), {})
+        failures = []
+        reflection = {}
+
+    def fake_build(**kwargs):
+        return FakeResult()
+
+    def fake_persist(task, result, *, root, storage_layout, persisted_at=None):
+        persisted["task"] = task
+        persisted["result"] = dict(result)
+        persisted["root"] = root
+        persisted["storage_layout"] = storage_layout
+        return {
+            "history_path": "/tmp/task_run_records/history/T13/run.json",
+            "latest_path": "/tmp/task_run_records/latest/T13.json",
+            "latest_index_path": "/tmp/task_run_records/task_results_latest.json",
+            "diagnosis_packet_path": "/tmp/task_run_records/diagnostics/history/T13/run.json",
+            "diagnosis_dossier_path": "/tmp/task_run_records/diagnostics/history/T13/run.md",
+            "latest_diagnosis_packet_path": "/tmp/task_run_records/diagnostics/latest/T13.json",
+            "latest_diagnosis_dossier_path": "/tmp/task_run_records/diagnostics/latest/T13.md",
+            "diagnosis_headline": "Demo task completed successfully.",
+            "diagnosis_failure_bucket": "success",
+            "diagnosis_decision_stage": "completed",
+            "diagnosis_next_action": "No action required.",
+            "diagnosis_persist_error": "",
+            "diagnosis_persist_skipped": "",
+        }
+
+    monkeypatch.setattr(
+        "trellis.agent.task_run_store.persist_task_run_record",
+        fake_persist,
+    )
+
+    isolated_root = Path("/tmp/task_run_records")
+    result = run_task(
+        {"id": "T13", "title": "European call: theta-method convergence order"},
+        market_state=object(),
+        build_fn=fake_build,
+        task_run_storage_root=isolated_root,
+        task_run_storage_layout="standalone",
+    )
+
+    assert persisted["task"]["id"] == "T13"
+    assert persisted["root"] == isolated_root
+    assert persisted["storage_layout"] == "standalone"
+    assert result["task_run_latest_path"] == "/tmp/task_run_records/latest/T13.json"
 
 
 def test_run_task_uses_single_construct_as_preferred_method():

--- a/trellis/agent/task_diagnostics.py
+++ b/trellis/agent/task_diagnostics.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Mapping, Literal
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -417,6 +417,7 @@ def save_task_diagnosis_artifacts(
     record: Mapping[str, Any],
     *,
     root: Path = ROOT,
+    storage_layout: Literal["repo", "standalone"] = "repo",
 ) -> TaskDiagnosisArtifacts:
     """Persist a packet and dossier alongside the run record."""
     packet = build_task_diagnosis_packet(record)
@@ -427,8 +428,15 @@ def save_task_diagnosis_artifacts(
     if not run_id:
         raise ValueError("run_id is required to persist diagnosis artifacts")
 
-    history_root = root / "task_runs" / "diagnostics" / "history" / task_id
-    latest_root = root / "task_runs" / "diagnostics" / "latest"
+    if storage_layout == "repo":
+        diagnosis_root = root / "task_runs" / "diagnostics"
+    elif storage_layout == "standalone":
+        diagnosis_root = root / "diagnostics"
+    else:
+        raise ValueError(f"Unsupported task diagnosis storage layout: {storage_layout}")
+
+    history_root = diagnosis_root / "history" / task_id
+    latest_root = diagnosis_root / "latest"
     history_root.mkdir(parents=True, exist_ok=True)
     latest_root.mkdir(parents=True, exist_ok=True)
 

--- a/trellis/agent/task_run_store.py
+++ b/trellis/agent/task_run_store.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 import os
 from pathlib import Path
 from statistics import median
-from typing import Any, Mapping
+from typing import Any, Mapping, Literal
 
 import yaml
 
@@ -42,25 +42,31 @@ def persist_task_run_record(
     result: dict[str, Any],
     *,
     root: Path = ROOT,
+    storage_layout: Literal["repo", "standalone"] = "repo",
     persisted_at: datetime | None = None,
 ) -> dict[str, str]:
     """Write a full task-run record to both the history archive and the latest-result snapshot."""
     persisted_at = persisted_at or datetime.now(timezone.utc)
     record = build_task_run_record(task, result, persisted_at=persisted_at)
 
-    history_root = root / "task_runs" / "history" / str(task["id"])
-    latest_root = root / "task_runs" / "latest"
-    latest_index_path = root / "task_results_latest.json"
+    task_run_root, latest_index_path = _task_run_storage_roots(root, storage_layout=storage_layout)
+    history_root = task_run_root / "history" / str(task["id"])
+    latest_root = task_run_root / "latest"
     history_root.mkdir(parents=True, exist_ok=True)
     latest_root.mkdir(parents=True, exist_ok=True)
 
+    run_id = _reserve_history_run_id(
+        history_root=history_root,
+        run_id=str(record["run_id"]),
+        persisted_at=persisted_at,
+    )
+    record["run_id"] = run_id
     history_path = history_root / f"{record['run_id']}.json"
     latest_path = latest_root / f"{task['id']}.json"
-    diagnosis_history_packet_path = (
-        root / DIAGNOSIS_HISTORY_ROOT.relative_to(ROOT) / str(task["id"]) / f"{record['run_id']}.json"
-    )
+    diagnosis_root = task_run_root / "diagnostics"
+    diagnosis_history_packet_path = diagnosis_root / "history" / str(task["id"]) / f"{record['run_id']}.json"
     diagnosis_history_dossier_path = diagnosis_history_packet_path.with_suffix(".md")
-    diagnosis_latest_packet_path = root / DIAGNOSIS_LATEST_ROOT.relative_to(ROOT) / f"{task['id']}.json"
+    diagnosis_latest_packet_path = diagnosis_root / "latest" / f"{task['id']}.json"
     diagnosis_latest_dossier_path = diagnosis_latest_packet_path.with_suffix(".md")
 
     record["storage"] = {
@@ -87,7 +93,11 @@ def persist_task_run_record(
         diagnosis_persist_skipped = f"env:{_SKIP_TASK_DIAGNOSIS_PERSIST_ENV}"
     else:
         try:
-            diagnosis = save_task_diagnosis_artifacts(record, root=root)
+            diagnosis = save_task_diagnosis_artifacts(
+                record,
+                root=root,
+                storage_layout=storage_layout,
+            )
         except Exception as exc:
             diagnosis_error = str(exc)[:200]
 
@@ -248,7 +258,8 @@ def persist_canary_batch_record(
     history_path = history_root / f"{batch_id}.json"
     latest_path = latest_root / f"{_scope_slug_to_latest_key(scope_slug, execution_mode, validation, knowledge_profile, model)}.json"
     history_path.write_text(json.dumps(record, indent=2, default=str))
-    latest_path.write_text(json.dumps(record, indent=2, default=str))
+    if not synthetic_source:
+        latest_path.write_text(json.dumps(record, indent=2, default=str))
     return {
         "batch_id": batch_id,
         "history_path": str(history_path),
@@ -584,6 +595,39 @@ def _run_id(result: dict[str, Any], persisted_at: datetime) -> str:
             .replace("+", "_")
         )
     return persisted_at.strftime("%Y%m%dT%H%M%S%fZ")
+
+
+def _reserve_history_run_id(
+    *,
+    history_root: Path,
+    run_id: str,
+    persisted_at: datetime,
+) -> str:
+    """Preserve append-only history even when a rerun reuses the same logical start time."""
+    history_path = history_root / f"{run_id}.json"
+    if not history_path.exists():
+        return run_id
+
+    suffix = persisted_at.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+    candidate = f"{run_id}__{suffix}"
+    counter = 2
+    while (history_root / f"{candidate}.json").exists():
+        candidate = f"{run_id}__{suffix}_{counter}"
+        counter += 1
+    return candidate
+
+
+def _task_run_storage_roots(
+    root: Path,
+    *,
+    storage_layout: Literal["repo", "standalone"],
+) -> tuple[Path, Path]:
+    """Return the task-run root plus latest-index path for one storage layout."""
+    if storage_layout == "repo":
+        return root / "task_runs", root / "task_results_latest.json"
+    if storage_layout == "standalone":
+        return root, root / "task_results_latest.json"
+    raise ValueError(f"Unsupported task-run storage layout: {storage_layout}")
 
 
 def _build_method_runs(result: dict[str, Any]) -> dict[str, Any]:

--- a/trellis/agent/task_runtime.py
+++ b/trellis/agent/task_runtime.py
@@ -1083,6 +1083,8 @@ def run_task(
     now_fn: Callable[[], datetime] = datetime.now,
     payoff_factory: Callable[[type, object, date], Any] | None = None,
     price_fn: Callable[[Any, Any], float] | None = None,
+    task_run_storage_root: Path | None = None,
+    task_run_storage_layout: str = "repo",
 ) -> dict:
     """Execute one task through the knowledge-aware build pipeline."""
     from trellis.agent.cassette import current_llm_cassette_context
@@ -1419,7 +1421,14 @@ def run_task(
     result_data["run_completed_at"] = now_fn().isoformat()
 
     try:
-        persisted = persist_task_run_record(task, result_data)
+        persist_root = task_run_storage_root or ROOT
+        persist_layout = task_run_storage_layout if task_run_storage_root is not None else "repo"
+        persisted = persist_task_run_record(
+            task,
+            result_data,
+            root=persist_root,
+            storage_layout=persist_layout,
+        )
         result_data["task_run_history_path"] = persisted["history_path"]
         result_data["task_run_latest_path"] = persisted["latest_path"]
         result_data["task_run_latest_index_path"] = persisted["latest_index_path"]


### PR DESCRIPTION
## Summary
- keep task-run history append-only even when reruns reuse a fixed logical start time
- keep benchmark and learning task-run ledgers isolated from the repo-wide canonical latest surface
- keep synthetic pytest canary batches from rewriting the tracked canary latest views
- make remediation analyze latest canonical task runs by default, with an explicit tranche fallback

## Validation
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_task_run_store.py tests/test_agent/test_task_runtime.py tests/test_agent/test_remediate.py tests/test_agent/test_canary_runner.py tests/test_agent/test_financepy_benchmark.py tests/test_agent/test_negative_task_benchmark.py tests/test_agent/test_task_learning_benchmark.py -q`