### PR TITLE
[codex] Retire instrument-keyed route dispatch

### DIFF
--- a/doc/plan/active__contract-ir-compiler-retiring-route-registry.md
+++ b/doc/plan/active__contract-ir-compiler-retiring-route-registry.md
@@ -4,7 +4,7 @@
 
 Active. Live execution mirror for `QUA-887`.
 
-Status mirror last synced: `2026-04-18`
+Status mirror last synced: `2026-05-05`
 
 ## Linked Linear
 
@@ -85,7 +85,7 @@ What is already in the code (so the plan is not starting from zero):
 | Ticket | Status | Scope |
 | --- | --- | --- |
 | `QUA-902` | Done | normalize CDS semantic/routing/lowering surfaces onto `event_triggered_two_legged_contract` and migrate both CDS helper-backed routes off product-shaped family matching |
-| `QUA-900` | Backlog | migrate the remaining low-complexity analytical instrument-keyed routes |
+| `QUA-900` | In Progress | migrate the remaining low-complexity analytical instrument-keyed routes |
 | `QUA-901` | Backlog | migrate the residual MC / PDE / credit routes that still dispatch by instrument |
 
 Pickup rule:

--- a/doc/plan/active__contract-ir-compiler-retiring-route-registry.md
+++ b/doc/plan/active__contract-ir-compiler-retiring-route-registry.md
@@ -86,7 +86,7 @@ What is already in the code (so the plan is not starting from zero):
 | --- | --- | --- |
 | `QUA-902` | Done | normalize CDS semantic/routing/lowering surfaces onto `event_triggered_two_legged_contract` and migrate both CDS helper-backed routes off product-shaped family matching |
 | `QUA-900` | In Progress | migrate the remaining low-complexity analytical instrument-keyed routes |
-| `QUA-901` | Backlog | migrate the residual MC / PDE / credit routes that still dispatch by instrument |
+| `QUA-901` | In Progress | migrate the residual MC / PDE / credit routes that still dispatch by instrument |
 
 Pickup rule:
 

--- a/doc/plan/done__contract-ir-compiler-retiring-route-registry.md
+++ b/doc/plan/done__contract-ir-compiler-retiring-route-registry.md
@@ -2,9 +2,9 @@
 
 ## Status
 
-Active. Live execution mirror for `QUA-887`.
+Done. Execution mirror for the `QUA-887` structural-dispatch closeout slice.
 
-Status mirror last synced: `2026-05-05`
+Status mirror last synced: `2026-05-06`
 
 ## Linked Linear
 
@@ -15,23 +15,25 @@ Status mirror last synced: `2026-05-05`
 - QUA-902 — Semantic dispatch: normalize CDS onto event-triggered two-legged
   contract family (Done)
 - QUA-900 — Semantic dispatch: rate and exotic analytical routes stop matching
-  by instrument
+  by instrument (Done)
 - QUA-901 — Semantic dispatch: residual instrument-keyed MC and PDE routes stop
-  matching by instrument
+  matching by instrument (Done)
 
 ## Purpose
 
-This plan is the live execution mirror for staged retirement of
-instrument-keyed route matching under `QUA-887`. The goal is to retire
-`ProductIR.instrument -> route_id` as the primary dispatch key and replace it
-with structural / pattern-based dispatch that composes with the existing
-semantic compiler, family IRs, and backend-binding surfaces.
+This plan records the completed staged retirement of positive instrument-keyed
+route matching under `QUA-887`. The closeout removes
+`ProductIR.instrument -> route_id` as the primary dispatch key for the canonical
+route registry and replaces it with structural / pattern-based dispatch that
+composes with the existing semantic compiler, family IRs, and backend-binding
+surfaces.
 
 `QUA-902` landed the foundational normalization slice. It froze one execution
 decision before broader route migration: single-name CDS now compiles and
 routes as an `event_triggered_two_legged_contract`, not as a product-shaped
-`credit_default_swap` computational family. The next front-of-queue slice is
-`QUA-900`.
+`credit_default_swap` computational family. `QUA-900` and `QUA-901` then
+closed the residual analytical, credit, Monte Carlo, QMC, and PDE route
+surfaces that still used positive `match.instruments` dispatch.
 
 ## Framing
 
@@ -62,10 +64,10 @@ What is already in the code (so the plan is not starting from zero):
   already emits dual views: legacy route/module hints and a conservative
   `dsl_lowering` companion. This is the natural splice point for a Contract
   IR dispatch.
-- `routes.yaml` has 30 routes, of which 14 are instrument-dispatch
-  (`match.instruments: [X]`), 5 use `match.methods` only, and 6 use
-  `conditional_primitives` — a pattern-style when-clause dispatch that
-  already works.
+- `routes.yaml` now has 19 canonical routes. None use positive
+  `match.instruments` dispatch; residual product-name guards are hard
+  `exclude_instruments` vetoes on generic fallback routes, not primary
+  dispatch keys.
 
 ## Execution Decisions
 
@@ -85,15 +87,14 @@ What is already in the code (so the plan is not starting from zero):
 | Ticket | Status | Scope |
 | --- | --- | --- |
 | `QUA-902` | Done | normalize CDS semantic/routing/lowering surfaces onto `event_triggered_two_legged_contract` and migrate both CDS helper-backed routes off product-shaped family matching |
-| `QUA-900` | In Progress | migrate the remaining low-complexity analytical instrument-keyed routes |
-| `QUA-901` | In Progress | migrate the residual MC / PDE / credit routes that still dispatch by instrument |
+| `QUA-900` | Done | migrate the remaining low-complexity analytical instrument-keyed routes |
+| `QUA-901` | Done | migrate the residual MC / PDE / credit routes that still dispatch by instrument |
 
 Pickup rule:
 
-- start with the first non-`Done` ticket in the queue
-- keep each slice parity-gated and reviewable
-- do not start additive Contract IR AST work until the structural-dispatch
-  queue above is materially landed or deliberately split further
+- the structural-dispatch queue above is complete
+- additive ContractIR follow-ons such as QUA-923 and QUA-924 remain separate
+  backlog work and are not part of this route-dispatch closeout
 
 ## Why Prior Attempts Stalled
 
@@ -492,44 +493,22 @@ attempts stalled.
    include the parity test output (old vs. new path for all affected
    fixtures and benchmarks) in the PR description.
 
-## Open Questions For The Reviewer
+## Closeout
 
-These are the places where the author is least certain and where
-outside judgment would help most.
+- QUA-902 normalized the CDS computational family onto
+  `event_triggered_two_legged_contract`.
+- QUA-900 collapsed the residual analytical exotic routes into structural
+  Black76 / short-rate pattern dispatch and synchronized backend-binding
+  authority.
+- QUA-901 removed the remaining positive `match.instruments` entries from the
+  credit basket and vanilla equity PDE route surfaces and added route-level
+  `model_family` matching.
+- The canonical registry now fails the route-registry regression if any route
+  reintroduces positive instrument matching.
+- `ProductIR.instrument` remains available for semantic identity, traces,
+  diagnostics, and compatibility; it is no longer the canonical route-registry
+  dispatch key.
 
