### PR TITLE
QUA-1112 Add semantic observable predicate grammar

### DIFF
--- a/tests/test_agent/test_semantic_observable_predicates.py
+++ b/tests/test_agent/test_semantic_observable_predicates.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from datetime import date
+
+import pytest
+
+from trellis.agent.semantic_observables import (
+    AndPredicate,
+    BetweenPredicate,
+    CmsRateObservable,
+    GreaterThanPredicate,
+    LessThanPredicate,
+    ObservationMetadata,
+    PredicateGrammarValidationError,
+    RateIndexObservable,
+    SpreadObservable,
+    predicate_support_blockers,
+    validate_conditional_accrual_predicate,
+)
+from trellis.agent.static_leg_contract import (
+    ConditionalAccrualLeg,
+    ConditionalAccrualPeriod,
+    FixedCouponFormula,
+    NotionalSchedule,
+    NotionalStep,
+    StaticLegIRWellFormednessError,
+)
+
+
+def _notional() -> NotionalSchedule:
+    return NotionalSchedule(
+        (
+            NotionalStep(
+                start_date=date(2026, 1, 15),
+                end_date=date(2026, 7, 15),
+                amount=1_000_000.0,
+            ),
+        )
+    )
+
+
+def _periods() -> tuple[ConditionalAccrualPeriod, ...]:
+    return (
+        ConditionalAccrualPeriod(
+            accrual_start=date(2026, 1, 15),
+            accrual_end=date(2026, 4, 15),
+            observation_date=date(2026, 4, 15),
+            payment_date=date(2026, 4, 17),
+            fixing_date=date(2026, 4, 15),
+        ),
+    )
+
+
+def _sofr_observable() -> RateIndexObservable:
+    return RateIndexObservable(
+        observable_id="sofr_3m",
+        index_name="SOFR",
+        tenor="3M",
+        observation=ObservationMetadata(
+            schedule_role="observation_dates",
+            fixing_date_role="fixing_dates",
+            missing_fixing_policy="project_forward_for_future_only",
+        ),
+    )
+
+
+def _ff_observable() -> RateIndexObservable:
+    return RateIndexObservable(
+        observable_id="ff_3m",
+        index_name="FF",
+        tenor="3M",
+    )
+
+
+def test_single_index_rate_between_predicate_is_frozen_and_admitted():
+    predicate = BetweenPredicate(
+        observable=_sofr_observable(),
+        lower_bound=0.015,
+        upper_bound=0.0325,
+    )
+
+    assert validate_conditional_accrual_predicate(predicate) == ()
+    assert predicate_support_blockers(predicate) == ()
+    assert predicate.observable.observable_family == "rate_index"
+
+    leg = ConditionalAccrualLeg(
+        currency="USD",
+        notional_schedule=_notional(),
+        accrual_periods=_periods(),
+        coupon_formula=FixedCouponFormula(0.0525),
+        day_count="ACT/365",
+        payment_frequency="quarterly",
+        accrual_condition_ref="sofr_in_range",
+        accrual_counter_ref="in_range_coupon_count",
+        accrual_condition=predicate,
+    )
+
+    assert leg.accrual_condition is predicate
+    with pytest.raises(FrozenInstanceError):
+        predicate.lower_bound = 0.01
+
+
+def test_predicate_grammar_rejects_invalid_bounds_and_missing_fixing_policy():
+    with pytest.raises(PredicateGrammarValidationError, match="lower_bound <= upper_bound"):
+        BetweenPredicate(
+            observable=_sofr_observable(),
+            lower_bound=0.04,
+            upper_bound=0.03,
+        )
+
+    with pytest.raises(PredicateGrammarValidationError, match="missing_fixing_policy"):
+        ObservationMetadata(missing_fixing_policy="guess")
+
+
+def test_boolean_composition_requires_predicates_and_preserves_order():
+    lower = GreaterThanPredicate(observable=_sofr_observable(), threshold=0.015)
+    upper = BetweenPredicate(
+        observable=_sofr_observable(),
+        lower_bound=0.0,
+        upper_bound=0.0325,
+    )
+    predicate = AndPredicate((lower, upper))
+
+    assert predicate.predicates == (lower, upper)
+    assert validate_conditional_accrual_predicate(predicate) == ()
+
+    with pytest.raises(PredicateGrammarValidationError, match="must be non-empty"):
+        AndPredicate(())
+
+
+def test_multi_index_rate_predicate_fails_closed():
+    predicate = AndPredicate(
+        (
+            GreaterThanPredicate(observable=_sofr_observable(), threshold=0.015),
+            LessThanPredicate(observable=_ff_observable(), threshold=0.0325),
+        )
+    )
+
+    blockers = predicate_support_blockers(predicate)
+    assert tuple(blocker.observable_family for blocker in blockers) == ("multi_index",)
+    assert blockers[0].blocker_id == "conditional_accrual_multi_index_predicate_pending"
+
+    with pytest.raises(PredicateGrammarValidationError, match="multi_index"):
+        validate_conditional_accrual_predicate(predicate)
+
+    with pytest.raises(StaticLegIRWellFormednessError, match="multi_index"):
+        ConditionalAccrualLeg(
+            currency="USD",
+            notional_schedule=_notional(),
+            accrual_periods=_periods(),
+            coupon_formula=FixedCouponFormula(0.0525),
+            day_count="ACT/365",
+            payment_frequency="quarterly",
+            accrual_condition_ref="mixed_rate_index_in_range",
+            accrual_counter_ref="in_range_coupon_count",
+            accrual_condition=predicate,
+        )
+
+
+def test_conditional_accrual_leg_preserves_positional_defaults():
+    leg = ConditionalAccrualLeg(
+        "USD",
+        _notional(),
+        _periods(),
+        FixedCouponFormula(0.0525),
+        "ACT/365",
+        "quarterly",
+        "sofr_in_range",
+        "in_range_coupon_count",
+        "coupon_period_cash_settlement",
+        "legacy_label",
+        {"semantic_family": "range_accrual"},
+    )
+
+    assert leg.settlement_rule == "coupon_period_cash_settlement"
+    assert leg.label == "legacy_label"
+    assert leg.metadata["semantic_family"] == "range_accrual"
+    assert leg.accrual_condition is None
+
+
+def test_cms_spread_predicate_emits_blockers_and_fails_closed_for_leg():
+    predicate = BetweenPredicate(
+        observable=SpreadObservable(
+            left=CmsRateObservable(
+                observable_id="usd_cms_10y",
+                curve_id="USD_SWAP",
+                tenor="10Y",
+            ),
+            right=RateIndexObservable(
+                observable_id="sofr_3m",
+                index_name="SOFR",
+                tenor="3M",
+            ),
+            spread_id="cms_minus_sofr",
+        ),
+        lower_bound=0.0,
+        upper_bound=0.025,
+    )
+
+    blockers = predicate_support_blockers(predicate)
+    assert tuple(blocker.observable_family for blocker in blockers) == (
+        "spread",
+        "cms_rate",
+    )
+    assert all(blocker.blocker_id for blocker in blockers)
+    with pytest.raises(
+        PredicateGrammarValidationError,
+        match="unsupported observable family",
+    ):
+        validate_conditional_accrual_predicate(predicate)
+
+    with pytest.raises(
+        StaticLegIRWellFormednessError,
+        match="unsupported observable family",
+    ):
+        ConditionalAccrualLeg(
+            currency="USD",
+            notional_schedule=_notional(),
+            accrual_periods=_periods(),
+            coupon_formula=FixedCouponFormula(0.0525),
+            day_count="ACT/365",
+            payment_frequency="quarterly",
+            accrual_condition_ref="cms_spread_in_range",
+            accrual_counter_ref="in_range_coupon_count",
+            accrual_condition=predicate,
+        )

