### PR TITLE
QUA-1113 Lower range accrual semantics to conditional leg

### DIFF
--- a/tests/test_agent/test_platform_requests.py
+++ b/tests/test_agent/test_platform_requests.py
@@ -544,6 +544,17 @@ def test_compile_build_request_preserves_missing_route_state_for_range_accrual_s
 
     assert compiled.semantic_contract is not None
     assert compiled.semantic_blueprint is not None
+    assert compiled.semantic_blueprint.static_leg_contract_ir is not None
+    assert (
+        compiled.semantic_blueprint.static_leg_contract_ir.metadata["semantic_family"]
+        == "range_accrual"
+    )
+    assert (
+        compiled.request.metadata["semantic_blueprint"]["static_leg_contract_ir"]["metadata"][
+            "range_accrual_spec_fields"
+        ]["reference_index"]
+        == "SOFR"
+    )
     assert compiled.semantic_blueprint.primitive_routes == ()
     assert compiled.semantic_blueprint.dsl_lowering.route_id is None
     assert compiled.generation_plan is not None

--- a/tests/test_agent/test_semantic_contracts.py
+++ b/tests/test_agent/test_semantic_contracts.py
@@ -281,6 +281,94 @@ def test_range_accrual_trade_entry_contract_validates_and_surfaces_term_fields()
     assert "trellis.models.range_accrual" in compiled.target_modules
 
 
