### PR TITLE
[codex] Add ContractIR canonicalization coverage ledger

### DIFF
--- a/tests/test_agent/test_contract_ir_simplify.py
+++ b/tests/test_agent/test_contract_ir_simplify.py
@@ -73,6 +73,86 @@ _SWAP_SCHEDULE = _finite_schedule("2026-11-15", "2027-11-15")
 _ASIAN_SCHEDULE = _finite_schedule("2025-01-01", "2025-02-01", "2025-03-01", "2025-04-01")
 _VARIANCE_INTERVAL = _interval("2025-01-01", "2025-11-15")
 
+PROPERTY_EXAMPLE_COUNTS = {
+    "idempotence": 1000,
+    "ordering_confluence": 500,
+    "semantic_preservation": 500,
+}
+
+REWRITE_RULE_TEST_COVERAGE = (
+    {
+        "rule_family": "commutative sort, flatten, singleton, and idempotence",
+        "contract": "Max/Min/Add/Mul normalize to deterministic variadic form.",
+        "tests": (
+            "test_extrema_idempotence_and_variadic_ordering_rules",
+            "test_canonicalize_agrees_on_equivalent_orderings",
+            "test_canonicalize_is_idempotent_property",
+        ),
+    },
+    {
+        "rule_family": "identity and absorbing elements",
+        "contract": "Add/Sub/Mul/Scaled drop identities and absorb zeros.",
+        "tests": (
+            "test_identity_absorbing_and_constant_fusion_rules",
+            "test_canonicalize_is_idempotent_property",
+        ),
+    },
+    {
+        "rule_family": "constant fusion",
+        "contract": "Add and Mul fuse numeric constants without reordering meaning.",
+        "tests": (
+            "test_identity_absorbing_and_constant_fusion_rules",
+            "test_canonicalize_preserves_numeric_semantics",
+        ),
+    },
+    {
+        "rule_family": "positive scalar factoring across extrema",
+        "contract": "Common locally positive extrema factors stay factored for matching.",
+        "tests": (
+            "test_factor_common_positive_scalar_out_of_max",
+            "test_canonicalize_preserves_numeric_semantics",
+        ),
+    },
+    {
+        "rule_family": "unknown or negative scalar distribution omitted",
+        "contract": "Uncertified or negative scales are not distributed through ramps.",
+        "tests": (
+            "test_negative_short_call_is_not_rewritten_into_put_orientation",
+            "test_positive_scaled_sum_stays_factorized",
+        ),
+    },
+    {
+        "rule_family": "ramp shape orientation",
+        "contract": "Call and put orientation live in Sub operand order.",
+        "tests": (
+            "test_call_shape_sorts_zero_to_second_argument",
+            "test_negative_short_call_is_not_rewritten_into_put_orientation",
+            "test_family_templates_canonicalize_to_expected_forms",
+        ),
+    },
+    {
+        "rule_family": "LinearBasket normalization",
+        "contract": "Zero-weight baskets collapse and singleton baskets become Scaled.",
+        "tests": (
+            "test_linear_basket_zero_and_singleton_rules",
+            "test_canonicalize_preserves_numeric_semantics",
+        ),
+    },
+    {
+        "rule_family": "semantic preservation",
+        "contract": "Canonicalization preserves PayoffExpr denotation in synthetic environments.",
+        "tests": (
+            "test_canonicalize_preserves_numeric_semantics",
+            "test_canonicalize_preserves_numeric_semantics_on_reference_environment",
+        ),
+    },
+    {
+        "rule_family": "family template fixed points",
+        "contract": "Each bounded Phase 2 payoff family remains in its documented normal form.",
+        "tests": ("test_family_templates_canonicalize_to_expected_forms",),
+    },
+)
+
 
 def _finite_float(min_value: float, max_value: float):
     return st.floats(
@@ -154,6 +234,46 @@ def _property_settings(*, max_examples: int):
 
 
 class TestContractIRSimplify:
+    def test_rewrite_rule_coverage_ledger_names_checked_contract(self):
+        test_names = {
+            name
+            for name in dir(type(self))
+            if name.startswith("test_")
+        }
+        assert PROPERTY_EXAMPLE_COUNTS == {
+            "idempotence": 1000,
+            "ordering_confluence": 500,
+            "semantic_preservation": 500,
+        }
+        assert len(REWRITE_RULE_TEST_COVERAGE) >= 8
+        for row in REWRITE_RULE_TEST_COVERAGE:
+            assert row["rule_family"]
+            assert row["contract"]
+            assert set(row["tests"]).issubset(test_names)
+
+    def test_extrema_idempotence_and_variadic_ordering_rules(self):
+        expr = Spot("AAPL")
+        assert canonicalize(Max((expr, expr))) == expr
+        assert canonicalize(Min((expr,))) == expr
+        assert canonicalize(Max((Max((Constant(0.0), expr)), expr))) == Max(
+            (expr, Constant(0.0))
+        )
+
+    def test_identity_absorbing_and_constant_fusion_rules(self):
+        expr = Spot("AAPL")
+        assert canonicalize(Add((expr, Constant(2.0), Constant(3.0)))) == Add(
+            (expr, Constant(5.0))
+        )
+        assert canonicalize(Sub(expr, Constant(0.0))) == expr
+        assert canonicalize(Sub(expr, expr)) == Constant(0.0)
+        assert canonicalize(Mul((expr, Constant(0.0)))) == Constant(0.0)
+        assert canonicalize(Mul((expr, Constant(2.0), Constant(3.0)))) == Mul(
+            (expr, Constant(6.0))
+        )
+        assert canonicalize(
+            Scaled(Constant(2.0), Scaled(Constant(3.0), expr))
+        ) == Scaled(Constant(6.0), expr)
+
     def test_call_shape_sorts_zero_to_second_argument(self):
         expr = Max((Constant(0.0), Sub(Spot("AAPL"), Strike(150.0))))
         assert canonicalize(expr) == Max(
@@ -275,21 +395,21 @@ class TestContractIRSimplify:
             )
         )
 
