### PR TITLE
QUA-1111 Add conditional accrual leg IR

### DIFF
--- a/tests/test_agent/test_conditional_accrual_leg_ir.py
+++ b/tests/test_agent/test_conditional_accrual_leg_ir.py
@@ -16,6 +16,7 @@ from trellis.agent.static_leg_contract import (
     StaticLegIRWellFormednessError,
 )
 from trellis.execution import compile_static_leg_execution_ir
+from trellis.execution.compiler import UnsupportedExecutionSemantics
 
 
 def _notional() -> NotionalSchedule:
@@ -147,3 +148,9 @@ def test_conditional_accrual_leg_represents_single_index_range_accrual_terms():
     execution_ir = compile_static_leg_execution_ir(contract)
     assert execution_ir.obligations == ()
     assert execution_ir.execution_metadata.unsupported_reasons
+    assert execution_ir.execution_metadata.unsupported_reasons == (
+        "static-leg execution lowering not admitted: No admissible static-leg lowering declaration was found.",
+    )
+
+    with pytest.raises(UnsupportedExecutionSemantics, match="No admissible static-leg lowering declaration was found"):
+        compile_static_leg_execution_ir(contract, fail_on_unsupported=True)

--- a/tests/test_agent/test_conditional_accrual_leg_ir.py
+++ b/tests/test_agent/test_conditional_accrual_leg_ir.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from datetime import date
+
+import pytest
+
+from trellis.agent.static_leg_contract import (
+    ConditionalAccrualLeg,
+    ConditionalAccrualPeriod,
+    FixedCouponFormula,
+    NotionalSchedule,
+    NotionalStep,
+    SignedLeg,
+    StaticLegContractIR,
+    StaticLegIRWellFormednessError,
+)
+from trellis.execution import compile_static_leg_execution_ir
+
+
+def _notional() -> NotionalSchedule:
+    return NotionalSchedule(
+        (
+            NotionalStep(
+                start_date=date(2026, 1, 15),
+                end_date=date(2026, 10, 15),
+                amount=1_000_000.0,
+            ),
+        )
+    )
+
+
+def _conditional_periods() -> tuple[ConditionalAccrualPeriod, ...]:
+    return (
+        ConditionalAccrualPeriod(
+            accrual_start=date(2026, 1, 15),
+            accrual_end=date(2026, 4, 15),
+            observation_date=date(2026, 4, 15),
+            payment_date=date(2026, 4, 17),
+            fixing_date=date(2026, 4, 15),
+        ),
+        ConditionalAccrualPeriod(
+            accrual_start=date(2026, 4, 15),
+            accrual_end=date(2026, 7, 15),
+            observation_date=date(2026, 7, 15),
+            payment_date=date(2026, 7, 17),
+            fixing_date=date(2026, 7, 15),
+        ),
+    )
+
+
+def _conditional_accrual_leg() -> ConditionalAccrualLeg:
+    return ConditionalAccrualLeg(
+        currency="usd",
+        notional_schedule=_notional(),
+        accrual_periods=_conditional_periods(),
+        coupon_formula=FixedCouponFormula(0.0525),
+        day_count="ACT/365",
+        payment_frequency="quarterly",
+        accrual_condition_ref="sofr_in_range",
+        accrual_counter_ref="in_range_coupon_count",
+        settlement_rule="coupon_period_cash_settlement",
+        label="range_coupon",
+        metadata={"semantic_family": "range_accrual"},
+    )
+
+
+def test_conditional_accrual_leg_is_frozen_and_normalized():
+    leg = _conditional_accrual_leg()
+
+    assert leg.currency == "USD"
+    assert leg.payment_frequency == "quarterly"
+    assert leg.accrual_condition_ref == "sofr_in_range"
+    assert leg.accrual_counter_ref == "in_range_coupon_count"
+    assert leg.settlement_rule == "coupon_period_cash_settlement"
+    assert leg.metadata["semantic_family"] == "range_accrual"
+
+    with pytest.raises(FrozenInstanceError):
+        leg.currency = "EUR"
+    with pytest.raises(TypeError):
+        leg.metadata["semantic_family"] = "other"
+
+
+def test_conditional_accrual_leg_rejects_missing_condition_or_coupon():
+    with pytest.raises(
+        StaticLegIRWellFormednessError,
+        match="ConditionalAccrualLeg.accrual_condition_ref",
+    ):
+        ConditionalAccrualLeg(
+            currency="USD",
+            notional_schedule=_notional(),
+            accrual_periods=_conditional_periods(),
+            coupon_formula=FixedCouponFormula(0.0525),
+            day_count="ACT/365",
+            payment_frequency="quarterly",
+            accrual_condition_ref="",
+            accrual_counter_ref="in_range_coupon_count",
+        )
+
+    with pytest.raises(
+        StaticLegIRWellFormednessError,
+        match="ConditionalAccrualLeg.coupon_formula",
+    ):
+        ConditionalAccrualLeg(
+            currency="USD",
+            notional_schedule=_notional(),
+            accrual_periods=_conditional_periods(),
+            coupon_formula=None,
+            day_count="ACT/365",
+            payment_frequency="quarterly",
+            accrual_condition_ref="sofr_in_range",
+            accrual_counter_ref="in_range_coupon_count",
+        )
+
+
+def test_conditional_accrual_period_rejects_observation_after_accrual_window():
+    with pytest.raises(
+        StaticLegIRWellFormednessError,
+        match="observation_date must be on or before accrual_end",
+    ):
+        ConditionalAccrualPeriod(
+            accrual_start=date(2026, 1, 15),
+            accrual_end=date(2026, 4, 15),
+            observation_date=date(2026, 4, 16),
+            payment_date=date(2026, 4, 17),
+            fixing_date=date(2026, 4, 16),
+        )
+
+
+def test_conditional_accrual_leg_represents_single_index_range_accrual_terms():
+    leg = _conditional_accrual_leg()
+
+    assert leg.notional_schedule.initial_notional == pytest.approx(1_000_000.0)
+    assert tuple(period.observation_date for period in leg.accrual_periods) == (
+        date(2026, 4, 15),
+        date(2026, 7, 15),
+    )
+    assert leg.coupon_formula.rate == pytest.approx(0.0525)
+    assert leg.day_count == "ACT/365"
+
+    contract = StaticLegContractIR(
+        legs=(SignedLeg(direction="receive", leg=leg),),
+        metadata={"semantic_family": "range_accrual"},
+    )
+
+    assert contract.currencies == ("USD",)
+    execution_ir = compile_static_leg_execution_ir(contract)
+    assert execution_ir.obligations == ()
+    assert execution_ir.execution_metadata.unsupported_reasons

