### PR TITLE
[codex] Calibration problem IR program

### DIFF
--- a/doc/plan/draft__universal-calibration-engine-prerequisites.md
+++ b/doc/plan/draft__universal-calibration-engine-prerequisites.md
@@ -2,12 +2,16 @@
 
 ## Status
 
-Draft planning document with first Linear execution ticket filed.
+Draft planning document with Linear execution queue filed.
 
 Filed queue:
 
 - QUA-1001 — Calibration engine: common problem IR program
 - QUA-1002 — Calibration engine: common problem IR and SABR adapter
+- QUA-1007 — Calibration engine: second workflow problem-IR adapter
+- QUA-1008 — Calibration engine: problem IR dependency graph compiler
+- QUA-1009 — Calibration engine: benchmark and replay problem-IR payloads
+- QUA-1010 — Calibration engine: gated public problem-IR orchestrator
 
 This document describes the missing contracts and implementation work required
 before Trellis can honestly claim a universal calibration engine. It is a
@@ -199,14 +203,15 @@ Deliverables:
 - typed validators for variables, quotes, transforms, and materialization
 - tests showing existing workflow metadata can be represented without solving
 
-### Phase 2: One Workflow Adapter
+### Phase 2: Workflow Adapters
 
-Adapt one low-risk workflow, preferably SABR smile or single-name credit, to
-build an IR and then execute through the existing solver path.
+Adapt low-risk workflows, starting with SABR smile and single-name credit, to
+build an IR and then execute through the existing solver paths.
 
 Deliverables:
 
 - adapter implementation (`QUA-1002` starts this with the SABR smile workflow)
+- second adapter implementation (`QUA-1007` adds single-name credit)
 - parity tests against the old workflow result
 - replay artifact comparison
 
@@ -281,3 +286,9 @@ Filed as `QUA-1002` with SABR smile as the first migrated workflow adapter.
 This first slice deliberately keeps `engine_backed = false` in the problem IR
 metadata: it proves representation and adapter parity, not a public universal
 engine.
+
+`QUA-1007` adds the second bounded adapter for the schedule-aware single-name
+credit curve workflow. It keeps the direct credit workflow authoritative,
+preserves the existing solve request and replay payload, and records the
+discount-curve dependency and credit-curve materialization intent in the common
+problem shape.

--- a/doc/plan/draft__universal-calibration-engine-prerequisites.md
+++ b/doc/plan/draft__universal-calibration-engine-prerequisites.md
@@ -244,6 +244,12 @@ Deliverables:
 - replay tests compare problem IR, solve request, result payload, and
   materialization output
 
+`QUA-1009` adds the first replay lock for the problem-IR contract. The
+supported calibration benchmark report now carries full problem-IR payloads for
+the adapter-backed SABR and single-name credit workflows, and replay tests
+compare the serialized solve-request portions against the live direct workflow
+outputs.
+
 ### Phase 5: Universal Orchestrator
 
 Introduce a public orchestrator only after multiple adapters prove the IR.
@@ -305,3 +311,8 @@ bounded two-node compile where a downstream basket-credit problem consumes the
 single-name credit curve materialized by the credit adapter. This remains a
 compile/validation step only; execution is deferred to the gated orchestrator
 work.
+
+`QUA-1009` adds benchmark and replay payload coverage for the adapter-backed
+problem IRs. This keeps non-IR workflows unchanged while making SABR and
+single-name credit problem payload drift observable in the checked benchmark
+artifact and replay tests.

--- a/doc/plan/draft__universal-calibration-engine-prerequisites.md
+++ b/doc/plan/draft__universal-calibration-engine-prerequisites.md
@@ -260,6 +260,13 @@ Deliverables:
 - support matrix listing which families are engine-backed
 - fail-closed behavior for unsupported families
 
+`QUA-1010` exposes this as the bounded `calibrate_problem_ir(...)`
+orchestrator plus `supported_calibration_problem_ir_adapters()`. The support
+matrix is limited to the adapter-backed SABR smile and single-name credit curve
+workflows, and each route requires explicit context (`surface` for SABR;
+`quotes` plus `market_state` for credit). Unsupported families raise a
+dedicated fail-closed error.
+
 ## Explicit Non-Goals
 
 - Do not build a single pricing formula registry inside the engine.
@@ -316,3 +323,7 @@ work.
 problem IRs. This keeps non-IR workflows unchanged while making SABR and
 single-name credit problem payload drift observable in the checked benchmark
 artifact and replay tests.
+
+`QUA-1010` adds the bounded public orchestrator. It intentionally exposes only
+the replay-backed SABR and single-name credit problem-IR adapters and records
+orchestrator provenance on returned calibration results.

--- a/doc/plan/draft__universal-calibration-engine-prerequisites.md
+++ b/doc/plan/draft__universal-calibration-engine-prerequisites.md
@@ -226,6 +226,13 @@ Deliverables:
 - basket-credit or bounded quanto route represented as a two-node graph
 - failure diagnostics for missing upstream materializations
 
+`QUA-1008` introduces this bridge as
+`compile_calibration_problem_dependency_graph(...)`. The compiler accepts
+concrete `CalibrationProblemIR` nodes, infers problem-level edges from
+`problem:<problem_id>` source refs or matching materialized object kind/name
+pairs, and delegates duplicate/missing/cycle validation to the existing
+`CalibrationDependencyGraph`.
+
 ### Phase 4: Benchmark And Replay Migration
 
 Move benchmark metadata and replay payloads to consume IR fields instead of
@@ -292,3 +299,9 @@ credit curve workflow. It keeps the direct credit workflow authoritative,
 preserves the existing solve request and replay payload, and records the
 discount-curve dependency and credit-curve materialization intent in the common
 problem shape.
+
+`QUA-1008` adds the internal problem-IR dependency graph compiler. It proves a
+bounded two-node compile where a downstream basket-credit problem consumes the
+single-name credit curve materialized by the credit adapter. This remains a
+compile/validation step only; execution is deferred to the gated orchestrator
+work.

--- a/doc/plan/draft__universal-calibration-engine-prerequisites.md
+++ b/doc/plan/draft__universal-calibration-engine-prerequisites.md
@@ -2,7 +2,12 @@
 
 ## Status
 
-Draft planning document. No Linear tickets have been created from this plan.
+Draft planning document with first Linear execution ticket filed.
+
+Filed queue:
+
+- QUA-1001 — Calibration engine: common problem IR program
+- QUA-1002 — Calibration engine: common problem IR and SABR adapter
 
 This document describes the missing contracts and implementation work required
 before Trellis can honestly claim a universal calibration engine. It is a
@@ -190,7 +195,7 @@ workflow inputs into `CalibrationProblemIR`.
 
 Deliverables:
 
-- new IR module under `trellis/models/calibration/`
+- new IR module under `trellis/models/calibration/` (`QUA-1002`)
 - typed validators for variables, quotes, transforms, and materialization
 - tests showing existing workflow metadata can be represented without solving
 
@@ -201,7 +206,7 @@ build an IR and then execute through the existing solver path.
 
 Deliverables:
 
-- adapter implementation
+- adapter implementation (`QUA-1002` starts this with the SABR smile workflow)
 - parity tests against the old workflow result
 - replay artifact comparison
 
@@ -271,3 +276,8 @@ Acceptance criteria:
   and diagnostics as before.
 - Unsupported workflows remain on their current direct functions and are not
   advertised as universal-engine-backed.
+
+Filed as `QUA-1002` with SABR smile as the first migrated workflow adapter.
+This first slice deliberately keeps `engine_backed = false` in the problem IR
+metadata: it proves representation and adapter parity, not a public universal
+engine.

--- a/docs/benchmarks/calibration_workflows.json
+++ b/docs/benchmarks/calibration_workflows.json
@@ -45,6 +45,7 @@
         "least_squares",
         "tree_pricing"
       ],
+      "problem_ir": null,
       "warm": {
         "calibrations_per_second": 3.326,
         "label": "swaption_strip",
@@ -123,6 +124,7 @@
         "caplet_surface",
         "price_quotes"
       ],
+      "problem_ir": null,
       "warm": null,
       "warm_speedup": null,
       "workflow": "caplet_strip"
@@ -167,6 +169,792 @@
         "implied_vol_fit",
         "synthetic_generation_contract_fixture"
       ],
+      "problem_ir": {
+        "dependencies": [],
+        "diagnostics": [
+          {
+            "diagnostic_id": "max_abs_vol_error",
+            "metadata": {},
+            "metric_name": "max_abs_vol_error",
+            "severity": "warning",
+            "tolerance": 0.0005
+          },
+          {
+            "diagnostic_id": "weighted_rms_vol_error",
+            "metadata": {},
+            "metric_name": "weighted_rms_vol_error",
+            "severity": "warning",
+            "tolerance": 0.0005
+          }
+        ],
+        "family_id": "sabr",
+        "materialization": {
+          "destination_field": "model_parameter_sets",
+          "metadata": {
+            "fixed_beta": 0.5,
+            "model_family": "sabr",
+            "parameter_names": [
+              "alpha",
+              "beta",
+              "rho",
+              "nu"
+            ]
+          },
+          "object_kind": "model_parameter_set",
+          "object_name": "usd_rates_smile",
+          "source_ref": "fit_sabr_smile_surface"
+        },
+        "metadata": {
+          "adapter_id": "sabr_smile_problem_ir_v1",
+          "engine_backed": false,
+          "source_ref": "build_sabr_smile_calibration_problem_ir",
+          "support_boundary": "problem_ir_adapter_only"
+        },
+        "objective": {
+          "derivative_method": "autodiff_scalar_gradient",
+          "loss_function": "weighted_sum_of_squares",
+          "metadata": {
+            "beta": 0.5,
+            "quote_map": {
+              "assumptions": [],
+              "convention": "black",
+              "metadata": {},
+              "quote_axes": [
+                {
+                  "axis_kind": "time_to_expiry",
+                  "axis_name": "expiry",
+                  "unit": "years"
+                },
+                {
+                  "axis_kind": "swap_rate",
+                  "axis_name": "strike",
+                  "unit": "decimal_rate"
+                }
+              ],
+              "quote_family": "implied_vol",
+              "quote_semantics": {
+                "convention": "black",
+                "quote_axes": [
+                  {
+                    "axis_kind": "time_to_expiry",
+                    "axis_name": "expiry",
+                    "unit": "years"
+                  },
+                  {
+                    "axis_kind": "swap_rate",
+                    "axis_name": "strike",
+                    "unit": "decimal_rate"
+                  }
+                ],
+                "quote_family": "implied_vol",
+                "quote_subject": "swaption",
+                "quote_unit": "decimal_volatility",
+                "quote_unit_spec": {
+                  "scaling": "absolute",
+                  "unit_name": "decimal_volatility",
+                  "value_domain": "volatility"
+                }
+              },
+              "quote_subject": "swaption",
+              "quote_unit": "decimal_volatility"
+            },
+            "target_transform": "black_implied_vol"
+          },
+          "objective_kind": "least_squares",
+          "regularization": {},
+          "residual_count": 7,
+          "solve_request_id": "sabr_smile_least_squares"
+        },
+        "problem_id": "sabr_smile_least_squares",
+        "replay_metadata": {
+          "surface": {
+            "atm_market_vol": 1.177411,
+            "atm_strike": 0.04,
+            "beta": 0.5,
+            "expiry_years": 1.0,
+            "forward": 0.04443994157739724,
+            "labels": [
+              "strike_0.01",
+              "strike_0.02",
+              "strike_0.03",
+              "strike_0.04",
+              "strike_0.05",
+              "strike_0.06",
+              "strike_0.07"
+            ],
+            "market_vols": [
+              1.726447,
+              1.432935,
+              1.278181,
+              1.177411,
+              1.105188,
+              1.050471,
+              1.007475
+            ],
+            "metadata": {},
+            "quote_map": {
+              "assumptions": [],
+              "convention": "black",
+              "metadata": {},
+              "quote_axes": [
+                {
+                  "axis_kind": "time_to_expiry",
+                  "axis_name": "expiry",
+                  "unit": "years"
+                },
+                {
+                  "axis_kind": "swap_rate",
+                  "axis_name": "strike",
+                  "unit": "decimal_rate"
+                }
+              ],
+              "quote_family": "implied_vol",
+              "quote_semantics": {
+                "convention": "black",
+                "quote_axes": [
+                  {
+                    "axis_kind": "time_to_expiry",
+                    "axis_name": "expiry",
+                    "unit": "years"
+                  },
+                  {
+                    "axis_kind": "swap_rate",
+                    "axis_name": "strike",
+                    "unit": "decimal_rate"
+                  }
+                ],
+                "quote_family": "implied_vol",
+                "quote_subject": "swaption",
+                "quote_unit": "decimal_volatility",
+                "quote_unit_spec": {
+                  "scaling": "absolute",
+                  "unit_name": "decimal_volatility",
+                  "value_domain": "volatility"
+                }
+              },
+              "quote_subject": "swaption",
+              "quote_unit": "decimal_volatility"
+            },
+            "source_kind": "option_surface",
+            "source_ref": "supported_calibration_benchmark_scenarios",
+            "strike_count": 7,
+            "strikes": [
+              0.01,
+              0.02,
+              0.03,
+              0.04,
+              0.05,
+              0.06,
+              0.07
+            ],
+            "surface_name": "usd_rates_smile",
+            "warnings": [
+              "ATM forward 0.0444399 not observed exactly; nearest strike 0.04 is used for diagnostics."
+            ],
+            "weights": [
+              1.0,
+              1.0,
+              1.0,
+              1.0,
+              1.0,
+              1.0,
+              1.0
+            ]
+          },
+          "warm_start_source": "atm_seed"
+        },
+        "solve_request": {
+          "bounds": {
+            "lower": [
+              1e-06,
+              -0.999,
+              1e-06
+            ],
+            "upper": [
+              null,
+              0.999,
+              null
+            ]
+          },
+          "constraints": [],
+          "initial_guess": [
+            0.24820745901191202,
+            0.0,
+            0.3
+          ],
+          "metadata": {
+            "problem_family": "sabr_smile",
+            "solver_family": "scipy",
+            "surface_name": "usd_rates_smile"
+          },
+          "objective": {
+            "derivatives": {
+              "hessian": "none",
+              "jacobian": "provided"
+            },
+            "labels": [
+              "strike_0.01",
+              "strike_0.02",
+              "strike_0.03",
+              "strike_0.04",
+              "strike_0.05",
+              "strike_0.06",
+              "strike_0.07"
+            ],
+            "metadata": {
+              "beta": 0.5,
+              "derivative_method": "autodiff_scalar_gradient",
+              "expiry_years": 1.0,
+              "forward": 0.04443994157739724,
+              "quote_map": {
+                "assumptions": [],
+                "convention": "black",
+                "metadata": {},
+                "quote_axes": [
+                  {
+                    "axis_kind": "time_to_expiry",
+                    "axis_name": "expiry",
+                    "unit": "years"
+                  },
+                  {
+                    "axis_kind": "swap_rate",
+                    "axis_name": "strike",
+                    "unit": "decimal_rate"
+                  }
+                ],
+                "quote_family": "implied_vol",
+                "quote_semantics": {
+                  "convention": "black",
+                  "quote_axes": [
+                    {
+                      "axis_kind": "time_to_expiry",
+                      "axis_name": "expiry",
+                      "unit": "years"
+                    },
+                    {
+                      "axis_kind": "swap_rate",
+                      "axis_name": "strike",
+                      "unit": "decimal_rate"
+                    }
+                  ],
+                  "quote_family": "implied_vol",
+                  "quote_subject": "swaption",
+                  "quote_unit": "decimal_volatility",
+                  "quote_unit_spec": {
+                    "scaling": "absolute",
+                    "unit_name": "decimal_volatility",
+                    "value_domain": "volatility"
+                  }
+                },
+                "quote_subject": "swaption",
+                "quote_unit": "decimal_volatility"
+              },
+              "surface_name": "usd_rates_smile"
+            },
+            "objective_kind": "least_squares",
+            "target_values": [
+              1.726447,
+              1.432935,
+              1.278181,
+              1.177411,
+              1.105188,
+              1.050471,
+              1.007475
+            ],
+            "weights": [
+              1.0,
+              1.0,
+              1.0,
+              1.0,
+              1.0,
+              1.0,
+              1.0
+            ]
+          },
+          "options": {},
+          "parameter_names": [
+            "alpha",
+            "rho",
+            "nu"
+          ],
+          "problem_kind": "least_squares",
+          "request_id": "sabr_smile_least_squares",
+          "solver_hint": "L-BFGS-B",
+          "warm_start": {
+            "metadata": {},
+            "parameter_values": [
+              0.24820745901191202,
+              0.0,
+              0.3
+            ],
+            "source": "atm_seed"
+          }
+        },
+        "targets": [
+          {
+            "instrument_id": "usd_rates_smile:strike_0.01",
+            "metadata": {
+              "expiry_years": 1.0,
+              "forward": 0.04443994157739724,
+              "strike": 0.01
+            },
+            "quote_convention": "black",
+            "quote_family": "implied_vol",
+            "quote_map": {
+              "assumptions": [],
+              "convention": "black",
+              "metadata": {},
+              "quote_axes": [
+                {
+                  "axis_kind": "time_to_expiry",
+                  "axis_name": "expiry",
+                  "unit": "years"
+                },
+                {
+                  "axis_kind": "swap_rate",
+                  "axis_name": "strike",
+                  "unit": "decimal_rate"
+                }
+              ],
+              "quote_family": "implied_vol",
+              "quote_semantics": {
+                "convention": "black",
+                "quote_axes": [
+                  {
+                    "axis_kind": "time_to_expiry",
+                    "axis_name": "expiry",
+                    "unit": "years"
+                  },
+                  {
+                    "axis_kind": "swap_rate",
+                    "axis_name": "strike",
+                    "unit": "decimal_rate"
+                  }
+                ],
+                "quote_family": "implied_vol",
+                "quote_subject": "swaption",
+                "quote_unit": "decimal_volatility",
+                "quote_unit_spec": {
+                  "scaling": "absolute",
+                  "unit_name": "decimal_volatility",
+                  "value_domain": "volatility"
+                }
+              },
+              "quote_subject": "swaption",
+              "quote_unit": "decimal_volatility"
+            },
+            "quote_value": 1.726447,
+            "target_id": "strike_0.01",
+            "validation_tags": [
+              "implied_vol",
+              "sabr_smile"
+            ],
+            "weight": 1.0
+          },
+          {
+            "instrument_id": "usd_rates_smile:strike_0.02",
+            "metadata": {
+              "expiry_years": 1.0,
+              "forward": 0.04443994157739724,
+              "strike": 0.02
+            },
+            "quote_convention": "black",
+            "quote_family": "implied_vol",
+            "quote_map": {
+              "assumptions": [],
+              "convention": "black",
+              "metadata": {},
+              "quote_axes": [
+                {
+                  "axis_kind": "time_to_expiry",
+                  "axis_name": "expiry",
+                  "unit": "years"
+                },
+                {
+                  "axis_kind": "swap_rate",
+                  "axis_name": "strike",
+                  "unit": "decimal_rate"
+                }
+              ],
+              "quote_family": "implied_vol",
+              "quote_semantics": {
+                "convention": "black",
+                "quote_axes": [
+                  {
+                    "axis_kind": "time_to_expiry",
+                    "axis_name": "expiry",
+                    "unit": "years"
+                  },
+                  {
+                    "axis_kind": "swap_rate",
+                    "axis_name": "strike",
+                    "unit": "decimal_rate"
+                  }
+                ],
+                "quote_family": "implied_vol",
+                "quote_subject": "swaption",
+                "quote_unit": "decimal_volatility",
+                "quote_unit_spec": {
+                  "scaling": "absolute",
+                  "unit_name": "decimal_volatility",
+                  "value_domain": "volatility"
+                }
+              },
+              "quote_subject": "swaption",
+              "quote_unit": "decimal_volatility"
+            },
+            "quote_value": 1.432935,
+            "target_id": "strike_0.02",
+            "validation_tags": [
+              "implied_vol",
+              "sabr_smile"
+            ],
+            "weight": 1.0
+          },
+          {
+            "instrument_id": "usd_rates_smile:strike_0.03",
+            "metadata": {
+              "expiry_years": 1.0,
+              "forward": 0.04443994157739724,
+              "strike": 0.03
+            },
+            "quote_convention": "black",
+            "quote_family": "implied_vol",
+            "quote_map": {
+              "assumptions": [],
+              "convention": "black",
+              "metadata": {},
+              "quote_axes": [
+                {
+                  "axis_kind": "time_to_expiry",
+                  "axis_name": "expiry",
+                  "unit": "years"
+                },
+                {
+                  "axis_kind": "swap_rate",
+                  "axis_name": "strike",
+                  "unit": "decimal_rate"
+                }
+              ],
+              "quote_family": "implied_vol",
+              "quote_semantics": {
+                "convention": "black",
+                "quote_axes": [
+                  {
+                    "axis_kind": "time_to_expiry",
+                    "axis_name": "expiry",
+                    "unit": "years"
+                  },
+                  {
+                    "axis_kind": "swap_rate",
+                    "axis_name": "strike",
+                    "unit": "decimal_rate"
+                  }
+                ],
+                "quote_family": "implied_vol",
+                "quote_subject": "swaption",
+                "quote_unit": "decimal_volatility",
+                "quote_unit_spec": {
+                  "scaling": "absolute",
+                  "unit_name": "decimal_volatility",
+                  "value_domain": "volatility"
+                }
+              },
+              "quote_subject": "swaption",
+              "quote_unit": "decimal_volatility"
+            },
+            "quote_value": 1.278181,
+            "target_id": "strike_0.03",
+            "validation_tags": [
+              "implied_vol",
+              "sabr_smile"
+            ],
+            "weight": 1.0
+          },
+          {
+            "instrument_id": "usd_rates_smile:strike_0.04",
+            "metadata": {
+              "expiry_years": 1.0,
+              "forward": 0.04443994157739724,
+              "strike": 0.04
+            },
+            "quote_convention": "black",
+            "quote_family": "implied_vol",
+            "quote_map": {
+              "assumptions": [],
+              "convention": "black",
+              "metadata": {},
+              "quote_axes": [
+                {
+                  "axis_kind": "time_to_expiry",
+                  "axis_name": "expiry",
+                  "unit": "years"
+                },
+                {
+                  "axis_kind": "swap_rate",
+                  "axis_name": "strike",
+                  "unit": "decimal_rate"
+                }
+              ],
+              "quote_family": "implied_vol",
+              "quote_semantics": {
+                "convention": "black",
+                "quote_axes": [
+                  {
+                    "axis_kind": "time_to_expiry",
+                    "axis_name": "expiry",
+                    "unit": "years"
+                  },
+                  {
+                    "axis_kind": "swap_rate",
+                    "axis_name": "strike",
+                    "unit": "decimal_rate"
+                  }
+                ],
+                "quote_family": "implied_vol",
+                "quote_subject": "swaption",
+                "quote_unit": "decimal_volatility",
+                "quote_unit_spec": {
+                  "scaling": "absolute",
+                  "unit_name": "decimal_volatility",
+                  "value_domain": "volatility"
+                }
+              },
+              "quote_subject": "swaption",
+              "quote_unit": "decimal_volatility"
+            },
+            "quote_value": 1.177411,
+            "target_id": "strike_0.04",
+            "validation_tags": [
+              "implied_vol",
+              "sabr_smile"
+            ],
+            "weight": 1.0
+          },
+          {
+            "instrument_id": "usd_rates_smile:strike_0.05",
+            "metadata": {
+              "expiry_years": 1.0,
+              "forward": 0.04443994157739724,
+              "strike": 0.05
+            },
+            "quote_convention": "black",
+            "quote_family": "implied_vol",
+            "quote_map": {
+              "assumptions": [],
+              "convention": "black",
+              "metadata": {},
+              "quote_axes": [
+                {
+                  "axis_kind": "time_to_expiry",
+                  "axis_name": "expiry",
+                  "unit": "years"
+                },
+                {
+                  "axis_kind": "swap_rate",
+                  "axis_name": "strike",
+                  "unit": "decimal_rate"
+                }
+              ],
+              "quote_family": "implied_vol",
+              "quote_semantics": {
+                "convention": "black",
+                "quote_axes": [
+                  {
+                    "axis_kind": "time_to_expiry",
+                    "axis_name": "expiry",
+                    "unit": "years"
+                  },
+                  {
+                    "axis_kind": "swap_rate",
+                    "axis_name": "strike",
+                    "unit": "decimal_rate"
+                  }
+                ],
+                "quote_family": "implied_vol",
+                "quote_subject": "swaption",
+                "quote_unit": "decimal_volatility",
+                "quote_unit_spec": {
+                  "scaling": "absolute",
+                  "unit_name": "decimal_volatility",
+                  "value_domain": "volatility"
+                }
+              },
+              "quote_subject": "swaption",
+              "quote_unit": "decimal_volatility"
+            },
+            "quote_value": 1.105188,
+            "target_id": "strike_0.05",
+            "validation_tags": [
+              "implied_vol",
+              "sabr_smile"
+            ],
+            "weight": 1.0
+          },
+          {
+            "instrument_id": "usd_rates_smile:strike_0.06",
+            "metadata": {
+              "expiry_years": 1.0,
+              "forward": 0.04443994157739724,
+              "strike": 0.06
+            },
+            "quote_convention": "black",
+            "quote_family": "implied_vol",
+            "quote_map": {
+              "assumptions": [],
+              "convention": "black",
+              "metadata": {},
+              "quote_axes": [
+                {
+                  "axis_kind": "time_to_expiry",
+                  "axis_name": "expiry",
+                  "unit": "years"
+                },
+                {
+                  "axis_kind": "swap_rate",
+                  "axis_name": "strike",
+                  "unit": "decimal_rate"
+                }
+              ],
+              "quote_family": "implied_vol",
+              "quote_semantics": {
+                "convention": "black",
+                "quote_axes": [
+                  {
+                    "axis_kind": "time_to_expiry",
+                    "axis_name": "expiry",
+                    "unit": "years"
+                  },
+                  {
+                    "axis_kind": "swap_rate",
+                    "axis_name": "strike",
+                    "unit": "decimal_rate"
+                  }
+                ],
+                "quote_family": "implied_vol",
+                "quote_subject": "swaption",
+                "quote_unit": "decimal_volatility",
+                "quote_unit_spec": {
+                  "scaling": "absolute",
+                  "unit_name": "decimal_volatility",
+                  "value_domain": "volatility"
+                }
+              },
+              "quote_subject": "swaption",
+              "quote_unit": "decimal_volatility"
+            },
+            "quote_value": 1.050471,
+            "target_id": "strike_0.06",
+            "validation_tags": [
+              "implied_vol",
+              "sabr_smile"
+            ],
+            "weight": 1.0
+          },
+          {
+            "instrument_id": "usd_rates_smile:strike_0.07",
+            "metadata": {
+              "expiry_years": 1.0,
+              "forward": 0.04443994157739724,
+              "strike": 0.07
+            },
+            "quote_convention": "black",
+            "quote_family": "implied_vol",
+            "quote_map": {
+              "assumptions": [],
+              "convention": "black",
+              "metadata": {},
+              "quote_axes": [
+                {
+                  "axis_kind": "time_to_expiry",
+                  "axis_name": "expiry",
+                  "unit": "years"
+                },
+                {
+                  "axis_kind": "swap_rate",
+                  "axis_name": "strike",
+                  "unit": "decimal_rate"
+                }
+              ],
+              "quote_family": "implied_vol",
+              "quote_semantics": {
+                "convention": "black",
+                "quote_axes": [
+                  {
+                    "axis_kind": "time_to_expiry",
+                    "axis_name": "expiry",
+                    "unit": "years"
+                  },
+                  {
+                    "axis_kind": "swap_rate",
+                    "axis_name": "strike",
+                    "unit": "decimal_rate"
+                  }
+                ],
+                "quote_family": "implied_vol",
+                "quote_subject": "swaption",
+                "quote_unit": "decimal_volatility",
+                "quote_unit_spec": {
+                  "scaling": "absolute",
+                  "unit_name": "decimal_volatility",
+                  "value_domain": "volatility"
+                }
+              },
+              "quote_subject": "swaption",
+              "quote_unit": "decimal_volatility"
+            },
+            "quote_value": 1.007475,
+            "target_id": "strike_0.07",
+            "validation_tags": [
+              "implied_vol",
+              "sabr_smile"
+            ],
+            "weight": 1.0
+          }
+        ],
+        "variables": [
+          {
+            "coordinate_chart": "positive",
+            "initial_value": 0.24820745901191202,
+            "lower_bound": 1e-06,
+            "metadata": {
+              "fixed_beta": 0.5,
+              "parameter_role": "sabr_parameter"
+            },
+            "name": "alpha",
+            "scaling": 1.0,
+            "upper_bound": null,
+            "warm_start_source": "atm_seed"
+          },
+          {
+            "coordinate_chart": "bounded_correlation",
+            "initial_value": 0.0,
+            "lower_bound": -0.999,
+            "metadata": {
+              "fixed_beta": 0.5,
+              "parameter_role": "sabr_parameter"
+            },
+            "name": "rho",
+            "scaling": 1.0,
+            "upper_bound": 0.999,
+            "warm_start_source": "atm_seed"
+          },
+          {
+            "coordinate_chart": "positive",
+            "initial_value": 0.3,
+            "lower_bound": 1e-06,
+            "metadata": {
+              "fixed_beta": 0.5,
+              "parameter_role": "sabr_parameter"
+            },
+            "name": "nu",
+            "scaling": 1.0,
+            "upper_bound": null,
+            "warm_start_source": "atm_seed"
+          }
+        ],
+        "workflow_id": "sabr_smile"
+      },
       "warm": {
         "calibrations_per_second": 290.707,
         "label": "single_smile",
@@ -249,6 +1037,7 @@
         "price_quotes",
         "synthetic_generation_contract_fixture"
       ],