-    @_property_settings(max_examples=1000)
+    @_property_settings(max_examples=PROPERTY_EXAMPLE_COUNTS["idempotence"])
     @given(_payoff_expr_strategy())
     def test_canonicalize_is_idempotent_property(self, expr):
         once = canonicalize(expr)
         twice = canonicalize(once)
         assert twice == once
 
-    @_property_settings(max_examples=500)
+    @_property_settings(max_examples=PROPERTY_EXAMPLE_COUNTS["ordering_confluence"])
     @given(_payoff_expr_strategy(), _payoff_expr_strategy(), _payoff_expr_strategy())
     def test_canonicalize_agrees_on_equivalent_orderings(self, a, b, c):
         assert canonicalize(Max((a, b, c))) == canonicalize(Max((c, a, b)))
         assert canonicalize(Add((a, b, c))) == canonicalize(Add((b, c, a)))
         assert canonicalize(Mul((a, b, c))) == canonicalize(Mul((c, b, a)))
 
-    @_property_settings(max_examples=500)
+    @_property_settings(max_examples=PROPERTY_EXAMPLE_COUNTS["semantic_preservation"])
     @given(_payoff_expr_strategy(), _environment_strategy())
     def test_canonicalize_preserves_numeric_semantics(self, expr, env):
         before = evaluate_payoff_expr(expr, env)


### PR DESCRIPTION
## Summary

- Add an explicit ContractIR canonicalization rewrite-rule coverage ledger in `tests/test_agent/test_contract_ir_simplify.py`.
- Promote the documented Hypothesis example-count bars into checked constants.
- Add focused regression checks for extrema idempotence / variadic ordering and identity, absorbing, and constant-fusion rules.

## Linear

- `QUA-923`: implemented by this PR.
- `QUA-924`: audited and closed as already satisfied by the existing decomposition fixture matrix.

## Validation

- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_contract_ir_simplify.py -q` (`13 passed`)
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_contract_ir_simplify.py tests/test_agent/test_decompose_contract_ir.py tests/test_agent/test_contract_ir_solver_parity.py -q` (`86 passed`)
- `make gate-pr` (`3660 passed, 5 deselected`; tier2 contracts `32 passed, 15 skipped, 6 deselected`)