--- a/trellis/agent/static_leg_contract.py
+++ b/trellis/agent/static_leg_contract.py
@@ -198,6 +198,53 @@ class CouponPeriod:
 
 
 @dataclass(frozen=True)
+class ConditionalAccrualPeriod:
+    accrual_start: date
+    accrual_end: date
+    observation_date: date
+    payment_date: date
+    fixing_date: date | None = None
+
+    def __post_init__(self) -> None:
+        if not all(
+            isinstance(item, date)
+            for item in (
+                self.accrual_start,
+                self.accrual_end,
+                self.observation_date,
+                self.payment_date,
+            )
+        ):
+            raise StaticLegIRWellFormednessError(
+                "ConditionalAccrualPeriod requires date boundaries"
+            )
+        if self.accrual_start >= self.accrual_end:
+            raise StaticLegIRWellFormednessError(
+                "ConditionalAccrualPeriod requires accrual_start < accrual_end"
+            )
+        if self.observation_date < self.accrual_start:
+            raise StaticLegIRWellFormednessError(
+                "ConditionalAccrualPeriod observation_date must be on or after accrual_start"
+            )
+        if self.observation_date > self.accrual_end:
+            raise StaticLegIRWellFormednessError(
+                "ConditionalAccrualPeriod observation_date must be on or before accrual_end"
+            )
+        if self.payment_date < self.accrual_end:
+            raise StaticLegIRWellFormednessError(
+                "ConditionalAccrualPeriod payment_date must be on or after accrual_end"
+            )
+        if self.payment_date < self.observation_date:
+            raise StaticLegIRWellFormednessError(
+                "ConditionalAccrualPeriod payment_date must be on or after observation_date"
+            )
+        if self.fixing_date is not None and not isinstance(self.fixing_date, date):
+            raise StaticLegIRWellFormednessError(
+                "ConditionalAccrualPeriod.fixing_date must be a date when present"
+            )
+
+
+@dataclass(frozen=True)
 class PeriodRateOptionPeriod:
     accrual_start: date
     accrual_end: date
@@ -276,6 +323,95 @@ class CouponLeg:
             _require_text(self.payment_frequency, label="CouponLeg.payment_frequency").lower(),
         )
         object.__setattr__(self, "label", str(self.label or "").strip())