+      "problem_ir": null,
       "warm": null,
       "warm_speedup": null,
       "workflow": "swaption_cube"
@@ -299,6 +1088,7 @@
         "quote_governance",
         "synthetic_generation_contract_fixture"
       ],
+      "problem_ir": null,
       "warm": null,
       "warm_speedup": null,
       "workflow": "equity_vol_surface"
@@ -343,6 +1133,7 @@
         "fft_pricing",
         "synthetic_generation_contract_fixture"
       ],
+      "problem_ir": null,
       "warm": {
         "calibrations_per_second": 14.517,
         "label": "single_smile",
@@ -421,6 +1212,7 @@
         "surface_compression",
         "synthetic_generation_contract_fixture"
       ],
+      "problem_ir": null,
       "warm": {
         "calibrations_per_second": 2.802,
         "label": "surface_compression",
@@ -503,6 +1295,7 @@
         "workflow_surface",
         "synthetic_generation_contract_fixture"
       ],
+      "problem_ir": null,
       "warm": null,
       "warm_speedup": null,
       "workflow": "local_vol"
@@ -547,6 +1340,1411 @@
         "least_squares",
         "model_consistency_contract_fixture"
       ],
+      "problem_ir": {
+        "dependencies": [
+          {
+            "dependency_id": "discount_curve",
+            "metadata": {
+              "curve_role": "discount_curve",
+              "required_for": "cds_par_spread_objective"
+            },
+            "object_kind": "yield_curve",
+            "object_name": "usd_ois",
+            "required": true,
+            "source_ref": "market_state.discount"
+          }
+        ],
+        "diagnostics": [
+          {
+            "diagnostic_id": "max_abs_repricing_error",
+            "metadata": {},
+            "metric_name": "max_abs_repricing_error",
+            "severity": "warning",
+            "tolerance": 5e-12
+          },
+          {
+            "diagnostic_id": "max_abs_quote_residual",
+            "metadata": {},
+            "metric_name": "max_abs_quote_residual",
+            "severity": "warning",
+            "tolerance": 1e-08
+          },
+          {
+            "diagnostic_id": "max_abs_hazard_residual",
+            "metadata": {},
+            "metric_name": "max_abs_hazard_residual",
+            "severity": "warning",
+            "tolerance": 1e-08
+          }
+        ],
+        "family_id": "credit",
+        "materialization": {
+          "destination_field": "credit_curve",
+          "metadata": {
+            "instrument_kind": "single_name_cds",
+            "model_family": "reduced_form_credit",
+            "potential_binding": {
+              "default_curve_name": "benchmark_single_name_credit",
+              "default_curve_role": "credit_curve",
+              "discount_curve_name": "usd_ois",
+              "discount_curve_role": "discount_curve",
+              "recovery": 0.4,
+              "risky_discount_formula": "discount(t) * survival_probability(t)"
+            },
+            "recovery": 0.4,
+            "tenors": [
+              1.0,
+              3.0,
+              5.002739726027397,
+              10.005479452054795
+            ]
+          },
+          "object_kind": "credit_curve",
+          "object_name": "benchmark_single_name_credit",
+          "source_ref": "calibrate_single_name_credit_curve_workflow"
+        },
+        "metadata": {
+          "adapter_id": "single_name_credit_problem_ir_v1",
+          "engine_backed": false,
+          "quote_normalization_method": "cds_pricer",
+          "source_ref": "build_single_name_credit_calibration_problem_ir",
+          "support_boundary": "problem_ir_adapter_only"
+        },
+        "objective": {
+          "derivative_method": "scipy_2point_residual_jacobian",
+          "loss_function": "weighted_sum_of_squares",
+          "metadata": {
+            "fit_space": "cds_par_spread",
+            "fit_value_kinds": [
+              "par_spread",
+              "par_spread",
+              "par_spread",
+              "par_spread"
+            ],
+            "potential_binding": {
+              "default_curve_name": "benchmark_single_name_credit",
+              "default_curve_role": "credit_curve",
+              "discount_curve_name": "usd_ois",
+              "discount_curve_role": "discount_curve",
+              "recovery": 0.4,
+              "risky_discount_formula": "discount(t) * survival_probability(t)"
+            }
+          },
+          "objective_kind": "least_squares",
+          "regularization": {},
+          "residual_count": 4,
+          "solve_request_id": "single_name_credit_cds_par_spread_least_squares"
+        },
+        "problem_id": "single_name_credit_cds_par_spread_least_squares",
+        "replay_metadata": {
+          "market_state": {
+            "as_of": "2024-11-15",
+            "selected_curve_names": {
+              "credit_curve": "usd_ig",
+              "discount_curve": "usd_ois",
+              "fixing_history": "USD-SOFR-3M",
+              "forecast_curve": "USD-SOFR-3M"
+            },
+            "settlement": "2024-11-15"
+          },
+          "max_hazard": 5.0,
+          "quotes": [
+            {
+              "business_day_adjustment": "FOLLOWING",
+              "calendar": "WeekendOnly",
+              "day_count": "ACT_360",
+              "frequency": "QUARTERLY",
+              "label": "usd_ig_1.0y",
+              "maturity_date": null,
+              "maturity_years": 1.0,
+              "payment_lag_days": 0,
+              "quote": 0.0059460163,
+              "quote_kind": "spread",
+              "roll_convention": "NONE",
+              "standard_running_spread": null,
+              "start_date": null,
+              "stub": "SHORT_LAST",
+              "weight": 1.0
+            },
+            {
+              "business_day_adjustment": "FOLLOWING",
+              "calendar": "WeekendOnly",
+              "day_count": "ACT_360",
+              "frequency": "QUARTERLY",
+              "label": "usd_ig_3.0y",
+              "maturity_date": null,
+              "maturity_years": 3.0,
+              "payment_lag_days": 0,
+              "quote": 0.0068962089,
+              "quote_kind": "spread",
+              "roll_convention": "NONE",
+              "standard_running_spread": null,
+              "start_date": null,
+              "stub": "SHORT_LAST",
+              "weight": 1.0
+            },
+            {
+              "business_day_adjustment": "FOLLOWING",
+              "calendar": "WeekendOnly",
+              "day_count": "ACT_360",
+              "frequency": "QUARTERLY",
+              "label": "usd_ig_5.0y",
+              "maturity_date": null,
+              "maturity_years": 5.0,
+              "payment_lag_days": 0,
+              "quote": 0.0078130616,
+              "quote_kind": "spread",
+              "roll_convention": "NONE",
+              "standard_running_spread": null,
+              "start_date": null,
+              "stub": "SHORT_LAST",
+              "weight": 1.0
+            },
+            {
+              "business_day_adjustment": "FOLLOWING",
+              "calendar": "WeekendOnly",
+              "day_count": "ACT_360",
+              "frequency": "QUARTERLY",
+              "label": "usd_ig_10.0y",
+              "maturity_date": null,
+              "maturity_years": 10.0,
+              "payment_lag_days": 0,
+              "quote": 0.0086865647,
+              "quote_kind": "spread",
+              "roll_convention": "NONE",
+              "standard_running_spread": null,
+              "start_date": null,
+              "stub": "SHORT_LAST",
+              "weight": 1.0
+            }
+          ],
+          "solver_replay_artifact": {
+            "backend": {
+              "backend_id": "scipy",
+              "backend_operator": null,
+              "derivative_method": "scipy_2point_residual_jacobian",
+              "derivative_method_category": "finite_difference_bump",
+              "derivative_method_support": "fallback",
+              "fallback_derivative_method": "scipy_2point_residual_jacobian",
+              "fallback_from": null,
+              "method": "trf",
+              "requested_backend": "scipy",
+              "resolved_derivative_method": "scipy_2point_residual_jacobian",
+              "solver_family": "scipy"
+            },
+            "options": {
+              "ftol": 1e-12,
+              "gtol": 1e-12,
+              "maxiter": 80,
+              "xtol": 1e-12
+            },
+            "request": {
+              "bounds": {
+                "lower": [
+                  0.0,
+                  0.0,
+                  0.0,
+                  0.0
+                ],
+                "upper": [
+                  5.0,
+                  5.0,
+                  5.0,
+                  5.0
+                ]
+              },
+              "constraints": [],
+              "initial_guess": [
+                0.009995596024839917,
+                0.011593310420375329,
+                0.013133513323050183,
+                0.014599771487912895
+              ],
+              "metadata": {
+                "curve_name": "benchmark_single_name_credit",
+                "fit_space": "cds_par_spread",
+                "fit_value_kinds": [
+                  "par_spread",
+                  "par_spread",
+                  "par_spread",
+                  "par_spread"
+                ],
+                "model_family": "reduced_form_credit",
+                "potential_binding": {
+                  "default_curve_name": "benchmark_single_name_credit",
+                  "default_curve_role": "credit_curve",
+                  "discount_curve_name": "usd_ois",
+                  "discount_curve_role": "discount_curve",
+                  "recovery": 0.4,
+                  "risky_discount_formula": "discount(t) * survival_probability(t)"
+                },
+                "selected_curve_names": {
+                  "credit_curve": "usd_ig",
+                  "discount_curve": "usd_ois",
+                  "fixing_history": "USD-SOFR-3M",
+                  "forecast_curve": "USD-SOFR-3M"
+                }
+              },
+              "objective": {
+                "derivatives": {
+                  "hessian": "none",
+                  "jacobian": "none"
+                },
+                "labels": [
+                  "usd_ig_1.0y",
+                  "usd_ig_3.0y",
+                  "usd_ig_5.0y",
+                  "usd_ig_10.0y"
+                ],
+                "metadata": {
+                  "curve_name": "benchmark_single_name_credit",
+                  "fit_space": "cds_par_spread",
+                  "fit_value_kinds": [
+                    "par_spread",
+                    "par_spread",
+                    "par_spread",
+                    "par_spread"
+                  ],
+                  "model_family": "reduced_form_credit",
+                  "potential_binding": {
+                    "default_curve_name": "benchmark_single_name_credit",
+                    "default_curve_role": "credit_curve",
+                    "discount_curve_name": "usd_ois",
+                    "discount_curve_role": "discount_curve",
+                    "recovery": 0.4,
+                    "risky_discount_formula": "discount(t) * survival_probability(t)"
+                  },
+                  "quote_maps": [
+                    {
+                      "assumptions": [
+                        "Reduced-form single-name calibration binds potential terms as risky_discount(t)=discount(t)*survival_probability(t).",
+                        "CDS repricing uses bounded quarterly ACT/360 schedules built from market_state.settlement with tenor maturities rounded to calendar months.",
+                        "Recovery assumption: 0.400000.",
+                        "Discount curve role: usd_ois."
+                      ],
+                      "convention": "",
+                      "has_inverse_transform": true,
+                      "metadata": {},
+                      "normalization_method": "running_spread_decimal",
+                      "potential_binding": {
+                        "default_curve_name": "benchmark_single_name_credit",
+                        "default_curve_role": "credit_curve",
+                        "discount_curve_name": "usd_ois",
+                        "discount_curve_role": "discount_curve",
+                        "recovery": 0.4,
+                        "risky_discount_formula": "discount(t) * survival_probability(t)"
+                      },
+                      "quote_axes": [
+                        {
+                          "axis_kind": "tenor",
+                          "axis_name": "maturity",
+                          "unit": "years"
+                        }
+                      ],
+                      "quote_family": "spread",
+                      "quote_kind": "spread",
+                      "quote_semantics": {
+                        "convention": "",
+                        "quote_axes": [
+                          {
+                            "axis_kind": "tenor",
+                            "axis_name": "maturity",
+                            "unit": "years"
+                          }
+                        ],
+                        "quote_family": "spread",
+                        "quote_settlement": {
+                          "discount_curve_role": "discount_curve",
+                          "numeraire": "discount_curve"
+                        },
+                        "quote_subject": "single_name_cds",
+                        "quote_unit": "decimal_running_spread",
+                        "quote_unit_spec": {
+                          "scaling": "absolute",
+                          "unit_name": "decimal_running_spread",
+                          "value_domain": "credit_spread"
+                        }
+                      },
+                      "quote_settlement": {
+                        "discount_curve_role": "discount_curve",
+                        "numeraire": "discount_curve"
+                      },
+                      "quote_subject": "single_name_cds",
+                      "quote_unit": "decimal_running_spread",
+                      "recovery": 0.4,
+                      "source_ref": "_spread_quote_map"
+                    },
+                    {
+                      "assumptions": [
+                        "Reduced-form single-name calibration binds potential terms as risky_discount(t)=discount(t)*survival_probability(t).",
+                        "CDS repricing uses bounded quarterly ACT/360 schedules built from market_state.settlement with tenor maturities rounded to calendar months.",
+                        "Recovery assumption: 0.400000.",
+                        "Discount curve role: usd_ois."
+                      ],
+                      "convention": "",
+                      "has_inverse_transform": true,
+                      "metadata": {},
+                      "normalization_method": "running_spread_decimal",
+                      "potential_binding": {
+                        "default_curve_name": "benchmark_single_name_credit",
+                        "default_curve_role": "credit_curve",
+                        "discount_curve_name": "usd_ois",
+                        "discount_curve_role": "discount_curve",
+                        "recovery": 0.4,
+                        "risky_discount_formula": "discount(t) * survival_probability(t)"
+                      },
+                      "quote_axes": [
+                        {
+                          "axis_kind": "tenor",
+                          "axis_name": "maturity",
+                          "unit": "years"
+                        }
+                      ],
+                      "quote_family": "spread",
+                      "quote_kind": "spread",
+                      "quote_semantics": {
+                        "convention": "",
+                        "quote_axes": [
+                          {
+                            "axis_kind": "tenor",
+                            "axis_name": "maturity",
+                            "unit": "years"
+                          }
+                        ],
+                        "quote_family": "spread",
+                        "quote_settlement": {
+                          "discount_curve_role": "discount_curve",
+                          "numeraire": "discount_curve"
+                        },
+                        "quote_subject": "single_name_cds",
+                        "quote_unit": "decimal_running_spread",
+                        "quote_unit_spec": {
+                          "scaling": "absolute",
+                          "unit_name": "decimal_running_spread",
+                          "value_domain": "credit_spread"
+                        }
+                      },
+                      "quote_settlement": {
+                        "discount_curve_role": "discount_curve",
+                        "numeraire": "discount_curve"
+                      },
+                      "quote_subject": "single_name_cds",
+                      "quote_unit": "decimal_running_spread",
+                      "recovery": 0.4,
+                      "source_ref": "_spread_quote_map"
+                    },
+                    {
+                      "assumptions": [
+                        "Reduced-form single-name calibration binds potential terms as risky_discount(t)=discount(t)*survival_probability(t).",
+                        "CDS repricing uses bounded quarterly ACT/360 schedules built from market_state.settlement with tenor maturities rounded to calendar months.",
+                        "Recovery assumption: 0.400000.",
+                        "Discount curve role: usd_ois."
+                      ],
+                      "convention": "",
+                      "has_inverse_transform": true,
+                      "metadata": {},
+                      "normalization_method": "running_spread_decimal",
+                      "potential_binding": {
+                        "default_curve_name": "benchmark_single_name_credit",
+                        "default_curve_role": "credit_curve",
+                        "discount_curve_name": "usd_ois",
+                        "discount_curve_role": "discount_curve",
+                        "recovery": 0.4,
+                        "risky_discount_formula": "discount(t) * survival_probability(t)"
+                      },
+                      "quote_axes": [
+                        {
+                          "axis_kind": "tenor",
+                          "axis_name": "maturity",
+                          "unit": "years"
+                        }
+                      ],
+                      "quote_family": "spread",
+                      "quote_kind": "spread",
+                      "quote_semantics": {
+                        "convention": "",
+                        "quote_axes": [
+                          {
+                            "axis_kind": "tenor",
+                            "axis_name": "maturity",
+                            "unit": "years"
+                          }
+                        ],
+                        "quote_family": "spread",
+                        "quote_settlement": {
+                          "discount_curve_role": "discount_curve",
+                          "numeraire": "discount_curve"
+                        },
+                        "quote_subject": "single_name_cds",
+                        "quote_unit": "decimal_running_spread",
+                        "quote_unit_spec": {
+                          "scaling": "absolute",
+                          "unit_name": "decimal_running_spread",
+                          "value_domain": "credit_spread"
+                        }
+                      },
+                      "quote_settlement": {
+                        "discount_curve_role": "discount_curve",
+                        "numeraire": "discount_curve"
+                      },
+                      "quote_subject": "single_name_cds",
+                      "quote_unit": "decimal_running_spread",
+                      "recovery": 0.4,
+                      "source_ref": "_spread_quote_map"
+                    },
+                    {
+                      "assumptions": [
+                        "Reduced-form single-name calibration binds potential terms as risky_discount(t)=discount(t)*survival_probability(t).",
+                        "CDS repricing uses bounded quarterly ACT/360 schedules built from market_state.settlement with tenor maturities rounded to calendar months.",
+                        "Recovery assumption: 0.400000.",
+                        "Discount curve role: usd_ois."
+                      ],
+                      "convention": "",
+                      "has_inverse_transform": true,
+                      "metadata": {},
+                      "normalization_method": "running_spread_decimal",
+                      "potential_binding": {
+                        "default_curve_name": "benchmark_single_name_credit",
+                        "default_curve_role": "credit_curve",
+                        "discount_curve_name": "usd_ois",
+                        "discount_curve_role": "discount_curve",
+                        "recovery": 0.4,
+                        "risky_discount_formula": "discount(t) * survival_probability(t)"
+                      },
+                      "quote_axes": [
+                        {
+                          "axis_kind": "tenor",
+                          "axis_name": "maturity",
+                          "unit": "years"
+                        }
+                      ],
+                      "quote_family": "spread",
+                      "quote_kind": "spread",
+                      "quote_semantics": {
+                        "convention": "",
+                        "quote_axes": [
+                          {
+                            "axis_kind": "tenor",
+                            "axis_name": "maturity",
+                            "unit": "years"
+                          }
+                        ],
+                        "quote_family": "spread",
+                        "quote_settlement": {
+                          "discount_curve_role": "discount_curve",
+                          "numeraire": "discount_curve"
+                        },
+                        "quote_subject": "single_name_cds",
+                        "quote_unit": "decimal_running_spread",
+                        "quote_unit_spec": {
+                          "scaling": "absolute",
+                          "unit_name": "decimal_running_spread",
+                          "value_domain": "credit_spread"
+                        }
+                      },
+                      "quote_settlement": {
+                        "discount_curve_role": "discount_curve",
+                        "numeraire": "discount_curve"
+                      },
+                      "quote_subject": "single_name_cds",
+                      "quote_unit": "decimal_running_spread",
+                      "recovery": 0.4,
+                      "source_ref": "_spread_quote_map"
+                    }
+                  ]
+                },
+                "objective_kind": "least_squares",
+                "target_values": [
+                  0.0059460163,
+                  0.0068962089,
+                  0.0078130616,
+                  0.0086865647
+                ],
+                "weights": [
+                  1.0,
+                  1.0,
+                  1.0,
+                  1.0
+                ]
+              },
+              "options": {
+                "ftol": 1e-12,
+                "gtol": 1e-12,
+                "maxiter": 80,
+                "xtol": 1e-12
+              },
+              "parameter_names": [
+                "hazard_1",
+                "hazard_2",
+                "hazard_3",
+                "hazard_4"
+              ],
+              "problem_kind": "least_squares",
+              "request_id": "single_name_credit_cds_par_spread_least_squares",
+              "solver_hint": "trf",
+              "warm_start": {
+                "metadata": {},
+                "parameter_values": [
+                  0.009995596024839917,
+                  0.011593310420375329,
+                  0.013133513323050183,
+                  0.014599771487912895
+                ],
+                "source": "quote_map_seed"
+              }
+            },
+            "residual_diagnostics": {
+              "l2_norm": 1.561865196510719e-13,
+              "max_abs_residual": 1.5618409343609585e-13,
+              "residual_count": 4,
+              "residual_vector": [
+                9.107298248878237e-17,
+                3.885780586188048e-16,
+                -7.73686670285656e-16,
+                -1.5618409343609585e-13
+              ]
+            },
+            "result": {
+              "iteration_count": 3,
+              "metadata": {
+                "backend_id": "scipy",
+                "derivative_method": "scipy_2point_residual_jacobian",
+                "derivative_method_category": "finite_difference_bump",
+                "derivative_method_support": "fallback",
+                "fallback_derivative_method": "scipy_2point_residual_jacobian",
+                "fallback_reason": null,
+                "message": "`gtol` termination condition is satisfied.",
+                "requested_backend": "scipy",
+                "resolved_derivative_method": "scipy_2point_residual_jacobian",
+                "solver_family": "scipy",
+                "warnings": []
+              },
+              "method": "trf",
+              "objective_value": 2.4394228920714676e-26,
+              "residual_vector": [
+                9.107298248878237e-17,
+                3.885780586188048e-16,
+                -7.73686670285656e-16,
+                -1.5618409343609585e-13
+              ],
+              "solution": [
+                0.009991144709751166,
+                0.011656335477398416,
+                0.013322503742017369,
+                0.01498696724632779
+              ],
+              "success": true
+            },
+            "termination": {
+              "iteration_count": 3,
+              "message": "`gtol` termination condition is satisfied.",
+              "objective_value": 2.4394228920714676e-26,
+              "reason": "`gtol` termination condition is satisfied.",
+              "success": true
+            }
+          }
+        },
+        "solve_request": {
+          "bounds": {
+            "lower": [
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "upper": [
+              5.0,
+              5.0,
+              5.0,
+              5.0
+            ]
+          },
+          "constraints": [],
+          "initial_guess": [
+            0.009995596024839917,
+            0.011593310420375329,
+            0.013133513323050183,
+            0.014599771487912895
+          ],
+          "metadata": {
+            "curve_name": "benchmark_single_name_credit",
+            "fit_space": "cds_par_spread",
+            "fit_value_kinds": [
+              "par_spread",
+              "par_spread",
+              "par_spread",
+              "par_spread"
+            ],
+            "model_family": "reduced_form_credit",
+            "potential_binding": {
+              "default_curve_name": "benchmark_single_name_credit",
+              "default_curve_role": "credit_curve",
+              "discount_curve_name": "usd_ois",
+              "discount_curve_role": "discount_curve",
+              "recovery": 0.4,
+              "risky_discount_formula": "discount(t) * survival_probability(t)"
+            },
+            "selected_curve_names": {
+              "credit_curve": "usd_ig",
+              "discount_curve": "usd_ois",
+              "fixing_history": "USD-SOFR-3M",
+              "forecast_curve": "USD-SOFR-3M"
+            }
+          },
+          "objective": {
+            "derivatives": {
+              "hessian": "none",
+              "jacobian": "none"
+            },
+            "labels": [
+              "usd_ig_1.0y",
+              "usd_ig_3.0y",
+              "usd_ig_5.0y",
+              "usd_ig_10.0y"
+            ],
+            "metadata": {
+              "curve_name": "benchmark_single_name_credit",
+              "fit_space": "cds_par_spread",
+              "fit_value_kinds": [
+                "par_spread",
+                "par_spread",
+                "par_spread",
+                "par_spread"
+              ],
+              "model_family": "reduced_form_credit",
+              "potential_binding": {
+                "default_curve_name": "benchmark_single_name_credit",
+                "default_curve_role": "credit_curve",
+                "discount_curve_name": "usd_ois",
+                "discount_curve_role": "discount_curve",
+                "recovery": 0.4,
+                "risky_discount_formula": "discount(t) * survival_probability(t)"
+              },
+              "quote_maps": [
+                {
+                  "assumptions": [
+                    "Reduced-form single-name calibration binds potential terms as risky_discount(t)=discount(t)*survival_probability(t).",
+                    "CDS repricing uses bounded quarterly ACT/360 schedules built from market_state.settlement with tenor maturities rounded to calendar months.",
+                    "Recovery assumption: 0.400000.",
+                    "Discount curve role: usd_ois."
+                  ],
+                  "convention": "",
+                  "has_inverse_transform": true,
+                  "metadata": {},
+                  "normalization_method": "running_spread_decimal",
+                  "potential_binding": {
+                    "default_curve_name": "benchmark_single_name_credit",
+                    "default_curve_role": "credit_curve",
+                    "discount_curve_name": "usd_ois",
+                    "discount_curve_role": "discount_curve",
+                    "recovery": 0.4,
+                    "risky_discount_formula": "discount(t) * survival_probability(t)"
+                  },
+                  "quote_axes": [
+                    {
+                      "axis_kind": "tenor",
+                      "axis_name": "maturity",
+                      "unit": "years"
+                    }
+                  ],
+                  "quote_family": "spread",
+                  "quote_kind": "spread",
+                  "quote_semantics": {
+                    "convention": "",
+                    "quote_axes": [
+                      {
+                        "axis_kind": "tenor",
+                        "axis_name": "maturity",
+                        "unit": "years"
+                      }
+                    ],
+                    "quote_family": "spread",
+                    "quote_settlement": {
+                      "discount_curve_role": "discount_curve",
+                      "numeraire": "discount_curve"
+                    },
+                    "quote_subject": "single_name_cds",
+                    "quote_unit": "decimal_running_spread",
+                    "quote_unit_spec": {
+                      "scaling": "absolute",
+                      "unit_name": "decimal_running_spread",
+                      "value_domain": "credit_spread"
+                    }
+                  },
+                  "quote_settlement": {
+                    "discount_curve_role": "discount_curve",
+                    "numeraire": "discount_curve"
+                  },
+                  "quote_subject": "single_name_cds",
+                  "quote_unit": "decimal_running_spread",
+                  "recovery": 0.4,
+                  "source_ref": "_spread_quote_map"
+                },
+                {
+                  "assumptions": [
+                    "Reduced-form single-name calibration binds potential terms as risky_discount(t)=discount(t)*survival_probability(t).",
+                    "CDS repricing uses bounded quarterly ACT/360 schedules built from market_state.settlement with tenor maturities rounded to calendar months.",
+                    "Recovery assumption: 0.400000.",
+                    "Discount curve role: usd_ois."
+                  ],
+                  "convention": "",
+                  "has_inverse_transform": true,
+                  "metadata": {},
+                  "normalization_method": "running_spread_decimal",
+                  "potential_binding": {
+                    "default_curve_name": "benchmark_single_name_credit",
+                    "default_curve_role": "credit_curve",
+                    "discount_curve_name": "usd_ois",
+                    "discount_curve_role": "discount_curve",
+                    "recovery": 0.4,
+                    "risky_discount_formula": "discount(t) * survival_probability(t)"
+                  },
+                  "quote_axes": [
+                    {
+                      "axis_kind": "tenor",
+                      "axis_name": "maturity",
+                      "unit": "years"
+                    }
+                  ],
+                  "quote_family": "spread",
+                  "quote_kind": "spread",
+                  "quote_semantics": {
+                    "convention": "",
+                    "quote_axes": [
+                      {
+                        "axis_kind": "tenor",
+                        "axis_name": "maturity",
+                        "unit": "years"
+                      }
+                    ],
+                    "quote_family": "spread",
+                    "quote_settlement": {
+                      "discount_curve_role": "discount_curve",
+                      "numeraire": "discount_curve"
+                    },
+                    "quote_subject": "single_name_cds",
+                    "quote_unit": "decimal_running_spread",
+                    "quote_unit_spec": {
+                      "scaling": "absolute",
+                      "unit_name": "decimal_running_spread",
+                      "value_domain": "credit_spread"
+                    }
+                  },
+                  "quote_settlement": {
+                    "discount_curve_role": "discount_curve",
+                    "numeraire": "discount_curve"
+                  },
+                  "quote_subject": "single_name_cds",
+                  "quote_unit": "decimal_running_spread",
+                  "recovery": 0.4,
+                  "source_ref": "_spread_quote_map"
+                },
+                {
+                  "assumptions": [
+                    "Reduced-form single-name calibration binds potential terms as risky_discount(t)=discount(t)*survival_probability(t).",
+                    "CDS repricing uses bounded quarterly ACT/360 schedules built from market_state.settlement with tenor maturities rounded to calendar months.",
+                    "Recovery assumption: 0.400000.",
+                    "Discount curve role: usd_ois."
+                  ],
+                  "convention": "",
+                  "has_inverse_transform": true,
+                  "metadata": {},
+                  "normalization_method": "running_spread_decimal",
+                  "potential_binding": {
+                    "default_curve_name": "benchmark_single_name_credit",
+                    "default_curve_role": "credit_curve",
+                    "discount_curve_name": "usd_ois",
+                    "discount_curve_role": "discount_curve",
+                    "recovery": 0.4,
+                    "risky_discount_formula": "discount(t) * survival_probability(t)"
+                  },
+                  "quote_axes": [
+                    {
+                      "axis_kind": "tenor",
+                      "axis_name": "maturity",
+                      "unit": "years"
+                    }
+                  ],
+                  "quote_family": "spread",
+                  "quote_kind": "spread",
+                  "quote_semantics": {
+                    "convention": "",
+                    "quote_axes": [
+                      {
+                        "axis_kind": "tenor",
+                        "axis_name": "maturity",
+                        "unit": "years"
+                      }
+                    ],
+                    "quote_family": "spread",
+                    "quote_settlement": {
+                      "discount_curve_role": "discount_curve",
+                      "numeraire": "discount_curve"
+                    },
+                    "quote_subject": "single_name_cds",
+                    "quote_unit": "decimal_running_spread",
+                    "quote_unit_spec": {
+                      "scaling": "absolute",
+                      "unit_name": "decimal_running_spread",
+                      "value_domain": "credit_spread"
+                    }
+                  },
+                  "quote_settlement": {
+                    "discount_curve_role": "discount_curve",
+                    "numeraire": "discount_curve"
+                  },
+                  "quote_subject": "single_name_cds",
+                  "quote_unit": "decimal_running_spread",
+                  "recovery": 0.4,
+                  "source_ref": "_spread_quote_map"
+                },
+                {
+                  "assumptions": [
+                    "Reduced-form single-name calibration binds potential terms as risky_discount(t)=discount(t)*survival_probability(t).",
+                    "CDS repricing uses bounded quarterly ACT/360 schedules built from market_state.settlement with tenor maturities rounded to calendar months.",
+                    "Recovery assumption: 0.400000.",
+                    "Discount curve role: usd_ois."
+                  ],
+                  "convention": "",
+                  "has_inverse_transform": true,
+                  "metadata": {},
+                  "normalization_method": "running_spread_decimal",
+                  "potential_binding": {
+                    "default_curve_name": "benchmark_single_name_credit",
+                    "default_curve_role": "credit_curve",
+                    "discount_curve_name": "usd_ois",
+                    "discount_curve_role": "discount_curve",
+                    "recovery": 0.4,
+                    "risky_discount_formula": "discount(t) * survival_probability(t)"
+                  },
+                  "quote_axes": [
+                    {
+                      "axis_kind": "tenor",
+                      "axis_name": "maturity",
+                      "unit": "years"
+                    }
+                  ],
+                  "quote_family": "spread",
+                  "quote_kind": "spread",
+                  "quote_semantics": {
+                    "convention": "",
+                    "quote_axes": [
+                      {
+                        "axis_kind": "tenor",
+                        "axis_name": "maturity",
+                        "unit": "years"
+                      }
+                    ],
+                    "quote_family": "spread",
+                    "quote_settlement": {
+                      "discount_curve_role": "discount_curve",
+                      "numeraire": "discount_curve"
+                    },
+                    "quote_subject": "single_name_cds",
+                    "quote_unit": "decimal_running_spread",
+                    "quote_unit_spec": {
+                      "scaling": "absolute",
+                      "unit_name": "decimal_running_spread",
+                      "value_domain": "credit_spread"
+                    }
+                  },
+                  "quote_settlement": {
+                    "discount_curve_role": "discount_curve",
+                    "numeraire": "discount_curve"
+                  },
+                  "quote_subject": "single_name_cds",
+                  "quote_unit": "decimal_running_spread",
+                  "recovery": 0.4,
+                  "source_ref": "_spread_quote_map"
+                }
+              ]
+            },
+            "objective_kind": "least_squares",
+            "target_values": [
+              0.0059460163,
+              0.0068962089,
+              0.0078130616,
+              0.0086865647
+            ],
+            "weights": [
+              1.0,
+              1.0,
+              1.0,
+              1.0
+            ]
+          },
+          "options": {
+            "ftol": 1e-12,
+            "gtol": 1e-12,
+            "maxiter": 80,
+            "xtol": 1e-12
+          },
+          "parameter_names": [
+            "hazard_1",
+            "hazard_2",
+            "hazard_3",
+            "hazard_4"
+          ],
+          "problem_kind": "least_squares",
+          "request_id": "single_name_credit_cds_par_spread_least_squares",
+          "solver_hint": "trf",
+          "warm_start": {
+            "metadata": {},
+            "parameter_values": [
+              0.009995596024839917,
+              0.011593310420375329,
+              0.013133513323050183,
+              0.014599771487912895
+            ],
+            "source": "quote_map_seed"
+          }
+        },
+        "targets": [
+          {
+            "instrument_id": "benchmark_single_name_credit:usd_ig_1.0y",
+            "metadata": {
+              "curve_tenor_years": 1.0,
+              "instrument_setup": {
+                "business_day_adjustment": "FOLLOWING",
+                "calendar": "WeekendOnly",
+                "curve_tenor_years": 1.0,
+                "day_count": "ACT_360",
+                "first_payment_date": "2025-02-17",
+                "frequency": "QUARTERLY",
+                "label": "usd_ig_1.0y",
+                "last_payment_date": "2025-11-17",
+                "maturity_date": "2025-11-15",
+                "maturity_years": 1.0,
+                "payment_lag_days": 0,
+                "period_count": 4,
+                "roll_convention": "NONE",
+                "standard_running_spread": null,
+                "start_date": "2024-11-15",
+                "stub": "SHORT_LAST"
+              },
+              "maturity_years": 1.0,
+              "target_hazard": 0.009995596024839917,
+              "target_running_spread": 0.0059460163
+            },
+            "quote_convention": "cds_par_spread",
+            "quote_family": "spread",
+            "quote_map": {
+              "assumptions": [
+                "Reduced-form single-name calibration binds potential terms as risky_discount(t)=discount(t)*survival_probability(t).",
+                "CDS repricing uses bounded quarterly ACT/360 schedules built from market_state.settlement with tenor maturities rounded to calendar months.",
+                "Recovery assumption: 0.400000.",
+                "Discount curve role: usd_ois."
+              ],
+              "convention": "",
+              "has_inverse_transform": true,
+              "metadata": {},
+              "normalization_method": "running_spread_decimal",
+              "potential_binding": {
+                "default_curve_name": "benchmark_single_name_credit",
+                "default_curve_role": "credit_curve",
+                "discount_curve_name": "usd_ois",
+                "discount_curve_role": "discount_curve",
+                "recovery": 0.4,
+                "risky_discount_formula": "discount(t) * survival_probability(t)"
+              },
+              "quote_axes": [
+                {
+                  "axis_kind": "tenor",
+                  "axis_name": "maturity",
+                  "unit": "years"
+                }
+              ],
+              "quote_family": "spread",
+              "quote_kind": "spread",
+              "quote_semantics": {
+                "convention": "",
+                "quote_axes": [
+                  {
+                    "axis_kind": "tenor",
+                    "axis_name": "maturity",
+                    "unit": "years"
+                  }
+                ],
+                "quote_family": "spread",
+                "quote_settlement": {
+                  "discount_curve_role": "discount_curve",
+                  "numeraire": "discount_curve"
+                },
+                "quote_subject": "single_name_cds",
+                "quote_unit": "decimal_running_spread",
+                "quote_unit_spec": {
+                  "scaling": "absolute",
+                  "unit_name": "decimal_running_spread",
+                  "value_domain": "credit_spread"
+                }
+              },
+              "quote_settlement": {
+                "discount_curve_role": "discount_curve",
+                "numeraire": "discount_curve"
+              },
+              "quote_subject": "single_name_cds",
+              "quote_unit": "decimal_running_spread",
+              "recovery": 0.4,
+              "source_ref": "_spread_quote_map"
+            },
+            "quote_value": 0.0059460163,
+            "target_id": "usd_ig_1.0y",
+            "validation_tags": [
+              "single_name_credit",
+              "cds",
+              "spread"
+            ],
+            "weight": 1.0
+          },
+          {
+            "instrument_id": "benchmark_single_name_credit:usd_ig_3.0y",
+            "metadata": {
+              "curve_tenor_years": 3.0,
+              "instrument_setup": {
+                "business_day_adjustment": "FOLLOWING",
+                "calendar": "WeekendOnly",
+                "curve_tenor_years": 3.0,
+                "day_count": "ACT_360",
+                "first_payment_date": "2025-02-17",
+                "frequency": "QUARTERLY",
+                "label": "usd_ig_3.0y",
+                "last_payment_date": "2027-11-15",
+                "maturity_date": "2027-11-15",
+                "maturity_years": 3.0,
+                "payment_lag_days": 0,
+                "period_count": 12,
+                "roll_convention": "NONE",
+                "standard_running_spread": null,
+                "start_date": "2024-11-15",
+                "stub": "SHORT_LAST"
+              },
+              "maturity_years": 3.0,
+              "target_hazard": 0.011593310420375329,
+              "target_running_spread": 0.0068962089
+            },
+            "quote_convention": "cds_par_spread",
+            "quote_family": "spread",
+            "quote_map": {
+              "assumptions": [
+                "Reduced-form single-name calibration binds potential terms as risky_discount(t)=discount(t)*survival_probability(t).",
+                "CDS repricing uses bounded quarterly ACT/360 schedules built from market_state.settlement with tenor maturities rounded to calendar months.",
+                "Recovery assumption: 0.400000.",
+                "Discount curve role: usd_ois."
+              ],
+              "convention": "",
+              "has_inverse_transform": true,
+              "metadata": {},
+              "normalization_method": "running_spread_decimal",
+              "potential_binding": {
+                "default_curve_name": "benchmark_single_name_credit",
+                "default_curve_role": "credit_curve",
+                "discount_curve_name": "usd_ois",
+                "discount_curve_role": "discount_curve",
+                "recovery": 0.4,
+                "risky_discount_formula": "discount(t) * survival_probability(t)"
+              },
+              "quote_axes": [
+                {
+                  "axis_kind": "tenor",
+                  "axis_name": "maturity",
+                  "unit": "years"
+                }
+              ],
+              "quote_family": "spread",
+              "quote_kind": "spread",
+              "quote_semantics": {
+                "convention": "",
+                "quote_axes": [
+                  {
+                    "axis_kind": "tenor",
+                    "axis_name": "maturity",
+                    "unit": "years"
+                  }
+                ],
+                "quote_family": "spread",
+                "quote_settlement": {
+                  "discount_curve_role": "discount_curve",
+                  "numeraire": "discount_curve"
+                },
+                "quote_subject": "single_name_cds",
+                "quote_unit": "decimal_running_spread",
+                "quote_unit_spec": {
+                  "scaling": "absolute",
+                  "unit_name": "decimal_running_spread",
+                  "value_domain": "credit_spread"
+                }
+              },
+              "quote_settlement": {
+                "discount_curve_role": "discount_curve",
+                "numeraire": "discount_curve"
+              },
+              "quote_subject": "single_name_cds",
+              "quote_unit": "decimal_running_spread",
+              "recovery": 0.4,
+              "source_ref": "_spread_quote_map"
+            },
+            "quote_value": 0.0068962089,
+            "target_id": "usd_ig_3.0y",
+            "validation_tags": [
+              "single_name_credit",
+              "cds",
+              "spread"
+            ],
+            "weight": 1.0
+          },
+          {
+            "instrument_id": "benchmark_single_name_credit:usd_ig_5.0y",
+            "metadata": {
+              "curve_tenor_years": 5.002739726027397,
+              "instrument_setup": {
+                "business_day_adjustment": "FOLLOWING",
+                "calendar": "WeekendOnly",
+                "curve_tenor_years": 5.002739726027397,
+                "day_count": "ACT_360",
+                "first_payment_date": "2025-02-17",
+                "frequency": "QUARTERLY",
+                "label": "usd_ig_5.0y",
+                "last_payment_date": "2029-11-15",
+                "maturity_date": "2029-11-15",
+                "maturity_years": 5.0,
+                "payment_lag_days": 0,
+                "period_count": 20,
+                "roll_convention": "NONE",
+                "standard_running_spread": null,
+                "start_date": "2024-11-15",
+                "stub": "SHORT_LAST"
+              },
+              "maturity_years": 5.0,
+              "target_hazard": 0.013133513323050183,
+              "target_running_spread": 0.0078130616
+            },
+            "quote_convention": "cds_par_spread",
+            "quote_family": "spread",
+            "quote_map": {
+              "assumptions": [
+                "Reduced-form single-name calibration binds potential terms as risky_discount(t)=discount(t)*survival_probability(t).",
+                "CDS repricing uses bounded quarterly ACT/360 schedules built from market_state.settlement with tenor maturities rounded to calendar months.",
+                "Recovery assumption: 0.400000.",
+                "Discount curve role: usd_ois."
+              ],
+              "convention": "",
+              "has_inverse_transform": true,
+              "metadata": {},
+              "normalization_method": "running_spread_decimal",
+              "potential_binding": {
+                "default_curve_name": "benchmark_single_name_credit",
+                "default_curve_role": "credit_curve",
+                "discount_curve_name": "usd_ois",
+                "discount_curve_role": "discount_curve",
+                "recovery": 0.4,
+                "risky_discount_formula": "discount(t) * survival_probability(t)"
+              },
+              "quote_axes": [
+                {
+                  "axis_kind": "tenor",
+                  "axis_name": "maturity",
+                  "unit": "years"
+                }
+              ],
+              "quote_family": "spread",
+              "quote_kind": "spread",
+              "quote_semantics": {
+                "convention": "",
+                "quote_axes": [
+                  {
+                    "axis_kind": "tenor",
+                    "axis_name": "maturity",
+                    "unit": "years"
+                  }
+                ],
+                "quote_family": "spread",
+                "quote_settlement": {
+                  "discount_curve_role": "discount_curve",
+                  "numeraire": "discount_curve"
+                },
+                "quote_subject": "single_name_cds",
+                "quote_unit": "decimal_running_spread",
+                "quote_unit_spec": {
+                  "scaling": "absolute",
+                  "unit_name": "decimal_running_spread",
+                  "value_domain": "credit_spread"
+                }
+              },
+              "quote_settlement": {
+                "discount_curve_role": "discount_curve",
+                "numeraire": "discount_curve"
+              },
+              "quote_subject": "single_name_cds",
+              "quote_unit": "decimal_running_spread",
+              "recovery": 0.4,
+              "source_ref": "_spread_quote_map"
+            },
+            "quote_value": 0.0078130616,
+            "target_id": "usd_ig_5.0y",
+            "validation_tags": [
+              "single_name_credit",
+              "cds",
+              "spread"
+            ],
+            "weight": 1.0
+          },
+          {
+            "instrument_id": "benchmark_single_name_credit:usd_ig_10.0y",
+            "metadata": {
+              "curve_tenor_years": 10.005479452054795,
+              "instrument_setup": {
+                "business_day_adjustment": "FOLLOWING",
+                "calendar": "WeekendOnly",
+                "curve_tenor_years": 10.005479452054795,
+                "day_count": "ACT_360",
+                "first_payment_date": "2025-02-17",
+                "frequency": "QUARTERLY",
+                "label": "usd_ig_10.0y",
+                "last_payment_date": "2034-11-15",
+                "maturity_date": "2034-11-15",
+                "maturity_years": 10.0,
+                "payment_lag_days": 0,
+                "period_count": 40,
+                "roll_convention": "NONE",
+                "standard_running_spread": null,
+                "start_date": "2024-11-15",
+                "stub": "SHORT_LAST"
+              },
+              "maturity_years": 10.0,
+              "target_hazard": 0.014599771487912895,
+              "target_running_spread": 0.0086865647
+            },
+            "quote_convention": "cds_par_spread",
+            "quote_family": "spread",
+            "quote_map": {
+              "assumptions": [
+                "Reduced-form single-name calibration binds potential terms as risky_discount(t)=discount(t)*survival_probability(t).",
+                "CDS repricing uses bounded quarterly ACT/360 schedules built from market_state.settlement with tenor maturities rounded to calendar months.",
+                "Recovery assumption: 0.400000.",
+                "Discount curve role: usd_ois."
+              ],
+              "convention": "",
+              "has_inverse_transform": true,
+              "metadata": {},
+              "normalization_method": "running_spread_decimal",
+              "potential_binding": {
+                "default_curve_name": "benchmark_single_name_credit",
+                "default_curve_role": "credit_curve",
+                "discount_curve_name": "usd_ois",
+                "discount_curve_role": "discount_curve",
+                "recovery": 0.4,
+                "risky_discount_formula": "discount(t) * survival_probability(t)"
+              },
+              "quote_axes": [
+                {
+                  "axis_kind": "tenor",
+                  "axis_name": "maturity",
+                  "unit": "years"
+                }
+              ],
+              "quote_family": "spread",
+              "quote_kind": "spread",
+              "quote_semantics": {
+                "convention": "",
+                "quote_axes": [
+                  {
+                    "axis_kind": "tenor",
+                    "axis_name": "maturity",
+                    "unit": "years"
+                  }
+                ],
+                "quote_family": "spread",
+                "quote_settlement": {
+                  "discount_curve_role": "discount_curve",
+                  "numeraire": "discount_curve"
+                },
+                "quote_subject": "single_name_cds",
+                "quote_unit": "decimal_running_spread",
+                "quote_unit_spec": {
+                  "scaling": "absolute",
+                  "unit_name": "decimal_running_spread",
+                  "value_domain": "credit_spread"
+                }
+              },
+              "quote_settlement": {
+                "discount_curve_role": "discount_curve",
+                "numeraire": "discount_curve"
+              },
+              "quote_subject": "single_name_cds",
+              "quote_unit": "decimal_running_spread",
+              "recovery": 0.4,
+              "source_ref": "_spread_quote_map"
+            },
+            "quote_value": 0.0086865647,
+            "target_id": "usd_ig_10.0y",
+            "validation_tags": [
+              "single_name_credit",
+              "cds",
+              "spread"
+            ],
+            "weight": 1.0
+          }
+        ],
+        "variables": [
+          {
+            "coordinate_chart": "positive_hazard_rate",
+            "initial_value": 0.009995596024839917,
+            "lower_bound": 0.0,
+            "metadata": {
+              "curve_name": "benchmark_single_name_credit",
+              "parameter_role": "piecewise_hazard_rate",
+              "tenor_years": 1.0
+            },
+            "name": "hazard_1",
+            "scaling": 1.0,
+            "upper_bound": 5.0,
+            "warm_start_source": "quote_map_seed"
+          },
+          {
+            "coordinate_chart": "positive_hazard_rate",
+            "initial_value": 0.011593310420375329,
+            "lower_bound": 0.0,
+            "metadata": {
+              "curve_name": "benchmark_single_name_credit",
+              "parameter_role": "piecewise_hazard_rate",
+              "tenor_years": 3.0
+            },
+            "name": "hazard_2",
+            "scaling": 1.0,
+            "upper_bound": 5.0,
+            "warm_start_source": "quote_map_seed"
+          },
+          {
+            "coordinate_chart": "positive_hazard_rate",
+            "initial_value": 0.013133513323050183,
+            "lower_bound": 0.0,
+            "metadata": {
+              "curve_name": "benchmark_single_name_credit",
+              "parameter_role": "piecewise_hazard_rate",
+              "tenor_years": 5.002739726027397
+            },
+            "name": "hazard_3",
+            "scaling": 1.0,
+            "upper_bound": 5.0,
+            "warm_start_source": "quote_map_seed"
+          },
+          {
+            "coordinate_chart": "positive_hazard_rate",
+            "initial_value": 0.014599771487912895,
+            "lower_bound": 0.0,
+            "metadata": {
+              "curve_name": "benchmark_single_name_credit",
+              "parameter_role": "piecewise_hazard_rate",
+              "tenor_years": 10.005479452054795
+            },
+            "name": "hazard_4",
+            "scaling": 1.0,
+            "upper_bound": 5.0,
+            "warm_start_source": "quote_map_seed"
+          }
+        ],
+        "workflow_id": "single_name_credit_curve"
+      },
       "warm": null,
       "warm_speedup": null,
       "workflow": "credit"
@@ -716,6 +2914,7 @@
         "desk_like_fixture",
         "linked_single_name_credit_curve"
       ],