--- a/trellis/agent/semantic_observables.py
+++ b/trellis/agent/semantic_observables.py
@@ -1,0 +1,615 @@
+"""Semantic observable and predicate grammar for conditional coupon contracts.
+
+The first executable conditional-accrual wave admits only single rate-index
+observables. CMS, spread, spot, basket, and transform nodes are intentionally
+representable but blocked until a later route/lowering ticket admits them.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+class PredicateGrammarValidationError(ValueError):
+    """Raised when a semantic observable or predicate expression is malformed."""
+
+
+FIRST_WAVE_CONDITIONAL_ACCRUAL_OBSERVABLES = frozenset({"rate_index"})
+SUPPORTED_MISSING_FIXING_POLICIES = frozenset(
+    {
+        "fail_fast",
+        "project_forward_for_future_only",
+        "require_history_for_observed",
+    }
+)
+
+
+def _text(value: object, *, label: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise PredicateGrammarValidationError(f"{label} must be a non-empty string")
+    return text
+
+
+def _optional_text(value: object) -> str:
+    return str(value or "").strip()
+
+
+def _lower_text(value: object, *, label: str) -> str:
+    return _text(value, label=label).lower()
+
+
+def _float(value: float | int, *, label: str) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError) as exc:  # pragma: no cover - defensive only
+        raise PredicateGrammarValidationError(f"{label} must be numeric") from exc
+
+
+def _tuple_text(values: object, *, label: str) -> tuple[str, ...]:
+    if isinstance(values, str):
+        values = (values,)
+    result: list[str] = []
+    for value in values or ():
+        text = str(value or "").strip()
+        if text and text not in result:
+            result.append(text)
+    if not result:
+        raise PredicateGrammarValidationError(f"{label} must be non-empty")
+    return tuple(result)
+
+
+@dataclass(frozen=True)
+class ObservationMetadata:
+    """Observation schedule and fixing policy attached to one observable."""
+
+    schedule_role: str = "observation_dates"
+    fixing_date_role: str = "fixing_dates"
+    missing_fixing_policy: str = "fail_fast"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "schedule_role",
+            _text(self.schedule_role, label="ObservationMetadata.schedule_role"),
+        )
+        object.__setattr__(
+            self,
+            "fixing_date_role",
+            _text(self.fixing_date_role, label="ObservationMetadata.fixing_date_role"),
+        )
+        policy = _lower_text(
+            self.missing_fixing_policy,
+            label="ObservationMetadata.missing_fixing_policy",
+        )
+        if policy not in SUPPORTED_MISSING_FIXING_POLICIES:
+            raise PredicateGrammarValidationError(
+                "ObservationMetadata.missing_fixing_policy must be one of "
+                f"{sorted(SUPPORTED_MISSING_FIXING_POLICIES)}"
+            )
+        object.__setattr__(self, "missing_fixing_policy", policy)
+
+
+@dataclass(frozen=True)
+class ObservableSupportBlocker:
+    """Structured blocker for an observable family not admitted in this slice."""
+
+    observable_family: str
+    blocker_id: str
+    reason: str
+    required_ticket: str = ""
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "observable_family",
+            _lower_text(
+                self.observable_family,
+                label="ObservableSupportBlocker.observable_family",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "blocker_id",
+            _text(self.blocker_id, label="ObservableSupportBlocker.blocker_id"),
+        )
+        object.__setattr__(
+            self,
+            "reason",
+            _text(self.reason, label="ObservableSupportBlocker.reason"),
+        )
+        object.__setattr__(self, "required_ticket", _optional_text(self.required_ticket))
+
+
+@dataclass(frozen=True)
+class RateIndexObservable:
+    """Single rate-index observable admitted for first-wave range accruals."""
+
+    observable_id: str
+    index_name: str
+    tenor: str = ""
+    observation: ObservationMetadata = field(default_factory=ObservationMetadata)
+    observable_family: str = field(default="rate_index", init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "observable_id",
+            _text(self.observable_id, label="RateIndexObservable.observable_id"),
+        )
+        object.__setattr__(
+            self,
+            "index_name",
+            _text(self.index_name, label="RateIndexObservable.index_name").upper(),
+        )
+        object.__setattr__(self, "tenor", _optional_text(self.tenor).upper())
+        if not isinstance(self.observation, ObservationMetadata):
+            raise PredicateGrammarValidationError(
+                "RateIndexObservable.observation must be ObservationMetadata"
+            )
+
+
+@dataclass(frozen=True)
+class CmsRateObservable:
+    """CMS rate placeholder; representable but not admitted for this wave."""
+
+    observable_id: str
+    curve_id: str
+    tenor: str
+    observation: ObservationMetadata = field(default_factory=ObservationMetadata)
+    observable_family: str = field(default="cms_rate", init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "observable_id",
+            _text(self.observable_id, label="CmsRateObservable.observable_id"),
+        )
+        object.__setattr__(
+            self,
+            "curve_id",
+            _text(self.curve_id, label="CmsRateObservable.curve_id").upper(),
+        )
+        object.__setattr__(
+            self,
+            "tenor",
+            _text(self.tenor, label="CmsRateObservable.tenor").upper(),
+        )
+        if not isinstance(self.observation, ObservationMetadata):
+            raise PredicateGrammarValidationError(
+                "CmsRateObservable.observation must be ObservationMetadata"
+            )
+
+
+@dataclass(frozen=True)
+class SpotObservable:
+    """Spot observable placeholder for later conditional equity/FX coupons."""
+
+    observable_id: str
+    asset_id: str
+    observation: ObservationMetadata = field(default_factory=ObservationMetadata)
+    observable_family: str = field(default="spot", init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "observable_id",
+            _text(self.observable_id, label="SpotObservable.observable_id"),
+        )
+        object.__setattr__(
+            self,
+            "asset_id",
+            _text(self.asset_id, label="SpotObservable.asset_id").upper(),
+        )
+        if not isinstance(self.observation, ObservationMetadata):
+            raise PredicateGrammarValidationError(
+                "SpotObservable.observation must be ObservationMetadata"
+            )
+
+
+@dataclass(frozen=True)
+class BasketObservable:
+    """Basket observable placeholder for later conditional basket coupons."""
+
+    observable_id: str
+    constituents: tuple[str, ...]
+    observation: ObservationMetadata = field(default_factory=ObservationMetadata)
+    observable_family: str = field(default="basket", init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "observable_id",
+            _text(self.observable_id, label="BasketObservable.observable_id"),
+        )
+        object.__setattr__(
+            self,
+            "constituents",
+            _tuple_text(self.constituents, label="BasketObservable.constituents"),
+        )
+        if not isinstance(self.observation, ObservationMetadata):
+            raise PredicateGrammarValidationError(
+                "BasketObservable.observation must be ObservationMetadata"
+            )
+
+
+@dataclass(frozen=True)
+class TransformObservable:
+    """Transform placeholder over one or more observable inputs."""
+
+    observable_id: str
+    transform_id: str
+    inputs: tuple["ObservableExpr", ...]
+    observation: ObservationMetadata = field(default_factory=ObservationMetadata)
+    observable_family: str = field(default="transform", init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "observable_id",
+            _text(self.observable_id, label="TransformObservable.observable_id"),
+        )
+        object.__setattr__(
+            self,
+            "transform_id",
+            _text(self.transform_id, label="TransformObservable.transform_id"),
+        )
+        if not isinstance(self.inputs, tuple):
+            object.__setattr__(self, "inputs", tuple(self.inputs))
+        if not self.inputs:
+            raise PredicateGrammarValidationError("TransformObservable.inputs must be non-empty")
+        for item in self.inputs:
+            _require_observable_expr(item, label="TransformObservable.inputs")
+        if not isinstance(self.observation, ObservationMetadata):
+            raise PredicateGrammarValidationError(
+                "TransformObservable.observation must be ObservationMetadata"
+            )
+
+
+@dataclass(frozen=True)
+class SpreadObservable:
+    """Spread placeholder over two observable expressions."""
+
+    left: "ObservableExpr"
+    right: "ObservableExpr"
+    spread_id: str = ""
+    observation: ObservationMetadata = field(default_factory=ObservationMetadata)
+    observable_family: str = field(default="spread", init=False)
+
+    def __post_init__(self) -> None:
+        _require_observable_expr(self.left, label="SpreadObservable.left")
+        _require_observable_expr(self.right, label="SpreadObservable.right")
+        object.__setattr__(self, "spread_id", _optional_text(self.spread_id))
+        if not isinstance(self.observation, ObservationMetadata):
+            raise PredicateGrammarValidationError(
+                "SpreadObservable.observation must be ObservationMetadata"
+            )
+
+
+ObservableExpr = (
+    RateIndexObservable
+    | CmsRateObservable
+    | SpotObservable
+    | BasketObservable
+    | TransformObservable
+    | SpreadObservable
+)
+
+
+@dataclass(frozen=True)
+class BetweenPredicate:
+    observable: ObservableExpr
+    lower_bound: float
+    upper_bound: float
+    inclusive_lower: bool = True
+    inclusive_upper: bool = True
+
+    def __post_init__(self) -> None:
+        _require_observable_expr(self.observable, label="BetweenPredicate.observable")
+        lower = _float(self.lower_bound, label="BetweenPredicate.lower_bound")
+        upper = _float(self.upper_bound, label="BetweenPredicate.upper_bound")
+        if lower > upper:
+            raise PredicateGrammarValidationError(
+                "BetweenPredicate requires lower_bound <= upper_bound"
+            )
+        object.__setattr__(self, "lower_bound", lower)
+        object.__setattr__(self, "upper_bound", upper)
+        object.__setattr__(self, "inclusive_lower", bool(self.inclusive_lower))
+        object.__setattr__(self, "inclusive_upper", bool(self.inclusive_upper))
+
+
+@dataclass(frozen=True)
+class GreaterThanPredicate:
+    observable: ObservableExpr
+    threshold: float
+    inclusive: bool = False
+
+    def __post_init__(self) -> None:
+        _require_observable_expr(self.observable, label="GreaterThanPredicate.observable")
+        object.__setattr__(
+            self,
+            "threshold",
+            _float(self.threshold, label="GreaterThanPredicate.threshold"),
+        )
+        object.__setattr__(self, "inclusive", bool(self.inclusive))
+
+
+@dataclass(frozen=True)
+class LessThanPredicate:
+    observable: ObservableExpr
+    threshold: float
+    inclusive: bool = False
+
+    def __post_init__(self) -> None:
+        _require_observable_expr(self.observable, label="LessThanPredicate.observable")
+        object.__setattr__(
+            self,
+            "threshold",
+            _float(self.threshold, label="LessThanPredicate.threshold"),
+        )
+        object.__setattr__(self, "inclusive", bool(self.inclusive))
+
+
+@dataclass(frozen=True)
+class AndPredicate:
+    predicates: tuple["PredicateExpr", ...]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "predicates", _predicate_tuple(self.predicates, label="AndPredicate.predicates"))
+
+
+@dataclass(frozen=True)
+class OrPredicate:
+    predicates: tuple["PredicateExpr", ...]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "predicates", _predicate_tuple(self.predicates, label="OrPredicate.predicates"))
+
+
+@dataclass(frozen=True)
+class NotPredicate:
+    predicate: "PredicateExpr"
+
+    def __post_init__(self) -> None:
+        _require_predicate_expr(self.predicate, label="NotPredicate.predicate")
+
+
+PredicateExpr = (
+    BetweenPredicate
+    | GreaterThanPredicate
+    | LessThanPredicate
+    | AndPredicate
+    | OrPredicate
+    | NotPredicate
+)
+
+
+def _require_observable_expr(value: object, *, label: str) -> None:
+    if not isinstance(
+        value,
+        (
+            RateIndexObservable,
+            CmsRateObservable,
+            SpotObservable,
+            BasketObservable,
+            TransformObservable,
+            SpreadObservable,
+        ),
+    ):
+        raise PredicateGrammarValidationError(f"{label} must be an ObservableExpr")
+
+
+def _require_predicate_expr(value: object, *, label: str) -> None:
+    if not isinstance(
+        value,
+        (
+            BetweenPredicate,
+            GreaterThanPredicate,
+            LessThanPredicate,
+            AndPredicate,
+            OrPredicate,
+            NotPredicate,
+        ),
+    ):
+        raise PredicateGrammarValidationError(f"{label} must be a PredicateExpr")
+
+
+def _predicate_tuple(values: object, *, label: str) -> tuple[PredicateExpr, ...]:
+    if values is None:
+        raise PredicateGrammarValidationError(f"{label} must be non-empty")
+    if not isinstance(values, tuple):
+        values = tuple(values)
+    if not values:
+        raise PredicateGrammarValidationError(f"{label} must be non-empty")
+    for value in values:
+        _require_predicate_expr(value, label=label)
+    return values
+
+
+def _dedupe_rate_index_keys(
+    keys: tuple[tuple[str, str], ...],
+) -> tuple[tuple[str, str], ...]:
+    result: list[tuple[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for key in keys:
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(key)
+    return tuple(result)
+
+
+def _rate_index_keys_from_observable(
+    observable: ObservableExpr,
+) -> tuple[tuple[str, str], ...]:
+    if isinstance(observable, RateIndexObservable):
+        return ((observable.index_name, observable.tenor),)
+    if isinstance(observable, SpreadObservable):
+        return _dedupe_rate_index_keys(
+            (
+                *_rate_index_keys_from_observable(observable.left),
+                *_rate_index_keys_from_observable(observable.right),
+            )
+        )
+    if isinstance(observable, TransformObservable):
+        return _dedupe_rate_index_keys(
+            tuple(
+                key
+                for item in observable.inputs
+                for key in _rate_index_keys_from_observable(item)
+            )
+        )
+    return ()
+
+
+def _rate_index_keys_from_predicate(
+    predicate: PredicateExpr,
+) -> tuple[tuple[str, str], ...]:
+    if isinstance(predicate, (BetweenPredicate, GreaterThanPredicate, LessThanPredicate)):
+        return _rate_index_keys_from_observable(predicate.observable)
+    if isinstance(predicate, (AndPredicate, OrPredicate)):
+        return _dedupe_rate_index_keys(
+            tuple(
+                key
+                for item in predicate.predicates
+                for key in _rate_index_keys_from_predicate(item)
+            )
+        )
+    if isinstance(predicate, NotPredicate):
+        return _rate_index_keys_from_predicate(predicate.predicate)
+    raise PredicateGrammarValidationError("predicate must be a PredicateExpr")
+
+
+def observable_support_blockers(observable: ObservableExpr) -> tuple[ObservableSupportBlocker, ...]:
+    """Return blockers that prevent first-wave conditional-accrual admission."""
+    _require_observable_expr(observable, label="observable")
+    if isinstance(observable, RateIndexObservable):
+        return ()
+    if isinstance(observable, SpreadObservable):
+        return (
+            _blocker(
+                "spread",
+                "conditional_accrual_spread_observable_pending",
+                "Spread observables are representable but not admitted for first-wave conditional accrual lowering.",
+                required_ticket="QUA-1115",
+            ),
+            *observable_support_blockers(observable.left),
+            *observable_support_blockers(observable.right),
+        )
+    if isinstance(observable, TransformObservable):
+        child_blockers = tuple(
+            blocker
+            for item in observable.inputs
+            for blocker in observable_support_blockers(item)
+        )
+        return (
+            _blocker(
+                "transform",
+                "conditional_accrual_transform_observable_pending",
+                "Transform observables require route-specific lowering support.",
+                required_ticket="follow_on",
+            ),
+            *child_blockers,
+        )
+    family = observable.observable_family
+    return (
+        _blocker(
+            family,
+            f"conditional_accrual_{family}_observable_pending",
+            f"{family} observables are representable but not admitted for first-wave conditional accrual lowering.",
+            required_ticket="follow_on",
+        ),
+    )
+
+
+def predicate_support_blockers(predicate: PredicateExpr) -> tuple[ObservableSupportBlocker, ...]:
+    """Return all observable-support blockers reachable from a predicate."""
+    _require_predicate_expr(predicate, label="predicate")
+    if isinstance(predicate, (BetweenPredicate, GreaterThanPredicate, LessThanPredicate)):
+        blockers = observable_support_blockers(predicate.observable)
+    elif isinstance(predicate, (AndPredicate, OrPredicate)):
+        blockers = tuple(
+            blocker
+            for item in predicate.predicates
+            for blocker in predicate_support_blockers(item)
+        )
+    elif isinstance(predicate, NotPredicate):
+        blockers = predicate_support_blockers(predicate.predicate)
+    else:
+        raise PredicateGrammarValidationError("predicate must be a PredicateExpr")
+    rate_index_keys = _rate_index_keys_from_predicate(predicate)
+    if len(rate_index_keys) > 1:
+        blockers = (
+            *blockers,
+            _blocker(
+                "multi_index",
+                "conditional_accrual_multi_index_predicate_pending",
+                "First-wave conditional accrual lowering admits exactly one rate-index observable identity.",
+                required_ticket="QUA-1115",
+            ),
+        )
+    return _dedupe_blockers(blockers)
+
+
+def validate_conditional_accrual_predicate(predicate: PredicateExpr) -> tuple[ObservableSupportBlocker, ...]:
+    """Validate that a predicate is admitted for first-wave conditional accrual."""
+    blockers = predicate_support_blockers(predicate)
+    if blockers:
+        families = ", ".join(blocker.observable_family for blocker in blockers)
+        raise PredicateGrammarValidationError(
+            f"unsupported observable family for conditional accrual predicate: {families}"
+        )
+    return ()
+
+
+def _blocker(
+    observable_family: str,
+    blocker_id: str,
+    reason: str,
+    *,
+    required_ticket: str,
+) -> ObservableSupportBlocker:
+    return ObservableSupportBlocker(
+        observable_family=observable_family,
+        blocker_id=blocker_id,
+        reason=reason,
+        required_ticket=required_ticket,
+    )
+
+
+def _dedupe_blockers(blockers) -> tuple[ObservableSupportBlocker, ...]:
+    result: list[ObservableSupportBlocker] = []
+    seen: set[tuple[str, str]] = set()
+    for blocker in blockers:
+        key = (blocker.observable_family, blocker.blocker_id)
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(blocker)
+    return tuple(result)
+
+
+__all__ = [
+    "AndPredicate",
+    "BasketObservable",
+    "BetweenPredicate",
+    "CmsRateObservable",
+    "FIRST_WAVE_CONDITIONAL_ACCRUAL_OBSERVABLES",
+    "GreaterThanPredicate",
+    "LessThanPredicate",
+    "NotPredicate",
+    "ObservableExpr",
+    "ObservableSupportBlocker",
+    "ObservationMetadata",
+    "OrPredicate",
+    "PredicateExpr",
+    "PredicateGrammarValidationError",
+    "RateIndexObservable",
+    "SpotObservable",
+    "SpreadObservable",
+    "SUPPORTED_MISSING_FIXING_POLICIES",
+    "TransformObservable",
+    "observable_support_blockers",
+    "predicate_support_blockers",
+    "validate_conditional_accrual_predicate",
+]

--- a/trellis/agent/static_leg_contract.py
+++ b/trellis/agent/static_leg_contract.py
@@ -14,6 +14,11 @@ from types import MappingProxyType
 from typing import Mapping
 
 from trellis.agent.contract_ir import CurveQuote, SurfaceQuote
+from trellis.agent.semantic_observables import (
+    PredicateExpr,
+    PredicateGrammarValidationError,
+    validate_conditional_accrual_predicate,
+)
 
 
 class StaticLegIRWellFormednessError(ValueError):
@@ -338,6 +343,7 @@ class ConditionalAccrualLeg:
     settlement_rule: str = "coupon_period_cash_settlement"
     label: str = ""
     metadata: Mapping[str, object] = field(default_factory=dict)
+    accrual_condition: PredicateExpr | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(
@@ -410,6 +416,11 @@ class ConditionalAccrualLeg:
                 label="ConditionalAccrualLeg.settlement_rule",
             ),
         )
+        if self.accrual_condition is not None:
+            try:
+                validate_conditional_accrual_predicate(self.accrual_condition)
+            except PredicateGrammarValidationError as exc:
+                raise StaticLegIRWellFormednessError(str(exc)) from exc
         object.__setattr__(self, "label", str(self.label or "").strip())
         object.__setattr__(self, "metadata", _freeze_mapping(self.metadata))
 


### PR DESCRIPTION
## Summary
- Add frozen semantic observable and predicate expression grammar for conditional coupon contracts
- Admit only first-wave single rate-index predicates for conditional accrual lowering
- Represent CMS/spread/spot/basket/transform observables as explicit blockers
- Wire ConditionalAccrualLeg to validate optional typed predicates fail-closed

## Validation
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_semantic_observable_predicates.py tests/test_agent/test_conditional_accrual_leg_ir.py tests/test_execution/test_static_leg_execution_ir.py tests/test_agent/test_semantic_contracts.py -q -k 'semantic_observable or conditional_accrual or static_leg or range_accrual'
- git diff --check