### PR TITLE
QUA-1100 Add option semantic axes

### DIFF
--- a/docs/developer/dsl_charter.md
+++ b/docs/developer/dsl_charter.md
@@ -49,8 +49,12 @@ wants."
 | Noun | Type | Description |
 |---|---|---|
 | `instrument` | str | Natural-language product label (request-only, not a routing key) |
-| `payoff_family` | enum | `vanilla`, `barrier`, `asian`, `lookback`, `basket`, `credit`, `rate`, `structured` |
+| `payoff_family` | enum | Payoff shape such as `vanilla_option`, `barrier_option`, `asian_option`, `swaption`, `credit_basket`, `rate_cap_floor_strip`, or `structured` |
+| `derivative_family` | enum | Broad derivative axis such as `option` or `swap`; this is semantic identity, not a route key |
+| `underlying_asset_class` | enum | Underlier asset-class axis such as `equity`, `fx`, `rate`, `future`, `credit`, or `commodity` |
+| `underlying_identifiers` | tuple | Canonical underlier names carried from the semantic contract underlier axes |
 | `exercise_style` | enum | `european`, `american`, `bermudan`, `issuer_call`, `holder_put` |
+| `option_type` | enum | `call` or `put` when the payoff side is part of the contract |
 | `path_dependence` | enum | `none`, `barrier`, `asian`, `lookback`, `cliquet`, `autocall` |
 | `schedule_dependence` | enum | `none`, `observation`, `fixing`, `accrual` |
 | `state_dependence` | enum | `terminal_markov`, `path_dependent`, `schedule_dependent` |
@@ -69,6 +73,13 @@ wants."
 static inference sets `unresolved_primitives`.
 
 **Output contract:** `ProductIR` (frozen dataclass in `knowledge/schema.py`).
+
+Option products are represented by axes rather than by forcing every
+combination into a new product family. For example, an American equity put can
+remain `payoff_family="vanilla_option"` while carrying
+`derivative_family="option"`, `underlying_asset_class="equity"`,
+`exercise_style="american"`, and `option_type="put"`. FX vanilla options,
+rate options, futures options, and equity options differ through the same axes.
 
 ### Layer 2 — Deterministic Validation
 

--- a/docs/developer/dsl_system_design_review.md
+++ b/docs/developer/dsl_system_design_review.md
@@ -45,9 +45,17 @@ This boundary is shipped code, not just prompt guidance.
 - `ObligationSpec`
 - `ControllerProtocol`
 - `EventMachine`
+- `SemanticUnderlyingAxes`
 
 Automatic triggers live in event/state machinery. Strategic rights live in
 `ControllerProtocol`.
+
+Option semantics use typed axes instead of treating every underlier/exercise
+combination as a separate product family. The semantic contract may retain a
+compatibility `semantic_id` such as `vanilla_option`, `american_option`, or
+`quanto_option`, but route/spec selection must also honor
+`derivative_family="option"`, the underlier asset class and identifiers,
+`exercise_style`, and the call/put `option_type` when it is defined.
 
 ### 2.2 Valuation authority
 
@@ -66,7 +74,11 @@ Automatic triggers live in event/state machinery. Strategic rights live in
 ### 2.3 Routing authority
 
 `ProductIR` is the shared checked summary used for route selection. It is not
-the full semantic contract and not a universal solver IR.
+the full semantic contract and not a universal solver IR. For options it mirrors
+the semantic axes as `derivative_family`, `underlying_asset_class`,
+`underlying_identifiers`, and `option_type` so a broad
+`payoff_family="vanilla_option"` does not erase the difference between American
+equity, FX vanilla, rate, futures, and quanto shapes.
 
 Typed route admissibility is owned by:
 

--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -600,9 +600,19 @@ generic ``bond`` and ``swap`` wording no longer produce a family on their own,
 and an explicit family such as ``zcb_option`` no longer gets silently redrafted
 into a generic ``vanilla_option`` semantic contract just because the request
 text contains phrases like ``European call option``. That keeps exact helper
-binding on the intended family-first path for the short-rate comparison cohort.
+binding on the intended family-first path for the short-rate comparison cohort,
 so ingress fallback only fires for phrases that still correspond to defended
 task families rather than widening broad desk summaries into a pricing schema.
+
+Option-family identity follows the same rule without requiring every combination
+to become a new product family. Semantic contracts and ``ProductIR`` now carry
+``derivative_family="option"``, ``payoff_family`` such as ``vanilla_option``,
+the underlier asset class and identifiers, ``exercise_style``, and
+``option_type`` when a call/put side is defined. Route and validation selection
+must consume those axes before accepting an adapter, so an American equity put
+can remain a vanilla-option payoff while still selecting early-exercise
+artifacts, and an FX vanilla adapter cannot satisfy a quanto or equity option
+only because the terminal payoff is numerically vanilla-shaped.
 
 Suggested Validation Order
 --------------------------

--- a/docs/quant/contract_ir.rst
+++ b/docs/quant/contract_ir.rst
@@ -17,6 +17,12 @@ Why It Exists
 ``ProductIR`` is intentionally coarse. It is good for broad routing and
 knowledge retrieval, but it collapses structurally different contracts onto
 shared string families such as ``vanilla_option`` or ``swaption``.
+For option requests, the coarse family is now paired with explicit semantic
+axes: ``derivative_family``, ``underlying_asset_class``,
+``underlying_identifiers``, ``exercise_style``, and ``option_type``. Those axes
+let the routing layer keep a broad payoff family like ``vanilla_option`` while
+still distinguishing American equity, FX vanilla, rate, futures, and quanto
+requests before helper or validation-bundle selection.
 
 ``ContractIR`` keeps the structural information that a kernel matcher needs.
 For example, these two products are no longer separated only by instrument