+      "problem_ir": null,
       "warm": null,
       "warm_speedup": null,
       "workflow": "basket_credit"
@@ -857,6 +3056,7 @@
         "bounded_quanto_correlation",
         "linked_market_state_materialization"
       ],
+      "problem_ir": null,
       "warm": {
         "calibrations_per_second": 344.142,
         "label": "desk_quanto_correlation",
@@ -944,6 +3144,7 @@
     "desk_like_workflow_count": 2,
     "latency_envelope_count": 2,
     "perturbation_diagnostic_count": 2,
+    "problem_ir_payload_count": 2,
     "warm_mean_seconds": 0.146565,
     "warm_start_workflow_count": 5,
     "workflow_count": 11

--- a/docs/benchmarks/calibration_workflows.md
+++ b/docs/benchmarks/calibration_workflows.md
@@ -5,6 +5,7 @@
 - Desk-like workflows: `2`
 - Perturbation diagnostics: `2`
 - Latency envelopes: `2`
+- Problem-IR payloads: `2`
 - Avg cold mean seconds: `1.122763`
 - Avg warm mean seconds: `0.146565`
 - Avg warm speedup: `10.047`x
@@ -44,6 +45,7 @@
 - Warm mean: `0.00344` s
 - Warm throughput: `290.707` runs/s
 - Warm speedup: `22.754`x
+- Problem IR: `sabr_smile_least_squares` via `sabr_smile_problem_ir_v1`
 - Metadata: `point_count`=7, `surface_name`='usd_rates_smile', `synthetic_generation_contract_version`='v2', `warm_start`=True
 - Note: least_squares
 - Note: implied_vol_fit
@@ -104,6 +106,7 @@
 - Cold mean: `0.701379` s
 - Cold throughput: `1.426` runs/s
 - Warm start: `n/a`
+- Problem IR: `single_name_credit_cds_par_spread_least_squares` via `single_name_credit_problem_ir_v1`
 - Metadata: `curve_name`='usd_ig', `model_consistency_contract_version`='v1', `point_count`=4, `quote_family`='spread', `warm_start`=False
 - Note: least_squares
 - Note: model_consistency_contract_fixture
@@ -114,7 +117,7 @@
 - Warm start: `n/a`
 - Latency envelope: `pass` (cold mean `3.055233` s <= `6.0` s)
 - Perturbation diagnostic: `pass` (max abs change `0.004268596412018488`)
-- Metadata: `fixture_style`='desk_like', `latency_envelope`={'workflow': 'basket_credit', 'label': 'desk_tranche_surface', 'fixture_style': 'desk_like', 'instrument_count': None, 'quote_count': 6, 'cold_mean_limit_seconds': 6.0, 'cold_max_limit_seconds': 8.0, 'warm_mean_limit_seconds': None}, `linked_credit_curve`='benchmark_single_name_credit', `maturity_count`=2, `perturbation_diagnostic`={'label': 'basket_credit_parallel_quote_up', 'perturbation_size': 0.0025, 'baseline_metrics': {'5y_0.00_0.03': 0.18000000000001112, '5y_0.03_0.07': 0.23999999999990046, '5y_0.07_0.10': 0.33999999999225816, '7y_0.00_0.03': 0.39, '7y_0.03_0.07': 0.48000000000000054, '7y_0.07_0.10': 0.5399999999999684}, 'perturbed_metrics': {'5y_0.00_0.03': 0.1781832312816442, '5y_0.03_0.07': 0.23573140358788197, '5y_0.07_0.10': 0.34400870869280414, '7y_0.00_0.03': 0.3880026451908997, '7y_0.03_0.07': 0.4774988971374956, '7y_0.07_0.10': 0.5361447035161097}, 'absolute_changes': {'5y_0.00_0.03': -0.0018167687183669179, '5y_0.03_0.07': -0.004268596412018488, '5y_0.07_0.10': 0.004008708700545982, '7y_0.00_0.03': -0.0019973548091002935, '7y_0.03_0.07': -0.0025011028625049336, '7y_0.07_0.10': -0.003855296483858739}, 'relative_changes': {'5y_0.00_0.03': -0.010093159546482253, '5y_0.03_0.07': -0.017785818383417744, '5y_0.07_0.10': 0.011790319707756649, '7y_0.00_0.03': -0.00512142258743665, '7y_0.03_0.07': -0.00521063096355194, '7y_0.07_0.10': -0.007139437933072156}, 'max_abs_change': 0.004268596412018488, 'max_relative_change': 0.017785818383417744, 'threshold_breaches': {}, 'status': 'pass'}, `quote_count`=6, `support_boundary`='homogeneous_representative_curve', `surface_name`='benchmark_tranche_correlation', `tranche_count`=3, `warm_start`=False
+- Metadata: `fixture_style`='desk_like', `latency_envelope`={'cold_max_limit_seconds': 8.0, 'cold_mean_limit_seconds': 6.0, 'fixture_style': 'desk_like', 'instrument_count': None, 'label': 'desk_tranche_surface', 'quote_count': 6, 'warm_mean_limit_seconds': None, 'workflow': 'basket_credit'}, `linked_credit_curve`='benchmark_single_name_credit', `maturity_count`=2, `perturbation_diagnostic`={'absolute_changes': {'5y_0.00_0.03': -0.0018167687183669179, '5y_0.03_0.07': -0.004268596412018488, '5y_0.07_0.10': 0.004008708700545982, '7y_0.00_0.03': -0.0019973548091002935, '7y_0.03_0.07': -0.0025011028625049336, '7y_0.07_0.10': -0.003855296483858739}, 'baseline_metrics': {'5y_0.00_0.03': 0.18000000000001112, '5y_0.03_0.07': 0.23999999999990046, '5y_0.07_0.10': 0.33999999999225816, '7y_0.00_0.03': 0.39, '7y_0.03_0.07': 0.48000000000000054, '7y_0.07_0.10': 0.5399999999999684}, 'label': 'basket_credit_parallel_quote_up', 'max_abs_change': 0.004268596412018488, 'max_relative_change': 0.017785818383417744, 'perturbation_size': 0.0025, 'perturbed_metrics': {'5y_0.00_0.03': 0.1781832312816442, '5y_0.03_0.07': 0.23573140358788197, '5y_0.07_0.10': 0.34400870869280414, '7y_0.00_0.03': 0.3880026451908997, '7y_0.03_0.07': 0.4774988971374956, '7y_0.07_0.10': 0.5361447035161097}, 'relative_changes': {'5y_0.00_0.03': -0.010093159546482253, '5y_0.03_0.07': -0.017785818383417744, '5y_0.07_0.10': 0.011790319707756649, '7y_0.00_0.03': -0.00512142258743665, '7y_0.03_0.07': -0.00521063096355194, '7y_0.07_0.10': -0.007139437933072156}, 'status': 'pass', 'threshold_breaches': {}}, `quote_count`=6, `support_boundary`='homogeneous_representative_curve', `surface_name`='benchmark_tranche_correlation', `tranche_count`=3, `warm_start`=False
 - Note: brentq_root_scan
 - Note: homogeneous_basket_credit
 - Note: desk_like_fixture
@@ -128,7 +131,7 @@
 - Warm speedup: `3.21`x
 - Latency envelope: `pass` (cold mean `0.009328` s <= `1.5` s)
 - Perturbation diagnostic: `pass` (max abs change `0.00741841223079881`)
-- Metadata: `correlation_keys`=['EURUSD_corr'], `fixture_style`='desk_like', `fx_pair`='EURUSD', `latency_envelope`={'workflow': 'quanto_correlation', 'label': 'desk_quanto_correlation', 'fixture_style': 'desk_like', 'instrument_count': None, 'quote_count': 3, 'cold_mean_limit_seconds': 1.5, 'cold_max_limit_seconds': 2.0, 'warm_mean_limit_seconds': 0.5}, `linked_curve_roles`={'discount_curve': 'usd_ois', 'forecast_curve': 'EUR-DISC'}, `linked_vol_surface`='quanto_flat_vol', `parameter_set_name`='benchmark_quanto_rho', `perturbation_diagnostic`={'label': 'quanto_correlation_parallel_quote_up', 'perturbation_size': 0.0025, 'baseline_metrics': {'quanto_correlation': 0.3499999999999991}, 'perturbed_metrics': {'quanto_correlation': 0.3425815877692003}, 'absolute_changes': {'quanto_correlation': -0.00741841223079881}, 'relative_changes': {'quanto_correlation': -0.021195463516568085}, 'max_abs_change': 0.00741841223079881, 'max_relative_change': 0.021195463516568085, 'threshold_breaches': {}, 'status': 'pass'}, `quote_count`=3, `support_boundary`='bounded_quanto_correlation', `warm_start`=True
+- Metadata: `correlation_keys`=['EURUSD_corr'], `fixture_style`='desk_like', `fx_pair`='EURUSD', `latency_envelope`={'cold_max_limit_seconds': 2.0, 'cold_mean_limit_seconds': 1.5, 'fixture_style': 'desk_like', 'instrument_count': None, 'label': 'desk_quanto_correlation', 'quote_count': 3, 'warm_mean_limit_seconds': 0.5, 'workflow': 'quanto_correlation'}, `linked_curve_roles`={'discount_curve': 'usd_ois', 'forecast_curve': 'EUR-DISC'}, `linked_vol_surface`='quanto_flat_vol', `parameter_set_name`='benchmark_quanto_rho', `perturbation_diagnostic`={'absolute_changes': {'quanto_correlation': -0.00741841223079881}, 'baseline_metrics': {'quanto_correlation': 0.3499999999999991}, 'label': 'quanto_correlation_parallel_quote_up', 'max_abs_change': 0.00741841223079881, 'max_relative_change': 0.021195463516568085, 'perturbation_size': 0.0025, 'perturbed_metrics': {'quanto_correlation': 0.3425815877692003}, 'relative_changes': {'quanto_correlation': -0.021195463516568085}, 'status': 'pass', 'threshold_breaches': {}}, `quote_count`=3, `support_boundary`='bounded_quanto_correlation', `warm_start`=True
 - Note: least_squares
 - Note: desk_like_fixture
 - Note: bounded_quanto_correlation

--- a/docs/mathematical/calibration.rst
+++ b/docs/mathematical/calibration.rst
@@ -151,16 +151,20 @@ is a typed, immutable representation of one calibration node. It records:
 - upstream dependencies, materialization intent, diagnostics, replay metadata,
   and the serialized solve request when available
 
-The first checked adapter is intentionally bounded. SABR smile calibration can
+The first checked adapters are intentionally bounded. SABR smile calibration can
 build a ``CalibrationProblemIR`` through
 ``build_sabr_smile_calibration_problem_ir(...)`` and execute the existing
-workflow through ``fit_sabr_smile_problem_ir(...)``. This proves the common
-problem shape against an existing workflow without changing the SABR objective,
-solver choice, solved parameters, diagnostics, or replay payload.
+workflow through ``fit_sabr_smile_problem_ir(...)``. Single-name credit curve
+calibration can do the same through
+``build_single_name_credit_calibration_problem_ir(...)`` and
+``fit_single_name_credit_problem_ir(...)``. These paths prove the common problem
+shape against existing workflows without changing their objectives, solver
+choices, solved parameters, diagnostics, or replay payloads.
 
 This is not yet a public universal calibration orchestrator. The IR-backed SABR
-path reports itself as adapter-only, and unsupported workflows remain on their
-current direct functions until they have parity adapters and replay coverage.
+and single-name credit paths report themselves as adapter-only, and unsupported
+workflows remain on their current direct functions until they have parity
+adapters and replay coverage.
 
 Quote Maps And Target Transforms
 --------------------------------
@@ -176,6 +180,7 @@ The shipped quote-map vocabulary is intentionally bounded:
 - ``ImpliedVol(Normal)``
 - ``ParRate``
 - ``Spread``
+- ``Upfront``
 - ``Hazard``
 
 Each quote map carries two directional transforms where applicable:

--- a/docs/mathematical/calibration.rst
+++ b/docs/mathematical/calibration.rst
@@ -138,6 +138,30 @@ now explicit and serializable before backend dispatch. That means calibration
 results can record the solve request itself in provenance instead of forcing
 replay tools to infer solver inputs from ad hoc backend calls.
 
+Calibration Problem IR
+----------------------
+
+Trellis now has a first calibration-engine migration artifact:
+``CalibrationProblemIR`` in ``trellis.models.calibration.problem_ir``. The IR
+is a typed, immutable representation of one calibration node. It records:
+
+- calibration variables and their coordinate charts
+- observed targets, quote conventions, quote maps, weights, and validation tags
+- objective shape, loss function, derivative method, and solve-request identity
+- upstream dependencies, materialization intent, diagnostics, replay metadata,
+  and the serialized solve request when available
+
+The first checked adapter is intentionally bounded. SABR smile calibration can
+build a ``CalibrationProblemIR`` through
+``build_sabr_smile_calibration_problem_ir(...)`` and execute the existing
+workflow through ``fit_sabr_smile_problem_ir(...)``. This proves the common
+problem shape against an existing workflow without changing the SABR objective,
+solver choice, solved parameters, diagnostics, or replay payload.
+
+This is not yet a public universal calibration orchestrator. The IR-backed SABR
+path reports itself as adapter-only, and unsupported workflows remain on their
+current direct functions until they have parity adapters and replay coverage.
+
 Quote Maps And Target Transforms
 --------------------------------
 

--- a/docs/mathematical/calibration.rst
+++ b/docs/mathematical/calibration.rst
@@ -166,6 +166,20 @@ and single-name credit paths report themselves as adapter-only, and unsupported
 workflows remain on their current direct functions until they have parity
 adapters and replay coverage.
 
+Problem-IR Dependency Graphs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``compile_calibration_problem_dependency_graph(...)`` bridges problem IR nodes
+onto the existing ``CalibrationDependencyGraph`` validator. A problem can
+depend on another problem by naming a ``problem:<problem_id>`` source reference
+or by consuming an object kind/name materialized by another problem. The
+compiled graph keeps the existing dependency-first ordering and fail-closed
+diagnostics for duplicate nodes, missing upstream references, and cycles.
+
+This graph compiler is still an internal coordination primitive. It does not
+execute arbitrary problem IRs by itself, and it does not promote adapter-only
+workflows to public universal-engine support.
+
 Quote Maps And Target Transforms
 --------------------------------
 

--- a/docs/mathematical/calibration.rst
+++ b/docs/mathematical/calibration.rst
@@ -191,6 +191,35 @@ problem variables, targets, quote maps, materialization intent, or solve-request
 construction visible before a public orchestrator starts consuming the IR as an
 execution contract.
 
+Gated Problem-IR Orchestrator
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``calibrate_problem_ir(...)`` is the bounded public orchestrator for problem-IR
+execution. It is fail-closed: only workflows returned by
+``supported_calibration_problem_ir_adapters()`` are accepted, and each supported
+workflow must receive its explicit context object.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Family
+     - Workflow
+     - Required context
+     - Result
+   * - ``sabr``
+     - ``sabr_smile``
+     - ``surface``
+     - ``SABRSmileCalibrationResult``
+   * - ``credit``
+     - ``single_name_credit_curve``
+     - ``quotes`` and ``market_state``
+     - ``CreditHazardCalibrationResult``
+
+The orchestrator delegates to the adapter-backed direct workflows and annotates
+result provenance with the selected problem-IR adapter. It does not discover or
+execute arbitrary calibration families, and it does not remove the direct
+workflow functions.
+
 Quote Maps And Target Transforms
 --------------------------------
 

--- a/docs/mathematical/calibration.rst
+++ b/docs/mathematical/calibration.rst
@@ -180,6 +180,17 @@ This graph compiler is still an internal coordination primitive. It does not
 execute arbitrary problem IRs by itself, and it does not promote adapter-only
 workflows to public universal-engine support.
 
+Problem-IR Replay Payloads
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The supported calibration benchmark report now carries full
+``CalibrationProblemIR`` payloads for the adapter-backed SABR and single-name
+credit workflows. Replay tests compare those payloads back to the live
+``SolveRequest`` payloads emitted by the direct workflows. This makes drift in
+problem variables, targets, quote maps, materialization intent, or solve-request
+construction visible before a public orchestrator starts consuming the IR as an
+execution contract.
+
 Quote Maps And Target Transforms
 --------------------------------
 

--- a/tests/test_models/test_calibration/test_benchmarking.py
+++ b/tests/test_models/test_calibration/test_benchmarking.py
@@ -53,6 +53,10 @@ def test_build_and_save_calibration_benchmark_report(tmp_path):
         warm_runner=lambda: {"mode": "warm"},
         notes=("least_squares",),
         metadata={"point_count": 7},
+        problem_ir_payload={
+            "problem_id": "sabr_smile_least_squares",
+            "metadata": {"adapter_id": "sabr_smile_problem_ir_v1"},
+        },
     )
     case = benchmark_calibration_scenario(scenario, repeats=2, warmups=0, timer=fake_timer)
     report = build_calibration_benchmark_report(
@@ -64,11 +68,14 @@ def test_build_and_save_calibration_benchmark_report(tmp_path):
 
     assert report["summary"]["workflow_count"] == 1
     assert report["summary"]["warm_start_workflow_count"] == 1
+    assert report["summary"]["problem_ir_payload_count"] == 1
     assert report["summary"]["average_warm_speedup"] > 1.0
+    assert report["cases"][0]["problem_ir"]["problem_id"] == "sabr_smile_least_squares"
 
     rendered = render_calibration_benchmark_report(report)
     assert "Calibration Benchmark" in rendered
     assert "Warm speedup" in rendered
+    assert "Problem IR" in rendered
     assert "single_smile" in rendered
 
     artifacts = save_calibration_benchmark_report(report, root=tmp_path, stem="supported_calibration_workflows")
@@ -110,6 +117,8 @@ def test_supported_calibration_benchmark_scenarios_cover_workflows():
     assert scenario_map["credit"].warm_runner is None
     assert scenario_map["sabr"].metadata["surface_name"] == "usd_rates_smile"
     assert scenario_map["sabr"].metadata["synthetic_generation_contract_version"] == "v2"
+    assert scenario_map["sabr"].problem_ir_payload["problem_id"] == "sabr_smile_least_squares"
+    assert scenario_map["sabr"].problem_ir_payload["metadata"]["adapter_id"] == "sabr_smile_problem_ir_v1"
     assert scenario_map["swaption_cube"].warm_runner is None
     assert scenario_map["swaption_cube"].metadata["surface_name"] == "usd_swaption_cube"
     assert scenario_map["swaption_cube"].metadata["synthetic_generation_contract_version"] == "v2"
@@ -122,6 +131,12 @@ def test_supported_calibration_benchmark_scenarios_cover_workflows():
     assert scenario_map["local_vol"].metadata["source_surface_name"] == "spx_heston_implied_vol"
     assert scenario_map["local_vol"].metadata["surface_name"] == "spx_local_vol"
     assert scenario_map["local_vol"].metadata["synthetic_generation_contract_version"] == "v2"
+    assert scenario_map["credit"].problem_ir_payload["problem_id"] == (
+        "single_name_credit_cds_par_spread_least_squares"
+    )
+    assert scenario_map["credit"].problem_ir_payload["metadata"]["adapter_id"] == (
+        "single_name_credit_problem_ir_v1"
+    )
     basket_credit = scenario_map["basket_credit"]
     assert basket_credit.warm_runner is None
     assert basket_credit.metadata["fixture_style"] == "desk_like"

--- a/tests/test_models/test_calibration/test_dependency_graph.py
+++ b/tests/test_models/test_calibration/test_dependency_graph.py
@@ -2,15 +2,111 @@
 
 from __future__ import annotations
 
+from datetime import date
+
 import pytest
 
+from trellis.core.market_state import MarketState
+from trellis.curves.yield_curve import YieldCurve
+from trellis.models.calibration.credit import (
+    CreditHazardCalibrationQuote,
+    build_single_name_credit_calibration_problem_ir,
+)
 from trellis.models.calibration.dependency_graph import (
     CalibrationDependencyCycleError,
     CalibrationDependencyGraph,
     CalibrationDependencyNode,
+    compile_calibration_problem_dependency_graph,
     DuplicateCalibrationDependencyNodeError,
     MissingCalibrationDependencyNodeError,
 )
+from trellis.models.calibration.problem_ir import (
+    CalibrationDependencySpec,
+    CalibrationMaterializationSpec,
+    CalibrationObjectiveSpec,
+    CalibrationProblemIR,
+    CalibrationTargetSpec,
+    CalibrationVariableSpec,
+)
+
+
+SETTLE = date(2024, 11, 15)
+
+
+def _credit_market_state() -> MarketState:
+    return MarketState(
+        as_of=SETTLE,
+        settlement=SETTLE,
+        discount=YieldCurve.flat(0.03),
+        selected_curve_names={"discount_curve": "usd_ois"},
+        market_provenance={"source_kind": "explicit_input", "source_ref": "dependency_graph_unit_test"},
+    )
+
+
+def _credit_problem():
+    return build_single_name_credit_calibration_problem_ir(
+        (
+            CreditHazardCalibrationQuote(1.0, 120.0, "spread", label="spread_1y"),
+            CreditHazardCalibrationQuote(5.0, 180.0, "spread", label="spread_5y"),
+        ),
+        _credit_market_state(),
+        recovery=0.4,
+        curve_name="benchmark_single_name_credit",
+    )
+
+
+def _dependent_basket_problem(
+    *,
+    dependency_source_ref: str = "",
+    dependency_object_name: str = "benchmark_single_name_credit",
+) -> CalibrationProblemIR:
+    return CalibrationProblemIR(
+        problem_id="basket_credit_tranche_correlation_problem",
+        workflow_id="basket_credit_problem_ir_graph_fixture",
+        family_id="basket_credit",
+        variables=(
+            CalibrationVariableSpec(
+                name="base_correlation",
+                coordinate_chart="bounded_correlation",
+                initial_value=0.3,
+                lower_bound=0.0,
+                upper_bound=0.999,
+            ),
+        ),
+        targets=(
+            CalibrationTargetSpec(
+                target_id="tranche_0_3",
+                instrument_id="basket_credit:tranche_0_3",
+                quote_family="spread",
+                quote_convention="tranche_running_spread",
+                quote_value=100.0,
+                validation_tags=("basket_credit", "problem_ir_graph_fixture"),
+            ),
+        ),
+        objective=CalibrationObjectiveSpec(
+            objective_kind="least_squares",
+            loss_function="weighted_sum_of_squares",
+            residual_count=1,
+            derivative_method="scipy_2point_residual_jacobian",
+            solve_request_id="basket_credit_graph_fixture",
+        ),
+        dependencies=(
+            CalibrationDependencySpec(
+                dependency_id="representative_credit_curve",
+                object_kind="credit_curve",
+                object_name=dependency_object_name,
+                source_ref=dependency_source_ref,
+            ),
+        ),
+        materialization=CalibrationMaterializationSpec(
+            object_kind="correlation_surface",
+            object_name="basket_base_correlation",
+            destination_field="model_parameter_sets",
+            source_ref="basket_credit_graph_fixture",
+        ),
+        solve_request_payload={"request_id": "basket_credit_graph_fixture"},
+        metadata={"adapter_id": "basket_credit_graph_fixture", "engine_backed": False},
+    )
 
 
 def test_dependency_graph_orders_dependencies_before_dependents():
@@ -201,4 +297,46 @@ def test_dependency_graph_rejects_cycles():
                 ),
             ),
             edges=(),