+
+
+@dataclass(frozen=True)
+class ConditionalAccrualLeg:
+    currency: str
+    notional_schedule: NotionalSchedule
+    accrual_periods: tuple[ConditionalAccrualPeriod, ...]
+    coupon_formula: CouponFormula
+    day_count: str
+    payment_frequency: str
+    accrual_condition_ref: str
+    accrual_counter_ref: str
+    settlement_rule: str = "coupon_period_cash_settlement"
+    label: str = ""
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "currency",
+            _require_text(self.currency, label="ConditionalAccrualLeg.currency").upper(),
+        )
+        if not isinstance(self.notional_schedule, NotionalSchedule):
+            raise StaticLegIRWellFormednessError(
+                "ConditionalAccrualLeg.notional_schedule must be a NotionalSchedule"
+            )
+        if not isinstance(self.accrual_periods, tuple):
+            object.__setattr__(self, "accrual_periods", tuple(self.accrual_periods))
+        if not self.accrual_periods:
+            raise StaticLegIRWellFormednessError(
+                "ConditionalAccrualLeg.accrual_periods must be non-empty"
+            )
+        previous_end: date | None = None
+        for period in self.accrual_periods:
+            if not isinstance(period, ConditionalAccrualPeriod):
+                raise StaticLegIRWellFormednessError(
+                    "ConditionalAccrualLeg.accrual_periods must contain ConditionalAccrualPeriod values"
+                )
+            if previous_end is not None and period.accrual_start < previous_end:
+                raise StaticLegIRWellFormednessError(
+                    "ConditionalAccrualLeg periods must be ordered and non-overlapping"
+                )
+            previous_end = period.accrual_end
+        if not isinstance(
+            self.coupon_formula,
+            (FixedCouponFormula, FloatingCouponFormula, QuotedCouponFormula),
+        ):
+            raise StaticLegIRWellFormednessError(
+                "ConditionalAccrualLeg.coupon_formula must be a CouponFormula"
+            )
+        object.__setattr__(
+            self,
+            "day_count",
+            _require_text(self.day_count, label="ConditionalAccrualLeg.day_count"),
+        )
+        object.__setattr__(
+            self,
+            "payment_frequency",
+            _require_text(
+                self.payment_frequency,
+                label="ConditionalAccrualLeg.payment_frequency",
+            ).lower(),
+        )
+        object.__setattr__(
+            self,
+            "accrual_condition_ref",
+            _require_text(
+                self.accrual_condition_ref,
+                label="ConditionalAccrualLeg.accrual_condition_ref",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "accrual_counter_ref",
+            _require_text(
+                self.accrual_counter_ref,
+                label="ConditionalAccrualLeg.accrual_counter_ref",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "settlement_rule",
+            _require_text(
+                self.settlement_rule,
+                label="ConditionalAccrualLeg.settlement_rule",
+            ),
+        )
+        object.__setattr__(self, "label", str(self.label or "").strip())
+        object.__setattr__(self, "metadata", _freeze_mapping(self.metadata))
 
 
 @dataclass(frozen=True)
@@ -399,7 +535,7 @@ class KnownCashflowLeg:
         object.__setattr__(self, "label", str(self.label or "").strip())
 
 
-Leg = CouponLeg | PeriodRateOptionStripLeg | KnownCashflowLeg
+Leg = CouponLeg | ConditionalAccrualLeg | PeriodRateOptionStripLeg | KnownCashflowLeg
 
 
 @dataclass(frozen=True)
@@ -414,9 +550,12 @@ class SignedLeg:
                 "SignedLeg.direction must be 'receive' or 'pay'"
             )
         object.__setattr__(self, "direction", normalized)
-        if not isinstance(self.leg, (CouponLeg, PeriodRateOptionStripLeg, KnownCashflowLeg)):
+        if not isinstance(
+            self.leg,
+            (CouponLeg, ConditionalAccrualLeg, PeriodRateOptionStripLeg, KnownCashflowLeg),
+        ):
             raise StaticLegIRWellFormednessError(
-                "SignedLeg.leg must be a CouponLeg, PeriodRateOptionStripLeg, or KnownCashflowLeg"
+                "SignedLeg.leg must be a CouponLeg, ConditionalAccrualLeg, PeriodRateOptionStripLeg, or KnownCashflowLeg"
             )
 
 
@@ -479,6 +618,8 @@ __all__ = [
     "CouponFormula",
     "CouponLeg",
     "CouponPeriod",
+    "ConditionalAccrualLeg",
+    "ConditionalAccrualPeriod",
     "FixedCouponFormula",
     "FloatingCouponFormula",
     "KnownCashflow",


### PR DESCRIPTION
## Summary
- Add frozen ConditionalAccrualPeriod and ConditionalAccrualLeg IR dataclasses to the static-leg contract surface
- Allow StaticLegContractIR to carry conditional accrual legs without admitting a pricing route yet
- Add focused tests for construction, validation failures, range-accrual term representation, and fail-closed execution lowering

## Validation
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_conditional_accrual_leg_ir.py -q
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_execution/test_static_leg_execution_ir.py tests/test_agent/test_conditional_accrual_leg_ir.py -q
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_semantic_contracts.py -q -k range_accrual
- git diff --check