+def test_range_accrual_semantic_compile_lowers_to_conditional_accrual_leg_ir():
+    from datetime import date
+
+    from trellis.agent.semantic_contract_compiler import compile_semantic_contract
+    from trellis.agent.semantic_contracts import make_range_accrual_contract
+    from trellis.agent.semantic_observables import BetweenPredicate, RateIndexObservable
+    from trellis.agent.static_leg_contract import (
+        ConditionalAccrualLeg,
+        FixedCouponFormula,
+        KnownCashflowLeg,
+        StaticLegContractIR,
+    )
+
+    contract = make_range_accrual_contract(
+        description=(
+            "Range accrual note on SOFR paying 5.25% when SOFR stays between "
+            "1.50% and 3.25% on quarterly 2026 observations."
+        ),
+        reference_index="SOFR",
+        observation_schedule=(
+            "2026-01-15",
+            "2026-04-15",
+            "2026-07-15",
+            "2026-10-15",
+        ),
+        coupon_definition={
+            "coupon_rate": 0.0525,
+            "coupon_style": "fixed_rate_if_in_range",
+        },
+        range_condition={
+            "lower_bound": 0.015,
+            "upper_bound": 0.0325,
+            "inclusive_lower": True,
+            "inclusive_upper": True,
+        },
+        callability={
+            "call_schedule": ("2026-07-15",),
+            "call_style": "issuer_callable",
+        },
+    )
+
+    compiled = compile_semantic_contract(contract)
+
+    assert isinstance(compiled.static_leg_contract_ir, StaticLegContractIR)
+    assert compiled.static_leg_lowering_selection is None
+    assert compiled.primitive_routes == ()
+    coupon_leg = compiled.static_leg_contract_ir.legs[0].leg
+    redemption_leg = compiled.static_leg_contract_ir.legs[1].leg
+    assert isinstance(coupon_leg, ConditionalAccrualLeg)
+    assert isinstance(coupon_leg.coupon_formula, FixedCouponFormula)
+    assert coupon_leg.coupon_formula.rate == pytest.approx(0.0525)
+    assert coupon_leg.accrual_condition_ref == "reference_rate_fixing_in_range"
+    assert coupon_leg.accrual_counter_ref == "in_range_coupon_count"
+    assert tuple(period.observation_date for period in coupon_leg.accrual_periods) == (
+        date(2026, 1, 15),
+        date(2026, 4, 15),
+        date(2026, 7, 15),
+        date(2026, 10, 15),
+    )
+    assert all(
+        period.accrual_start < period.observation_date <= period.accrual_end
+        for period in coupon_leg.accrual_periods
+    )
+    assert isinstance(coupon_leg.accrual_condition, BetweenPredicate)
+    assert coupon_leg.accrual_condition.lower_bound == pytest.approx(0.015)
+    assert coupon_leg.accrual_condition.upper_bound == pytest.approx(0.0325)
+    assert isinstance(coupon_leg.accrual_condition.observable, RateIndexObservable)
+    assert coupon_leg.accrual_condition.observable.index_name == "SOFR"
+    assert coupon_leg.metadata["semantic_family"] == "range_accrual"
+    assert coupon_leg.metadata["callability"] == {
+        "call_schedule": ("2026-07-15",),
+        "call_style": "issuer_callable",
+    }
+    assert coupon_leg.metadata["range_accrual_spec_fields"]["reference_index"] == "SOFR"
+    assert coupon_leg.metadata["range_accrual_spec_fields"]["observation_dates"] == (
+        "2026-01-15",
+        "2026-04-15",
+        "2026-07-15",
+        "2026-10-15",
+    )
+    assert isinstance(redemption_leg, KnownCashflowLeg)
+    assert redemption_leg.cashflows[0].payment_date == date(2026, 10, 15)
+    assert compiled.static_leg_contract_ir.metadata["callability"] == {
+        "call_schedule": ("2026-07-15",),
+        "call_style": "issuer_callable",
+    }
+
+
 @pytest.mark.parametrize(
     "contract_factory",
     [

--- a/tests/test_platform/test_pricing_service.py
+++ b/tests/test_platform/test_pricing_service.py
@@ -64,6 +64,7 @@ def test_build_callable_bond_spec_preserves_explicit_zero_call_price():
 
 
 def test_build_range_accrual_spec_preserves_explicit_zero_principal_redemption():
+    from trellis.agent.static_leg_contract import KnownCashflowLeg
     from trellis.platform.services.pricing_service import PricingService
     from trellis.platform.services.trade_service import TradeService
 
@@ -102,6 +103,12 @@ def test_build_range_accrual_spec_preserves_explicit_zero_principal_redemption()
     )
 
     assert spec.principal_redemption == 0.0
+    static_ir = parsed_trade.semantic_blueprint.static_leg_contract_ir
+    assert static_ir.metadata["range_accrual_spec_fields"]["principal_redemption"] == 0.0
+    assert not any(
+        isinstance(signed_leg.leg, KnownCashflowLeg)
+        for signed_leg in static_ir.legs
+    )
 
 
 def test_desk_review_projects_agent_cycle_surface_for_approved_model_runs():

--- a/trellis/agent/semantic_contract_compiler.py
+++ b/trellis/agent/semantic_contract_compiler.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field, replace
+from datetime import date
 import logging
+import re
 from types import MappingProxyType
 from typing import Mapping
 
@@ -183,14 +185,18 @@ def compile_semantic_contract(
         )
     static_leg_contract_ir = None
     try:
-        static_leg_contract_ir = decompose_to_static_leg_contract_ir(
-            contract.description or contract.semantic_id,
-            instrument_type=(
-                getattr(getattr(contract, "product", None), "instrument_class", None)
-                or getattr(product_ir, "instrument", None)
-            ),
-            product_ir=product_ir,
+        static_leg_contract_ir = _lower_static_leg_contract_ir_from_semantic_contract(
+            contract
         )
+        if static_leg_contract_ir is None:
+            static_leg_contract_ir = decompose_to_static_leg_contract_ir(
+                contract.description or contract.semantic_id,
+                instrument_type=(
+                    getattr(getattr(contract, "product", None), "instrument_class", None)
+                    or getattr(product_ir, "instrument", None)
+                ),
+                product_ir=product_ir,
+            )
     except Exception:
         _LOG.warning(
             "Static-leg Contract IR decomposition failed for semantic contract %s",
@@ -399,6 +405,238 @@ def _specialize_contract_for_preferred_method(contract, preferred_method: str):
         contract,
         preferred_method=preferred_method,
     )
+
+
+def _lower_static_leg_contract_ir_from_semantic_contract(contract):
+    """Lower semantic contracts whose normalized fields define static-leg IR."""
+
+    semantic_id = str(getattr(contract, "semantic_id", "") or "").strip().lower()
+    product = getattr(contract, "product", None)
+    product_semantic_id = str(getattr(product, "semantic_id", "") or "").strip().lower()
+    if semantic_id != "range_accrual" and product_semantic_id != "range_accrual":
+        return None
+    return _lower_range_accrual_to_static_leg_contract_ir(contract)
+
+
+def _lower_range_accrual_to_static_leg_contract_ir(contract):
+    """Lower the bounded single-index range-accrual semantic contract to static legs."""
+
+    from trellis.agent.semantic_observables import (
+        BetweenPredicate,
+        ObservationMetadata,
+        RateIndexObservable,
+    )
+    from trellis.agent.static_leg_contract import (
+        ConditionalAccrualLeg,
+        ConditionalAccrualPeriod,
+        FixedCouponFormula,
+        KnownCashflow,
+        KnownCashflowLeg,
+        NotionalSchedule,
+        NotionalStep,
+        SettlementRule,
+        SignedLeg,
+        StaticLegContractIR,
+    )
+
+    product = getattr(contract, "product", None)
+    term_fields = dict(getattr(product, "term_fields", {}) or {})
+    reference_index = str(term_fields.get("reference_index") or "").strip().upper()
+    schedule = tuple(str(item).strip() for item in getattr(product, "observation_schedule", ()) or ())
+    if not reference_index or len(schedule) < 2:
+        return None
+    try:
+        observation_dates = tuple(date.fromisoformat(item) for item in schedule)
+    except ValueError:
+        return None
+    if any(left >= right for left, right in zip(observation_dates, observation_dates[1:])):
+        return None
+
+    coupon_definition = dict(term_fields.get("coupon_definition") or {})
+    range_condition = dict(term_fields.get("range_condition") or {})
+    settlement_profile = dict(term_fields.get("settlement_profile") or {})
+    callability = dict(term_fields.get("callability") or {})
+    if (
+        coupon_definition.get("coupon_rate") is None
+        or range_condition.get("lower_bound") is None
+        or range_condition.get("upper_bound") is None
+    ):
+        return None
+
+    first_gap = observation_dates[1] - observation_dates[0]
+    accrual_start_dates = (observation_dates[0] - first_gap, *observation_dates[:-1])
+    payment_dates = observation_dates
+    currency = _range_accrual_currency(contract, reference_index)
+    index_name, tenor = _split_range_accrual_reference_index(reference_index)
+    principal_redemption = _range_accrual_principal_redemption(
+        term_fields,
+        settlement_profile,
+    )
+    day_count = (
+        str(getattr(getattr(product, "conventions", None), "day_count_convention", "") or "").strip()
+        or "ACT/365"
+    )
+
+    spec_fields = {
+        "reference_index": reference_index,
+        "coupon_rate": float(coupon_definition["coupon_rate"]),
+        "lower_bound": float(range_condition["lower_bound"]),
+        "upper_bound": float(range_condition["upper_bound"]),
+        "observation_dates": schedule,
+        "accrual_start_dates": tuple(item.isoformat() for item in accrual_start_dates),
+        "payment_dates": tuple(item.isoformat() for item in payment_dates),
+        "principal_redemption": principal_redemption,
+        "inclusive_lower": bool(range_condition.get("inclusive_lower", True)),
+        "inclusive_upper": bool(range_condition.get("inclusive_upper", True)),
+        "day_count": day_count,
+    }
+    notional_schedule = NotionalSchedule(
+        (
+            NotionalStep(
+                start_date=accrual_start_dates[0],
+                end_date=observation_dates[-1],
+                amount=1.0,
+            ),
+        )
+    )
+    condition = BetweenPredicate(
+        observable=RateIndexObservable(
+            observable_id="reference_rate_fixing",
+            index_name=index_name,
+            tenor=tenor,
+            observation=ObservationMetadata(
+                schedule_role="observation_dates",
+                fixing_date_role="fixing_dates",
+                missing_fixing_policy="project_forward_for_future_only",
+            ),
+        ),
+        lower_bound=float(range_condition["lower_bound"]),
+        upper_bound=float(range_condition["upper_bound"]),
+        inclusive_lower=bool(range_condition.get("inclusive_lower", True)),
+        inclusive_upper=bool(range_condition.get("inclusive_upper", True)),
+    )
+    periods = tuple(
+        ConditionalAccrualPeriod(
+            accrual_start=start,
+            accrual_end=observation,
+            observation_date=observation,
+            payment_date=payment,
+            fixing_date=observation,
+        )
+        for start, observation, payment in zip(
+            accrual_start_dates,
+            observation_dates,
+            payment_dates,
+        )
+    )
+    conditional_leg = ConditionalAccrualLeg(
+        currency=currency,
+        notional_schedule=notional_schedule,
+        accrual_periods=periods,
+        coupon_formula=FixedCouponFormula(float(coupon_definition["coupon_rate"])),
+        day_count=day_count,
+        payment_frequency=_infer_range_accrual_frequency(observation_dates),
+        accrual_condition_ref="reference_rate_fixing_in_range",
+        accrual_counter_ref="in_range_coupon_count",
+        settlement_rule=str(
+            settlement_profile.get("coupon_settlement", "coupon_period_cash_settlement")
+        ).strip()
+        or "coupon_period_cash_settlement",
+        label="range_accrual_coupon",
+        metadata={
+            "semantic_family": "range_accrual",
+            "lowering_source": "semantic_contract.term_fields",
+            "reference_index": reference_index,
+            "coupon_definition": coupon_definition,
+            "range_condition": range_condition,
+            "settlement_profile": settlement_profile,
+            "callability": callability,
+            "range_accrual_spec_fields": spec_fields,
+        },
+        accrual_condition=condition,
+    )
+    legs = [SignedLeg(direction="receive", leg=conditional_leg)]
+    if principal_redemption != 0.0:
+        principal_leg = KnownCashflowLeg(
+            currency=currency,
+            cashflows=(
+                KnownCashflow(
+                    payment_date=payment_dates[-1],
+                    amount=principal_redemption,
+                    currency=currency,
+                    label="principal_redemption",
+                ),
+            ),
+            label="range_accrual_principal",
+        )
+        legs.append(SignedLeg(direction="receive", leg=principal_leg))
+    return StaticLegContractIR(
+        legs=tuple(legs),
+        settlement=SettlementRule(
+            payout_currency=currency,
+            settlement_kind="cash",
+            settlement_lag_days=0,
+        ),
+        metadata={
+            "semantic_id": "range_accrual",
+            "semantic_family": "range_accrual",
+            "lowering_source": "semantic_contract.term_fields",
+            "callability": callability,
+            "range_accrual_spec_fields": spec_fields,
+        },
+    )
+
+
+def _range_accrual_currency(contract, reference_index: str) -> str:
+    product = getattr(contract, "product", None)
+    conventions = getattr(product, "conventions", None)
+    for value in (
+        getattr(conventions, "payment_currency", ""),
+        getattr(conventions, "reporting_currency", ""),
+    ):
+        currency = str(value or "").strip().upper()
+        if currency:
+            return currency
+    parts = [part for part in re.split(r"[-_/ ]+", reference_index.upper()) if part]
+    if parts and len(parts[0]) == 3:
+        return parts[0]
+    if reference_index.upper() in {"SOFR", "FF", "FEDFUNDS"}:
+        return "USD"
+    return "USD"
+
+
+def _split_range_accrual_reference_index(reference_index: str) -> tuple[str, str]:
+    normalized = str(reference_index or "").strip().upper()
+    parts = [part for part in re.split(r"[-_/ ]+", normalized) if part]
+    if len(parts) >= 2 and re.fullmatch(r"\d+[DWMY]", parts[-1]):
+        return "-".join(parts[:-1]), parts[-1]
+    return normalized, ""
+
+
+def _range_accrual_principal_redemption(
+    term_fields: Mapping[str, object],
+    settlement_profile: Mapping[str, object],
+) -> float:
+    value = term_fields.get("principal_redemption")
+    if value in {None, ""}:
+        value = settlement_profile.get("principal_redemption", 1.0)
+    return float(value)
+
+
+def _infer_range_accrual_frequency(observation_dates: tuple[date, ...]) -> str:
+    if len(observation_dates) < 2:
+        return "scheduled"
+    average_days = sum(
+        (right - left).days
+        for left, right in zip(observation_dates, observation_dates[1:])
+    ) / float(len(observation_dates) - 1)
+    if average_days <= 40:
+        return "monthly"
+    if average_days <= 100:
+        return "quarterly"
+    if average_days <= 200:
+        return "semiannual"
+    return "annual"
 
 
 def _connector_binding_hints(market_binding_spec) -> dict[str, object]:

--- a/trellis/agent/semantic_contracts.py
+++ b/trellis/agent/semantic_contracts.py
@@ -4873,18 +4873,20 @@ def _default_range_accrual_settlement_profile() -> Mapping[str, object]:
 def _normalize_settlement_profile(payload: Mapping[str, object] | None) -> MappingProxyType:
     """Normalize the settlement profile for the range-accrual contract."""
     payload = dict(_default_range_accrual_settlement_profile() if payload is None else payload)
-    return _freeze_mapping(
-        {
-            "coupon_settlement": str(
-                payload.get("coupon_settlement", "coupon_period_cash_settlement")
-            ).strip()
-            or "coupon_period_cash_settlement",
-            "principal_settlement": str(
-                payload.get("principal_settlement", "principal_at_maturity")
-            ).strip()
-            or "principal_at_maturity",
-        }
-    )
+    normalized: dict[str, object] = {
+        "coupon_settlement": str(
+            payload.get("coupon_settlement", "coupon_period_cash_settlement")
+        ).strip()
+        or "coupon_period_cash_settlement",
+        "principal_settlement": str(
+            payload.get("principal_settlement", "principal_at_maturity")
+        ).strip()
+        or "principal_at_maturity",
+    }
+    principal_redemption = payload.get("principal_redemption")
+    if principal_redemption not in {None, ""}:
+        normalized["principal_redemption"] = float(principal_redemption)
+    return _freeze_mapping(normalized)
 
 
 def _normalize_callability(payload: Mapping[str, object] | None) -> MappingProxyType:

--- a/trellis/platform/services/trade_service.py
+++ b/trellis/platform/services/trade_service.py
@@ -859,6 +859,16 @@ class TradeService:
             "callable_range_note",
             "callable_range_accrual",
         }:
+            settlement_profile = structured_trade.get("settlement_profile")
+            if structured_trade.get("principal_redemption") not in {None, ""}:
+                settlement_profile = (
+                    dict(settlement_profile)
+                    if isinstance(settlement_profile, Mapping)
+                    else {}
+                )
+                settlement_profile["principal_redemption"] = structured_trade[
+                    "principal_redemption"
+                ]
             try:
                 contract = make_range_accrual_contract(
                     description=payload_description,
@@ -871,7 +881,7 @@ class TradeService:
                     observation_schedule=schedule,
                     coupon_definition=self._structured_coupon_definition(structured_trade),
                     range_condition=self._structured_range_condition(structured_trade),
-                    settlement_profile=structured_trade.get("settlement_profile"),
+                    settlement_profile=settlement_profile,
                     callability=self._structured_callability(structured_trade),
                     preferred_method=str(structured_trade.get("preferred_method", "analytical")).strip() or "analytical",
                 )


### PR DESCRIPTION
## Summary
- lower bounded range_accrual semantic contracts to StaticLegContractIR with a ConditionalAccrualLeg side channel
- preserve range-accrual spec fields, settlement, principal redemption, and callability hooks in metadata
- keep current pricing route behavior unchanged until QUA-1114 admits the conditional leg route

## Tests
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_semantic_contracts.py tests/test_agent/test_platform_requests.py::test_compile_build_request_preserves_missing_route_state_for_range_accrual_semantics tests/test_mcp/test_trade_service.py::test_trade_parse_supports_structured_range_accrual_input tests/test_mcp/test_trade_service.py::test_trade_parse_range_accrual_still_requires_observation_schedule tests/test_models/test_range_accrual.py tests/test_mcp/test_price_trade_tool.py::test_price_trade_prices_range_accrual_from_imported_snapshot tests/test_mcp/test_price_trade_tool.py::test_price_trade_projects_trader_review_bundle_for_range_accrual tests/test_platform/test_pricing_service.py::test_build_range_accrual_spec_preserves_explicit_zero_principal_redemption -q
- git diff --check