+        )
+
+
+def test_problem_ir_dependency_graph_infers_materialized_upstream_edges():
+    credit_problem = _credit_problem()
+    basket_problem = _dependent_basket_problem()
+
+    compiled = compile_calibration_problem_dependency_graph(
+        "basket_credit_problem_ir_program",
+        problems=(basket_problem, credit_problem),
+    )
+    payload = compiled.to_payload()
+
+    assert compiled.problem_ids == (
+        "basket_credit_tranche_correlation_problem",
+        "single_name_credit_cds_par_spread_least_squares",
+    )
+    assert compiled.dependency_order() == (
+        "single_name_credit_cds_par_spread_least_squares",
+        "basket_credit_tranche_correlation_problem",
+    )
+    assert [problem.problem_id for problem in compiled.topological_problems] == list(compiled.dependency_order())
+    assert payload["dependency_graph"]["edges"] == [
+        [
+            "basket_credit_tranche_correlation_problem",
+            "single_name_credit_cds_par_spread_least_squares",
+        ],
+    ]
+    assert payload["problems"][0]["problem_id"] == "basket_credit_tranche_correlation_problem"
+    assert payload["problems"][1]["materialization"]["object_kind"] == "credit_curve"
+
+
+def test_problem_ir_dependency_graph_rejects_missing_problem_source_refs():
+    with pytest.raises(MissingCalibrationDependencyNodeError, match="missing target 'missing_credit_problem'"):
+        compile_calibration_problem_dependency_graph(
+            "missing_problem_ref",
+            problems=(
+                _dependent_basket_problem(
+                    dependency_source_ref="problem:missing_credit_problem",
+                    dependency_object_name="missing_credit_curve",
+                ),
+            ),
         )