--- a/tests/test_agent/test_lite_review.py
+++ b/tests/test_agent/test_lite_review.py
@@ -945,6 +945,9 @@ def test_validate_build_uses_quanto_family_validation_bundle(monkeypatch):
         "Quanto option on SAP settled in USD",
         instrument_type="quanto_option",
     )
+    assert compiled.product_ir.derivative_family == "option"
+    assert compiled.product_ir.underlying_asset_class == "equity"
+    assert compiled.product_ir.underlying_identifiers == ("underlier",)
 
     spec_schema = SimpleNamespace(
         class_name="QuantoOptionAnalyticalPayoff",

--- a/tests/test_agent/test_semantic_contracts.py
+++ b/tests/test_agent/test_semantic_contracts.py
@@ -740,6 +740,107 @@ def test_representative_derivative_contracts_validate_and_compile(
     assert all("himalaya" not in module.lower() for module in compiled.route_modules)
 
 
+def test_option_axes_survive_american_equity_contract_compilation():
+    from trellis.agent.semantic_contract_compiler import compile_semantic_contract
+    from trellis.agent.semantic_contracts import semantic_contract_summary
+    from trellis.agent.semantic_contract_validation import validate_semantic_contract
+
+    contract = _draft_contract(
+        "American put option on AAPL with strike 100 and expiry 2025-11-15",
+        "american_option",
+    )
+
+    assert contract is not None
+    assert contract.product.semantic_id == "american_option"
+    assert contract.product.derivative_family == "option"
+    assert contract.product.payoff_family == "vanilla_option"
+    assert contract.product.underlying.asset_class == "equity"
+    assert contract.product.underlying.identifiers == ("AAPL",)
+    assert contract.product.exercise_style == "american"
+    assert contract.product.option_type == "put"
+
+    summary = semantic_contract_summary(contract)
+    assert summary["product"]["derivative_family"] == "option"
+    assert summary["product"]["underlying"] == {
+        "asset_class": "equity",
+        "identifiers": ["AAPL"],
+    }
+    assert summary["product"]["option_type"] == "put"
+
+    report = validate_semantic_contract(contract)
+    assert report.ok
+
+    compiled = compile_semantic_contract(contract)
+    assert compiled.product_ir.derivative_family == "option"
+    assert compiled.product_ir.payoff_family == "vanilla_option"
+    assert compiled.product_ir.underlying_asset_class == "equity"
+    assert compiled.product_ir.underlying_identifiers == ("AAPL",)
+    assert compiled.product_ir.exercise_style == "american"
+    assert compiled.product_ir.option_type == "put"
+
+
+def test_option_axes_distinguish_fx_vanilla_without_new_product_family():
+    from trellis.agent.knowledge.decompose import build_product_ir
+    from trellis.agent.semantic_contracts import make_vanilla_option_contract
+
+    contract = make_vanilla_option_contract(
+        description="European call FX vanilla option on EURUSD with expiry 2025-11-15",
+        underliers=("EURUSD",),
+        observation_schedule=("2025-11-15",),
+        underlying_asset_class="fx",
+        option_type="call",
+    )
+
+    assert contract.product.derivative_family == "option"
+    assert contract.product.payoff_family == "vanilla_option"
+    assert contract.product.underlying.asset_class == "fx"
+    assert contract.product.option_type == "call"
+    assert contract.product.instrument_class == "european_option"
+
+    product_ir = build_product_ir(
+        description="Legacy FX vanilla option task with EURUSD call",
+        instrument="fx_vanilla",
+        payoff_family="vanilla_option",
+        exercise_style="european",
+        model_family="fx",
+        option_type="call",
+    )
+
+    assert product_ir.derivative_family == "option"
+    assert product_ir.payoff_family == "vanilla_option"
+    assert product_ir.underlying_asset_class == "fx"
+    assert product_ir.option_type == "call"
+
+
+def test_option_axis_validation_rejects_contradictory_underlying_asset_class():
+    from dataclasses import replace
+
+    from trellis.agent.semantic_contracts import SemanticUnderlyingAxes, make_american_option_contract
+    from trellis.agent.semantic_contract_validation import validate_semantic_contract
+
+    contract = make_american_option_contract(
+        description="American put option on AAPL with strike 100 and expiry 2025-11-15",
+        underliers=("AAPL",),
+        observation_schedule=("2025-11-15",),
+        option_type="put",
+    )
+    bad = replace(
+        contract,
+        product=replace(
+            contract.product,
+            underlying=SemanticUnderlyingAxes(
+                asset_class="rate",
+                identifiers=contract.product.underlying.identifiers,
+            ),
+        ),
+    )
+
+    report = validate_semantic_contract(bad)
+
+    assert not report.ok
+    assert any("underlying.asset_class" in error for error in report.errors)
+
+
 def test_rate_cap_floor_strip_draft_uses_structural_schedule_placeholder_when_dates_are_absent():
     contract = _draft_contract(
         "Build a pricer for: Cap/floor: Black caplet stack vs MC rate simulation",
@@ -750,9 +851,48 @@ def test_rate_cap_floor_strip_draft_uses_structural_schedule_placeholder_when_da
     assert contract.semantic_id == "period_rate_option_strip"
     assert contract.product.instrument_class == "cap"
     assert contract.product.payoff_family == "period_rate_option_strip"
+    assert contract.product.derivative_family == "option"
+    assert contract.product.underlying.asset_class == "rate"
+    assert contract.product.option_type == "call"
     assert contract.product.observation_schedule
     assert contract.product.term_fields["schedule_authority"] == "structural_placeholder"
     assert contract.product.term_fields["option_type"] == "call"
+
+
+def test_rate_cap_floor_strips_carry_rate_option_axes_without_option_prose():
+    from trellis.agent.knowledge.decompose import build_product_ir
+    from trellis.agent.semantic_contract_compiler import compile_semantic_contract
+    from trellis.agent.semantic_contracts import make_period_rate_option_strip_contract
+    from trellis.agent.semantic_contract_validation import validate_semantic_contract
+
+    cap_contract = make_period_rate_option_strip_contract(
+        description="SOFR cap strip with annual fixings through 2029-11-15",
+        instrument_class="cap",
+        observation_schedule=("2026-11-15", "2027-11-15", "2028-11-15", "2029-11-15"),
+    )
+    floor_ir = build_product_ir(
+        description="USD SOFR floor strip under Black caplet stack pricing",
+        instrument="floor",
+        payoff_family="period_rate_option_strip",
+        model_family="interest_rate",
+    )
+
+    assert cap_contract.product.derivative_family == "option"
+    assert cap_contract.product.payoff_family == "period_rate_option_strip"
+    assert cap_contract.product.underlying.asset_class == "rate"
+    assert cap_contract.product.option_type == "call"
+    assert validate_semantic_contract(cap_contract).ok
+
+    compiled = compile_semantic_contract(cap_contract)
+    assert compiled.product_ir.derivative_family == "option"
+    assert compiled.product_ir.payoff_family == "period_rate_option_strip"
+    assert compiled.product_ir.underlying_asset_class == "rate"
+    assert compiled.product_ir.option_type == "call"
+
+    assert floor_ir.derivative_family == "option"
+    assert floor_ir.payoff_family == "period_rate_option_strip"
+    assert floor_ir.underlying_asset_class == "rate"
+    assert floor_ir.option_type == "put"
 
 
 def test_rate_cap_floor_strip_contract_uses_registered_surface_schema_hints():

--- a/trellis/agent/family_contract_templates.py
+++ b/trellis/agent/family_contract_templates.py
@@ -20,6 +20,7 @@ from trellis.agent.semantic_contracts import (
     SemanticMarketInputSpec,
     SemanticMethodContract,
     SemanticProductSemantics,
+    SemanticUnderlyingAxes,
     SemanticValidationContract,
 )
 
@@ -244,6 +245,11 @@ def _family_semantic_overrides(family_id: str) -> dict:
             "settlement_rule": "cash_settle_at_expiry_after_fx_conversion",
             "observation_schedule": ("single_expiry",),
             "constituents": ("underlier",),
+            "derivative_family": "option",
+            "underlying": SemanticUnderlyingAxes(
+                asset_class="equity",
+                identifiers=("underlier",),
+            ),
         }
     return {}
 
@@ -274,6 +280,9 @@ def _family_contract_to_semantic(fc: FamilyContract) -> SemanticContract:
         instrument_class=fc.product.instrument,
         instrument_aliases=fc.product.instrument_aliases,
         payoff_family=fc.product.payoff_family,
+        derivative_family=overrides.get("derivative_family", ""),
+        underlying=overrides.get("underlying", SemanticUnderlyingAxes()),
+        option_type=overrides.get("option_type", ""),
         underlier_structure=overrides.get("underlier_structure", ""),
         payoff_rule=overrides.get("payoff_rule", ""),
         settlement_rule=overrides.get("settlement_rule", ""),

--- a/trellis/agent/knowledge/decompose.py
+++ b/trellis/agent/knowledge/decompose.py
@@ -1663,6 +1663,10 @@ def build_product_ir(
     preferred_method: str | None = None,
     store: KnowledgeStore | None = None,
     event_machine: object | None = None,
+    derivative_family: str | None = None,
+    underlying_asset_class: str | None = None,
+    underlying_identifiers: tuple[str, ...] | list[str] = (),
+    option_type: str | None = None,
 ) -> ProductIR:
     """Build a ``ProductIR`` from explicit structured fields.
 
@@ -1734,6 +1738,28 @@ def build_product_ir(
             resolved_model_family,
         )
     )
+    resolved_derivative_family = (
+        _normalize_axis_token(derivative_family)
+        or _derivative_family_for(
+            normalized_instrument,
+            resolved_payoff_family,
+            description,
+        )
+    )
+    resolved_underlying_asset_class = (
+        _normalize_axis_token(underlying_asset_class)
+        or _underlying_asset_class_for(
+            normalized_instrument,
+            resolved_payoff_family,
+            resolved_model_family,
+            description,
+        )
+    )
+    resolved_option_type = _option_type_for(
+        description,
+        instrument=normalized_instrument,
+        explicit=option_type,
+    )
 
     return _augment_ir_with_promoted_route_support(_augment_ir_with_contextual_support(ProductIR(
         instrument=normalized_instrument,
@@ -1754,6 +1780,10 @@ def build_product_ir(
         unresolved_primitives=resolved_unresolved_primitives,
         supported=len(resolved_unresolved_primitives) == 0 if supported is None else supported,
         event_machine=event_machine,
+        derivative_family=resolved_derivative_family,
+        underlying_asset_class=resolved_underlying_asset_class,
+        underlying_identifiers=_string_tuple(underlying_identifiers),
+        option_type=resolved_option_type,
     ), description))
 
 
@@ -2403,13 +2433,14 @@ def _product_ir_from_decomposition(
 ) -> ProductIR:
     """Convert a canonical product decomposition into ``ProductIR``."""
     payoff_traits = tuple(sorted(set(decomposition.features)))
+    payoff_family = _payoff_family_for(instrument, payoff_traits, description)
     exercise_style = _exercise_style_for(instrument, payoff_traits, description)
     schedule_dependence = _schedule_dependence_for(instrument, payoff_traits)
     state_dependence = _state_dependence_for(instrument, payoff_traits, schedule_dependence)
     model_family = _model_family_for(instrument, payoff_traits, decomposition.method, description)
     route_families = _route_families_for(
         instrument,
-        _payoff_family_for(instrument, payoff_traits, description),
+        payoff_family,
         exercise_style,
         model_family,
     )
@@ -2428,7 +2459,7 @@ def _product_ir_from_decomposition(
         candidate_engine_families = tuple(dict.fromkeys((*candidate_engine_families, "analytical")))
     return _augment_ir_with_promoted_route_support(_augment_ir_with_contextual_support(ProductIR(
         instrument=instrument,
-        payoff_family=_payoff_family_for(instrument, payoff_traits, description),
+        payoff_family=payoff_family,
         payoff_traits=payoff_traits,
         exercise_style=exercise_style,
         state_dependence=state_dependence,
@@ -2442,6 +2473,14 @@ def _product_ir_from_decomposition(
         reusable_primitives=decomposition.method_modules,
         unresolved_primitives=(),
         supported=True,
+        derivative_family=_derivative_family_for(instrument, payoff_family, description),
+        underlying_asset_class=_underlying_asset_class_for(
+            instrument,
+            payoff_family,
+            model_family,
+            description,
+        ),
+        option_type=_option_type_for(description, instrument=instrument),
     ), description))
 
 
@@ -2453,13 +2492,14 @@ def _infer_composite_ir(
     """Rule-based IR for unsupported or composite products."""
     desc = _normalise(description)
     payoff_traits = _traits_from_text(desc)
+    payoff_family = _payoff_family_for(instrument or "", payoff_traits, description)
     schedule_dependence = _schedule_dependence_for(instrument or "", payoff_traits)
     state_dependence = _state_dependence_for(instrument or "", payoff_traits, schedule_dependence)
     model_family = _model_family_for(instrument or "", payoff_traits, "", description)
     exercise_style = _exercise_style_for(instrument or "", payoff_traits, description)
     route_families = _route_families_for(
         instrument or "",
-        _payoff_family_for(instrument or "", payoff_traits, description),
+        payoff_family,
         exercise_style,
         model_family,
     )
@@ -2479,7 +2519,7 @@ def _infer_composite_ir(
     )
     return _augment_ir_with_promoted_route_support(_augment_ir_with_contextual_support(ProductIR(
         instrument=instrument or _normalise(description),
-        payoff_family=_payoff_family_for(instrument or "", payoff_traits, description),
+        payoff_family=payoff_family,
         payoff_traits=payoff_traits,
         exercise_style=exercise_style,
         state_dependence=state_dependence,
@@ -2491,6 +2531,14 @@ def _infer_composite_ir(
         reusable_primitives=_reusable_primitives_for(payoff_traits, model_family),
         unresolved_primitives=unresolved_primitives,
         supported=len(unresolved_primitives) == 0,
+        derivative_family=_derivative_family_for(instrument or "", payoff_family, description),
+        underlying_asset_class=_underlying_asset_class_for(
+            instrument or "",
+            payoff_family,
+            model_family,
+            description,
+        ),
+        option_type=_option_type_for(description, instrument=instrument or ""),
     ), description))
 
 
@@ -2684,6 +2732,195 @@ def _payoff_family_for(
     if "option" in _normalise(description):
         return "composite_option"
     return instrument or "generic_product"
+
+
+_CURRENCY_CODES = frozenset(
+    {
+        "AUD",
+        "BRL",
+        "CAD",
+        "CHF",
+        "CNY",
+        "EUR",
+        "GBP",
+        "HKD",
+        "JPY",
+        "MXN",
+        "NOK",
+        "NZD",
+        "SEK",
+        "SGD",
+        "USD",
+        "ZAR",
+    }
+)
+
+
+def _normalize_axis_token(value: object) -> str:
+    """Normalize one ProductIR semantic-axis token."""
+    return str(value or "").strip().lower().replace(" ", "_").replace("-", "_")
+
+
+def _axis_tokens(value: object) -> frozenset[str]:
+    """Split normalized prose into stable semantic hint tokens."""
+    return frozenset(
+        part for part in re.split(r"[^a-z0-9]+", str(value or "").lower()) if part
+    )
+
+
+def _string_tuple(values: tuple[str, ...] | list[str] | None) -> tuple[str, ...]:
+    """Return a compact tuple of non-empty strings."""
+    if not values:
+        return ()
+    return tuple(str(value).strip() for value in values if str(value).strip())
+
+
+def _looks_like_currency_pair(value: str) -> bool:
+    """Return whether a compact identifier looks like a six-letter currency pair."""
+    token = str(value or "").strip().upper().replace("/", "").replace("-", "")
+    return (
+        len(token) == 6
+        and token[:3] in _CURRENCY_CODES
+        and token[3:] in _CURRENCY_CODES
+    )
+
+
+def _derivative_family_for(instrument: str, payoff_family: str, description: str) -> str:
+    """Infer the broad derivative-family axis without changing route identity."""
+    normalized_instrument = _normalise(instrument)
+    normalized_payoff = _normalise(payoff_family)
+    description_tokens = _axis_tokens(description)
+    option_instruments = {
+        "american_option",
+        "american_put",
+        "asian_option",
+        "barrier_option",
+        "basket_option",
+        "bermudan_swaption",
+        "cap",
+        "chooser_option",
+        "cliquet_option",
+        "compound_option",
+        "digital_option",
+        "equity_vanilla",
+        "european_option",
+        "floor",
+        "fx_option",
+        "fx_vanilla",
+        "fx_vanilla_option",
+        "heston_option",
+        "lookback_option",
+        "period_rate_option_strip",
+        "quanto_option",
+        "swaption",
+        "zcb_option",
+    }
+    option_payoffs = {
+        "asian_option",
+        "barrier_option",
+        "basket_option",
+        "basket_path_payoff",
+        "digital_option",
+        "period_rate_option_strip",
+        "quanto_option",
+        "rate_cap_floor_strip",
+        "swaption",
+        "vanilla_option",
+        "zcb_option",
+    }
+    if (
+        normalized_instrument in option_instruments
+        or normalized_payoff in option_payoffs
+        or "option" in description_tokens
+        or "options" in description_tokens
+        or "swaption" in description_tokens
+    ):
+        return "option"
+    if "swap" in normalized_instrument or "swap" in normalized_payoff:
+        return "swap"
+    return ""
+
+
+def _underlying_asset_class_for(
+    instrument: str,
+    payoff_family: str,
+    model_family: str,
+    description: str,
+) -> str:
+    """Infer the underlier asset-class axis from stable deterministic hints."""
+    normalized_instrument = _normalise(instrument)
+    normalized_payoff = _normalise(payoff_family)
+    normalized_model = _normalise(model_family)
+    normalized_description = _normalise(description)
+    description_tokens = _axis_tokens(description)
+    if (
+        normalized_instrument in {"fx_option", "fx_vanilla", "fx_vanilla_option"}
+        or normalized_model == "fx"
+        or "fx" in description_tokens
+        or {"foreign", "exchange"}.issubset(description_tokens)
+        or any(_looks_like_currency_pair(part) for part in normalized_description.split("_"))
+    ):
+        return "fx"
+    if (
+        normalized_instrument in {"swaption", "bermudan_swaption", "cap", "floor", "period_rate_option_strip"}
+        or normalized_payoff in {"swaption", "period_rate_option_strip", "rate_cap_floor_strip"}
+        or normalized_model in {"rate", "rates", "rate_style", "hull_white"}
+        or "swaption" in description_tokens
+        or "rate" in description_tokens
+    ):
+        return "rate"
+    if "future" in description_tokens or "futures" in description_tokens:
+        return "future"
+    if normalized_instrument in {"cds", "credit_default_swap", "nth_to_default", "cdo"}:
+        return "credit"
+    if "commodity" in description_tokens:
+        return "commodity"
+    if (
+        normalized_instrument in {
+            "american_option",
+            "american_put",
+            "asian_option",
+            "barrier_option",
+            "basket_option",
+            "digital_option",
+            "equity_vanilla",
+            "european_option",
+            "heston_option",
+            "quanto_option",
+        }
+        or normalized_model in {"equity_diffusion", "heston"}
+        or "equity" in description_tokens
+        or "stock" in description_tokens
+    ):
+        return "equity"
+    return ""
+
+
+def _option_type_for(
+    description: str,
+    *,
+    instrument: str,
+    explicit: str | None = None,
+) -> str:
+    """Infer the call/put side axis when the request or manifest provides one."""
+    normalized_explicit = _normalize_axis_token(explicit)
+    if normalized_explicit in {"call", "put"}:
+        return normalized_explicit
+    normalized_description = f" {_normalise(description).replace('_', ' ')} "
+    if " put " in normalized_description:
+        return "put"
+    if " call " in normalized_description:
+        return "call"
+    normalized_instrument = _normalise(instrument)
+    if normalized_instrument == "cap":
+        return "call"
+    if normalized_instrument == "floor":
+        return "put"
+    if "put" in normalized_instrument:
+        return "put"
+    if "call" in normalized_instrument:
+        return "call"
+    return normalized_explicit
 
 
 def _exercise_style_for(

--- a/trellis/agent/knowledge/schema.py
+++ b/trellis/agent/knowledge/schema.py
@@ -102,6 +102,10 @@ class ProductIR:
     unresolved_primitives: tuple[str, ...] = ()
     supported: bool = True
     event_machine: object | None = None  # EventMachine when typed, None for legacy
+    derivative_family: str = ""
+    underlying_asset_class: str = ""
+    underlying_identifiers: tuple[str, ...] = ()
+    option_type: str = ""
 
 
 @dataclass(frozen=True)

--- a/trellis/agent/semantic_contract_compiler.py
+++ b/trellis/agent/semantic_contract_compiler.py
@@ -151,6 +151,18 @@ def compile_semantic_contract(
         supported=not bool(contract.blueprint.blocked_by),
         preferred_method=preferred_method,
         event_machine=getattr(contract.product, "event_machine", None),
+        derivative_family=getattr(contract.product, "derivative_family", ""),
+        underlying_asset_class=getattr(
+            getattr(contract.product, "underlying", None),
+            "asset_class",
+            "",
+        ),
+        underlying_identifiers=getattr(
+            getattr(contract.product, "underlying", None),
+            "identifiers",
+            (),
+        ),
+        option_type=getattr(contract.product, "option_type", ""),
     )
     product_ir = _augment_product_ir_with_contract_route_hints(product_ir, contract)
     contract_ir = None

--- a/trellis/agent/semantic_contract_validation.py
+++ b/trellis/agent/semantic_contract_validation.py
@@ -75,6 +75,10 @@ _ALLOWED_STATE_TAGS = frozenset(
         "locked_cashflow_state",
     }
 )
+_ALLOWED_OPTION_TYPES = frozenset({"call", "put"})
+_ALLOWED_OPTION_UNDERLYING_ASSET_CLASSES = frozenset(
+    {"equity", "fx", "rate", "future", "credit", "commodity"}
+)
 _AUTOMATIC_ACTION_HINTS = (
     "settle",
     "lock",
@@ -1739,12 +1743,67 @@ def _validate_ranked_observation_basket_shape(
         )
 
 
+def _validate_option_axes(
+    contract: SemanticContract,
+    errors: list[str],
+    *,
+    allowed_underlying_asset_classes: frozenset[str],
+    require_option_type: bool = False,
+) -> None:
+    """Validate canonical option axes carried beside legacy semantic IDs."""
+    product = contract.product
+    derivative_family = str(getattr(product, "derivative_family", "") or "").strip().lower()
+    if derivative_family != "option":
+        errors.append(
+            "Option semantics require derivative_family `option`, "
+            f"got `{product.derivative_family}`."
+        )
+    if product.payoff_family == "vanilla_option":
+        option_type = str(getattr(product, "option_type", "") or "").strip().lower()
+        if option_type and option_type not in _ALLOWED_OPTION_TYPES:
+            errors.append(
+                "Vanilla option semantics only support option_type `call` or `put`, "
+                f"got `{product.option_type}`."
+            )
+        elif require_option_type and not option_type:
+            errors.append(
+                "Vanilla option semantics require option_type `call` or `put`, "
+                f"got `{product.option_type}`."
+            )
+    underlying = getattr(product, "underlying", None)
+    asset_class = str(getattr(underlying, "asset_class", "") or "").strip().lower()
+    if not asset_class:
+        errors.append("Option semantics require underlying.asset_class.")
+    elif asset_class not in _ALLOWED_OPTION_UNDERLYING_ASSET_CLASSES:
+        errors.append(
+            "Option semantics received unsupported underlying.asset_class "
+            f"`{asset_class}`."
+        )
+    elif asset_class not in allowed_underlying_asset_classes:
+        allowed = ", ".join(sorted(allowed_underlying_asset_classes))
+        errors.append(
+            "Option semantic shape does not support underlying.asset_class "
+            f"`{asset_class}`; expected one of: {allowed}."
+        )
+    identifiers = tuple(getattr(underlying, "identifiers", ()) or ())
+    constituents = tuple(getattr(product, "constituents", ()) or ())
+    if constituents and identifiers and identifiers != constituents:
+        errors.append(
+            "Option semantics require underlying.identifiers to match product constituents."
+        )
+
+
 def _validate_vanilla_option_shape(
     contract: SemanticContract,
     errors: list[str],
     warnings: list[str],
 ) -> None:
     """Validate a single-underlier vanilla option semantic shape."""
+    _validate_option_axes(
+        contract,
+        errors,
+        allowed_underlying_asset_classes=_ALLOWED_OPTION_UNDERLYING_ASSET_CLASSES,
+    )
     required_capabilities = _validate_market_capabilities(
         contract,
         errors,
@@ -1780,6 +1839,11 @@ def _validate_american_option_shape(
     warnings: list[str],
 ) -> None:
     """Validate a single-underlier holder-controlled vanilla option shape."""
+    _validate_option_axes(
+        contract,
+        errors,
+        allowed_underlying_asset_classes=frozenset({"equity"}),
+    )
     required_capabilities = _validate_market_capabilities(
         contract,
         errors,
@@ -1821,6 +1885,12 @@ def _validate_quanto_option_shape(
     warnings: list[str],
 ) -> None:
     """Validate a cross-currency quanto option semantic shape."""
+    _validate_option_axes(
+        contract,
+        errors,
+        allowed_underlying_asset_classes=frozenset({"equity", "commodity"}),
+        require_option_type=False,
+    )
     required_capabilities = _validate_market_capabilities(
         contract,
         errors,
@@ -1979,6 +2049,11 @@ def _validate_period_rate_option_strip_shape(
     warnings: list[str],
 ) -> None:
     """Validate a schedule-driven period rate-option strip semantic shape."""
+    _validate_option_axes(
+        contract,
+        errors,
+        allowed_underlying_asset_classes=frozenset({"rate"}),
+    )
     required_capabilities = _validate_market_capabilities(
         contract,
         errors,
@@ -2030,6 +2105,12 @@ def _validate_period_rate_option_strip_shape(
     if option_type != expected_option_type:
         errors.append(
             f"Rate cap/floor strip semantics require option_type `{expected_option_type}`, got `{option_type}`."
+        )
+    product_option_type = str(getattr(product, "option_type", "") or "").strip().lower()
+    if product_option_type != expected_option_type:
+        errors.append(
+            "Rate cap/floor strip semantics require product option_type "
+            f"`{expected_option_type}`, got `{product_option_type}`."
         )
     if product.controller_protocol.controller_style != "identity":
         errors.append("Rate cap/floor strip semantics cannot declare a strategic controller.")

--- a/trellis/agent/semantic_contracts.py
+++ b/trellis/agent/semantic_contracts.py
@@ -52,6 +52,14 @@ def _string_list(values) -> list[str]:
 
 def _yaml_safe_value(value):
     """Project MappingProxyType-heavy values onto YAML-safe primitives."""
+    if not isinstance(value, type) and dataclasses.is_dataclass(value):
+        result = {}
+        for field in dataclasses.fields(value):
+            item = getattr(value, field.name)
+            if item is None or item == "" or item == ():
+                continue
+            result[field.name] = _yaml_safe_value(item)
+        return result
     if isinstance(value, MappingProxyType):
         value = dict(value)
     if isinstance(value, Mapping):
@@ -712,6 +720,14 @@ class SemanticMarketInputSpec:
 
 
 @dataclass(frozen=True)
+class SemanticUnderlyingAxes:
+    """Canonical underlier axes carried independently from route identity."""
+
+    asset_class: str = ""
+    identifiers: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
 class SemanticDraftRule:
     """One ordered semantic-contract drafting rule."""
 
@@ -790,6 +806,9 @@ class SemanticProductSemantics:
     instrument_class: str
     instrument_aliases: tuple[str, ...]
     payoff_family: str
+    derivative_family: str = ""
+    underlying: SemanticUnderlyingAxes = field(default_factory=SemanticUnderlyingAxes)
+    option_type: str = ""
 
     # --- Underlier & Payoff ---
     conventions: ConventionEnv = field(default_factory=ConventionEnv)
@@ -953,8 +972,11 @@ def semantic_contract_summary(contract: SemanticContract | dict[str, Any] | str)
         "semantic_concept": semantic_concept_summary(concept),
         "product": {
             "instrument_class": parsed.product.instrument_class,
+            "derivative_family": parsed.product.derivative_family,
             "underlier_structure": parsed.product.underlier_structure,
+            "underlying": _yaml_safe_value(parsed.product.underlying),
             "payoff_family": parsed.product.payoff_family,
+            "option_type": parsed.product.option_type,
             "payoff_rule": parsed.product.payoff_rule,
             "settlement_rule": parsed.product.settlement_rule,
             "observation_schedule": list(parsed.product.observation_schedule),
@@ -1483,6 +1505,86 @@ def _extract_primary_underlier(text: str, term_sheet) -> tuple[str, ...]:
     return ()
 
 
+_CURRENCY_CODES = frozenset(
+    {
+        "AUD",
+        "BRL",
+        "CAD",
+        "CHF",
+        "CNY",
+        "EUR",
+        "GBP",
+        "HKD",
+        "JPY",
+        "MXN",
+        "NOK",
+        "NZD",
+        "SEK",
+        "SGD",
+        "USD",
+        "ZAR",
+    }
+)
+
+
+def _normalize_axis_token(value: object) -> str:
+    """Normalize one semantic-axis token without inventing aliases."""
+    return str(value or "").strip().lower().replace(" ", "_").replace("-", "_")
+
+
+def _infer_option_type(text: str, explicit: str | None = None) -> str:
+    """Infer the canonical call/put side when a vanilla option request states it."""
+    normalized_explicit = _normalize_axis_token(explicit)
+    if normalized_explicit in {"call", "put"}:
+        return normalized_explicit
+    lower = f" {str(text or '').lower()} "
+    if re.search(r"\bput\b", lower):
+        return "put"
+    if re.search(r"\bcall\b", lower):
+        return "call"
+    return normalized_explicit
+
+
+def _looks_like_currency_pair(value: str) -> bool:
+    """Return whether a compact identifier looks like a currency pair."""
+    token = str(value or "").strip().upper().replace("/", "").replace("-", "")
+    return (
+        len(token) == 6
+        and token[:3] in _CURRENCY_CODES
+        and token[3:] in _CURRENCY_CODES
+    )
+
+
+def _infer_underlying_asset_class(
+    text: str,
+    *,
+    underliers: tuple[str, ...] | list[str] = (),
+    explicit: str | None = None,
+    default: str = "",
+) -> str:
+    """Infer the canonical underlier asset-class axis from explicit hints or request text."""
+    normalized_explicit = _normalize_axis_token(explicit)
+    if normalized_explicit:
+        return normalized_explicit
+    normalized_default = _normalize_axis_token(default)
+    lower = f" {str(text or '').lower()} "
+    if " fx " in lower or "foreign exchange" in lower or "currency pair" in lower:
+        return "fx"
+    if any(_looks_like_currency_pair(item) for item in _tuple(underliers)):
+        return "fx"
+    if " rate " in lower or " swaption " in lower or " caplet " in lower or " floorlet " in lower:
+        return "rate"
+    if " future " in lower or " futures " in lower:
+        return "future"
+    if " credit " in lower or " cds " in lower:
+        return "credit"
+    if " commodity " in lower:
+        return "commodity"
+    if " equity " in lower or " stock " in lower or " share " in lower:
+        return "equity"
+    return normalized_default
+
+
 def _extract_rate_cap_floor_schedule(
     text: str,
     term_sheet,
@@ -1523,6 +1625,8 @@ def make_vanilla_option_contract(
     underliers: tuple[str, ...] | list[str],
     observation_schedule: tuple[str, ...] | list[str],
     preferred_method: str = "analytical",
+    underlying_asset_class: str | None = None,
+    option_type: str | None = None,
 ) -> SemanticContract:
     """Construct a generic vanilla option semantic contract."""
     underlier_names = _tuple(underliers)
@@ -1535,6 +1639,13 @@ def make_vanilla_option_contract(
         raise ValueError("Vanilla option contract requires at least one underlier.")
     if not schedule:
         raise ValueError("Vanilla option contract requires an expiry or exercise schedule.")
+    resolved_underlying_asset_class = _infer_underlying_asset_class(
+        description,
+        underliers=underlier_names,
+        explicit=underlying_asset_class,
+        default="equity",
+    )
+    resolved_option_type = _infer_option_type(description, option_type)
 
     product = SemanticProductSemantics(
         semantic_id="vanilla_option",
@@ -1542,6 +1653,12 @@ def make_vanilla_option_contract(
         instrument_class="european_option",
         instrument_aliases=("vanilla_option", "european_option", "option"),
         payoff_family="vanilla_option",
+        derivative_family="option",
+        underlying=SemanticUnderlyingAxes(
+            asset_class=resolved_underlying_asset_class,
+            identifiers=underlier_names,
+        ),
+        option_type=resolved_option_type,
         timeline=_default_semantic_timeline(
             schedule,
             includes_decision=True,
@@ -1679,6 +1796,8 @@ def make_american_option_contract(
     observation_schedule: tuple[str, ...] | list[str],
     preferred_method: str = "rate_tree",
     exercise_style: str = "american",
+    underlying_asset_class: str | None = None,
+    option_type: str | None = None,
 ) -> SemanticContract:
     """Construct a bounded early-exercise single-underlier option contract."""
     underlier_names = _tuple(underliers)
@@ -1695,6 +1814,13 @@ def make_american_option_contract(
     normalized_exercise = str(exercise_style).strip().lower()
     if normalized_exercise not in {"american", "bermudan"}:
         raise ValueError("American option contract only supports american or bermudan exercise.")
+    resolved_underlying_asset_class = _infer_underlying_asset_class(
+        description,
+        underliers=underlier_names,
+        explicit=underlying_asset_class,
+        default="equity",
+    )
+    resolved_option_type = _infer_option_type(description, option_type)
 
     product = SemanticProductSemantics(
         semantic_id="american_option",
@@ -1702,6 +1828,12 @@ def make_american_option_contract(
         instrument_class="american_option",
         instrument_aliases=("american_option", "bermudan_option", "option"),
         payoff_family="vanilla_option",
+        derivative_family="option",
+        underlying=SemanticUnderlyingAxes(
+            asset_class=resolved_underlying_asset_class,
+            identifiers=underlier_names,
+        ),
+        option_type=resolved_option_type,
         timeline=_default_semantic_timeline(
             schedule,
             includes_decision=True,
@@ -1838,6 +1970,8 @@ def make_quanto_option_contract(
     underliers: tuple[str, ...] | list[str],
     observation_schedule: tuple[str, ...] | list[str],
     preferred_method: str = "analytical",
+    underlying_asset_class: str | None = None,
+    option_type: str | None = None,
 ) -> SemanticContract:
     """Construct a generic quanto-style semantic contract."""
     underlier_names = _tuple(underliers)
@@ -1850,6 +1984,13 @@ def make_quanto_option_contract(
         raise ValueError("Quanto option contract requires at least one underlier.")
     if not schedule:
         raise ValueError("Quanto option contract requires an expiry or exercise schedule.")
+    resolved_underlying_asset_class = _infer_underlying_asset_class(
+        description,
+        underliers=underlier_names,
+        explicit=underlying_asset_class,
+        default="equity",
+    )
+    resolved_option_type = _infer_option_type(description, option_type)
 
     product = SemanticProductSemantics(
         semantic_id="quanto_option",
@@ -1857,6 +1998,12 @@ def make_quanto_option_contract(
         instrument_class="quanto_option",
         instrument_aliases=("quanto_option", "quanto", "fx_option"),
         payoff_family="vanilla_option",
+        derivative_family="option",
+        underlying=SemanticUnderlyingAxes(
+            asset_class=resolved_underlying_asset_class,
+            identifiers=underlier_names,
+        ),
+        option_type=resolved_option_type,
         timeline=_default_semantic_timeline(
             schedule,
             includes_decision=True,
@@ -2675,6 +2822,9 @@ def make_period_rate_option_strip_contract(
             normalized_instrument,
         ),
         payoff_family="period_rate_option_strip",
+        derivative_family="option",
+        underlying=SemanticUnderlyingAxes(asset_class="rate"),
+        option_type=option_type,
         timeline=_default_semantic_timeline(
             schedule,
             settlement_dates=schedule,
@@ -3418,6 +3568,8 @@ def _rebuild_vanilla_option_contract(
         underliers=tuple(getattr(product, "constituents", ()) or ()),
         observation_schedule=tuple(getattr(product, "observation_schedule", ()) or ()),
         preferred_method=normalized_method,
+        underlying_asset_class=getattr(getattr(product, "underlying", None), "asset_class", ""),
+        option_type=str(getattr(product, "option_type", "") or ""),
     )
 
 
@@ -3433,6 +3585,8 @@ def _rebuild_american_option_contract(
         observation_schedule=tuple(getattr(product, "observation_schedule", ()) or ()),
         preferred_method=normalized_method,
         exercise_style=str(getattr(product, "exercise_style", "american") or "american"),
+        underlying_asset_class=getattr(getattr(product, "underlying", None), "asset_class", ""),
+        option_type=str(getattr(product, "option_type", "") or ""),
     )
 
 
@@ -3447,6 +3601,8 @@ def _rebuild_quanto_option_contract(
         underliers=tuple(getattr(product, "constituents", ()) or ()),
         observation_schedule=tuple(getattr(product, "observation_schedule", ()) or ()),
         preferred_method=normalized_method,
+        underlying_asset_class=getattr(getattr(product, "underlying", None), "asset_class", ""),
+        option_type=str(getattr(product, "option_type", "") or ""),
     )
 
 
@@ -3692,6 +3848,20 @@ def _parse_market_input_spec(payload: SemanticMarketInputSpec | dict[str, Any]) 
     )
 
 
+def _parse_underlying_axes(
+    payload: SemanticUnderlyingAxes | dict[str, Any] | None,
+) -> SemanticUnderlyingAxes:
+    """Normalize canonical underlier-axis metadata."""
+    if isinstance(payload, SemanticUnderlyingAxes):
+        return payload
+    if not payload:
+        return SemanticUnderlyingAxes()
+    return SemanticUnderlyingAxes(
+        asset_class=str(payload.get("asset_class", "")).strip().lower(),
+        identifiers=_tuple(payload.get("identifiers", ())),
+    )
+
+
 def _parse_product_semantics(
     payload: SemanticProductSemantics | dict[str, Any],
 ) -> SemanticProductSemantics:
@@ -3709,6 +3879,9 @@ def _parse_product_semantics(
         instrument_class=instrument_class,
         instrument_aliases=_tuple(payload.get("instrument_aliases", ())),
         payoff_family=str(payload["payoff_family"]).strip(),
+        derivative_family=str(payload.get("derivative_family", "")).strip().lower(),
+        underlying=_parse_underlying_axes(payload.get("underlying")),
+        option_type=str(payload.get("option_type", "")).strip().lower(),
         conventions=_parse_convention_env(payload.get("conventions", {})),
         timeline=_parse_semantic_timeline(
             payload.get("timeline", {}),


### PR DESCRIPTION
## Summary
- add option semantic axes to SemanticProductSemantics and ProductIR
- thread axes through semantic contract compilation and deterministic ProductIR construction
- validate option axes so broad vanilla payoff identity does not erase underlier/exercise/call-put semantics
- document the option-axis model in developer and quant docs

## Tests
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_semantic_contracts.py -q
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_semantic_contracts.py tests/test_agent/test_decomposition_ir.py -q
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_semantic_contract_compiler.py tests/test_agent/test_semantic_contract_compiler_contract_ir.py tests/test_agent/test_dsl_integration.py tests/test_agent/test_market_binding.py tests/test_agent/test_decomposition_ir.py tests/test_agent/test_contract_pattern_eval.py tests/test_agent/test_route_registry.py tests/test_agent/test_benchmark_contracts.py -q
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_knowledge_store.py -q
- git diff --check