-1. Should Phase 1 and Phase 2 overlap? Phase 1 uses pattern-keyed
-   `conditional_primitives` inside `routes.yaml`. Phase 2 introduces a
-   proper Contract IR. Is there a path where Phase 1's patterns are
-   Contract IR patterns from the start, rather than two separate layers?
-   This could collapse Phases 1 and 2 but might overconstrain Phase 1.
-2. What is the smallest possible Phase 2? The current pick is vanilla +
-   variance + digital + asian (four). Could it be two (vanilla +
-   variance)? The fewer the scope, the more likely the phase lands, but
-   below some threshold the Contract IR does not prove its generality.
-3. Kernel normalization — decorator vs. subtyping. The proposal uses
-   `@solves_pattern(ir, adapter_fn)`. Alternative: kernels implement a
-   `Pricer[IR]` protocol with an `apply(ir, market_state) -> float`
-   method. Protocol-based is more discoverable; decorator-based is more
-   additive. Which does the codebase's conventions prefer?
-4. Relationship to QUA-792. This plan assumes Contract IR completes
-   what QUA-792 started. Is that the right framing, or should the
-   Contract IR compiler be a parallel epic that feeds into QUA-792
-   epic 5 (exotic composition proof)? The reviewer may see this
-   differently.
-5. Parity tolerance ε. FinancePy parity runs use 1–3% tolerance today.
-   For dual-path parity (old vs. new Trellis paths) ε should probably be
-   much lower — around 1e-10 relative, since both paths should produce
-   bit-identical outputs when the math is equivalent. Kernels with Monte
-   Carlo components have RNG state, so ε has to be strategy-dependent.
-   Worth deciding up front.
-
-## Next Steps
-
-- Land this document as a draft plan doc for review.
-- Collect reviewer feedback on the five open questions.
-- Promote to `active__contract-ir-compiler-retiring-route-registry.md`
-  once the framing is endorsed and the first implementation ticket is
-  queued.
-- The first implementation ticket is the smallest Phase 1 slice: one
-  instrument-keyed route converted to a pattern declaration, with its
-  parity test.
+Follow-on work remains outside this closeout: QUA-923 and QUA-924 continue the
+broader ContractIR foundation and fixture-hardening program, but they do not
+block closing the instrument-keyed route-dispatch epic.