--- a/tests/test_models/test_calibration/test_problem_ir.py
+++ b/tests/test_models/test_calibration/test_problem_ir.py
@@ -1,0 +1,137 @@
+"""Tests for calibration problem IR and the first SABR adapter."""
+
+from __future__ import annotations
+
+import pytest
+
+from trellis.models.calibration.problem_ir import (
+    CalibrationObjectiveSpec,
+    CalibrationProblemIR,
+    CalibrationTargetSpec,
+    CalibrationVariableSpec,
+)
+from trellis.models.calibration.sabr_fit import (
+    build_sabr_smile_calibration_problem_ir,
+    fit_sabr_smile_problem_ir,
+    fit_sabr_smile_surface,
+)
+from trellis.models.processes.sabr import SABRProcess
+
+
+def _sabr_surface():
+    from trellis.models.calibration.sabr_fit import build_sabr_smile_surface
+
+    forward = 100.0
+    expiry = 1.0
+    beta = 0.5
+    sabr = SABRProcess(0.20, beta, -0.3, 0.4)
+    strikes = [80.0, 90.0, 95.0, 100.0, 105.0, 110.0, 120.0]
+    market_vols = [sabr.implied_vol(forward, strike, expiry) for strike in strikes]
+    return build_sabr_smile_surface(
+        forward,
+        expiry,
+        strikes,
+        market_vols,
+        beta=beta,
+        labels=[f"pt_{index}" for index in range(len(strikes))],
+        weights=[1.0, 1.0, 1.5, 2.0, 1.5, 1.0, 1.0],
+        surface_name="usd_rates_1y_smile",
+        metadata={"fixture": "problem_ir"},
+    )
+
+
+def test_calibration_problem_ir_validates_unique_names_and_targets():
+    variable = CalibrationVariableSpec(
+        name="alpha",
+        coordinate_chart="positive",
+        initial_value=0.2,
+        lower_bound=1e-6,
+    )
+    target = CalibrationTargetSpec(
+        target_id="pt_0",
+        instrument_id="strike_100",
+        quote_family="implied_vol",
+        quote_convention="black",
+        quote_value=0.2,
+    )
+    objective = CalibrationObjectiveSpec(
+        objective_kind="least_squares",
+        loss_function="weighted_sum_of_squares",
+        residual_count=1,
+        derivative_method="autodiff_scalar_gradient",
+    )
+
+    with pytest.raises(ValueError, match="duplicate variable"):
+        CalibrationProblemIR(
+            problem_id="duplicate_variables",
+            workflow_id="demo",
+            family_id="demo",
+            variables=(variable, variable),
+            targets=(target,),
+            objective=objective,
+        )
+
+    with pytest.raises(ValueError, match="duplicate target"):
+        CalibrationProblemIR(
+            problem_id="duplicate_targets",
+            workflow_id="demo",
+            family_id="demo",
+            variables=(variable,),
+            targets=(target, target),
+            objective=objective,
+        )
+
+
+def test_sabr_problem_ir_represents_existing_solve_request_payload():
+    surface = _sabr_surface()
+
+    problem = build_sabr_smile_calibration_problem_ir(surface)
+    direct = fit_sabr_smile_surface(surface)
+
+    payload = problem.to_payload()
+
+    assert problem.problem_id == "sabr_smile_least_squares"
+    assert problem.workflow_id == "sabr_smile"
+    assert [variable.name for variable in problem.variables] == ["alpha", "rho", "nu"]
+    assert [target.target_id for target in problem.targets] == list(surface.labels)
+    assert problem.objective.derivative_method == "autodiff_scalar_gradient"
+    assert problem.objective.residual_count == len(surface.points)
+    assert problem.solve_request_payload == direct.solve_request.to_payload()
+    assert payload["objective"]["metadata"]["quote_map"]["quote_family"] == "implied_vol"
+    assert payload["materialization"]["object_kind"] == "model_parameter_set"
+    assert payload["metadata"]["engine_backed"] is False
+
+
+def test_sabr_problem_ir_adapter_matches_direct_workflow():
+    surface = _sabr_surface()
+    problem = build_sabr_smile_calibration_problem_ir(surface)
+
+    direct = fit_sabr_smile_surface(surface)
+    adapted = fit_sabr_smile_problem_ir(problem, surface)
+
+    assert adapted.sabr.alpha == pytest.approx(direct.sabr.alpha, abs=1e-12)
+    assert adapted.sabr.rho == pytest.approx(direct.sabr.rho, abs=1e-12)
+    assert adapted.sabr.nu == pytest.approx(direct.sabr.nu, abs=1e-12)
+    assert adapted.solve_request.to_payload() == direct.solve_request.to_payload()
+    assert adapted.solver_replay_artifact.request == direct.solver_replay_artifact.request
+    assert adapted.diagnostics.to_payload() == direct.diagnostics.to_payload()
+    assert adapted.summary == direct.summary
+    assert adapted.provenance["calibration_problem_ir"]["problem_id"] == problem.problem_id
+    assert adapted.provenance["calibration_problem_ir"]["adapter_id"] == "sabr_smile_problem_ir_v1"
+
+
+def test_sabr_problem_ir_adapter_rejects_wrong_problem_family():
+    surface = _sabr_surface()
+    problem = build_sabr_smile_calibration_problem_ir(surface)
+    wrong_problem = CalibrationProblemIR(
+        problem_id=problem.problem_id,
+        workflow_id="credit_curve",
+        family_id=problem.family_id,
+        variables=problem.variables,
+        targets=problem.targets,
+        objective=problem.objective,
+        solve_request_payload=problem.solve_request_payload,
+    )
+
+    with pytest.raises(ValueError, match="SABR smile"):
+        fit_sabr_smile_problem_ir(wrong_problem, surface)

--- a/tests/test_models/test_calibration/test_problem_ir.py
+++ b/tests/test_models/test_calibration/test_problem_ir.py
@@ -2,8 +2,18 @@
 
 from __future__ import annotations
 
+from datetime import date
+
 import pytest
 
+from trellis.core.market_state import MarketState
+from trellis.curves.yield_curve import YieldCurve
+from trellis.models.calibration.credit import (
+    CreditHazardCalibrationQuote,
+    build_single_name_credit_calibration_problem_ir,
+    calibrate_single_name_credit_curve_workflow,
+    fit_single_name_credit_problem_ir,
+)
 from trellis.models.calibration.problem_ir import (
     CalibrationObjectiveSpec,
     CalibrationProblemIR,
@@ -16,6 +26,9 @@ from trellis.models.calibration.sabr_fit import (
     fit_sabr_smile_surface,
 )
 from trellis.models.processes.sabr import SABRProcess
+
+
+SETTLE = date(2024, 11, 15)
 
 
 def _sabr_surface():
@@ -37,6 +50,23 @@ def _sabr_surface():
         weights=[1.0, 1.0, 1.5, 2.0, 1.5, 1.0, 1.0],
         surface_name="usd_rates_1y_smile",
         metadata={"fixture": "problem_ir"},
+    )
+
+
+def _credit_market_state() -> MarketState:
+    return MarketState(
+        as_of=SETTLE,
+        settlement=SETTLE,
+        discount=YieldCurve.flat(0.03),
+        selected_curve_names={"discount_curve": "usd_ois"},
+        market_provenance={"source_kind": "explicit_input", "source_ref": "problem_ir_unit_test"},
+    )
+
+
+def _credit_quotes():
+    return (
+        CreditHazardCalibrationQuote(1.0, 120.0, "spread", label="spread_1y"),
+        CreditHazardCalibrationQuote(5.0, 180.0, "spread", label="spread_5y"),
     )
 
 
@@ -135,3 +165,91 @@ def test_sabr_problem_ir_adapter_rejects_wrong_problem_family():
 
     with pytest.raises(ValueError, match="SABR smile"):
         fit_sabr_smile_problem_ir(wrong_problem, surface)
+
+
+def test_single_name_credit_problem_ir_represents_existing_solve_request_payload():
+    market_state = _credit_market_state()
+    quotes = _credit_quotes()
+
+    problem = build_single_name_credit_calibration_problem_ir(
+        quotes,
+        market_state,
+        recovery=0.4,
+        curve_name="acme_credit",
+    )
+    direct = calibrate_single_name_credit_curve_workflow(
+        quotes,
+        market_state,
+        recovery=0.4,
+        curve_name="acme_credit",
+    )
+    payload = problem.to_payload()
+
+    assert problem.problem_id == "single_name_credit_cds_par_spread_least_squares"
+    assert problem.workflow_id == "single_name_credit_curve"
+    assert problem.family_id == "credit"
+    assert [variable.name for variable in problem.variables] == ["hazard_1", "hazard_2"]
+    assert [target.target_id for target in problem.targets] == ["spread_1y", "spread_5y"]
+    assert [target.quote_family for target in problem.targets] == ["spread", "spread"]
+    assert problem.objective.derivative_method == "scipy_2point_residual_jacobian"
+    assert problem.objective.residual_count == len(quotes)
+    assert problem.solve_request_payload == direct.solve_request.to_payload()
+    assert payload["materialization"]["object_kind"] == "credit_curve"
+    assert payload["dependencies"][0]["dependency_id"] == "discount_curve"
+    assert payload["metadata"]["engine_backed"] is False
+
+
+def test_single_name_credit_problem_ir_adapter_matches_direct_workflow():
+    market_state = _credit_market_state()
+    quotes = _credit_quotes()
+    problem = build_single_name_credit_calibration_problem_ir(
+        quotes,
+        market_state,
+        recovery=0.4,
+        curve_name="acme_credit",
+    )
+
+    direct = calibrate_single_name_credit_curve_workflow(
+        quotes,
+        market_state,
+        recovery=0.4,
+        curve_name="acme_credit",
+    )
+    adapted = fit_single_name_credit_problem_ir(
+        problem,
+        quotes,
+        market_state,
+        recovery=0.4,
+        curve_name="acme_credit",
+    )
+
+    assert adapted.solve_request.to_payload() == direct.solve_request.to_payload()
+    assert adapted.solver_replay_artifact.request == direct.solver_replay_artifact.request
+    assert adapted.target_hazards == pytest.approx(direct.target_hazards, abs=1e-12)
+    assert adapted.model_hazards == pytest.approx(direct.model_hazards, abs=1e-12)
+    assert adapted.credit_curve.hazard_rates == pytest.approx(direct.credit_curve.hazard_rates, abs=1e-12)
+    assert adapted.summary == direct.summary
+    assert adapted.provenance["calibration_problem_ir"]["problem_id"] == problem.problem_id
+    assert adapted.provenance["calibration_problem_ir"]["adapter_id"] == "single_name_credit_problem_ir_v1"
+
+
+def test_single_name_credit_problem_ir_adapter_rejects_wrong_problem_family():
+    market_state = _credit_market_state()
+    problem = build_single_name_credit_calibration_problem_ir(
+        _credit_quotes(),
+        market_state,
+        recovery=0.4,
+        curve_name="acme_credit",
+    )
+    wrong_problem = CalibrationProblemIR(
+        problem_id=problem.problem_id,
+        workflow_id="sabr_smile",
+        family_id="sabr",
+        variables=problem.variables,
+        targets=problem.targets,
+        objective=problem.objective,
+        solve_request_payload=problem.solve_request_payload,
+    )
+
+    with pytest.raises(ValueError, match="single-name credit"):
+        fit_single_name_credit_problem_ir(wrong_problem, _credit_quotes(), market_state)

--- a/tests/test_models/test_calibration/test_problem_ir.py
+++ b/tests/test_models/test_calibration/test_problem_ir.py
@@ -14,6 +14,11 @@ from trellis.models.calibration.credit import (
     calibrate_single_name_credit_curve_workflow,
     fit_single_name_credit_problem_ir,
 )
+from trellis.models.calibration.orchestrator import (
+    UnsupportedCalibrationProblemIRError,
+    calibrate_problem_ir,
+    supported_calibration_problem_ir_adapters,
+)
 from trellis.models.calibration.problem_ir import (
     CalibrationObjectiveSpec,
     CalibrationProblemIR,
@@ -253,3 +258,78 @@ def test_single_name_credit_problem_ir_adapter_rejects_wrong_problem_family():
 
     with pytest.raises(ValueError, match="single-name credit"):
         fit_single_name_credit_problem_ir(wrong_problem, _credit_quotes(), market_state)
+
+
+def test_problem_ir_orchestrator_lists_bounded_supported_workflows():
+    supported = {
+        (adapter.family_id, adapter.workflow_id): adapter
+        for adapter in supported_calibration_problem_ir_adapters()
+    }
+
+    assert ("sabr", "sabr_smile") in supported
+    assert ("credit", "single_name_credit_curve") in supported
+    assert supported[("sabr", "sabr_smile")].required_context == ("surface",)
+    assert supported[("credit", "single_name_credit_curve")].required_context == (
+        "quotes",
+        "market_state",
+    )
+
+
+def test_problem_ir_orchestrator_dispatches_sabr_adapter_with_provenance():
+    surface = _sabr_surface()
+    problem = build_sabr_smile_calibration_problem_ir(surface)
+    direct = fit_sabr_smile_surface(surface)
+
+    orchestrated = calibrate_problem_ir(problem, surface=surface)
+
+    assert orchestrated.solve_request.to_payload() == direct.solve_request.to_payload()
+    assert orchestrated.sabr.alpha == pytest.approx(direct.sabr.alpha, abs=1e-12)
+    assert orchestrated.provenance["calibration_problem_ir_orchestrator"]["adapter_id"] == (
+        "sabr_smile_problem_ir_v1"
+    )
+
+
+def test_problem_ir_orchestrator_dispatches_credit_adapter_with_provenance():
+    market_state = _credit_market_state()
+    quotes = _credit_quotes()
+    problem = build_single_name_credit_calibration_problem_ir(
+        quotes,
+        market_state,
+        recovery=0.4,
+        curve_name="acme_credit",
+    )
+    direct = calibrate_single_name_credit_curve_workflow(
+        quotes,
+        market_state,
+        recovery=0.4,
+        curve_name="acme_credit",
+    )
+
+    orchestrated = calibrate_problem_ir(problem, quotes=quotes, market_state=market_state)
+
+    assert orchestrated.solve_request.to_payload() == direct.solve_request.to_payload()
+    assert orchestrated.credit_curve.hazard_rates == pytest.approx(direct.credit_curve.hazard_rates, abs=1e-12)
+    assert orchestrated.provenance["calibration_problem_ir_orchestrator"]["adapter_id"] == (
+        "single_name_credit_problem_ir_v1"
+    )
+
+
+def test_problem_ir_orchestrator_fails_closed_for_unsupported_or_incomplete_context():
+    surface = _sabr_surface()
+    problem = build_sabr_smile_calibration_problem_ir(surface)
+
+    with pytest.raises(ValueError, match="requires `surface`"):
+        calibrate_problem_ir(problem)
+
+    unsupported = CalibrationProblemIR(
+        problem_id="unsupported_problem",
+        workflow_id="heston_surface",
+        family_id="heston",
+        variables=problem.variables,
+        targets=problem.targets,
+        objective=problem.objective,
+        solve_request_payload=problem.solve_request_payload,
+    )
+
+    with pytest.raises(UnsupportedCalibrationProblemIRError, match="Unsupported calibration problem IR"):
+        calibrate_problem_ir(unsupported)

--- a/tests/test_public_api_surface.py
+++ b/tests/test_public_api_surface.py
@@ -141,6 +141,7 @@ def test_models_package_exports():
         HullWhiteCalibrationResult,
         LocalVolCalibrationResult,
         ObjectiveBundle,
+        CalibrationProblemIRAdapterSpec,
         SABRSmileCalibrationResult,
         SABRSmileFitDiagnostics,
         SABRSmilePoint,
@@ -154,6 +155,7 @@ def test_models_package_exports():
         SolveReplayArtifact,
         SolveResult,
         UnsupportedSolveCapabilityError,
+        UnsupportedCalibrationProblemIRError,
         WarmStart,
         build_heston_smile_surface,
         build_supported_calibration_benchmark_report,
@@ -163,6 +165,7 @@ def test_models_package_exports():
         calibrate_heston_smile_workflow,
         calibrate_hull_white,
         calibrate_local_vol_surface_workflow,
+        calibrate_problem_ir,
         calibrate_single_name_credit_curve_workflow,
         calibrate_sabr_smile_workflow,
         calibrate_cap_floor_black_vol,
@@ -172,6 +175,7 @@ def test_models_package_exports():
         fit_heston_smile_surface,
         fit_sabr_smile_surface,
         save_calibration_benchmark_report,
+        supported_calibration_problem_ir_adapters,
         swaption_terms,
     )
     from trellis.models.vol_surface import FlatVol, GridVolSurface, VolSurface
@@ -193,6 +197,7 @@ def test_models_package_exports():
     assert models.calibration.HullWhiteCalibrationInstrument is HullWhiteCalibrationInstrument
     assert models.calibration.HullWhiteCalibrationResult is HullWhiteCalibrationResult
     assert models.calibration.LocalVolCalibrationResult is LocalVolCalibrationResult
+    assert models.calibration.CalibrationProblemIRAdapterSpec is CalibrationProblemIRAdapterSpec
     assert models.calibration.CreditHazardCalibrationQuote is CreditHazardCalibrationQuote
     assert models.calibration.CreditHazardCalibrationResult is CreditHazardCalibrationResult
     assert models.calibration.SABRSmilePoint is SABRSmilePoint
@@ -210,6 +215,7 @@ def test_models_package_exports():
     assert models.calibration.SolveReplayArtifact is SolveReplayArtifact
     assert models.calibration.SolveResult is SolveResult
     assert models.calibration.UnsupportedSolveCapabilityError is UnsupportedSolveCapabilityError
+    assert models.calibration.UnsupportedCalibrationProblemIRError is UnsupportedCalibrationProblemIRError
     assert models.calibration.WarmStart is WarmStart
     assert models.calibration.build_supported_calibration_benchmark_report is build_supported_calibration_benchmark_report
     assert models.calibration.build_solve_provenance is build_solve_provenance
@@ -219,6 +225,7 @@ def test_models_package_exports():
     assert models.calibration.calibrate_heston_smile_workflow is calibrate_heston_smile_workflow
     assert models.calibration.calibrate_hull_white is calibrate_hull_white
     assert models.calibration.calibrate_local_vol_surface_workflow is calibrate_local_vol_surface_workflow
+    assert models.calibration.calibrate_problem_ir is calibrate_problem_ir
     assert (
         models.calibration.calibrate_single_name_credit_curve_workflow
         is calibrate_single_name_credit_curve_workflow
@@ -231,6 +238,10 @@ def test_models_package_exports():
     assert models.calibration.fit_heston_smile_surface is fit_heston_smile_surface
     assert models.calibration.fit_sabr_smile_surface is fit_sabr_smile_surface
     assert models.calibration.save_calibration_benchmark_report is save_calibration_benchmark_report
+    assert (
+        models.calibration.supported_calibration_problem_ir_adapters
+        is supported_calibration_problem_ir_adapters
+    )
     assert models.calibration.swaption_terms is swaption_terms
     assert models.FlatVol is FlatVol
     assert models.GridVolSurface is GridVolSurface

--- a/tests/test_verification/test_calibration_replay.py
+++ b/tests/test_verification/test_calibration_replay.py
@@ -34,6 +34,7 @@ def test_supported_calibration_workflows_preserve_replay_contracts_and_fit_toler
     sabr = scenarios["sabr"].cold_runner()
     assert sabr.solver_provenance.backend["backend_id"] == "scipy"
     assert sabr.solver_replay_artifact.request["request_id"] == "sabr_smile_least_squares"
+    assert scenarios["sabr"].problem_ir_payload["solve_request"] == sabr.solve_request.to_payload()
     assert sabr.diagnostics.max_abs_vol_error < 5e-4
 
     swaption_cube = scenarios["swaption_cube"].cold_runner()
@@ -70,6 +71,7 @@ def test_supported_calibration_workflows_preserve_replay_contracts_and_fit_toler
         credit.solver_replay_artifact.request["request_id"]
         == "single_name_credit_cds_par_spread_least_squares"
     )
+    assert scenarios["credit"].problem_ir_payload["solve_request"] == credit.solve_request.to_payload()
     assert credit.max_abs_repricing_error < 5e-12
     assert credit.max_abs_quote_residual < 1e-8
     assert credit.provenance["potential_binding"]["discount_curve_name"] == "usd_ois"
@@ -194,6 +196,7 @@ def test_live_supported_calibration_benchmark_report_covers_warm_start_shape():
     assert report["summary"]["desk_like_workflow_count"] == 2
     assert report["summary"]["perturbation_diagnostic_count"] == 2
     assert report["summary"]["latency_envelope_count"] == 2