--- a/tests/test_agent/test_backend_bindings.py
+++ b/tests/test_agent/test_backend_bindings.py
@@ -241,7 +241,7 @@ def test_resolve_backend_binding_spec_uses_basket_option_exact_helpers():
         pytest.param(
             ProductIR(
                 instrument="digital_option",
-                payoff_family="composite_option",
+                payoff_family="digital_option",
                 payoff_traits=(
                     "discounting",
                     "terminal_markov",
@@ -261,7 +261,7 @@ def test_resolve_backend_binding_spec_uses_basket_option_exact_helpers():
         pytest.param(
             ProductIR(
                 instrument="lookback_option",
-                payoff_family="composite_option",
+                payoff_family="lookback_option",
                 payoff_traits=(
                     "discounting",
                     "path_dependent",
@@ -281,7 +281,7 @@ def test_resolve_backend_binding_spec_uses_basket_option_exact_helpers():
         pytest.param(
             ProductIR(
                 instrument="chooser_option",
-                payoff_family="composite_option",
+                payoff_family="chooser_option",
                 payoff_traits=(
                     "discounting",
                     "terminal_markov",
@@ -301,7 +301,7 @@ def test_resolve_backend_binding_spec_uses_basket_option_exact_helpers():
         pytest.param(
             ProductIR(
                 instrument="compound_option",
-                payoff_family="composite_option",
+                payoff_family="compound_option",
                 payoff_traits=(
                     "discounting",
                     "terminal_markov",
@@ -321,7 +321,7 @@ def test_resolve_backend_binding_spec_uses_basket_option_exact_helpers():
         pytest.param(
             ProductIR(
                 instrument="cliquet_option",
-                payoff_family="composite_option",
+                payoff_family="cliquet_option",
                 payoff_traits=("vanilla_option",),
                 exercise_style="european",
                 state_dependence="terminal_markov",

--- a/tests/test_agent/test_backend_bindings_dsl_when.py
+++ b/tests/test_agent/test_backend_bindings_dsl_when.py
@@ -535,6 +535,16 @@ class TestLegacyBindingCatalogRegression:
             "variance_payoff",
         }
         dsl_styles = set()
+        expected_absorbed_styles = {
+            "barrier_payoff": "european",
+            "chooser_payoff": "european",
+            "cliquet_payoff": "european",
+            "compound_payoff": "european",
+            "digital_payoff": "european",
+            "lookback_payoff": "european",
+            "variance_payoff": "none",
+        }
+        absorbed_styles = {}
         for cp in dsl_forms:
             exercise = cp.contract_pattern.exercise  # type: ignore[union-attr]
             if exercise is not None:
@@ -547,7 +557,11 @@ class TestLegacyBindingCatalogRegression:
                 )
                 if style_value is not None:
                     dsl_styles.add(style_value)
-        assert dsl_styles == {"bermudan", "european"}, (
-            f"expected DSL clauses to cover {{'bermudan', 'european'}} "
+                    kind = cp.contract_pattern.payoff.kind  # type: ignore[union-attr]
+                    if kind in expected_absorbed_styles:
+                        absorbed_styles[kind] = style_value
+        assert dsl_styles == {"bermudan", "european", "none"}, (
+            f"expected DSL clauses to cover {{'bermudan', 'european', 'none'}} "
             f"exercise styles, got {dsl_styles}"
         )
+        assert absorbed_styles == expected_absorbed_styles

--- a/tests/test_agent/test_backend_bindings_dsl_when.py
+++ b/tests/test_agent/test_backend_bindings_dsl_when.py
@@ -490,14 +490,14 @@ class TestLegacyBindingCatalogRegression:
                         f"malformed when-clause: {cp.when!r}"
                     )
 
-    def test_analytical_black76_uses_dsl_form_for_two_swaption_clauses(self):
-        """QUA-921 migration lock: the two swaption-structural
-        ``analytical_black76`` clauses in ``backend_bindings.yaml`` are DSL
-        form.  The other three clauses (vanilla, period_rate_option_strip,
-        basket) and the ``default`` sentinel intentionally stay legacy
-        (see the module docstring in
-        ``test_backend_bindings_black76_dsl_parity.py`` for the per-clause
-        rationale).
+    def test_analytical_black76_uses_dsl_form_for_structural_clauses(self):
+        """QUA-921 / QUA-900 migration lock: the swaption and absorbed
+        analytical-exotic ``analytical_black76`` clauses in
+        ``backend_bindings.yaml`` are DSL form.  The vanilla,
+        period_rate_option_strip, basket, and ``default`` sentinel clauses
+        intentionally stay legacy (see the module docstring in
+        ``test_backend_bindings_black76_dsl_parity.py`` for the remaining
+        per-clause rationale).
 
         This regression lock prevents an accidental revert of the migration
         (``backend_bindings.yaml`` edited back to string-tag form) from
@@ -514,22 +514,26 @@ class TestLegacyBindingCatalogRegression:
         dsl_forms = [
             cp for cp in binding.conditional_primitives if cp.contract_pattern is not None
         ]
-        # Two structural DSL clauses landed by QUA-921:
-        #   - swaption + bermudan
-        #   - swaption + european
-        assert len(dsl_forms) == 2, (
-            f"analytical_black76 binding should carry exactly two DSL "
-            f"structural clauses after QUA-921, found {len(dsl_forms)}"
+        # QUA-921 landed two swaption DSL clauses; QUA-900 moved the
+        # absorbed analytical exotics to structural DSL payoff tags too.
+        assert len(dsl_forms) == 9, (
+            f"analytical_black76 binding should carry exactly nine DSL "
+            f"structural clauses after QUA-900, found {len(dsl_forms)}"
         )
 
-        # Spot-check the two DSL patterns are the expected swaption shapes.
         dsl_kinds = {
             cp.contract_pattern.payoff.kind for cp in dsl_forms  # type: ignore[union-attr]
         }
-        assert dsl_kinds == {"swaption_payoff"}, (
-            f"expected both DSL clauses to use 'swaption_payoff', got "
-            f"{dsl_kinds}"
-        )
+        assert dsl_kinds == {
+            "barrier_payoff",
+            "chooser_payoff",
+            "cliquet_payoff",
+            "compound_payoff",
+            "digital_payoff",
+            "lookback_payoff",
+            "swaption_payoff",
+            "variance_payoff",
+        }
         dsl_styles = set()
         for cp in dsl_forms:
             exercise = cp.contract_pattern.exercise  # type: ignore[union-attr]

--- a/tests/test_agent/test_codegen_guardrails.py
+++ b/tests/test_agent/test_codegen_guardrails.py
@@ -853,7 +853,7 @@ def test_cds_analytical_route_card_surfaces_helper_signature_keywords():
         ),
     ],
 )
-def test_absorbed_black76_nested_composite_route_uses_exact_helper_binding(
+def test_absorbed_black76_structural_exotic_route_uses_exact_helper_binding(
     instrument_type,
     expected_helper_ref,
 ):
@@ -870,7 +870,7 @@ def test_absorbed_black76_nested_composite_route_uses_exact_helper_binding(
         inspected_modules=("trellis.models.analytical.equity_exotics",),
         product_ir=ProductIR(
             instrument=instrument_type,
-            payoff_family="composite_option",
+            payoff_family=instrument_type,
             payoff_traits=("discounting", "terminal_markov", "vol_surface_dependence"),
             exercise_style="european",
             state_dependence="terminal_markov",

--- a/tests/test_agent/test_decomposition_ir.py
+++ b/tests/test_agent/test_decomposition_ir.py
@@ -173,6 +173,20 @@ class TestProductIR:
         assert "analytical" in ir.candidate_engine_families
         assert ir.supported is True
 
+    def test_ir_for_nth_to_default_uses_specific_payoff_family(self):
+        from trellis.agent.knowledge.decompose import decompose_to_ir
+
+        ir = decompose_to_ir(
+            "First-to-default basket on five names with Gaussian copula",
+            instrument_type="nth_to_default",
+        )
+
+        assert ir.instrument == "nth_to_default"
+        assert ir.payoff_family == "nth_to_default"
+        assert ir.model_family == "credit_copula"
+        assert "nth_to_default" in ir.route_families
+        assert ir.supported is True
+
     def test_ir_normalizes_american_option_alias(self):
         from trellis.agent.knowledge.decompose import decompose_to_ir
 

--- a/tests/test_agent/test_decomposition_ir.py
+++ b/tests/test_agent/test_decomposition_ir.py
@@ -74,6 +74,47 @@ class TestProductIR:
         assert "pde_solver" in ir.route_families
         assert ir.supported is True
 
+    def test_ir_for_absorbed_analytical_exotics_uses_specific_payoff_families(self):
+        from trellis.agent.knowledge.decompose import decompose_to_ir
+
+        cases = (
+            (
+                "Cash-or-nothing digital call on AAPL paying 1 if spot exceeds 150 at expiry",
+                "digital_option",
+                "digital_option",
+            ),
+            (
+                "Fixed-strike lookback option on AAPL expiring 2025-11-15",
+                "lookback_option",
+                "lookback_option",
+            ),
+            (
+                "Chooser option on AAPL strike 150 expiring 2025-11-15",
+                "chooser_option",
+                "chooser_option",
+            ),
+            (
+                "Compound option on AAPL strike 150 expiring 2025-11-15",
+                "compound_option",
+                "compound_option",
+            ),
+            (
+                "Cliquet option on AAPL with annual reset dates",
+                "cliquet_option",
+                "cliquet_option",
+            ),
+        )
+
+        for description, instrument_type, expected_family in cases:
+            ir = decompose_to_ir(description, instrument_type=instrument_type)
+            assert ir.instrument == instrument_type
+            assert ir.payoff_family == expected_family
+            assert ir.exercise_style == "european"
+            inferred = decompose_to_ir(description)
+            assert inferred.instrument == instrument_type
+            assert inferred.payoff_family == expected_family
+            assert inferred.exercise_style == "european"
+
     def test_ir_for_callable_bond(self):
         from trellis.agent.knowledge.decompose import decompose_to_ir
 

--- a/tests/test_agent/test_route_registry.py
+++ b/tests/test_agent/test_route_registry.py
@@ -480,7 +480,11 @@ class TestCreditRoutes:
         payoff_family="event_triggered_two_legged_contract",
         route_families=("event_triggered_two_legged_contract",),
     )
-    NTD_IR = ProductIR(instrument="nth_to_default", payoff_family="nth_to_default")
+    NTD_IR = ProductIR(
+        instrument="nth_to_default",
+        payoff_family="nth_to_default",
+        model_family="credit_copula",
+    )
 
     def test_cds_analytical(self, registry):
         new = _new_routes(
@@ -509,6 +513,14 @@ class TestCreditRoutes:
         plan = _make_plan("monte_carlo", market_data={"discount_curve", "credit_curve"})
         new = _new_routes(registry, "monte_carlo", self.NTD_IR, pricing_plan=plan)
         assert new == ("credit_basket_nth_to_default",)
+
+    def test_nth_to_default_route_no_longer_matches_by_instrument(self, registry):
+        spec = find_route_by_id("credit_basket_nth_to_default", registry)
+
+        assert spec is not None
+        assert spec.match_instruments is None
+        assert spec.match_payoff_family == ("nth_to_default",)
+        assert spec.match_model_family == ("credit_copula",)
 
     _PRE_COLLAPSE_ANALYTICAL_PRIMITIVES = frozenset({
         ("trellis.core.date_utils", "year_fraction", "time_measure"),
@@ -1733,6 +1745,7 @@ class TestFallbackRoutes:
             instrument="european_option",
             payoff_family="vanilla_option",
             exercise_style="european",
+            model_family="equity_diffusion",
         )
         new = _new_routes(registry, "pde_solver", ir)
         assert new == ("vanilla_equity_theta_pde", "pde_theta_1d")
@@ -1814,6 +1827,7 @@ class TestFallbackRoutes:
             instrument="european_option",
             payoff_family="vanilla_option",
             exercise_style="european",
+            model_family="equity_diffusion",
         )
         new_prims = resolve_route_primitives(spec, ir)
         expected_prims = {
@@ -1821,12 +1835,21 @@ class TestFallbackRoutes:
         }
         assert _prim_set(new_prims) == expected_prims
 
+    def test_vanilla_equity_pde_route_no_longer_matches_by_instrument(self, registry):
+        spec = find_route_by_id("vanilla_equity_theta_pde", registry)
+
+        assert spec is not None
+        assert spec.match_instruments is None
+        assert spec.match_payoff_family == ("vanilla_option",)
+        assert spec.match_model_family == ("equity_diffusion",)
+
     def test_vanilla_equity_pde_helper_route_is_thin(self, registry):
         spec = [r for r in registry.routes if r.id == "vanilla_equity_theta_pde"][0]
         ir = ProductIR(
             instrument="european_option",
             payoff_family="vanilla_option",
             exercise_style="european",
+            model_family="equity_diffusion",
         )
         assert resolve_route_notes(spec, ir) == ()
         assert resolve_route_adapters(spec, ir) == ()
@@ -2155,6 +2178,15 @@ class TestEngineFamilyCoverage:
         route_ids = {r.id for r in registry.routes}
         expected_ids = set(self.EXPECTED.keys())
         assert route_ids == expected_ids, f"Missing: {expected_ids - route_ids}, Extra: {route_ids - expected_ids}"
+
+    def test_canonical_routes_do_not_use_positive_instrument_matching(self, registry):
+        instrument_keyed = {
+            route.id: route.match_instruments
+            for route in registry.routes
+            if route.match_instruments is not None
+        }
+
+        assert instrument_keyed == {}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_agent/test_route_registry.py
+++ b/tests/test_agent/test_route_registry.py
@@ -514,6 +514,14 @@ class TestCreditRoutes:
         new = _new_routes(registry, "monte_carlo", self.NTD_IR, pricing_plan=plan)
         assert new == ("credit_basket_nth_to_default",)
 
+    def test_nth_to_default_minimal_ir_still_matches_for_gap_audits(self, registry):
+        ir = ProductIR(instrument="nth_to_default", payoff_family="nth_to_default")
+        plan = _make_plan("monte_carlo", market_data={"discount_curve", "credit_curve"})
+
+        new = _new_routes(registry, "monte_carlo", ir, pricing_plan=plan)
+
+        assert new == ("credit_basket_nth_to_default",)
+
     def test_nth_to_default_route_no_longer_matches_by_instrument(self, registry):
         spec = find_route_by_id("credit_basket_nth_to_default", registry)
 
@@ -1748,6 +1756,17 @@ class TestFallbackRoutes:
             model_family="equity_diffusion",
         )
         new = _new_routes(registry, "pde_solver", ir)
+        assert new == ("vanilla_equity_theta_pde", "pde_theta_1d")
+
+    def test_vanilla_equity_pde_minimal_ir_still_matches_for_gap_audits(self, registry):
+        ir = ProductIR(
+            instrument="european_option",
+            payoff_family="vanilla_option",
+            exercise_style="european",
+        )
+
+        new = _new_routes(registry, "pde_solver", ir)
+
         assert new == ("vanilla_equity_theta_pde", "pde_theta_1d")
 
     def test_copula_candidate(self, registry):

--- a/tests/test_agent/test_route_registry.py
+++ b/tests/test_agent/test_route_registry.py
@@ -1173,7 +1173,7 @@ class TestAnalyticalRoutes:
     )
     DIGITAL_IR = ProductIR(
         instrument="digital_option",
-        payoff_family="composite_option",
+        payoff_family="digital_option",
         payoff_traits=("discounting", "terminal_markov", "vol_surface_dependence"),
         exercise_style="european",
         state_dependence="terminal_markov",
@@ -1181,7 +1181,7 @@ class TestAnalyticalRoutes:
     )
     LOOKBACK_IR = ProductIR(
         instrument="lookback_option",
-        payoff_family="composite_option",
+        payoff_family="lookback_option",
         payoff_traits=("discounting", "path_dependent", "vol_surface_dependence"),
         exercise_style="european",
         state_dependence="path_dependent",
@@ -1189,7 +1189,7 @@ class TestAnalyticalRoutes:
     )
     CHOOSER_IR = ProductIR(
         instrument="chooser_option",
-        payoff_family="composite_option",
+        payoff_family="chooser_option",
         payoff_traits=("discounting", "terminal_markov", "vol_surface_dependence"),
         exercise_style="european",
         state_dependence="terminal_markov",
@@ -1197,7 +1197,7 @@ class TestAnalyticalRoutes:
     )
     COMPOUND_IR = ProductIR(
         instrument="compound_option",
-        payoff_family="composite_option",
+        payoff_family="compound_option",
         payoff_traits=("discounting", "terminal_markov", "vol_surface_dependence"),
         exercise_style="european",
         state_dependence="terminal_markov",
@@ -1205,7 +1205,7 @@ class TestAnalyticalRoutes:
     )
     CLIQUET_IR = ProductIR(
         instrument="cliquet_option",
-        payoff_family="composite_option",
+        payoff_family="cliquet_option",
         payoff_traits=("vanilla_option",),
         exercise_style="european",
         state_dependence="terminal_markov",
@@ -1231,6 +1231,17 @@ class TestAnalyticalRoutes:
         "analytical",
         market_data={"discount_curve", "black_vol_surface"},
     )
+
+    def test_analytical_black76_absorbed_exotics_do_not_match_by_instrument(self, registry):
+        spec = [r for r in registry.routes if r.id == "analytical_black76"][0]
+
+        assert spec.match_instruments is None
+        legacy_instrument_conditions = [
+            cond.when
+            for cond in spec.conditional_primitives
+            if isinstance(cond.when, dict) and "instrument" in cond.when
+        ]
+        assert legacy_instrument_conditions == []
 
     def test_swaption_candidate(self, registry):
         new = _new_routes(
@@ -1279,6 +1290,22 @@ class TestAnalyticalRoutes:
             registry, "analytical", self.COMPOUND_IR, pricing_plan=self.BLACK76_PLAN,
         )
         assert new == ("analytical_black76",)
+
+    def test_unknown_composite_candidate_does_not_widen_into_black76(self, registry):
+        unknown_ir = ProductIR(
+            instrument="unknown_composite_option",
+            payoff_family="composite_option",
+            payoff_traits=("discounting", "terminal_markov", "vol_surface_dependence"),
+            exercise_style="european",
+            state_dependence="terminal_markov",
+            model_family="equity_diffusion",
+        )
+
+        new = _new_routes(
+            registry, "analytical", unknown_ir, pricing_plan=self.BLACK76_PLAN,
+        )
+
+        assert "analytical_black76" not in new
 
     def test_zcb_candidate(self, registry):
         # QUA-915: ZCB option family collapsed into short_rate_bond_option.

--- a/tests/test_agent/test_route_registry_dsl_when.py
+++ b/tests/test_agent/test_route_registry_dsl_when.py
@@ -586,3 +586,37 @@ class TestLegacyRegistryRegression:
             f"analytical_black76 default clause should use 'default' sentinel; "
             f"got when={default_cp.when!r}"
         )
+
+    def test_absorbed_analytical_exotic_dsl_clauses_keep_exercise_guards(self):
+        """Absorbed exotics must not widen beyond their old exercise guard."""
+        registry = load_route_registry()
+        black76 = next(
+            (r for r in registry.routes if r.id == "analytical_black76"), None
+        )
+        assert black76 is not None, "analytical_black76 missing from registry"
+
+        expected_styles = {
+            "barrier_payoff": "european",
+            "chooser_payoff": "european",
+            "cliquet_payoff": "european",
+            "compound_payoff": "european",
+            "digital_payoff": "european",
+            "lookback_payoff": "european",
+            "variance_payoff": "none",
+        }
+        seen: dict[str, str] = {}
+        for cp in black76.conditional_primitives:
+            pattern = cp.contract_pattern
+            if pattern is None or pattern.payoff is None:
+                continue
+            kind = getattr(pattern.payoff, "kind", None)
+            if kind not in expected_styles:
+                continue
+            assert pattern.exercise is not None, (
+                f"{kind} clause must declare an exercise style guard"
+            )
+            style = pattern.exercise.style
+            style_value = style if isinstance(style, str) else getattr(style, "value", None)
+            seen[kind] = style_value
+
+        assert seen == expected_styles

--- a/trellis/agent/codegen_guardrails.py
+++ b/trellis/agent/codegen_guardrails.py
@@ -1813,7 +1813,11 @@ def _route_score(
         if resolved_roles.intersection(model_support_roles):
             score += 1.0
 
-        capability = evaluate_route_capability_match(spec, product_ir)
+        capability = evaluate_route_capability_match(
+            spec,
+            product_ir,
+            method=scoring_method,
+        )
         if capability.ok:
             score += 1.0 + 0.25 * len(capability.matched_predicates)
         else:

--- a/trellis/agent/knowledge/canonical/backend_bindings.yaml
+++ b/trellis/agent/knowledge/canonical/backend_bindings.yaml
@@ -371,7 +371,10 @@ bindings:
     # not only inside ``route_registry._conditional_primitive_matches``.
     #
     # The ``vanilla_option``, ``period_rate_option_strip``, and ``basket_option``
-    # clauses intentionally stay in legacy string-tag form.  Specifically:
+    # clauses intentionally stay in legacy string-tag form.  The absorbed
+    # equity-exotic helpers below use structural ContractPattern tags now that
+    # ProductIR exposes distinct payoff-family labels for the admitted helper
+    # cohorts.  Specifically:
     #
     # * ``vanilla_option`` stays legacy because the DSL ``vanilla_payoff``
     #   tag matches trait-level ``vanilla_option`` entries via
@@ -390,8 +393,9 @@ bindings:
     #   current ``ContractPattern`` AST cannot express.
     #
     # Extending the DSL with a payoff-trait predicate (and tightening the
-    # ``vanilla_payoff`` tag semantics) would unlock the remaining clauses;
-    # those are tracked as separate follow-ons rather than scope creep here.
+    # ``vanilla_payoff`` tag semantics) would unlock the remaining
+    # vanilla/basket/rate-strip clauses; those are tracked as separate
+    # follow-ons rather than scope creep here.
     #
     # The final ``when: default`` clause intentionally stays in legacy sentinel
     # form: it is a fall-through marker, not a structural pattern match.
@@ -470,15 +474,17 @@ bindings:
             symbol: price_swaption_black76
             role: route_helper
       - when:
-          payoff_family: barrier_option
-          exercise_style: [european]
-          model_family: [equity_diffusion]
+          contract_pattern:
+            payoff:
+              kind: barrier_payoff
         primitives:
           - module: trellis.models.analytical.barrier
             symbol: barrier_option_price
             role: route_helper
       - when:
-          payoff_family: variance_swap
+          contract_pattern:
+            payoff:
+              kind: variance_payoff
         primitives:
           - module: trellis.models.analytical.equity_exotics
             symbol: price_equity_variance_swap_analytical
@@ -488,43 +494,41 @@ bindings:
             role: pricing_kernel
             required: false
       - when:
-          payoff_family: composite_option
-          payoff_traits: [path_dependent]
-          exercise_style: [european]
-          model_family: [equity_diffusion]
+          contract_pattern:
+            payoff:
+              kind: lookback_payoff
         primitives:
           - module: trellis.models.analytical.equity_exotics
             symbol: price_equity_fixed_lookback_option_analytical
             role: route_helper
       - when:
-          instrument: chooser_option
-          exercise_style: [european]
-          model_family: [equity_diffusion]
+          contract_pattern:
+            payoff:
+              kind: chooser_payoff
         primitives:
           - module: trellis.models.analytical.equity_exotics
             symbol: price_equity_chooser_option_analytical
             role: route_helper
       - when:
-          instrument: compound_option
-          exercise_style: [european]
-          model_family: [equity_diffusion]
+          contract_pattern:
+            payoff:
+              kind: compound_payoff
         primitives:
           - module: trellis.models.analytical.equity_exotics
             symbol: price_equity_compound_option_analytical
             role: route_helper
       - when:
-          payoff_family: composite_option
-          payoff_traits: [vanilla_option]
-          exercise_style: [european]
-          model_family: [equity_diffusion]
+          contract_pattern:
+            payoff:
+              kind: cliquet_payoff
         primitives:
           - module: trellis.models.analytical.equity_exotics
             symbol: price_equity_cliquet_option_analytical
             role: route_helper
       - when:
-          payoff_family: composite_option
-          exercise_style: [european]
-          model_family: [equity_diffusion]
+          contract_pattern:
+            payoff:
+              kind: digital_payoff
         primitives:
           - module: trellis.models.analytical.equity_exotics
             symbol: price_equity_digital_option_analytical

--- a/trellis/agent/knowledge/canonical/backend_bindings.yaml
+++ b/trellis/agent/knowledge/canonical/backend_bindings.yaml
@@ -477,6 +477,8 @@ bindings:
           contract_pattern:
             payoff:
               kind: barrier_payoff
+            exercise:
+              style: european
         primitives:
           - module: trellis.models.analytical.barrier
             symbol: barrier_option_price
@@ -485,6 +487,8 @@ bindings:
           contract_pattern:
             payoff:
               kind: variance_payoff
+            exercise:
+              style: none
         primitives:
           - module: trellis.models.analytical.equity_exotics
             symbol: price_equity_variance_swap_analytical
@@ -497,6 +501,8 @@ bindings:
           contract_pattern:
             payoff:
               kind: lookback_payoff
+            exercise:
+              style: european
         primitives:
           - module: trellis.models.analytical.equity_exotics
             symbol: price_equity_fixed_lookback_option_analytical
@@ -505,6 +511,8 @@ bindings:
           contract_pattern:
             payoff:
               kind: chooser_payoff
+            exercise:
+              style: european
         primitives:
           - module: trellis.models.analytical.equity_exotics
             symbol: price_equity_chooser_option_analytical
@@ -513,6 +521,8 @@ bindings:
           contract_pattern:
             payoff:
               kind: compound_payoff
+            exercise:
+              style: european
         primitives:
           - module: trellis.models.analytical.equity_exotics
             symbol: price_equity_compound_option_analytical
@@ -521,6 +531,8 @@ bindings:
           contract_pattern:
             payoff:
               kind: cliquet_payoff
+            exercise:
+              style: european
         primitives:
           - module: trellis.models.analytical.equity_exotics
             symbol: price_equity_cliquet_option_analytical
@@ -529,6 +541,8 @@ bindings:
           contract_pattern:
             payoff:
               kind: digital_payoff
+            exercise:
+              style: european
         primitives:
           - module: trellis.models.analytical.equity_exotics
             symbol: price_equity_digital_option_analytical

--- a/trellis/agent/knowledge/canonical/routes.yaml
+++ b/trellis/agent/knowledge/canonical/routes.yaml
@@ -676,17 +676,11 @@ routes:
       non_european_penalty: -4.0
     match:
       methods: [analytical]
-      # QUA-909 / QUA-910: Black76 now hosts the helper-backed closed-form
-      # equity exotics that still live on the same vol-surface-driven
-      # analytical lane. ``barrier_option`` and ``variance_swap`` already
-      # surface route-local payoff families, while ``digital_option``,
-      # ``lookback_option``, and ``cliquet_option`` still decompose to
-      # ``payoff_family="composite_option"`` today. Admit those three via an
-      # explicit instrument-positive list until the semantic layer emits more
-      # specific payoff-family tags; barrier / variance are also listed so
-      # ``_augment_ir_with_promoted_route_support`` can project the promoted
-      # analytical family into their benchmark IRs. Chooser / compound stay out
-      # by omission so QUA-911 can absorb them separately.
+      # QUA-900 / QUA-909 / QUA-910: Black76 now hosts the helper-backed
+      # closed-form equity exotics that still live on the same vol-surface-
+      # driven analytical lane. The absorbed exotic cohorts expose specific
+      # payoff-family labels, so this positive filter stays structural and
+      # no longer needs a companion ``match.instruments`` clause.
       #
       # The ``exercise: [european, bermudan, none]`` positive filter is the
       # principled discriminant against American exercise vanilla options.
@@ -718,9 +712,8 @@ routes:
       # retiring). Once the decomposer emits a more specific
       # ``payoff_family`` for quanto / FX-vanilla (Phase 2+ work), this
       # exclusion becomes redundant and can be dropped.
-      instruments: [barrier_option, digital_option, lookback_option, chooser_option, compound_option, cliquet_option, variance_swap]
       required_market_data: [black_vol_surface]
-      payoff_family: [vanilla_option, basket_option, swaption, barrier_option, variance_swap]
+      payoff_family: [vanilla_option, basket_option, swaption, barrier_option, digital_option, lookback_option, chooser_option, compound_option, cliquet_option, variance_swap]
       exercise: [european, bermudan, none]
       exclude_required_market_data: [fx_rates]
     admissibility:
@@ -732,14 +725,11 @@ routes:
       supports_sensitivity_outputs: true
       supported_state_tags: [terminal_markov, recombining_safe, schedule_state, path_dependent]
       supports_calibration: false
-    # QUA-920 / QUA-910 / QUA-911: the first four structural when-clauses
-    # below stay in DSL form, while the absorbed equity-exotic helper clauses
-    # stay in legacy tag-filter form. The current ProductIR does not yet
-    # expose distinct payoff-family tags for digital / lookback / chooser /
-    # compound / cliquet; chooser and compound also share the same
-    # ``payoff_traits`` tuple as digital. Their helper selection therefore
-    # stays instrument-keyed until the semantic layer grows a narrower
-    # discriminant than ``composite_option``.
+    # QUA-900 / QUA-920 / QUA-910 / QUA-911: the absorbed
+    # equity-exotic helpers now dispatch through structural
+    # ContractPattern tags. ProductIR exposes distinct payoff-family
+    # labels for each admitted helper cohort, so helper selection no
+    # longer depends on ``ProductIR.instrument``.
     conditional_primitives:
       - when:
           contract_pattern:
@@ -820,9 +810,9 @@ routes:
         adapters: []
         notes: []
       - when:
-          payoff_family: barrier_option
-          exercise_style: [european]
-          model_family: [equity_diffusion]
+          contract_pattern:
+            payoff:
+              kind: barrier_payoff
         primitives:
           - module: trellis.models.analytical.barrier
             symbol: barrier_option_price
@@ -832,7 +822,9 @@ routes:
           - "Use `barrier_option_price` directly with scalar spot/strike/barrier/rate/sigma/T inputs instead of instantiating `ResolvedBarrierInputs` in generated adapters."
           - "When the contract carries discrete monitoring or non-zero dividend carry, pass `observations_per_year` and `q` through explicitly."
       - when:
-          payoff_family: variance_swap
+          contract_pattern:
+            payoff:
+              kind: variance_payoff
         primitives:
           - module: trellis.models.analytical.equity_exotics
             symbol: price_equity_variance_swap_analytical
@@ -845,10 +837,9 @@ routes:
         notes:
           - "Use the variance-swap helper with `market_state` and `spec`; keep fair-strike and price output assembly in the shared analytical module."
       - when:
-          payoff_family: composite_option
-          payoff_traits: [path_dependent]
-          exercise_style: [european]
-          model_family: [equity_diffusion]
+          contract_pattern:
+            payoff:
+              kind: lookback_payoff
         primitives:
           - module: trellis.models.analytical.equity_exotics
             symbol: price_equity_fixed_lookback_option_analytical
@@ -857,9 +848,9 @@ routes:
         notes:
           - "Use the dedicated lookback helper with `market_state` and `spec`; do not restate the running-extreme formula inside the generated payoff."
       - when:
-          instrument: chooser_option
-          exercise_style: [european]
-          model_family: [equity_diffusion]
+          contract_pattern:
+            payoff:
+              kind: chooser_payoff
         primitives:
           - module: trellis.models.analytical.equity_exotics
             symbol: price_equity_chooser_option_analytical
@@ -868,9 +859,9 @@ routes:
         notes:
           - "Use the chooser helper with `market_state` and `spec`; keep the critical-spot solve inside the shared helper."
       - when:
-          instrument: compound_option
-          exercise_style: [european]
-          model_family: [equity_diffusion]
+          contract_pattern:
+            payoff:
+              kind: compound_payoff
         primitives:
           - module: trellis.models.analytical.equity_exotics
             symbol: price_equity_compound_option_analytical
@@ -879,10 +870,9 @@ routes:
         notes:
           - "Use the compound-option helper with `market_state` and `spec`; keep the critical-spot solve inside the shared helper."
       - when:
-          payoff_family: composite_option
-          payoff_traits: [vanilla_option]
-          exercise_style: [european]
-          model_family: [equity_diffusion]
+          contract_pattern:
+            payoff:
+              kind: cliquet_payoff
         primitives:
           - module: trellis.models.analytical.equity_exotics
             symbol: price_equity_cliquet_option_analytical
@@ -891,9 +881,9 @@ routes:
         notes:
           - "Use the cliquet helper with `market_state` and `spec`; keep observation-date resets and carry handling in the shared helper."
       - when:
-          payoff_family: composite_option
-          exercise_style: [european]
-          model_family: [equity_diffusion]
+          contract_pattern:
+            payoff:
+              kind: digital_payoff
         primitives:
           - module: trellis.models.analytical.equity_exotics
             symbol: price_equity_digital_option_analytical

--- a/trellis/agent/knowledge/canonical/routes.yaml
+++ b/trellis/agent/knowledge/canonical/routes.yaml
@@ -813,6 +813,8 @@ routes:
           contract_pattern:
             payoff:
               kind: barrier_payoff
+            exercise:
+              style: european
         primitives:
           - module: trellis.models.analytical.barrier
             symbol: barrier_option_price
@@ -825,6 +827,8 @@ routes:
           contract_pattern:
             payoff:
               kind: variance_payoff
+            exercise:
+              style: none
         primitives:
           - module: trellis.models.analytical.equity_exotics
             symbol: price_equity_variance_swap_analytical
@@ -840,6 +844,8 @@ routes:
           contract_pattern:
             payoff:
               kind: lookback_payoff
+            exercise:
+              style: european
         primitives:
           - module: trellis.models.analytical.equity_exotics
             symbol: price_equity_fixed_lookback_option_analytical
@@ -851,6 +857,8 @@ routes:
           contract_pattern:
             payoff:
               kind: chooser_payoff
+            exercise:
+              style: european
         primitives:
           - module: trellis.models.analytical.equity_exotics
             symbol: price_equity_chooser_option_analytical
@@ -862,6 +870,8 @@ routes:
           contract_pattern:
             payoff:
               kind: compound_payoff
+            exercise:
+              style: european
         primitives:
           - module: trellis.models.analytical.equity_exotics
             symbol: price_equity_compound_option_analytical
@@ -873,6 +883,8 @@ routes:
           contract_pattern:
             payoff:
               kind: cliquet_payoff
+            exercise:
+              style: european
         primitives:
           - module: trellis.models.analytical.equity_exotics
             symbol: price_equity_cliquet_option_analytical
@@ -884,6 +896,8 @@ routes:
           contract_pattern:
             payoff:
               kind: digital_payoff
+            exercise:
+              style: european
         primitives:
           - module: trellis.models.analytical.equity_exotics
             symbol: price_equity_digital_option_analytical

--- a/trellis/agent/knowledge/canonical/routes.yaml
+++ b/trellis/agent/knowledge/canonical/routes.yaml
@@ -143,9 +143,9 @@ routes:
       payoff_family_bonus: {nth_to_default: 2.0}
     match:
       methods: [analytical, monte_carlo, qmc, copula]
-      instruments: [nth_to_default]
       required_market_data: [credit_curve]
       payoff_family: [nth_to_default]
+      model_family: [credit_copula]
     conditional_primitives:
       - when:
           methods: [analytical]
@@ -1118,8 +1118,8 @@ routes:
       payoff_family_bonus: {vanilla_option: 2.0}
     match:
       methods: [pde_solver]
-      instruments: [european_option]
       payoff_family: [vanilla_option]
+      model_family: [equity_diffusion]
       exercise: [european]
     admissibility:
       control_styles: [identity, holder_max]

--- a/trellis/agent/knowledge/decompose.py
+++ b/trellis/agent/knowledge/decompose.py
@@ -2675,7 +2675,9 @@ def _payoff_family_for(
         return "vanilla_option"
     if instrument == "credit_loss_distribution":
         return "credit_loss_distribution"
-    if instrument in {"cdo", "nth_to_default"}:
+    if instrument == "nth_to_default":
+        return "nth_to_default"
+    if instrument == "cdo":
         return "credit_basket"
     if instrument == "mbs":
         return "mortgage_pool"
@@ -2934,6 +2936,7 @@ def _route_matches_product_ir(route, ir: ProductIR) -> bool:
     exercise = getattr(ir, "exercise_style", "none")
     payoff_family = getattr(ir, "payoff_family", "")
     payoff_traits = set(getattr(ir, "payoff_traits", ()) or ())
+    model_family = getattr(ir, "model_family", "")
     required_market_data = set(getattr(ir, "required_market_data", ()) or ())
 
     if route.exclude_instruments and instrument in route.exclude_instruments:
@@ -2941,6 +2944,11 @@ def _route_matches_product_ir(route, ir: ProductIR) -> bool:
     if route.match_exercise is not None and exercise not in route.match_exercise:
         return False
     if route.exclude_exercise and exercise in route.exclude_exercise:
+        return False
+    if (
+        getattr(route, "match_model_family", None) is not None
+        and model_family not in route.match_model_family
+    ):
         return False
     if route.match_required_market_data is not None and not all(
         item in required_market_data for item in route.match_required_market_data
@@ -2980,6 +2988,8 @@ _STRUCTURAL_PROMOTED_SUPPORT_PAYOFFS: dict[str, frozenset[str]] = {
     ),
     "short_rate_bond_option": frozenset({"zcb_option"}),
     "credit_default_swap": frozenset({EVENT_TRIGGERED_TWO_LEGGED_CONTRACT_FAMILY}),
+    "credit_basket_nth_to_default": frozenset({"nth_to_default"}),
+    "vanilla_equity_theta_pde": frozenset({"vanilla_option"}),
 }
 
 

--- a/trellis/agent/knowledge/decompose.py
+++ b/trellis/agent/knowledge/decompose.py
@@ -2334,6 +2334,21 @@ def _infer_instrument(description: str, instrument_type: str | None) -> str | No
         ("american_option", ("american_option", "american option")),
         ("barrier_option", ("barrier_option", "barrier option")),
         ("asian_option", ("asian_option", "asian option")),
+        (
+            "digital_option",
+            (
+                "digital_option",
+                "digital option",
+                "cash_or_nothing",
+                "cash or nothing",
+                "asset_or_nothing",
+                "asset or nothing",
+            ),
+        ),
+        ("lookback_option", ("lookback_option", "lookback option", "lookback")),
+        ("chooser_option", ("chooser_option", "chooser option", "chooser")),
+        ("compound_option", ("compound_option", "compound option")),
+        ("cliquet_option", ("cliquet_option", "cliquet option", "cliquet")),
         ("heston_option", ("heston_option", "heston option", "heston")),
         ("variance_swap", ("variance_swap", "variance swap")),
         (
@@ -2484,7 +2499,17 @@ def _traits_from_text(desc: str) -> tuple[str, ...]:
     trait_aliases = {
         "asian": ("asian",),
         "barrier": ("barrier",),
+        "digital": (
+            "digital",
+            "cash_or_nothing",
+            "asset_or_nothing",
+            "cash-or-nothing",
+            "asset-or-nothing",
+        ),
         "lookback": ("lookback",),
+        "chooser": ("chooser",),
+        "compound": ("compound",),
+        "cliquet": ("cliquet",),
         "callable": ("callable",),
         "puttable": ("puttable",),
         "bermudan": ("bermudan",),
@@ -2638,6 +2663,14 @@ def _payoff_family_for(
         return "asian_option"
     if instrument in {"barrier_option"}:
         return "barrier_option"
+    if instrument in {
+        "digital_option",
+        "lookback_option",
+        "chooser_option",
+        "compound_option",
+        "cliquet_option",
+    }:
+        return instrument
     if instrument in {"american_put", "american_option", "european_option", "heston_option"}:
         return "vanilla_option"
     if instrument == "credit_loss_distribution":
@@ -2670,6 +2703,11 @@ def _exercise_style_for(
         "swaption",
         "barrier_option",
         "asian_option",
+        "digital_option",
+        "lookback_option",
+        "chooser_option",
+        "compound_option",
+        "cliquet_option",
         "european_option",
         "heston_option",
     }:
@@ -2679,7 +2717,19 @@ def _exercise_style_for(
 
 def _schedule_dependence_for(instrument: str, payoff_traits: tuple[str, ...]) -> bool:
     """Return whether the product is schedule dependent."""
-    if instrument in {"american_put", "american_option", "european_option", "heston_option", "asian_option", "barrier_option"}:
+    if instrument in {
+        "american_put",
+        "american_option",
+        "european_option",
+        "heston_option",
+        "asian_option",
+        "barrier_option",
+        "digital_option",
+        "lookback_option",
+        "chooser_option",
+        "compound_option",
+        "cliquet_option",
+    }:
         return False
     if any(
         trait in payoff_traits
@@ -2734,7 +2784,18 @@ def _model_family_for(
         return "credit_copula"
     if method == "waterfall" or instrument == "mbs":
         return "cashflow_structured"
-    if "option" in desc or instrument in {"barrier_option", "asian_option", "american_put", "american_option", "european_option"}:
+    if "option" in desc or instrument in {
+        "barrier_option",
+        "asian_option",
+        "american_put",
+        "american_option",
+        "european_option",
+        "digital_option",
+        "lookback_option",
+        "chooser_option",
+        "compound_option",
+        "cliquet_option",
+    }:
         return "equity_diffusion"
     return "generic"
 
@@ -2831,6 +2892,8 @@ def _augment_ir_with_promoted_route_support(ir: ProductIR) -> ProductIR:
             continue
         if not _route_matches_product_ir(route, ir):
             continue
+        if not _route_contributes_promoted_support(route, ir):
+            continue
         # QUA-909: a route whose scorer declares ``non_european_penalty`` is
         # signaling that it is a lower-bound / fallback approximation for
         # non-European exercise styles and must not be advertised as a
@@ -2849,12 +2912,7 @@ def _augment_ir_with_promoted_route_support(ir: ProductIR) -> ProductIR:
                 continue
 
         route_family = str(getattr(route, "route_family", "") or "").strip()
-        if (
-            route_family
-            and getattr(route, "match_instruments", None) is not None
-            and ir.instrument in route.match_instruments
-            and route_family not in route_families
-        ):
+        if route_family and route_family not in route_families:
             route_families.append(route_family)
 
         for engine_family in _candidate_engine_families_from_route(route.engine_family):
@@ -2906,6 +2964,39 @@ def _route_matches_product_ir(route, ir: ProductIR) -> bool:
     if has_positive_filter and not (instrument_ok or payoff_family_ok or payoff_traits_ok):
         return False
     return has_positive_filter
+
+
+_STRUCTURAL_PROMOTED_SUPPORT_PAYOFFS: dict[str, frozenset[str]] = {
+    "analytical_black76": frozenset(
+        {
+            "barrier_option",
+            "digital_option",
+            "lookback_option",
+            "chooser_option",
+            "compound_option",
+            "cliquet_option",
+            "variance_swap",
+        }
+    ),
+    "short_rate_bond_option": frozenset({"zcb_option"}),
+    "credit_default_swap": frozenset({EVENT_TRIGGERED_TWO_LEGGED_CONTRACT_FAMILY}),
+}
+
+
+def _route_contributes_promoted_support(route, ir: ProductIR) -> bool:
+    """Return whether a matched route should augment ProductIR support hints."""
+    instrument = getattr(ir, "instrument", None)
+    if (
+        getattr(route, "match_instruments", None) is not None
+        and instrument in route.match_instruments
+    ):
+        return True
+
+    structural_payoffs = _STRUCTURAL_PROMOTED_SUPPORT_PAYOFFS.get(
+        str(getattr(route, "id", "") or "").strip()
+    )
+    payoff_family = str(getattr(ir, "payoff_family", "") or "").strip()
+    return bool(structural_payoffs and payoff_family in structural_payoffs)
 
 
 def _candidate_engine_families_from_route(engine_family: str) -> tuple[str, ...]:

--- a/trellis/agent/knowledge/decompose.py
+++ b/trellis/agent/knowledge/decompose.py
@@ -2937,6 +2937,7 @@ def _route_matches_product_ir(route, ir: ProductIR) -> bool:
     payoff_family = getattr(ir, "payoff_family", "")
     payoff_traits = set(getattr(ir, "payoff_traits", ()) or ())
     model_family = getattr(ir, "model_family", "")
+    has_specific_model_family = str(model_family or "").strip() not in {"", "generic", "unknown"}
     required_market_data = set(getattr(ir, "required_market_data", ()) or ())
 
     if route.exclude_instruments and instrument in route.exclude_instruments:
@@ -2947,6 +2948,7 @@ def _route_matches_product_ir(route, ir: ProductIR) -> bool:
         return False
     if (
         getattr(route, "match_model_family", None) is not None
+        and has_specific_model_family
         and model_family not in route.match_model_family
     ):
         return False

--- a/trellis/agent/route_registry.py
+++ b/trellis/agent/route_registry.py
@@ -789,6 +789,7 @@ def match_candidate_routes(
     payoff_family = getattr(product_ir, "payoff_family", "") if product_ir is not None else ""
     payoff_traits = set(getattr(product_ir, "payoff_traits", ())) if product_ir is not None else set()
     model_family = getattr(product_ir, "model_family", "") if product_ir is not None else ""
+    has_specific_model_family = str(model_family or "").strip() not in {"", "generic", "unknown"}
     required_market_data = set()
     if pricing_plan is not None:
         required_market_data = set(getattr(pricing_plan, "required_market_data", ()) or ())
@@ -850,7 +851,11 @@ def match_candidate_routes(
             continue
         if route.exclude_exercise and exercise in route.exclude_exercise:
             continue
-        if route.match_model_family is not None and model_family not in route.match_model_family:
+        if (
+            route.match_model_family is not None
+            and has_specific_model_family
+            and model_family not in route.match_model_family
+        ):
             continue
 
         # Required market data match.  Skipped in gap-audit mode because

--- a/trellis/agent/route_registry.py
+++ b/trellis/agent/route_registry.py
@@ -203,6 +203,7 @@ class RouteSpec:
     discovered_from: str | None = None
     reuse_module_paths: tuple[str, ...] = ()
     successful_builds: int = 0
+    match_model_family: tuple[str, ...] | None = None
 
 
 @dataclass(frozen=True)
@@ -641,6 +642,7 @@ def _parse_route(raw: dict) -> RouteSpec:
         exclude_exercise=_str_tuple(match.get("exclude_exercise")),
         match_payoff_family=_optional_str_tuple(match.get("payoff_family")),
         match_payoff_traits=_optional_str_tuple(match.get("payoff_traits")),
+        match_model_family=_optional_str_tuple(match.get("model_family")),
         match_required_market_data=_optional_str_tuple(match.get("required_market_data")),
         exclude_required_market_data=_optional_str_tuple(match.get("exclude_required_market_data")),
         primitives=tuple(_parse_primitive(p) for p in raw.get("primitives", ())),
@@ -786,6 +788,7 @@ def match_candidate_routes(
     exercise = getattr(product_ir, "exercise_style", "none") if product_ir is not None else "none"
     payoff_family = getattr(product_ir, "payoff_family", "") if product_ir is not None else ""
     payoff_traits = set(getattr(product_ir, "payoff_traits", ())) if product_ir is not None else set()
+    model_family = getattr(product_ir, "model_family", "") if product_ir is not None else ""
     required_market_data = set()
     if pricing_plan is not None:
         required_market_data = set(getattr(pricing_plan, "required_market_data", ()) or ())
@@ -813,9 +816,10 @@ def match_candidate_routes(
         if not capability.ok:
             continue
 
-        # Instrument/payoff family/payoff traits — OR match
+        # Instrument/payoff family/payoff traits — OR match. Model family and
+        # exercise filters are separate structural refinements below.
         # The old _candidate_routes checks instrument OR payoff_family OR
-        # payoff_traits with OR semantics.  Any positive match qualifies;
+        # payoff_traits with OR semantics. Any positive match qualifies;
         # exclusions are always AND (hard veto).
         if route.exclude_instruments and instrument in route.exclude_instruments:
             continue
@@ -845,6 +849,8 @@ def match_candidate_routes(
         if route.match_exercise is not None and exercise not in route.match_exercise:
             continue
         if route.exclude_exercise and exercise in route.exclude_exercise:
+            continue
+        if route.match_model_family is not None and model_family not in route.match_model_family:
             continue
 
         # Required market data match.  Skipped in gap-audit mode because


### PR DESCRIPTION
## Summary

- Migrate the remaining analytical exotic, credit basket, and vanilla equity PDE routes off positive `match.instruments` dispatch.
- Add route-level `match.model_family` parsing/filtering and preserve structural ProductIR support hints for migrated routes.
- Normalize absorbed exotic and nth-to-default ProductIR/decomposition surfaces so canonical route selection is keyed by structural payoff/model metadata.
- Close the structural-dispatch execution mirror by moving the active plan doc to `done__contract-ir-compiler-retiring-route-registry.md`.

## Validation

- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_route_registry.py tests/test_agent/test_backend_bindings.py tests/test_agent/test_codegen_guardrails.py tests/test_agent/test_decomposition_ir.py tests/test_agent/test_knowledge_store.py -x -q -m "not integration"` — 301 passed.
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_route_registry_dsl_when.py tests/test_agent/test_backend_bindings_dsl_when.py tests/test_agent/test_route_registry_black76_dsl_parity.py tests/test_agent/test_backend_bindings_black76_dsl_parity.py -q -m "not integration"` — 63 passed.
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_platform_requests.py tests/test_agent/test_primitive_planning.py tests/test_agent/test_financepy_benchmark.py tests/test_agent/test_benchmark_contracts.py tests/test_agent/test_contract_pattern_eval.py -q -m "not integration"` — 194 passed.
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_route_registry.py tests/test_agent/test_route_scoring.py tests/test_agent/test_primitive_planning.py tests/test_agent/test_codegen_guardrails.py -x -q -m "not integration"` — 217 passed.
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_decomposition_ir.py tests/test_agent/test_knowledge_store.py -x -q -m "not integration"` — 98 passed.
- `/Users/steveyang/miniforge3/bin/python3 scripts/remediate.py --analyze-only` — completed; existing F01/T105 failures only.
- `make gate-pr` — passed; 3654 broad tests passed plus 32 tier-2 contract tests passed.
- `git diff --check origin/main...HEAD` — passed.

## Notes

- The canonical registry now has a regression that fails if any canonical route reintroduces positive `match.instruments` dispatch.
- `ProductIR.instrument` remains available for semantic identity, traces, diagnostics, and compatibility, but it is no longer the canonical route-registry dispatch key.
- QUA-923 and QUA-924 remain separate ContractIR follow-on work and are outside this route-dispatch closeout.