+    assert report["summary"]["problem_ir_payload_count"] == 2
     assert set(cases) == {
         "hull_white",
         "caplet_strip",
@@ -225,6 +228,8 @@ def test_live_supported_calibration_benchmark_report_covers_warm_start_shape():
     assert cases["caplet_strip"]["metadata"]["surface_name"] == "usd_caplet_strip"
     assert cases["sabr"]["metadata"]["surface_name"] == "usd_rates_smile"
     assert cases["sabr"]["metadata"]["synthetic_generation_contract_version"] == "v2"
+    assert cases["sabr"]["problem_ir"]["metadata"]["adapter_id"] == "sabr_smile_problem_ir_v1"
+    assert cases["sabr"]["problem_ir"]["solve_request"]["request_id"] == "sabr_smile_least_squares"
     assert cases["swaption_cube"]["metadata"]["surface_name"] == "usd_swaption_cube"
     assert cases["swaption_cube"]["metadata"]["synthetic_generation_contract_version"] == "v2"
     assert cases["equity_vol_surface"]["metadata"]["surface_name"] == "spx_surface_authority"
@@ -236,6 +241,8 @@ def test_live_supported_calibration_benchmark_report_covers_warm_start_shape():
     assert cases["local_vol"]["metadata"]["source_surface_name"] == "spx_heston_implied_vol"
     assert cases["local_vol"]["metadata"]["surface_name"] == "spx_local_vol"
     assert cases["local_vol"]["metadata"]["synthetic_generation_contract_version"] == "v2"
+    assert cases["credit"]["problem_ir"]["metadata"]["adapter_id"] == "single_name_credit_problem_ir_v1"
+    assert cases["credit"]["problem_ir"]["materialization"]["object_kind"] == "credit_curve"
     assert cases["basket_credit"]["metadata"]["fixture_style"] == "desk_like"
     assert cases["basket_credit"]["metadata"]["linked_credit_curve"] == "benchmark_single_name_credit"
     assert cases["basket_credit"]["metadata"]["perturbation_diagnostic"]["threshold_breaches"] == {}
@@ -259,6 +266,7 @@ def test_checked_calibration_benchmark_artifact_covers_supported_workflows():
     assert payload["summary"]["desk_like_workflow_count"] == 2
     assert payload["summary"]["perturbation_diagnostic_count"] == 2
     assert payload["summary"]["latency_envelope_count"] == 2
+    assert payload["summary"]["problem_ir_payload_count"] == 2
     assert set(cases) == {
         "hull_white",
         "caplet_strip",
@@ -288,6 +296,8 @@ def test_checked_calibration_benchmark_artifact_covers_supported_workflows():
     assert cases["caplet_strip"]["metadata"]["surface_name"] == "usd_caplet_strip"
     assert cases["sabr"]["metadata"]["surface_name"] == "usd_rates_smile"
     assert cases["sabr"]["metadata"]["synthetic_generation_contract_version"] == "v2"
+    assert cases["sabr"]["problem_ir"]["metadata"]["adapter_id"] == "sabr_smile_problem_ir_v1"
+    assert cases["sabr"]["problem_ir"]["solve_request"]["request_id"] == "sabr_smile_least_squares"
     assert cases["swaption_cube"]["metadata"]["surface_name"] == "usd_swaption_cube"
     assert cases["swaption_cube"]["metadata"]["synthetic_generation_contract_version"] == "v2"
     assert cases["equity_vol_surface"]["metadata"]["surface_name"] == "spx_surface_authority"
@@ -299,6 +309,10 @@ def test_checked_calibration_benchmark_artifact_covers_supported_workflows():
     assert cases["local_vol"]["metadata"]["source_surface_name"] == "spx_heston_implied_vol"
     assert cases["local_vol"]["metadata"]["surface_name"] == "spx_local_vol"
     assert cases["local_vol"]["metadata"]["synthetic_generation_contract_version"] == "v2"
+    assert cases["credit"]["problem_ir"]["metadata"]["adapter_id"] == "single_name_credit_problem_ir_v1"
+    assert cases["credit"]["problem_ir"]["solve_request"]["request_id"] == (
+        "single_name_credit_cds_par_spread_least_squares"
+    )
     assert cases["basket_credit"]["metadata"]["fixture_style"] == "desk_like"
     assert cases["basket_credit"]["metadata"]["linked_credit_curve"] == "benchmark_single_name_credit"
     assert cases["basket_credit"]["metadata"]["perturbation_diagnostic"]["threshold_breaches"] == {}

--- a/trellis/models/calibration/__init__.py
+++ b/trellis/models/calibration/__init__.py
@@ -70,9 +70,11 @@ from trellis.models.calibration.sabr_fit import (
     SABRSmilePoint,
     SABRSmileSurface,
     build_sabr_smile_surface,
+    build_sabr_smile_calibration_problem_ir,
     calibrate_sabr_smile_workflow,
     calibrate_sabr,
     fit_sabr_smile_surface,
+    fit_sabr_smile_problem_ir,
 )
 from trellis.models.calibration.local_vol import (
     LocalVolCalibrationResult,
@@ -124,6 +126,15 @@ from trellis.models.calibration.dependency_graph import (
     CalibrationDependencyNode,
     DuplicateCalibrationDependencyNodeError,
     MissingCalibrationDependencyNodeError,
+)
+from trellis.models.calibration.problem_ir import (
+    CalibrationDependencySpec,
+    CalibrationDiagnosticSpec,
+    CalibrationMaterializationSpec,
+    CalibrationObjectiveSpec,
+    CalibrationProblemIR,
+    CalibrationTargetSpec,
+    CalibrationVariableSpec,
 )
 from trellis.models.calibration.quanto import (
     QuantoCorrelationCalibrationDiagnostics,
@@ -210,7 +221,9 @@ __all__ = [
     "SABRSmileFitDiagnostics",
     "SABRSmileCalibrationResult",
     "build_sabr_smile_surface",
+    "build_sabr_smile_calibration_problem_ir",
     "fit_sabr_smile_surface",
+    "fit_sabr_smile_problem_ir",
     "calibrate_sabr_smile_workflow",
     "calibrate_sabr",
     "LocalVolCalibrationResult",
@@ -250,6 +263,13 @@ __all__ = [
     "CalibrationDependencyGraph",
     "CalibrationDependencyGraphError",
     "CalibrationDependencyNode",
+    "CalibrationDependencySpec",
+    "CalibrationDiagnosticSpec",
+    "CalibrationMaterializationSpec",
+    "CalibrationObjectiveSpec",
+    "CalibrationProblemIR",
+    "CalibrationTargetSpec",
+    "CalibrationVariableSpec",
     "DuplicateCalibrationDependencyNodeError",
     "MissingCalibrationDependencyNodeError",
     "QuantoCorrelationCalibrationDiagnostics",

--- a/trellis/models/calibration/__init__.py
+++ b/trellis/models/calibration/__init__.py
@@ -85,7 +85,9 @@ from trellis.models.calibration.local_vol import (
 from trellis.models.calibration.credit import (
     CreditHazardCalibrationQuote,
     CreditHazardCalibrationResult,
+    build_single_name_credit_calibration_problem_ir,
     calibrate_single_name_credit_curve_workflow,
+    fit_single_name_credit_problem_ir,
 )
 from trellis.models.calibration.basket_credit import (
     BasketCreditCalibrationDiagnostics,
@@ -232,7 +234,9 @@ __all__ = [
     "dupire_local_vol",
     "CreditHazardCalibrationQuote",
     "CreditHazardCalibrationResult",
+    "build_single_name_credit_calibration_problem_ir",
     "calibrate_single_name_credit_curve_workflow",
+    "fit_single_name_credit_problem_ir",
     "BasketCreditCalibrationDiagnostics",
     "BasketCreditCorrelationCalibrationResult",
     "BasketCreditCorrelationPoint",

--- a/trellis/models/calibration/__init__.py
+++ b/trellis/models/calibration/__init__.py
@@ -140,6 +140,12 @@ from trellis.models.calibration.problem_ir import (
     CalibrationTargetSpec,
     CalibrationVariableSpec,
 )
+from trellis.models.calibration.orchestrator import (
+    CalibrationProblemIRAdapterSpec,
+    UnsupportedCalibrationProblemIRError,
+    calibrate_problem_ir,
+    supported_calibration_problem_ir_adapters,
+)
 from trellis.models.calibration.quanto import (
     QuantoCorrelationCalibrationDiagnostics,
     QuantoCorrelationCalibrationQuote,
@@ -276,8 +282,12 @@ __all__ = [
     "CalibrationMaterializationSpec",
     "CalibrationObjectiveSpec",
     "CalibrationProblemIR",
+    "CalibrationProblemIRAdapterSpec",
     "CalibrationTargetSpec",
     "CalibrationVariableSpec",
+    "UnsupportedCalibrationProblemIRError",
+    "calibrate_problem_ir",
+    "supported_calibration_problem_ir_adapters",
     "DuplicateCalibrationDependencyNodeError",
     "MissingCalibrationDependencyNodeError",
     "QuantoCorrelationCalibrationDiagnostics",

--- a/trellis/models/calibration/__init__.py
+++ b/trellis/models/calibration/__init__.py
@@ -126,6 +126,8 @@ from trellis.models.calibration.dependency_graph import (
     CalibrationDependencyGraph,
     CalibrationDependencyGraphError,
     CalibrationDependencyNode,
+    CalibrationProblemDependencyGraph,
+    compile_calibration_problem_dependency_graph,
     DuplicateCalibrationDependencyNodeError,
     MissingCalibrationDependencyNodeError,
 )
@@ -267,6 +269,8 @@ __all__ = [
     "CalibrationDependencyGraph",
     "CalibrationDependencyGraphError",
     "CalibrationDependencyNode",
+    "CalibrationProblemDependencyGraph",
+    "compile_calibration_problem_dependency_graph",
     "CalibrationDependencySpec",
     "CalibrationDiagnosticSpec",
     "CalibrationMaterializationSpec",

--- a/trellis/models/calibration/benchmarking.py
+++ b/trellis/models/calibration/benchmarking.py
@@ -83,10 +83,16 @@ class CalibrationBenchmarkScenario:
     warm_runner: Callable[[], object] | None = field(default=None, repr=False, compare=False)
     notes: tuple[str, ...] = ()
     metadata: Mapping[str, object] = field(default_factory=dict)
+    problem_ir_payload: Mapping[str, object] | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "notes", tuple(str(note) for note in self.notes))
         object.__setattr__(self, "metadata", _freeze_mapping(self.metadata))
+        object.__setattr__(
+            self,
+            "problem_ir_payload",
+            None if self.problem_ir_payload is None else _freeze_mapping(self.problem_ir_payload),
+        )
 
 
 @dataclass(frozen=True)
@@ -396,6 +402,7 @@ def benchmark_calibration_scenario(
         "label": scenario.label,
         "notes": list(scenario.notes),
         "metadata": dict(scenario.metadata),
+        "problem_ir": None if scenario.problem_ir_payload is None else dict(scenario.problem_ir_payload),
         "cold": cold.to_dict(),
         "warm": None if warm is None else warm.to_dict(),
         "warm_speedup": None if warm_speedup is None else round(warm_speedup, 3),
@@ -462,6 +469,7 @@ def build_calibration_benchmark_report(
                 if isinstance(dict(case.get("metadata") or {}).get("perturbation_diagnostic"), Mapping)
             ),
             "latency_envelope_count": sum(1 for case in cases if isinstance(case.get("latency_envelope"), Mapping)),
+            "problem_ir_payload_count": sum(1 for case in cases if isinstance(case.get("problem_ir"), Mapping)),
             "cold_mean_seconds": round(float(raw_np.mean(cold_means)), 6) if cold_means else 0.0,
             "warm_mean_seconds": round(float(raw_np.mean(warm_means)), 6) if warm_means else 0.0,
             "average_warm_speedup": round(float(raw_np.mean(speedups)), 3) if speedups else None,
@@ -484,6 +492,7 @@ def render_calibration_benchmark_report(report: Mapping[str, object]) -> str:
         f"- Desk-like workflows: `{summary.get('desk_like_workflow_count', 0)}`",
         f"- Perturbation diagnostics: `{summary.get('perturbation_diagnostic_count', 0)}`",
         f"- Latency envelopes: `{summary.get('latency_envelope_count', 0)}`",
+        f"- Problem-IR payloads: `{summary.get('problem_ir_payload_count', 0)}`",
         f"- Avg cold mean seconds: `{summary['cold_mean_seconds']}`",
         f"- Avg warm mean seconds: `{summary['warm_mean_seconds']}`",
     ]
@@ -528,6 +537,15 @@ def render_calibration_benchmark_report(report: Mapping[str, object]) -> str:
                 f"`{latency['status']}` "
                 f"(cold mean `{latency['cold_mean_seconds']}` s <= "
                 f"`{latency['cold_mean_limit_seconds']}` s)"
+            )
+        problem_ir = case.get("problem_ir")
+        if isinstance(problem_ir, Mapping):
+            problem_metadata = dict(problem_ir.get("metadata") or {})
+            adapter_id = problem_metadata.get("adapter_id", "")
+            lines.append(
+                "- Problem IR: "
+                f"`{problem_ir.get('problem_id', '')}`"
+                + (f" via `{adapter_id}`" if adapter_id else "")
             )
         perturbation = dict(case.get("metadata") or {}).get("perturbation_diagnostic")
         if isinstance(perturbation, Mapping):
@@ -609,6 +627,7 @@ def supported_calibration_benchmark_scenarios() -> tuple[CalibrationBenchmarkSce
     )
     from trellis.models.calibration.credit import (
         CreditHazardCalibrationQuote,
+        build_single_name_credit_calibration_problem_ir,
         calibrate_single_name_credit_curve_workflow,
     )
     from trellis.models.calibration.equity_vol_surface import calibrate_equity_vol_surface_workflow
@@ -629,7 +648,11 @@ def supported_calibration_benchmark_scenarios() -> tuple[CalibrationBenchmarkSce
         calibrate_caplet_vol_strip_workflow,
         calibrate_swaption_vol_cube_workflow,
     )
-    from trellis.models.calibration.sabr_fit import calibrate_sabr_smile_workflow
+    from trellis.models.calibration.sabr_fit import (
+        build_sabr_smile_calibration_problem_ir,
+        build_sabr_smile_surface,
+        calibrate_sabr_smile_workflow,
+    )
     from trellis.models.credit_basket_copula import price_credit_basket_tranche_result
     from trellis.models.processes.sabr import SABRProcess
     from trellis.models.quanto_option import price_quanto_option_analytical_from_market_state
@@ -774,6 +797,17 @@ def supported_calibration_benchmark_scenarios() -> tuple[CalibrationBenchmarkSce
     sabr_forward = float(mock_snapshot.forecast_curves[forecast_curve_name].zero_rate(sabr_expiry))
     sabr_beta = float(rate_vol_model.get("beta", 0.5))
     sabr_market_vols = [rate_surface.black_vol(sabr_expiry, strike) for strike in sabr_strikes]
+    sabr_problem_ir_payload = build_sabr_smile_calibration_problem_ir(
+        build_sabr_smile_surface(
+            sabr_forward,
+            sabr_expiry,
+            sabr_strikes,
+            sabr_market_vols,
+            beta=sabr_beta,
+            surface_name=rate_surface_name,
+            source_ref="supported_calibration_benchmark_scenarios",
+        )
+    ).to_payload()
 
     swaption_cube_state = market_state()
     swaption_cube_expiries = (date(2025, 11, 15), date(2026, 11, 15))
@@ -891,6 +925,12 @@ def supported_calibration_benchmark_scenarios() -> tuple[CalibrationBenchmarkSce
         recovery=credit_recovery,
         curve_name="benchmark_single_name_credit",
     )
+    credit_problem_ir_payload = build_single_name_credit_calibration_problem_ir(
+        credit_quotes,
+        credit_state,
+        recovery=credit_recovery,
+        curve_name="benchmark_single_name_credit",
+    ).to_payload()
     basket_credit_state = benchmark_credit_result.apply_to_market_state(credit_state)
     basket_notional = 100_000_000.0
     basket_n_names = 125
@@ -1157,6 +1197,7 @@ def supported_calibration_benchmark_scenarios() -> tuple[CalibrationBenchmarkSce
                 "surface_name": rate_surface_name,
                 "synthetic_generation_contract_version": str(synthetic_generation_contract.get("version", "")),
             },
+            problem_ir_payload=sabr_problem_ir_payload,
         ),
         CalibrationBenchmarkScenario(
             workflow="swaption_cube",
@@ -1286,6 +1327,7 @@ def supported_calibration_benchmark_scenarios() -> tuple[CalibrationBenchmarkSce
                 "model_consistency_contract_version": str(model_consistency_contract.get("version", "")),
                 "curve_name": credit_curve_name,
             },
+            problem_ir_payload=credit_problem_ir_payload,
         ),
         CalibrationBenchmarkScenario(
             workflow="basket_credit",

--- a/trellis/models/calibration/credit.py
+++ b/trellis/models/calibration/credit.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import date
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Literal, Sequence
 
 import numpy as raw_np
@@ -16,6 +16,15 @@ from trellis.core.market_state import MarketState
 from trellis.core.types import DayCountConvention, Frequency
 from trellis.curves.credit_curve import CreditCurve
 from trellis.models.calibration.materialization import materialize_credit_curve
+from trellis.models.calibration.problem_ir import (
+    CalibrationDependencySpec,
+    CalibrationDiagnosticSpec,
+    CalibrationMaterializationSpec,
+    CalibrationObjectiveSpec,
+    CalibrationProblemIR,
+    CalibrationTargetSpec,
+    CalibrationVariableSpec,
+)
 from trellis.models.calibration.quote_maps import (
     CalibrationQuoteMap,
     QuoteAxisSpec,
@@ -1240,8 +1249,235 @@ def calibrate_single_name_credit_curve_workflow(
     )
 
 
+def _credit_problem_quote_convention(quote: CreditHazardCalibrationQuote) -> str:
+    """Return the objective-space quote convention for one credit target."""
+    if quote.quote_kind == "upfront":
+        return "standard_coupon_upfront"
+    return "cds_par_spread"
+
+
+def _single_name_credit_result_to_problem_ir(
+    result: CreditHazardCalibrationResult,
+    market_state: MarketState,
+    *,
+    max_hazard: float,
+) -> CalibrationProblemIR:
+    """Represent one existing single-name credit fit as a calibration problem IR."""
+    solve_request = result.solve_request
+    bounds_payload = solve_request.bounds.to_payload()
+    lower_bounds = tuple(bounds_payload["lower"])
+    upper_bounds = tuple(bounds_payload["upper"])
+    variables = tuple(
+        CalibrationVariableSpec(
+            name=name,
+            coordinate_chart="positive_hazard_rate",
+            initial_value=solve_request.initial_guess[index],
+            lower_bound=lower_bounds[index],
+            upper_bound=upper_bounds[index],
+            warm_start_source=(
+                solve_request.warm_start.source
+                if solve_request.warm_start is not None
+                else ""
+            ),
+            metadata={
+                "parameter_role": "piecewise_hazard_rate",
+                "tenor_years": float(result.tenors[index]),
+                "curve_name": result.curve_name,
+            },
+        )
+        for index, name in enumerate(solve_request.parameter_names)
+    )
+
+    target_payload = dict(result.provenance.get("calibration_target") or {})
+    quote_maps = tuple(target_payload.get("quote_maps") or ())
+    instrument_setups = tuple(target_payload.get("instrument_setup") or ())
+    labels = tuple(target_payload.get("labels") or solve_request.objective.labels)
+    targets = tuple(
+        CalibrationTargetSpec(
+            target_id=str(labels[index]),
+            instrument_id=f"{result.curve_name}:{labels[index]}",
+            quote_family=quote.quote_kind,
+            quote_convention=_credit_problem_quote_convention(quote),
+            quote_value=quote.quote,
+            weight=quote.weight,
+            quote_map_payload=quote_maps[index] if index < len(quote_maps) else {},
+            validation_tags=("single_name_credit", "cds", quote.quote_kind),
+            metadata={
+                "maturity_years": float(quote.maturity_years),
+                "curve_tenor_years": float(result.tenors[index]),
+                "target_running_spread": float(result.target_running_spreads[index]),
+                "target_hazard": float(result.target_hazards[index]),
+                "instrument_setup": (
+                    dict(instrument_setups[index])
+                    if index < len(instrument_setups)
+                    else {}
+                ),
+            },
+        )
+        for index, quote in enumerate(result.quotes)
+    )
+
+    objective = CalibrationObjectiveSpec(
+        objective_kind=solve_request.problem_kind,
+        loss_function="weighted_sum_of_squares",
+        residual_count=len(targets),
+        derivative_method=str(
+            result.solver_provenance.backend.get("resolved_derivative_method", "")
+            or result.solver_provenance.backend.get("derivative_method", "")
+        ),
+        solve_request_id=solve_request.request_id,
+        metadata={
+            "fit_space": dict(result.provenance.get("fit_diagnostics") or {}).get("fit_space", ""),
+            "fit_value_kinds": list(solve_request.objective.metadata.get("fit_value_kinds") or ()),
+            "potential_binding": dict(result.potential_binding),
+        },
+    )
+
+    selected_curve_names = dict(market_state.selected_curve_names or {})
+    dependencies = (
+        CalibrationDependencySpec(
+            dependency_id="discount_curve",
+            object_kind="yield_curve",
+            object_name=str(selected_curve_names.get("discount_curve") or "discount_curve"),
+            source_ref="market_state.discount",
+            metadata={
+                "curve_role": "discount_curve",
+                "required_for": "cds_par_spread_objective",
+            },
+        ),
+    )
+    materialization = CalibrationMaterializationSpec(
+        object_kind="credit_curve",
+        object_name=result.curve_name,
+        destination_field="credit_curve",
+        source_ref="calibrate_single_name_credit_curve_workflow",
+        metadata={
+            "model_family": "reduced_form_credit",
+            "instrument_kind": "single_name_cds",
+            "tenors": list(result.tenors),
+            "recovery": float(result.recovery),
+            "potential_binding": dict(result.potential_binding),
+        },
+    )
+    diagnostics = (
+        CalibrationDiagnosticSpec(
+            diagnostic_id="max_abs_repricing_error",
+            metric_name="max_abs_repricing_error",
+            tolerance=5e-12,
+            severity="warning",
+        ),
+        CalibrationDiagnosticSpec(
+            diagnostic_id="max_abs_quote_residual",
+            metric_name="max_abs_quote_residual",
+            tolerance=1e-8,
+            severity="warning",
+        ),
+        CalibrationDiagnosticSpec(
+            diagnostic_id="max_abs_hazard_residual",
+            metric_name="max_abs_hazard_residual",
+            tolerance=1e-8,
+            severity="warning",
+        ),
+    )
+    return CalibrationProblemIR(
+        problem_id=solve_request.request_id,
+        workflow_id="single_name_credit_curve",
+        family_id="credit",
+        variables=variables,
+        targets=targets,
+        objective=objective,
+        dependencies=dependencies,
+        materialization=materialization,
+        diagnostics=diagnostics,
+        solve_request_payload=solve_request.to_payload(),
+        replay_metadata={
+            "quotes": [quote.to_payload() for quote in result.quotes],
+            "market_state": {
+                "as_of": market_state.as_of.isoformat() if market_state.as_of is not None else None,
+                "settlement": (
+                    market_state.settlement.isoformat()
+                    if market_state.settlement is not None
+                    else None
+                ),
+                "selected_curve_names": selected_curve_names,
+            },
+            "solver_replay_artifact": result.solver_replay_artifact.to_payload(),
+            "max_hazard": float(max_hazard),
+        },
+        metadata={
+            "adapter_id": "single_name_credit_problem_ir_v1",
+            "engine_backed": False,
+            "support_boundary": "problem_ir_adapter_only",
+            "source_ref": "build_single_name_credit_calibration_problem_ir",
+            "quote_normalization_method": result.summary.get("quote_normalization_method", ""),
+        },
+    )
+
+
+def build_single_name_credit_calibration_problem_ir(
+    quotes: Sequence[CreditHazardCalibrationQuote],
+    market_state: MarketState,
+    *,
+    recovery: float = 0.4,
+    curve_name: str = "single_name_credit",
+    max_hazard: float = 5.0,
+) -> CalibrationProblemIR:
+    """Represent the supported single-name credit workflow as a calibration problem IR."""
+    result = calibrate_single_name_credit_curve_workflow(
+        quotes,
+        market_state,
+        recovery=recovery,
+        curve_name=curve_name,
+        max_hazard=max_hazard,
+    )
+    return _single_name_credit_result_to_problem_ir(
+        result,
+        market_state,
+        max_hazard=max_hazard,
+    )
+
+
+def fit_single_name_credit_problem_ir(
+    problem: CalibrationProblemIR,
+    quotes: Sequence[CreditHazardCalibrationQuote],
+    market_state: MarketState,
+    *,
+    recovery: float = 0.4,
+    curve_name: str = "single_name_credit",
+    max_hazard: float = 5.0,
+) -> CreditHazardCalibrationResult:
+    """Execute the current single-name credit workflow through its problem-IR adapter."""
+    if problem.workflow_id != "single_name_credit_curve" or problem.family_id != "credit":
+        raise ValueError("fit_single_name_credit_problem_ir requires a single-name credit calibration problem")
+    result = calibrate_single_name_credit_curve_workflow(
+        quotes,
+        market_state,
+        recovery=recovery,
+        curve_name=curve_name,
+        max_hazard=max_hazard,
+    )
+    if tuple(variable.name for variable in problem.variables) != result.solve_request.parameter_names:
+        raise ValueError("single-name credit calibration problem hazard variables are stale or inconsistent")
+    if len(problem.targets) != len(result.quotes):
+        raise ValueError("single-name credit calibration problem target count is stale or inconsistent")
+    if problem.solve_request_payload and dict(problem.solve_request_payload) != result.solve_request.to_payload():
+        raise ValueError("single-name credit calibration problem solve_request_payload is stale or inconsistent")
+
+    provenance = dict(result.provenance)
+    provenance["calibration_problem_ir"] = {
+        "problem_id": problem.problem_id,
+        "workflow_id": problem.workflow_id,
+        "family_id": problem.family_id,
+        "adapter_id": problem.metadata.get("adapter_id", ""),
+        "engine_backed": bool(problem.metadata.get("engine_backed", False)),
+    }
+    return replace(result, provenance=provenance)
+
+
 __all__ = [
     "CreditHazardCalibrationQuote",
     "CreditHazardCalibrationResult",
+    "build_single_name_credit_calibration_problem_ir",
     "calibrate_single_name_credit_curve_workflow",
+    "fit_single_name_credit_problem_ir",
 ]

--- a/trellis/models/calibration/dependency_graph.py
+++ b/trellis/models/calibration/dependency_graph.py
@@ -7,6 +7,8 @@ from heapq import heappop, heappush
 from types import MappingProxyType
 from typing import Mapping, Sequence
 
+from trellis.models.calibration.problem_ir import CalibrationProblemIR
+
 
 def _normalize_str(value: object) -> str:
     """Return a stripped string representation."""
@@ -297,11 +299,163 @@ class CalibrationDependencyGraph:
         return tuple(ordered)
 
 
+def _problem_materialization_key(problem: CalibrationProblemIR) -> tuple[str, str] | None:
+    """Return the materialized object key produced by a problem, if any."""
+    materialization = problem.materialization
+    if materialization is None:
+        return None
+    object_kind = _normalize_str(materialization.object_kind)
+    object_name = _normalize_str(materialization.object_name)
+    if not object_kind or not object_name:
+        return None
+    return object_kind, object_name
+
+
+def _problem_source_ref(source_ref: str) -> str | None:
+    """Return a problem id named by a problem dependency source_ref."""
+    prefix = "problem:"
+    normalized = _normalize_str(source_ref)
+    if not normalized.startswith(prefix):
+        return None
+    problem_id = _normalize_str(normalized[len(prefix):])
+    return problem_id or None
+
+
+def _problem_dependency_edges(
+    problems: Sequence[CalibrationProblemIR],
+) -> tuple[tuple[str, str], ...]:
+    """Infer problem-level edges from materialization keys and source refs."""
+    materialized_by: dict[tuple[str, str], str] = {}
+    duplicate_materializations: list[tuple[str, str]] = []
+    for problem in problems:
+        key = _problem_materialization_key(problem)
+        if key is None:
+            continue
+        if key in materialized_by and key not in duplicate_materializations:
+            duplicate_materializations.append(key)
+        materialized_by[key] = problem.problem_id
+    if duplicate_materializations:
+        duplicate_text = ", ".join(f"{kind}:{name}" for kind, name in duplicate_materializations)
+        raise DuplicateCalibrationDependencyNodeError(
+            f"CalibrationProblemDependencyGraph contains duplicate materialization target(s): {duplicate_text}"
+        )
+
+    edges: list[tuple[str, str]] = []
+    for problem in problems:
+        for dependency in problem.dependencies:
+            source_ref_problem_id = _problem_source_ref(dependency.source_ref)
+            if source_ref_problem_id is not None:
+                edges.append((problem.problem_id, source_ref_problem_id))
+                continue
+            upstream_problem_id = materialized_by.get((dependency.object_kind, dependency.object_name))
+            if upstream_problem_id is not None and upstream_problem_id != problem.problem_id:
+                edges.append((problem.problem_id, upstream_problem_id))
+    return tuple(dict.fromkeys(edges))
+
+
+def _problem_dependency_node(problem: CalibrationProblemIR) -> CalibrationDependencyNode:
+    """Build generic dependency-node metadata for one problem IR."""
+    materialization = problem.materialization
+    object_kind = "calibration_problem" if materialization is None else materialization.object_kind
+    object_name = problem.problem_id if materialization is None else materialization.object_name
+    return CalibrationDependencyNode(
+        node_id=problem.problem_id,
+        object_kind=object_kind,
+        object_name=object_name,
+        source_ref=str(problem.metadata.get("source_ref", "")),
+        description=f"{problem.family_id}:{problem.workflow_id}",
+        metadata={
+            "problem_id": problem.problem_id,
+            "workflow_id": problem.workflow_id,
+            "family_id": problem.family_id,
+            "variable_names": [variable.name for variable in problem.variables],
+            "target_count": len(problem.targets),
+            "materialization": (
+                None
+                if problem.materialization is None
+                else problem.materialization.to_payload()
+            ),
+        },
+    )
+
+
+@dataclass(frozen=True)
+class CalibrationProblemDependencyGraph:
+    """Compiled dependency graph over concrete calibration problem IR nodes."""
+
+    workflow_id: str
+    problems: tuple[CalibrationProblemIR, ...]
+    dependency_graph: CalibrationDependencyGraph
+
+    def __post_init__(self) -> None:
+        workflow_id = _normalize_str(self.workflow_id)
+        problems = tuple(self.problems)
+        if not workflow_id:
+            raise ValueError("CalibrationProblemDependencyGraph requires a non-empty workflow_id")
+        if not problems:
+            raise ValueError("CalibrationProblemDependencyGraph requires at least one problem")
+        object.__setattr__(self, "workflow_id", workflow_id)
+        object.__setattr__(self, "problems", problems)
+
+    @property
+    def problem_ids(self) -> tuple[str, ...]:
+        """Return problem ids in input order."""
+        return tuple(problem.problem_id for problem in self.problems)
+
+    def dependency_order(self) -> tuple[str, ...]:
+        """Return dependency-first problem ids."""
+        return self.dependency_graph.dependency_order()
+
+    @property
+    def topological_problems(self) -> tuple[CalibrationProblemIR, ...]:
+        """Return problem IR nodes in dependency-first order."""
+        problem_lookup = {problem.problem_id: problem for problem in self.problems}
+        return tuple(problem_lookup[problem_id] for problem_id in self.dependency_order())
+
+    def to_payload(self) -> dict[str, object]:
+        """Return a deterministic JSON-friendly problem graph payload."""
+        return {
+            "workflow_id": self.workflow_id,
+            "problem_ids": list(self.problem_ids),
+            "dependency_order": list(self.dependency_order()),
+            "dependency_graph": self.dependency_graph.to_payload(),
+            "problems": [problem.to_payload() for problem in self.problems],
+        }
+
+
+def compile_calibration_problem_dependency_graph(
+    workflow_id: str,
+    problems: Sequence[CalibrationProblemIR],
+    *,
+    edges: Sequence[Sequence[object]] = (),
+) -> CalibrationProblemDependencyGraph:
+    """Compile problem IR nodes into the existing calibration dependency graph.
+
+    Edge direction follows ``CalibrationDependencyGraph``: ``(source, target)``
+    means ``source`` depends on ``target`` and ``target`` must run first.
+    """
+    normalized_problems = tuple(problems)
+    graph_edges = tuple(dict.fromkeys(tuple(_normalize_edge(edge) for edge in edges)))
+    inferred_edges = _problem_dependency_edges(normalized_problems)
+    dependency_graph = CalibrationDependencyGraph(
+        workflow_id=workflow_id,
+        nodes=tuple(_problem_dependency_node(problem) for problem in normalized_problems),
+        edges=tuple(dict.fromkeys(graph_edges + inferred_edges)),
+    )
+    return CalibrationProblemDependencyGraph(
+        workflow_id=workflow_id,
+        problems=normalized_problems,
+        dependency_graph=dependency_graph,
+    )
+
+
 __all__ = [
     "CalibrationDependencyCycleError",
     "CalibrationDependencyGraph",
     "CalibrationDependencyGraphError",
     "CalibrationDependencyNode",
+    "CalibrationProblemDependencyGraph",
+    "compile_calibration_problem_dependency_graph",
     "DuplicateCalibrationDependencyNodeError",
     "MissingCalibrationDependencyNodeError",
 ]

--- a/trellis/models/calibration/orchestrator.py
+++ b/trellis/models/calibration/orchestrator.py
@@ -1,0 +1,192 @@
+"""Bounded public orchestrator for supported calibration problem IRs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from types import MappingProxyType
+from typing import Mapping, Sequence
+
+from trellis.core.market_state import MarketState
+from trellis.models.calibration.credit import (
+    CreditHazardCalibrationQuote,
+    fit_single_name_credit_problem_ir,
+)
+from trellis.models.calibration.problem_ir import CalibrationProblemIR
+from trellis.models.calibration.sabr_fit import (
+    SABRSmileSurface,
+    fit_sabr_smile_problem_ir,
+)
+
+
+def _freeze_mapping(mapping: Mapping[str, object] | None) -> Mapping[str, object]:
+    """Return an immutable mapping proxy."""
+    return MappingProxyType(dict(mapping or {}))
+
+
+@dataclass(frozen=True)
+class CalibrationProblemIRAdapterSpec:
+    """One supported problem-IR orchestrator adapter."""
+
+    adapter_id: str
+    family_id: str
+    workflow_id: str
+    required_context: tuple[str, ...]
+    result_type: str
+    description: str = ""
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "adapter_id", str(self.adapter_id).strip())
+        object.__setattr__(self, "family_id", str(self.family_id).strip())
+        object.__setattr__(self, "workflow_id", str(self.workflow_id).strip())
+        object.__setattr__(self, "required_context", tuple(str(value).strip() for value in self.required_context))
+        object.__setattr__(self, "result_type", str(self.result_type).strip())
+        object.__setattr__(self, "description", str(self.description).strip())
+        object.__setattr__(self, "metadata", _freeze_mapping(self.metadata))
+
+    def to_payload(self) -> dict[str, object]:
+        """Return a JSON-friendly support-matrix payload."""
+        return {
+            "adapter_id": self.adapter_id,
+            "family_id": self.family_id,
+            "workflow_id": self.workflow_id,
+            "required_context": list(self.required_context),
+            "result_type": self.result_type,
+            "description": self.description,
+            "metadata": dict(self.metadata),
+        }
+
+
+class UnsupportedCalibrationProblemIRError(ValueError):
+    """Raised when the public problem-IR orchestrator has no matching adapter."""
+
+    def __init__(self, problem: CalibrationProblemIR, supported: Sequence[CalibrationProblemIRAdapterSpec]):
+        self.problem = problem
+        self.supported = tuple(supported)
+        supported_text = ", ".join(
+            f"{adapter.family_id}:{adapter.workflow_id}" for adapter in self.supported
+        )
+        super().__init__(
+            "Unsupported calibration problem IR "
+            f"{problem.family_id}:{problem.workflow_id}. "
+            f"Supported workflows: {supported_text}"
+        )
+
+
+_SABR_ADAPTER = CalibrationProblemIRAdapterSpec(
+    adapter_id="sabr_smile_problem_ir_v1",
+    family_id="sabr",
+    workflow_id="sabr_smile",
+    required_context=("surface",),
+    result_type="SABRSmileCalibrationResult",
+    description="Adapter-backed SABR smile calibration through the checked direct workflow.",
+    metadata={"support_boundary": "bounded_problem_ir_orchestrator"},
+)
+
+_CREDIT_ADAPTER = CalibrationProblemIRAdapterSpec(
+    adapter_id="single_name_credit_problem_ir_v1",
+    family_id="credit",
+    workflow_id="single_name_credit_curve",
+    required_context=("quotes", "market_state"),
+    result_type="CreditHazardCalibrationResult",
+    description="Adapter-backed single-name credit curve calibration through the checked direct workflow.",
+    metadata={"support_boundary": "bounded_problem_ir_orchestrator"},
+)
+
+
+def supported_calibration_problem_ir_adapters() -> tuple[CalibrationProblemIRAdapterSpec, ...]:
+    """Return the bounded public problem-IR support matrix."""
+    return (_SABR_ADAPTER, _CREDIT_ADAPTER)
+
+
+def _resolve_adapter(problem: CalibrationProblemIR) -> CalibrationProblemIRAdapterSpec:
+    for adapter in supported_calibration_problem_ir_adapters():
+        if adapter.family_id == problem.family_id and adapter.workflow_id == problem.workflow_id:
+            return adapter
+    raise UnsupportedCalibrationProblemIRError(problem, supported_calibration_problem_ir_adapters())
+
+
+def _credit_curve_name(problem: CalibrationProblemIR, curve_name: str | None) -> str:
+    if curve_name is not None:
+        return str(curve_name)
+    if problem.materialization is not None and problem.materialization.object_name:
+        return problem.materialization.object_name
+    return "single_name_credit"
+
+
+def _credit_recovery(problem: CalibrationProblemIR, recovery: float | None) -> float:
+    if recovery is not None:
+        return float(recovery)
+    if problem.materialization is not None:
+        value = problem.materialization.metadata.get("recovery")
+        if value is not None:
+            return float(value)
+    return 0.4
+
+
+def _credit_max_hazard(problem: CalibrationProblemIR, max_hazard: float | None) -> float:
+    if max_hazard is not None:
+        return float(max_hazard)
+    value = problem.replay_metadata.get("max_hazard")
+    if value is not None:
+        return float(value)
+    return 5.0
+
+
+def _attach_orchestrator_provenance(
+    result: object,
+    problem: CalibrationProblemIR,
+    adapter: CalibrationProblemIRAdapterSpec,
+) -> object:
+    """Return a result with bounded orchestrator provenance attached."""
+    provenance = dict(getattr(result, "provenance", {}) or {})
+    provenance["calibration_problem_ir_orchestrator"] = {
+        "adapter_id": adapter.adapter_id,
+        "family_id": adapter.family_id,
+        "workflow_id": adapter.workflow_id,
+        "problem_id": problem.problem_id,
+        "support_boundary": adapter.metadata.get("support_boundary", ""),
+    }
+    return replace(result, provenance=provenance)
+
+
+def calibrate_problem_ir(
+    problem: CalibrationProblemIR,
+    *,
+    surface: SABRSmileSurface | None = None,
+    quotes: Sequence[CreditHazardCalibrationQuote] | None = None,
+    market_state: MarketState | None = None,
+    recovery: float | None = None,
+    curve_name: str | None = None,
+    max_hazard: float | None = None,
+) -> object:
+    """Execute one supported calibration problem IR through a fail-closed adapter."""
+    adapter = _resolve_adapter(problem)
+    if adapter is _SABR_ADAPTER:
+        if surface is None:
+            raise ValueError("SABR problem-IR orchestration requires `surface` context")
+        result = fit_sabr_smile_problem_ir(problem, surface)
+        return _attach_orchestrator_provenance(result, problem, adapter)
+    if adapter is _CREDIT_ADAPTER:
+        if quotes is None:
+            raise ValueError("single-name credit problem-IR orchestration requires `quotes` context")
+        if market_state is None:
+            raise ValueError("single-name credit problem-IR orchestration requires `market_state` context")
+        result = fit_single_name_credit_problem_ir(
+            problem,
+            quotes,
+            market_state,
+            recovery=_credit_recovery(problem, recovery),
+            curve_name=_credit_curve_name(problem, curve_name),
+            max_hazard=_credit_max_hazard(problem, max_hazard),
+        )
+        return _attach_orchestrator_provenance(result, problem, adapter)
+    raise UnsupportedCalibrationProblemIRError(problem, supported_calibration_problem_ir_adapters())
+
+
+__all__ = [
+    "CalibrationProblemIRAdapterSpec",
+    "UnsupportedCalibrationProblemIRError",
+    "calibrate_problem_ir",
+    "supported_calibration_problem_ir_adapters",
+]

--- a/trellis/models/calibration/problem_ir.py
+++ b/trellis/models/calibration/problem_ir.py
@@ -1,0 +1,442 @@
+"""Typed calibration problem IR for engine-backed calibration migration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Mapping, Sequence
+
+import numpy as raw_np
+
+
+def _normalize_str(value: object, *, field_name: str) -> str:
+    normalized = "" if value is None else str(value).strip()
+    if not normalized:
+        raise ValueError(f"{field_name} must be non-empty")
+    return normalized
+
+
+def _optional_str(value: object) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _freeze_mapping(mapping: Mapping[str, object] | None) -> Mapping[str, object]:
+    return MappingProxyType(dict(mapping or {}))
+
+
+def _normalize_str_tuple(values: Sequence[object] | None) -> tuple[str, ...]:
+    if values is None:
+        return ()
+    if isinstance(values, str):
+        values = (values,)
+    return tuple(str(value).strip() for value in values if str(value).strip())
+
+
+def _normalize_mapping(mapping: Mapping[str, object] | None) -> Mapping[str, object]:
+    return _freeze_mapping(mapping)
+
+
+def _payload_mapping(mapping: Mapping[str, object]) -> dict[str, object]:
+    return dict(mapping)
+
+
+def _validate_finite(value: float, *, field_name: str) -> float:
+    normalized = float(value)
+    if not raw_np.isfinite(normalized):
+        raise ValueError(f"{field_name} must be finite")
+    return normalized
+
+
+@dataclass(frozen=True)
+class CalibrationVariableSpec:
+    """One calibration coordinate in a problem IR."""
+
+    name: str
+    coordinate_chart: str
+    initial_value: float
+    lower_bound: float | None = None
+    upper_bound: float | None = None
+    scaling: float = 1.0
+    warm_start_source: str = ""
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        name = _normalize_str(self.name, field_name="CalibrationVariableSpec.name")
+        chart = _normalize_str(self.coordinate_chart, field_name=f"CalibrationVariableSpec {name!r} coordinate_chart")
+        initial_value = _validate_finite(
+            self.initial_value,
+            field_name=f"CalibrationVariableSpec {name!r} initial_value",
+        )
+        lower_bound = None if self.lower_bound is None else _validate_finite(
+            self.lower_bound,
+            field_name=f"CalibrationVariableSpec {name!r} lower_bound",
+        )
+        upper_bound = None if self.upper_bound is None else _validate_finite(
+            self.upper_bound,
+            field_name=f"CalibrationVariableSpec {name!r} upper_bound",
+        )
+        scaling = _validate_finite(self.scaling, field_name=f"CalibrationVariableSpec {name!r} scaling")
+        if scaling <= 0.0:
+            raise ValueError(f"CalibrationVariableSpec {name!r} scaling must be positive")
+        if lower_bound is not None and upper_bound is not None and lower_bound > upper_bound:
+            raise ValueError(f"CalibrationVariableSpec {name!r} lower_bound must not exceed upper_bound")
+        if lower_bound is not None and initial_value < lower_bound:
+            raise ValueError(f"CalibrationVariableSpec {name!r} initial_value is below lower_bound")
+        if upper_bound is not None and initial_value > upper_bound:
+            raise ValueError(f"CalibrationVariableSpec {name!r} initial_value is above upper_bound")
+
+        object.__setattr__(self, "name", name)
+        object.__setattr__(self, "coordinate_chart", chart)
+        object.__setattr__(self, "initial_value", initial_value)
+        object.__setattr__(self, "lower_bound", lower_bound)
+        object.__setattr__(self, "upper_bound", upper_bound)
+        object.__setattr__(self, "scaling", scaling)
+        object.__setattr__(self, "warm_start_source", _optional_str(self.warm_start_source))
+        object.__setattr__(self, "metadata", _freeze_mapping(self.metadata))
+
+    def to_payload(self) -> dict[str, object]:
+        """Return a JSON-friendly variable payload."""
+        return {
+            "name": self.name,
+            "coordinate_chart": self.coordinate_chart,
+            "initial_value": float(self.initial_value),
+            "lower_bound": self.lower_bound,
+            "upper_bound": self.upper_bound,
+            "scaling": float(self.scaling),
+            "warm_start_source": self.warm_start_source,
+            "metadata": _payload_mapping(self.metadata),
+        }
+
+
+@dataclass(frozen=True)
+class CalibrationTargetSpec:
+    """One observed market target in a calibration problem IR."""
+
+    target_id: str
+    instrument_id: str
+    quote_family: str
+    quote_value: float
+    quote_convention: str = ""
+    weight: float = 1.0
+    quote_map_payload: Mapping[str, object] = field(default_factory=dict)
+    validation_tags: tuple[str, ...] = ()
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        target_id = _normalize_str(self.target_id, field_name="CalibrationTargetSpec.target_id")
+        instrument_id = _normalize_str(
+            self.instrument_id,
+            field_name=f"CalibrationTargetSpec {target_id!r} instrument_id",
+        )
+        quote_family = _normalize_str(
+            self.quote_family,
+            field_name=f"CalibrationTargetSpec {target_id!r} quote_family",
+        )
+        quote_value = _validate_finite(
+            self.quote_value,
+            field_name=f"CalibrationTargetSpec {target_id!r} quote_value",
+        )
+        weight = _validate_finite(self.weight, field_name=f"CalibrationTargetSpec {target_id!r} weight")
+        if weight <= 0.0:
+            raise ValueError(f"CalibrationTargetSpec {target_id!r} weight must be positive")
+
+        object.__setattr__(self, "target_id", target_id)
+        object.__setattr__(self, "instrument_id", instrument_id)
+        object.__setattr__(self, "quote_family", quote_family)
+        object.__setattr__(self, "quote_convention", _optional_str(self.quote_convention))
+        object.__setattr__(self, "quote_value", quote_value)
+        object.__setattr__(self, "weight", weight)
+        object.__setattr__(self, "quote_map_payload", _normalize_mapping(self.quote_map_payload))
+        object.__setattr__(self, "validation_tags", _normalize_str_tuple(self.validation_tags))
+        object.__setattr__(self, "metadata", _freeze_mapping(self.metadata))
+
+    def to_payload(self) -> dict[str, object]:
+        """Return a JSON-friendly target payload."""
+        return {
+            "target_id": self.target_id,
+            "instrument_id": self.instrument_id,
+            "quote_family": self.quote_family,
+            "quote_convention": self.quote_convention,
+            "quote_value": float(self.quote_value),
+            "weight": float(self.weight),
+            "quote_map": _payload_mapping(self.quote_map_payload),
+            "validation_tags": list(self.validation_tags),
+            "metadata": _payload_mapping(self.metadata),
+        }
+
+
+@dataclass(frozen=True)
+class CalibrationObjectiveSpec:
+    """Objective metadata for a calibration problem IR."""
+
+    objective_kind: str
+    loss_function: str
+    residual_count: int
+    derivative_method: str = ""
+    solve_request_id: str = ""
+    regularization: Mapping[str, object] = field(default_factory=dict)
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        objective_kind = _normalize_str(self.objective_kind, field_name="CalibrationObjectiveSpec.objective_kind")
+        loss_function = _normalize_str(self.loss_function, field_name="CalibrationObjectiveSpec.loss_function")
+        residual_count = int(self.residual_count)
+        if residual_count <= 0:
+            raise ValueError("CalibrationObjectiveSpec residual_count must be positive")
+        object.__setattr__(self, "objective_kind", objective_kind)
+        object.__setattr__(self, "loss_function", loss_function)
+        object.__setattr__(self, "residual_count", residual_count)
+        object.__setattr__(self, "derivative_method", _optional_str(self.derivative_method))
+        object.__setattr__(self, "solve_request_id", _optional_str(self.solve_request_id))
+        object.__setattr__(self, "regularization", _freeze_mapping(self.regularization))
+        object.__setattr__(self, "metadata", _freeze_mapping(self.metadata))
+
+    def to_payload(self) -> dict[str, object]:
+        """Return a JSON-friendly objective payload."""
+        return {
+            "objective_kind": self.objective_kind,
+            "loss_function": self.loss_function,
+            "residual_count": int(self.residual_count),
+            "derivative_method": self.derivative_method,
+            "solve_request_id": self.solve_request_id,
+            "regularization": _payload_mapping(self.regularization),
+            "metadata": _payload_mapping(self.metadata),
+        }
+
+
+@dataclass(frozen=True)
+class CalibrationDependencySpec:
+    """One upstream dependency consumed by a calibration problem."""
+
+    dependency_id: str
+    object_kind: str
+    object_name: str
+    required: bool = True
+    source_ref: str = ""
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        dependency_id = _normalize_str(self.dependency_id, field_name="CalibrationDependencySpec.dependency_id")
+        object.__setattr__(self, "dependency_id", dependency_id)
+        object.__setattr__(
+            self,
+            "object_kind",
+            _normalize_str(self.object_kind, field_name=f"CalibrationDependencySpec {dependency_id!r} object_kind"),
+        )
+        object.__setattr__(
+            self,
+            "object_name",
+            _normalize_str(self.object_name, field_name=f"CalibrationDependencySpec {dependency_id!r} object_name"),
+        )
+        object.__setattr__(self, "required", bool(self.required))
+        object.__setattr__(self, "source_ref", _optional_str(self.source_ref))
+        object.__setattr__(self, "metadata", _freeze_mapping(self.metadata))
+
+    def to_payload(self) -> dict[str, object]:
+        """Return a JSON-friendly dependency payload."""
+        return {
+            "dependency_id": self.dependency_id,
+            "object_kind": self.object_kind,
+            "object_name": self.object_name,
+            "required": bool(self.required),
+            "source_ref": self.source_ref,
+            "metadata": _payload_mapping(self.metadata),
+        }
+
+
+@dataclass(frozen=True)
+class CalibrationMaterializationSpec:
+    """Runtime materialization target declared by a calibration problem."""
+
+    object_kind: str
+    object_name: str
+    destination_field: str
+    source_ref: str = ""
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object_kind = _normalize_str(self.object_kind, field_name="CalibrationMaterializationSpec.object_kind")
+        object.__setattr__(self, "object_kind", object_kind)
+        object.__setattr__(
+            self,
+            "object_name",
+            _normalize_str(self.object_name, field_name=f"CalibrationMaterializationSpec {object_kind!r} object_name"),
+        )
+        object.__setattr__(
+            self,
+            "destination_field",
+            _normalize_str(
+                self.destination_field,
+                field_name=f"CalibrationMaterializationSpec {object_kind!r} destination_field",
+            ),
+        )
+        object.__setattr__(self, "source_ref", _optional_str(self.source_ref))
+        object.__setattr__(self, "metadata", _freeze_mapping(self.metadata))
+
+    def to_payload(self) -> dict[str, object]:
+        """Return a JSON-friendly materialization payload."""
+        return {
+            "object_kind": self.object_kind,
+            "object_name": self.object_name,
+            "destination_field": self.destination_field,
+            "source_ref": self.source_ref,
+            "metadata": _payload_mapping(self.metadata),
+        }
+
+
+@dataclass(frozen=True)
+class CalibrationDiagnosticSpec:
+    """One required diagnostic or tolerance for a problem IR."""
+
+    diagnostic_id: str
+    metric_name: str
+    tolerance: float | None = None
+    severity: str = "warning"
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        diagnostic_id = _normalize_str(self.diagnostic_id, field_name="CalibrationDiagnosticSpec.diagnostic_id")
+        tolerance = None if self.tolerance is None else _validate_finite(
+            self.tolerance,
+            field_name=f"CalibrationDiagnosticSpec {diagnostic_id!r} tolerance",
+        )
+        if tolerance is not None and tolerance < 0.0:
+            raise ValueError(f"CalibrationDiagnosticSpec {diagnostic_id!r} tolerance must be non-negative")
+        object.__setattr__(self, "diagnostic_id", diagnostic_id)
+        object.__setattr__(
+            self,
+            "metric_name",
+            _normalize_str(self.metric_name, field_name=f"CalibrationDiagnosticSpec {diagnostic_id!r} metric_name"),
+        )
+        object.__setattr__(self, "tolerance", tolerance)
+        object.__setattr__(self, "severity", _optional_str(self.severity) or "warning")
+        object.__setattr__(self, "metadata", _freeze_mapping(self.metadata))
+
+    def to_payload(self) -> dict[str, object]:
+        """Return a JSON-friendly diagnostic payload."""
+        return {
+            "diagnostic_id": self.diagnostic_id,
+            "metric_name": self.metric_name,
+            "tolerance": self.tolerance,
+            "severity": self.severity,
+            "metadata": _payload_mapping(self.metadata),
+        }
+
+
+@dataclass(frozen=True)
+class CalibrationProblemIR:
+    """Typed, immutable representation of one calibration problem node."""
+
+    problem_id: str
+    workflow_id: str
+    family_id: str
+    variables: tuple[CalibrationVariableSpec, ...]
+    targets: tuple[CalibrationTargetSpec, ...]
+    objective: CalibrationObjectiveSpec
+    dependencies: tuple[CalibrationDependencySpec, ...] = ()
+    materialization: CalibrationMaterializationSpec | None = None
+    diagnostics: tuple[CalibrationDiagnosticSpec, ...] = ()
+    solve_request_payload: Mapping[str, object] = field(default_factory=dict)
+    replay_metadata: Mapping[str, object] = field(default_factory=dict)
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        problem_id = _normalize_str(self.problem_id, field_name="CalibrationProblemIR.problem_id")
+        workflow_id = _normalize_str(self.workflow_id, field_name=f"CalibrationProblemIR {problem_id!r} workflow_id")
+        family_id = _normalize_str(self.family_id, field_name=f"CalibrationProblemIR {problem_id!r} family_id")
+        variables = tuple(self.variables)
+        targets = tuple(self.targets)
+        dependencies = tuple(self.dependencies)
+        diagnostics = tuple(self.diagnostics)
+        if not variables:
+            raise ValueError(f"CalibrationProblemIR {problem_id!r} requires at least one variable")
+        if not targets:
+            raise ValueError(f"CalibrationProblemIR {problem_id!r} requires at least one target")
+        self._validate_unique(
+            [variable.name for variable in variables],
+            problem_id=problem_id,
+            kind="variable",
+        )
+        self._validate_unique(
+            [target.target_id for target in targets],
+            problem_id=problem_id,
+            kind="target",
+        )
+        self._validate_unique(
+            [dependency.dependency_id for dependency in dependencies],
+            problem_id=problem_id,
+            kind="dependency",
+        )
+        self._validate_unique(
+            [diagnostic.diagnostic_id for diagnostic in diagnostics],
+            problem_id=problem_id,
+            kind="diagnostic",
+        )
+        if self.objective.residual_count != len(targets):
+            raise ValueError(
+                f"CalibrationProblemIR {problem_id!r} objective residual_count must match target count"
+            )
+        solve_request_payload = _freeze_mapping(self.solve_request_payload)
+        request_id = solve_request_payload.get("request_id")
+        if self.objective.solve_request_id and request_id and str(request_id) != self.objective.solve_request_id:
+            raise ValueError(
+                f"CalibrationProblemIR {problem_id!r} solve_request_payload request_id "
+                "must match objective solve_request_id"
+            )
+
+        object.__setattr__(self, "problem_id", problem_id)
+        object.__setattr__(self, "workflow_id", workflow_id)
+        object.__setattr__(self, "family_id", family_id)
+        object.__setattr__(self, "variables", variables)
+        object.__setattr__(self, "targets", targets)
+        object.__setattr__(self, "dependencies", dependencies)
+        object.__setattr__(self, "diagnostics", diagnostics)
+        object.__setattr__(self, "solve_request_payload", solve_request_payload)
+        object.__setattr__(self, "replay_metadata", _freeze_mapping(self.replay_metadata))
+        object.__setattr__(self, "metadata", _freeze_mapping(self.metadata))
+
+    def initial_guess(self) -> tuple[float, ...]:
+        """Return variables' initial values in parameter order."""
+        return tuple(variable.initial_value for variable in self.variables)
+
+    def to_payload(self) -> dict[str, object]:
+        """Return a deterministic JSON-friendly problem payload."""
+        return {
+            "problem_id": self.problem_id,
+            "workflow_id": self.workflow_id,
+            "family_id": self.family_id,
+            "variables": [variable.to_payload() for variable in self.variables],
+            "targets": [target.to_payload() for target in self.targets],
+            "objective": self.objective.to_payload(),
+            "dependencies": [dependency.to_payload() for dependency in self.dependencies],
+            "materialization": None if self.materialization is None else self.materialization.to_payload(),
+            "diagnostics": [diagnostic.to_payload() for diagnostic in self.diagnostics],
+            "solve_request": _payload_mapping(self.solve_request_payload),
+            "replay_metadata": _payload_mapping(self.replay_metadata),
+            "metadata": _payload_mapping(self.metadata),
+        }
+
+    @staticmethod
+    def _validate_unique(values: Sequence[str], *, problem_id: str, kind: str) -> None:
+        seen: set[str] = set()
+        duplicates: list[str] = []
+        for value in values:
+            if value in seen and value not in duplicates:
+                duplicates.append(value)
+            seen.add(value)
+        if duplicates:
+            duplicate_text = ", ".join(repr(value) for value in duplicates)
+            raise ValueError(f"CalibrationProblemIR {problem_id!r} has duplicate {kind} id(s): {duplicate_text}")
+
+
+__all__ = [
+    "CalibrationDependencySpec",
+    "CalibrationDiagnosticSpec",
+    "CalibrationMaterializationSpec",
+    "CalibrationObjectiveSpec",
+    "CalibrationProblemIR",
+    "CalibrationTargetSpec",
+    "CalibrationVariableSpec",
+]

--- a/trellis/models/calibration/sabr_fit.py
+++ b/trellis/models/calibration/sabr_fit.py
@@ -21,6 +21,14 @@ from trellis.models.calibration.solve_request import (
     build_solve_replay_artifact,
     execute_solve_request,
 )
+from trellis.models.calibration.problem_ir import (
+    CalibrationDiagnosticSpec,
+    CalibrationMaterializationSpec,
+    CalibrationObjectiveSpec,
+    CalibrationProblemIR,
+    CalibrationTargetSpec,
+    CalibrationVariableSpec,
+)
 from trellis.models.calibration.quote_maps import (
     QuoteAxisSpec,
     QuoteMapSpec,
@@ -389,23 +397,27 @@ def _fit_diagnostics(
     )
 
 
-def fit_sabr_smile_surface(
+def _resolve_sabr_initial_guess(
+    surface: SABRSmileSurface,
+    initial_guess: tuple[float, float, float] | None,
+) -> tuple[tuple[float, float, float], str]:
+    """Resolve SABR initial values and their provenance label."""
+    if initial_guess is None:
+        alpha0 = float(surface.market_vols[surface.atm_index]) * float(surface.forward) ** (1 - float(surface.beta))
+        return (float(alpha0), 0.0, 0.3), "atm_seed"
+    return tuple(float(value) for value in initial_guess), "explicit_seed"
+
+
+def _build_sabr_smile_solve_request(
     surface: SABRSmileSurface,
     *,
-    initial_guess: tuple[float, float, float] | None = None,
-) -> SABRSmileCalibrationResult:
-    """Fit SABR parameters to one reusable smile surface."""
+    resolved_initial_guess: tuple[float, float, float],
+    warm_start_source: str,
+) -> SolveRequest:
+    """Build the checked SABR smile solve request from a resolved surface."""
     strikes = raw_np.asarray(surface.strikes, dtype=float)
     market_vols = raw_np.asarray(surface.market_vols, dtype=float)
     weights = raw_np.asarray(surface.weights, dtype=float)
-
-    if initial_guess is None:
-        alpha0 = float(surface.market_vols[surface.atm_index]) * float(surface.forward) ** (1 - float(surface.beta))
-        resolved_initial_guess = (float(alpha0), 0.0, 0.3)
-        warm_start_source = "atm_seed"
-    else:
-        resolved_initial_guess = tuple(float(value) for value in initial_guess)
-        warm_start_source = "explicit_seed"
 
     def objective(params):
         """Return the weighted squared-error objective for one SABR parameter vector."""
@@ -418,7 +430,7 @@ def fit_sabr_smile_surface(
         return np.sum(weights * residuals ** 2)
 
     objective_grad = gradient(objective)
-    solve_request = SolveRequest(
+    return SolveRequest(
         request_id="sabr_smile_least_squares",
         problem_kind="least_squares",
         parameter_names=("alpha", "rho", "nu"),
@@ -459,6 +471,13 @@ def fit_sabr_smile_surface(
             "surface_name": surface.surface_name,
         },
     )
+
+
+def _finish_sabr_smile_fit(
+    surface: SABRSmileSurface,
+    solve_request: SolveRequest,
+) -> SABRSmileCalibrationResult:
+    """Execute a SABR solve request and assemble the reusable result surface."""
     solve_result = execute_solve_request(solve_request)
     if not solve_result.success:
         raise ValueError(f"SABR calibration failed: {solve_result.metadata.get('message', 'unknown failure')}")
@@ -518,6 +537,181 @@ def fit_sabr_smile_surface(
         warnings=surface.warnings,
         provenance=provenance,
         summary=summary,
+    )
+
+
+def fit_sabr_smile_surface(
+    surface: SABRSmileSurface,
+    *,
+    initial_guess: tuple[float, float, float] | None = None,
+) -> SABRSmileCalibrationResult:
+    """Fit SABR parameters to one reusable smile surface."""
+    resolved_initial_guess, warm_start_source = _resolve_sabr_initial_guess(surface, initial_guess)
+    return _finish_sabr_smile_fit(
+        surface,
+        _build_sabr_smile_solve_request(
+            surface,
+            resolved_initial_guess=resolved_initial_guess,
+            warm_start_source=warm_start_source,
+        ),
+    )
+
+
+def build_sabr_smile_calibration_problem_ir(
+    surface: SABRSmileSurface,
+    *,
+    initial_guess: tuple[float, float, float] | None = None,
+) -> CalibrationProblemIR:
+    """Represent the supported SABR smile workflow as a calibration problem IR."""
+    resolved_initial_guess, warm_start_source = _resolve_sabr_initial_guess(surface, initial_guess)
+    solve_request = _build_sabr_smile_solve_request(
+        surface,
+        resolved_initial_guess=resolved_initial_guess,
+        warm_start_source=warm_start_source,
+    )
+    bounds_payload = solve_request.bounds.to_payload()
+    lower_bounds = tuple(bounds_payload["lower"])
+    upper_bounds = tuple(bounds_payload["upper"])
+    variable_charts = {
+        "alpha": "positive",
+        "rho": "bounded_correlation",
+        "nu": "positive",
+    }
+    variables = tuple(
+        CalibrationVariableSpec(
+            name=name,
+            coordinate_chart=variable_charts[name],
+            initial_value=resolved_initial_guess[index],
+            lower_bound=lower_bounds[index],
+            upper_bound=upper_bounds[index],
+            warm_start_source=warm_start_source,
+            metadata={
+                "parameter_role": "sabr_parameter",
+                "fixed_beta": float(surface.beta),
+            },
+        )
+        for index, name in enumerate(solve_request.parameter_names)
+    )
+    quote_map_payload = surface.quote_map_spec.to_payload()
+    targets = tuple(
+        CalibrationTargetSpec(
+            target_id=label,
+            instrument_id=f"{surface.surface_name or 'sabr_smile'}:{label}",
+            quote_family=surface.quote_map_spec.quote_family,
+            quote_convention=surface.quote_map_spec.convention,
+            quote_value=point.market_vol,
+            weight=point.weight,
+            quote_map_payload=quote_map_payload,
+            validation_tags=("implied_vol", "sabr_smile"),
+            metadata={
+                "strike": float(point.strike),
+                "expiry_years": float(surface.expiry_years),
+                "forward": float(surface.forward),
+            },
+        )
+        for label, point in zip(surface.labels, surface.points)
+    )
+    objective = CalibrationObjectiveSpec(
+        objective_kind="least_squares",
+        loss_function="weighted_sum_of_squares",
+        residual_count=len(targets),
+        derivative_method="autodiff_scalar_gradient",
+        solve_request_id=solve_request.request_id,
+        metadata={
+            "target_transform": "black_implied_vol",
+            "quote_map": quote_map_payload,
+            "beta": float(surface.beta),
+        },
+    )
+    materialization = CalibrationMaterializationSpec(
+        object_kind="model_parameter_set",
+        object_name=surface.surface_name or "sabr_smile",
+        destination_field="model_parameter_sets",
+        source_ref="fit_sabr_smile_surface",
+        metadata={
+            "model_family": "sabr",
+            "parameter_names": ["alpha", "beta", "rho", "nu"],
+            "fixed_beta": float(surface.beta),
+        },
+    )
+    diagnostics = (
+        CalibrationDiagnosticSpec(
+            diagnostic_id="max_abs_vol_error",
+            metric_name="max_abs_vol_error",
+            tolerance=5e-4,
+            severity="warning",
+        ),
+        CalibrationDiagnosticSpec(
+            diagnostic_id="weighted_rms_vol_error",
+            metric_name="weighted_rms_vol_error",
+            tolerance=5e-4,
+            severity="warning",
+        ),
+    )
+    return CalibrationProblemIR(
+        problem_id=solve_request.request_id,
+        workflow_id="sabr_smile",
+        family_id="sabr",
+        variables=variables,
+        targets=targets,
+        objective=objective,
+        materialization=materialization,
+        diagnostics=diagnostics,
+        solve_request_payload=solve_request.to_payload(),
+        replay_metadata={
+            "surface": surface.to_payload(),
+            "warm_start_source": warm_start_source,
+        },
+        metadata={
+            "adapter_id": "sabr_smile_problem_ir_v1",
+            "engine_backed": False,
+            "support_boundary": "problem_ir_adapter_only",
+            "source_ref": "build_sabr_smile_calibration_problem_ir",
+        },
+    )
+
+
+def fit_sabr_smile_problem_ir(
+    problem: CalibrationProblemIR,
+    surface: SABRSmileSurface,
+) -> SABRSmileCalibrationResult:
+    """Execute the current SABR workflow through its problem-IR adapter."""
+    if problem.workflow_id != "sabr_smile" or problem.family_id != "sabr":
+        raise ValueError("fit_sabr_smile_problem_ir requires a SABR smile calibration problem")
+    if tuple(variable.name for variable in problem.variables) != ("alpha", "rho", "nu"):
+        raise ValueError("fit_sabr_smile_problem_ir requires SABR alpha/rho/nu variables")
+    warm_start_source = str(problem.replay_metadata.get("warm_start_source") or "explicit_seed")
+    solve_request = _build_sabr_smile_solve_request(
+        surface,
+        resolved_initial_guess=(
+            float(problem.variables[0].initial_value),
+            float(problem.variables[1].initial_value),
+            float(problem.variables[2].initial_value),
+        ),
+        warm_start_source=warm_start_source,
+    )
+    if problem.solve_request_payload and dict(problem.solve_request_payload) != solve_request.to_payload():
+        raise ValueError("SABR smile calibration problem solve_request_payload is stale or inconsistent")
+    result = _finish_sabr_smile_fit(surface, solve_request)
+    provenance = dict(result.provenance)
+    provenance["calibration_problem_ir"] = {
+        "problem_id": problem.problem_id,
+        "workflow_id": problem.workflow_id,
+        "family_id": problem.family_id,
+        "adapter_id": problem.metadata.get("adapter_id", ""),
+        "engine_backed": bool(problem.metadata.get("engine_backed", False)),
+    }
+    return SABRSmileCalibrationResult(
+        surface=result.surface,
+        sabr=result.sabr,
+        solve_request=result.solve_request,
+        solve_result=result.solve_result,
+        solver_provenance=result.solver_provenance,
+        solver_replay_artifact=result.solver_replay_artifact,
+        diagnostics=result.diagnostics,
+        warnings=result.warnings,
+        provenance=provenance,
+        summary=result.summary,
     )
 
 
@@ -600,7 +794,9 @@ __all__ = [
     "SABRSmileFitDiagnostics",
     "SABRSmileCalibrationResult",
     "build_sabr_smile_surface",
+    "build_sabr_smile_calibration_problem_ir",
     "fit_sabr_smile_surface",
+    "fit_sabr_smile_problem_ir",
     "calibrate_sabr_smile_workflow",
     "calibrate_sabr",
 ]


### PR DESCRIPTION
## Summary

Completes the QUA-1001 calibration problem-IR epic as a bounded, core-library implementation:

- Adds `CalibrationProblemIR` and validated spec dataclasses for variables, targets, objectives, dependencies, materialization, diagnostics, replay metadata, and serialized solve requests.
- Adds adapter-backed SABR and single-name credit problem-IR workflows while preserving the existing direct workflows as the source of truth.
- Adds a problem-IR dependency graph compiler over the existing calibration dependency graph validator.
- Adds benchmark/replay payload capture for the supported IR-backed workflows.
- Adds a fail-closed public `calibrate_problem_ir(...)` orchestrator for the bounded SABR and credit support set.
- Updates calibration docs, benchmark artifacts, public API guards, and the planning mirror.

## Ticket Map

- QUA-1002: common problem IR and SABR adapter
- QUA-1007: single-name credit problem-IR adapter
- QUA-1008: problem-IR dependency graph compiler
- QUA-1009: benchmark and replay problem-IR payloads
- QUA-1010: gated public problem-IR orchestrator

## Support Boundary

This is intentionally not a universal calibration engine claim. The public orchestrator only supports:

- `sabr:sabr_smile` with explicit `surface` context
- `credit:single_name_credit_curve` with explicit `quotes` and `market_state` context

Unsupported problem IRs fail closed via `UnsupportedCalibrationProblemIRError`.

## Validation

- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_models/test_calibration/test_problem_ir.py -q -x`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_models/test_calibration/test_problem_ir.py tests/test_models/test_calibration/test_credit_calibration.py -q -x`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_models/test_calibration/test_dependency_graph.py tests/test_models/test_calibration/test_problem_ir.py -q -x`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_models/test_calibration/test_benchmarking.py tests/test_verification/test_calibration_replay.py -q -x`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_models/test_calibration -q -x`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_public_api_surface.py -q -x`
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_verification/test_calibration_replay.py -q -x`
- `make gate-pr`

`make gate-pr` completed successfully. It printed pre-existing stale test-hygiene findings before running the gate, then passed the main non-integration pytest slice and tier-2 contracts.