### PR TITLE
QUA-1115 preserve range accrual dynamic blockers

### DIFF
--- a/tests/test_agent/test_platform_requests.py
+++ b/tests/test_agent/test_platform_requests.py
@@ -556,6 +556,7 @@ def test_compile_build_request_routes_range_accrual_through_conditional_leg_auth
         == "SOFR"
     )
     assert compiled.semantic_blueprint.static_leg_lowering_selection is not None
+    assert compiled.semantic_blueprint.static_leg_admission_blockers == ()
     assert (
         compiled.semantic_blueprint.static_leg_lowering_selection.declaration_id
         == "static_leg_range_accrual_discounted"
@@ -571,6 +572,7 @@ def test_compile_build_request_routes_range_accrual_through_conditional_leg_auth
     assert compiled.request.metadata["semantic_blueprint"]["static_leg_lowering_selection"][
         "declaration_id"
     ] == "static_leg_range_accrual_discounted"
+    assert compiled.request.metadata["semantic_blueprint"]["static_leg_admission_blockers"] == []
     assert compiled.request.metadata["route_binding_authority"]["authority_kind"] == (
         "exact_backend_fit"
     )
@@ -579,6 +581,47 @@ def test_compile_build_request_routes_range_accrual_through_conditional_leg_auth
     ] == (
         "range_accrual"
     )
+
+
+def test_semantic_blueprint_summary_preserves_range_accrual_callability_blockers():
+    from trellis.agent.platform_requests import _semantic_blueprint_summary
+    from trellis.agent.semantic_contract_compiler import compile_semantic_contract
+    from trellis.agent.semantic_contracts import make_range_accrual_contract
+
+    contract = make_range_accrual_contract(
+        description="Callable range accrual on SOFR.",
+        reference_index="SOFR",
+        coupon_definition={"coupon_rate": 0.0525},
+        range_condition={"lower_bound": 0.015, "upper_bound": 0.0325},
+        observation_schedule=(
+            "2026-01-15",
+            "2026-04-15",
+            "2026-07-15",
+            "2026-10-15",
+        ),
+        callability={
+            "call_schedule": ("2026-07-15",),
+            "call_style": "issuer_callable",
+        },
+    )
+
+    blueprint = compile_semantic_contract(contract)
+    summary = _semantic_blueprint_summary(blueprint)
+
+    assert blueprint.static_leg_lowering_selection is None
+    assert tuple(
+        blocker.blocker_id for blocker in blueprint.static_leg_admission_blockers
+    ) == ("conditional_range_accrual_callability_pending",)
+    assert summary["static_leg_admission_blockers"] == [
+        {
+            "blocker_id": "conditional_range_accrual_callability_pending",
+            "reason": (
+                "Callable range accrual requires a dynamic exercise wrapper "
+                "before the checked static-leg route may be used."
+            ),
+            "required_ticket": "QUA-1115",
+        }
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_agent/test_platform_traces.py
+++ b/tests/test_agent/test_platform_traces.py
@@ -797,6 +797,30 @@ def test_platform_trace_summary_reads_legacy_top_level_route_binding_fields():
     assert construction_identity["backend_engine_family"] == "analytical"
 
 
+def test_platform_trace_lowering_summary_preserves_static_leg_admission_blockers():
+    from trellis.agent.platform_traces import _generation_boundary_summary
+
+    blocker = {
+        "blocker_id": "conditional_range_accrual_callability_pending",
+        "reason": (
+            "Callable range accrual requires a dynamic exercise wrapper before "
+            "the checked static-leg route may be used."
+        ),
+        "required_ticket": "QUA-1115",
+    }
+
+    lowering = _generation_boundary_summary(
+        SimpleNamespace(request_metadata={"semantic_blueprint": {}}),
+        request_metadata={
+            "semantic_blueprint": {
+                "static_leg_admission_blockers": [blocker],
+            }
+        },
+    )["lowering"]
+
+    assert lowering["static_leg_admission_blockers"] == [blocker]
+
+
 def test_platform_trace_records_checked_range_accrual_static_leg_binding(tmp_path):
     from trellis.agent.platform_requests import compile_build_request
     from trellis.agent.platform_traces import (

--- a/tests/test_agent/test_semantic_observable_predicates.py
+++ b/tests/test_agent/test_semantic_observable_predicates.py
@@ -24,7 +24,6 @@ from trellis.agent.static_leg_contract import (
     FixedCouponFormula,
     NotionalSchedule,
     NotionalStep,
-    StaticLegIRWellFormednessError,
 )
 
 
@@ -144,18 +143,19 @@ def test_multi_index_rate_predicate_fails_closed():
     with pytest.raises(PredicateGrammarValidationError, match="multi_index"):
         validate_conditional_accrual_predicate(predicate)
 
-    with pytest.raises(StaticLegIRWellFormednessError, match="multi_index"):
-        ConditionalAccrualLeg(
-            currency="USD",
-            notional_schedule=_notional(),
-            accrual_periods=_periods(),
-            coupon_formula=FixedCouponFormula(0.0525),
-            day_count="ACT/365",
-            payment_frequency="quarterly",
-            accrual_condition_ref="mixed_rate_index_in_range",
-            accrual_counter_ref="in_range_coupon_count",
-            accrual_condition=predicate,
-        )
+    leg = ConditionalAccrualLeg(
+        currency="USD",
+        notional_schedule=_notional(),
+        accrual_periods=_periods(),
+        coupon_formula=FixedCouponFormula(0.0525),
+        day_count="ACT/365",
+        payment_frequency="quarterly",
+        accrual_condition_ref="mixed_rate_index_in_range",
+        accrual_counter_ref="in_range_coupon_count",
+        accrual_condition=predicate,
+    )
+
+    assert leg.accrual_condition is predicate
 
 
 def test_conditional_accrual_leg_preserves_positional_defaults():
@@ -210,18 +210,16 @@ def test_cms_spread_predicate_emits_blockers_and_fails_closed_for_leg():
     ):
         validate_conditional_accrual_predicate(predicate)
 
-    with pytest.raises(
-        StaticLegIRWellFormednessError,
-        match="unsupported observable family",
-    ):
-        ConditionalAccrualLeg(
-            currency="USD",
-            notional_schedule=_notional(),
-            accrual_periods=_periods(),
-            coupon_formula=FixedCouponFormula(0.0525),
-            day_count="ACT/365",
-            payment_frequency="quarterly",
-            accrual_condition_ref="cms_spread_in_range",
-            accrual_counter_ref="in_range_coupon_count",
-            accrual_condition=predicate,
-        )
+    leg = ConditionalAccrualLeg(
+        currency="USD",
+        notional_schedule=_notional(),
+        accrual_periods=_periods(),
+        coupon_formula=FixedCouponFormula(0.0525),
+        day_count="ACT/365",
+        payment_frequency="quarterly",
+        accrual_condition_ref="cms_spread_in_range",
+        accrual_counter_ref="in_range_coupon_count",
+        accrual_condition=predicate,
+    )
+
+    assert leg.accrual_condition is predicate

--- a/tests/test_agent/test_static_leg_admission.py
+++ b/tests/test_agent/test_static_leg_admission.py
@@ -12,9 +12,11 @@ from trellis.agent.static_leg_admission import (
 )
 from trellis.agent.semantic_observables import (
     BetweenPredicate,
+    CmsRateObservable,
     GreaterThanPredicate,
     ObservationMetadata,
     RateIndexObservable,
+    SpreadObservable,
 )
 from trellis.agent.static_leg_contract import (
     ConditionalAccrualLeg,
@@ -221,6 +223,7 @@ def _period_rate_option_strip() -> StaticLegContractIR:
 def _conditional_range_accrual_contract(
     *,
     callability: dict[str, object] | None = None,
+    dynamic_features: dict[str, object] | None = None,
     condition=None,
     fixing_dates: tuple[date | None, ...] | None = None,
     principal_payment_date: date | None = None,
@@ -274,6 +277,7 @@ def _conditional_range_accrual_contract(
         metadata={
             "semantic_family": "range_accrual",
             "callability": callability or {},
+            "dynamic_features": dynamic_features or {},
         },
         accrual_condition=condition,
     )
@@ -300,6 +304,7 @@ def _conditional_range_accrual_contract(
         metadata={
             "semantic_family": "range_accrual",
             "callability": callability or {},
+            "dynamic_features": dynamic_features or {},
         },
     )
 
@@ -520,6 +525,61 @@ class TestStaticLegAdmission:
 
         assert tuple(blocker.blocker_id for blocker in blockers) == (
             "conditional_range_accrual_between_predicate_required",
+        )
+        with pytest.raises(StaticLegLoweringNoMatchError):
+            select_static_leg_lowering(contract, requested_method="analytical")
+
+    def test_cms_spread_conditional_range_accrual_fails_closed_with_observable_blockers(self):
+        contract = _conditional_range_accrual_contract(
+            condition=BetweenPredicate(
+                observable=SpreadObservable(
+                    left=CmsRateObservable(
+                        observable_id="usd_cms_10y",
+                        curve_id="USD_SWAP",
+                        tenor="10Y",
+                    ),
+                    right=RateIndexObservable(
+                        observable_id="sofr_3m",
+                        index_name="SOFR",
+                        tenor="3M",
+                    ),
+                    spread_id="cms_minus_sofr",
+                ),
+                lower_bound=0.0,
+                upper_bound=0.025,
+            )
+        )
+
+        blockers = conditional_range_accrual_admission_blockers(contract)
+
+        assert tuple(blocker.blocker_id for blocker in blockers) == (
+            "conditional_accrual_spread_observable_pending",
+            "conditional_accrual_cms_rate_observable_pending",
+        )
+        assert tuple(blocker.required_ticket for blocker in blockers) == (
+            "QUA-1115",
+            "follow_on",
+        )
+        with pytest.raises(StaticLegLoweringNoMatchError):
+            select_static_leg_lowering(contract, requested_method="analytical")
+
+    def test_interrupted_conditional_range_accrual_fails_closed_with_dynamic_blockers(self):
+        contract = _conditional_range_accrual_contract(
+            dynamic_features={
+                "interruption_events": ("issuer_suspend_accrual",),
+                "barrier_state": {"barrier_type": "knock_out"},
+            }
+        )
+
+        blockers = conditional_range_accrual_admission_blockers(contract)
+
+        assert tuple(blocker.blocker_id for blocker in blockers) == (
+            "conditional_range_accrual_interruption_state_pending",
+            "conditional_range_accrual_barrier_state_pending",
+        )
+        assert tuple(blocker.required_ticket for blocker in blockers) == (
+            "QUA-1115",
+            "QUA-1115",
         )
         with pytest.raises(StaticLegLoweringNoMatchError):
             select_static_leg_lowering(contract, requested_method="analytical")

--- a/tests/test_agent/test_static_leg_admission.py
+++ b/tests/test_agent/test_static_leg_admission.py
@@ -224,6 +224,7 @@ def _conditional_range_accrual_contract(
     *,
     callability: dict[str, object] | None = None,
     dynamic_features: dict[str, object] | None = None,
+    contract_dynamic_features: dict[str, object] | None = None,
     condition=None,
     fixing_dates: tuple[date | None, ...] | None = None,
     principal_payment_date: date | None = None,
@@ -277,7 +278,11 @@ def _conditional_range_accrual_contract(
         metadata={
             "semantic_family": "range_accrual",
             "callability": callability or {},
-            "dynamic_features": dynamic_features or {},
+            "dynamic_features": (
+                dynamic_features
+                if dynamic_features is not None
+                else {}
+            ),
         },
         accrual_condition=condition,
     )
@@ -304,7 +309,11 @@ def _conditional_range_accrual_contract(
         metadata={
             "semantic_family": "range_accrual",
             "callability": callability or {},
-            "dynamic_features": dynamic_features or {},
+            "dynamic_features": (
+                contract_dynamic_features
+                if contract_dynamic_features is not None
+                else dynamic_features or {}
+            ),
         },
     )
 
@@ -580,6 +589,20 @@ class TestStaticLegAdmission:
         assert tuple(blocker.required_ticket for blocker in blockers) == (
             "QUA-1115",
             "QUA-1115",
+        )
+        with pytest.raises(StaticLegLoweringNoMatchError):
+            select_static_leg_lowering(contract, requested_method="analytical")
+
+    def test_contract_dynamic_range_accrual_blockers_are_not_masked_by_leg_metadata(self):
+        contract = _conditional_range_accrual_contract(
+            dynamic_features={"leg_marker": True},
+            contract_dynamic_features={"barrier_state": {"barrier_type": "knock_out"}},
+        )
+
+        blockers = conditional_range_accrual_admission_blockers(contract)
+
+        assert tuple(blocker.blocker_id for blocker in blockers) == (
+            "conditional_range_accrual_barrier_state_pending",
         )
         with pytest.raises(StaticLegLoweringNoMatchError):
             select_static_leg_lowering(contract, requested_method="analytical")

--- a/tests/test_mcp/test_trade_service.py
+++ b/tests/test_mcp/test_trade_service.py
@@ -98,6 +98,12 @@ def test_trade_parse_supports_structured_range_accrual_input():
         "call_schedule": ["2026-07-15"],
         "call_style": "issuer_callable",
     }
+    assert result.semantic_blueprint is not None
+    assert result.semantic_blueprint.static_leg_lowering_selection is None
+    assert tuple(
+        blocker.blocker_id
+        for blocker in result.semantic_blueprint.static_leg_admission_blockers
+    ) == ("conditional_range_accrual_callability_pending",)
     assert result.required_market_data == (
         "discount_curve",
         "fixing_history",
@@ -121,6 +127,39 @@ def test_trade_parse_range_accrual_still_requires_observation_schedule():
 
     assert result.parse_status == "incomplete"
     assert result.missing_fields == ("observation_schedule",)
+
+
+def test_trade_parse_blocks_interrupted_range_accrual_from_plain_static_route():
+    from trellis.platform.services.trade_service import TradeService
+
+    result = TradeService().parse_trade(
+        structured_trade={
+            "instrument_type": "range_accrual",
+            "reference_index": "SOFR",
+            "coupon_rate": 0.0525,
+            "lower_bound": 0.015,
+            "upper_bound": 0.0325,
+            "observation_schedule": (
+                "2026-01-15",
+                "2026-04-15",
+                "2026-07-15",
+                "2026-10-15",
+            ),
+            "interruption_events": ("issuer_suspend_accrual",),
+            "barrier_state": {"barrier_type": "knock_out"},
+        }
+    )
+
+    assert result.parse_status == "parsed"
+    assert result.semantic_blueprint is not None
+    assert result.semantic_blueprint.static_leg_lowering_selection is None
+    assert tuple(
+        blocker.blocker_id
+        for blocker in result.semantic_blueprint.static_leg_admission_blockers
+    ) == (
+        "conditional_range_accrual_interruption_state_pending",
+        "conditional_range_accrual_barrier_state_pending",
+    )
 
 
 def test_trade_parse_supports_structured_callable_bond_input_with_term_fields():

--- a/trellis/agent/platform_requests.py
+++ b/trellis/agent/platform_requests.py
@@ -606,6 +606,9 @@ def _semantic_blueprint_summary(semantic_blueprint) -> dict[str, object]:
         "static_leg_lowering_selection": _yaml_safe_value(
             getattr(semantic_blueprint, "static_leg_lowering_selection", None)
         ),
+        "static_leg_admission_blockers": _yaml_safe_value(
+            getattr(semantic_blueprint, "static_leg_admission_blockers", ()) or ()
+        ),
         "requested_outputs": list(getattr(semantic_blueprint, "requested_outputs", ()) or ()),
         "valuation_context": valuation_context_summary(semantic_blueprint.valuation_context)
         if getattr(semantic_blueprint, "valuation_context", None) is not None

--- a/trellis/agent/platform_traces.py
+++ b/trellis/agent/platform_traces.py
@@ -556,6 +556,9 @@ def _generation_boundary_summary(
         ),
         "target_bindings": list(semantic_blueprint.get("dsl_target_bindings") or ()),
         "lowering_errors": list(semantic_blueprint.get("dsl_lowering_errors") or ()),
+        "static_leg_admission_blockers": list(
+            semantic_blueprint.get("static_leg_admission_blockers") or ()
+        ),
     }
     lane_summary = (
         {

--- a/trellis/agent/semantic_contract_compiler.py
+++ b/trellis/agent/semantic_contract_compiler.py
@@ -88,6 +88,7 @@ class SemanticImplementationBlueprint:
     contract_ir_solver_shadow: object | None = None
     static_leg_contract_ir: object | None = None
     static_leg_lowering_selection: object | None = None
+    static_leg_admission_blockers: tuple[object, ...] = ()
 
     def __post_init__(self):
         """Freeze mapping metadata for stable traces and tests."""
@@ -259,6 +260,9 @@ def compile_semantic_contract(
         static_leg_contract_ir=static_leg_contract_ir,
         preferred_method=preferred_method,
     )
+    static_leg_admission_blockers = _compile_static_leg_admission_blockers(
+        static_leg_contract_ir
+    )
     if contract_ir_solver_selection is not None:
         primitive_routes = ()
         dsl_lowering = _route_free_lowering_from_structural_selection(
@@ -359,6 +363,7 @@ def compile_semantic_contract(
         contract_ir_solver_shadow=contract_ir_solver_shadow,
         static_leg_contract_ir=static_leg_contract_ir,
         static_leg_lowering_selection=static_leg_lowering_selection,
+        static_leg_admission_blockers=static_leg_admission_blockers,
     )
 
 
@@ -458,6 +463,7 @@ def _lower_range_accrual_to_static_leg_contract_ir(contract):
     range_condition = dict(term_fields.get("range_condition") or {})
     settlement_profile = dict(term_fields.get("settlement_profile") or {})
     callability = dict(term_fields.get("callability") or {})
+    dynamic_features = dict(term_fields.get("dynamic_features") or {})
     if (
         coupon_definition.get("coupon_rate") is None
         or range_condition.get("lower_bound") is None
@@ -553,6 +559,7 @@ def _lower_range_accrual_to_static_leg_contract_ir(contract):
             "range_condition": range_condition,
             "settlement_profile": settlement_profile,
             "callability": callability,
+            "dynamic_features": dynamic_features,
             "range_accrual_spec_fields": spec_fields,
         },
         accrual_condition=condition,
@@ -584,6 +591,7 @@ def _lower_range_accrual_to_static_leg_contract_ir(contract):
             "semantic_family": "range_accrual",
             "lowering_source": "semantic_contract.term_fields",
             "callability": callability,
+            "dynamic_features": dynamic_features,
             "range_accrual_spec_fields": spec_fields,
         },
     )
@@ -922,6 +930,42 @@ def _compile_static_leg_lowering_selection(
             exc_info=True,
         )
         return None
+
+
+def _compile_static_leg_admission_blockers(static_leg_contract_ir):
+    """Return bounded static-leg admission blockers for recognized semantic routes."""
+
+    if static_leg_contract_ir is None:
+        return ()
+    if not _is_range_accrual_static_leg_contract_ir(static_leg_contract_ir):
+        return ()
+
+    from trellis.agent.static_leg_admission import (
+        conditional_range_accrual_admission_blockers,
+    )
+
+    return conditional_range_accrual_admission_blockers(static_leg_contract_ir)
+
+
+def _is_range_accrual_static_leg_contract_ir(static_leg_contract_ir) -> bool:
+    metadata = dict(getattr(static_leg_contract_ir, "metadata", {}) or {})
+    if (
+        str(metadata.get("semantic_family") or metadata.get("semantic_id") or "")
+        .strip()
+        .lower()
+        == "range_accrual"
+    ):
+        return True
+    for signed_leg in getattr(static_leg_contract_ir, "legs", ()) or ():
+        leg_metadata = dict(getattr(getattr(signed_leg, "leg", None), "metadata", {}) or {})
+        if (
+            str(leg_metadata.get("semantic_family") or "")
+            .strip()
+            .lower()
+            == "range_accrual"
+        ):
+            return True
+    return False
 
 
 def _compile_contract_ir_solver_shadow(

--- a/trellis/agent/semantic_contract_validation.py
+++ b/trellis/agent/semantic_contract_validation.py
@@ -2016,6 +2016,7 @@ def _validate_range_accrual_shape(
     callability = dict(term_fields.get("callability") or {})
     if callability and not callability.get("call_schedule"):
         errors.append("Range-accrual callability hooks must include call_schedule when present.")
+    dynamic_features = dict(term_fields.get("dynamic_features") or {})
 
     observable_types = {
         str(getattr(item, "observable_type", "")).strip().lower()
@@ -2036,6 +2037,10 @@ def _validate_range_accrual_shape(
     if callability:
         warnings.append(
             "Range-accrual callability hooks are captured as trade-entry metadata; callable execution remains a later slice."
+        )
+    if dynamic_features:
+        warnings.append(
+            "Range-accrual dynamic feature hooks are captured as trade-entry metadata; dynamic execution remains a later slice."
         )
     if not contract.blueprint.primitive_families:
         warnings.append(

--- a/trellis/agent/semantic_contracts.py
+++ b/trellis/agent/semantic_contracts.py
@@ -2359,6 +2359,7 @@ def make_range_accrual_contract(
     range_condition: Mapping[str, object] | None = None,
     settlement_profile: Mapping[str, object] | None = None,
     callability: Mapping[str, object] | None = None,
+    dynamic_features: Mapping[str, object] | None = None,
     preferred_method: str = "analytical",
 ) -> SemanticContract:
     """Construct the first checked semantic trade-entry contract for range accruals."""
@@ -2372,6 +2373,9 @@ def make_range_accrual_contract(
     normalized_range = _normalize_range_condition(range_condition)
     normalized_settlement = _normalize_settlement_profile(settlement_profile)
     normalized_callability = _normalize_callability(callability)
+    normalized_dynamic_features = _normalize_range_accrual_dynamic_features(
+        dynamic_features
+    )
 
     if not normalized_index:
         raise ValueError("Range accrual contract requires a reference index.")
@@ -2480,6 +2484,7 @@ def make_range_accrual_contract(
                 "range_condition": dict(normalized_range),
                 "settlement_profile": dict(normalized_settlement),
                 "callability": dict(normalized_callability),
+                "dynamic_features": dict(normalized_dynamic_features),
             }
         ),
         exercise_style="none",
@@ -3634,6 +3639,7 @@ def _rebuild_range_accrual_contract(
         range_condition=term_fields.get("range_condition"),
         settlement_profile=term_fields.get("settlement_profile"),
         callability=term_fields.get("callability"),
+        dynamic_features=term_fields.get("dynamic_features"),
         preferred_method=normalized_method,
     )
 
@@ -4907,6 +4913,54 @@ def _normalize_callability(payload: Mapping[str, object] | None) -> MappingProxy
             or "issuer_callable",
         }
     )
+
+
+def _normalize_range_accrual_dynamic_features(
+    payload: Mapping[str, object] | None,
+) -> MappingProxyType:
+    """Normalize unsupported dynamic range-accrual hooks for fail-closed admission."""
+    payload = dict(payload or {})
+    normalized: dict[str, object] = {}
+
+    interruption_events = (
+        payload.get("interruption_events")
+        or payload.get("interruptions")
+        or payload.get("accrual_interruptions")
+        or ()
+    )
+    if isinstance(interruption_events, str):
+        interruption_events = _parse_name_list(interruption_events)
+    elif isinstance(interruption_events, (tuple, list, set, frozenset)):
+        interruption_events = tuple(
+            str(item).strip()
+            for item in interruption_events
+            if str(item).strip()
+        )
+    else:
+        interruption_events = (str(interruption_events).strip(),)
+    if interruption_events:
+        normalized["interruption_events"] = interruption_events
+
+    barrier_state = payload.get("barrier_state")
+    if not barrier_state:
+        barrier_state = {
+            key: payload[key]
+            for key in (
+                "barrier_events",
+                "knockout_condition",
+                "knock_out",
+                "knock_in",
+            )
+            if key in payload and payload[key] is not None and payload[key] != ""
+        }
+    if barrier_state:
+        normalized["barrier_state"] = (
+            dict(barrier_state)
+            if isinstance(barrier_state, Mapping)
+            else {"condition": barrier_state}
+        )
+
+    return _freeze_mapping(normalized)
 
 
 def _normalize_instrument_alias(instrument_type: str | None) -> str:

--- a/trellis/agent/static_leg_admission.py
+++ b/trellis/agent/static_leg_admission.py
@@ -26,6 +26,7 @@ from trellis.agent.static_leg_contract import (
 from trellis.agent.semantic_observables import (
     BetweenPredicate,
     RateIndexObservable,
+    predicate_support_blockers,
 )
 
 
@@ -232,6 +233,19 @@ def _admission_blocker(
     )
 
 
+def _observable_support_admission_blockers(
+    predicate,
+) -> tuple[StaticLegAdmissionBlocker, ...]:
+    return tuple(
+        _admission_blocker(
+            blocker.blocker_id,
+            blocker.reason,
+            required_ticket=blocker.required_ticket,
+        )
+        for blocker in predicate_support_blockers(predicate)
+    )
+
+
 def _conditional_range_accrual_signed_leg(
     contract: StaticLegContractIR,
 ) -> SignedLeg | None:
@@ -284,10 +298,55 @@ def conditional_range_accrual_admission_blockers(
         blockers.append(
             _admission_blocker(
                 "conditional_range_accrual_callability_pending",
-                "Callable range-accrual wrappers require dynamic control admission.",
+                (
+                    "Callable range accrual requires a dynamic exercise wrapper "
+                    "before the checked static-leg route may be used."
+                ),
                 required_ticket="QUA-1115",
             )
         )
+    dynamic_features = (
+        leg_metadata.get("dynamic_features")
+        or contract_metadata.get("dynamic_features")
+        or {}
+    )
+    if isinstance(dynamic_features, Mapping):
+        interruption_events = (
+            dynamic_features.get("interruption_events")
+            or dynamic_features.get("interruptions")
+            or dynamic_features.get("accrual_interruptions")
+            or ()
+        )
+        if interruption_events:
+            blockers.append(
+                _admission_blocker(
+                    "conditional_range_accrual_interruption_state_pending",
+                    (
+                        "Interrupted range accrual requires dynamic event-state "
+                        "admission before the checked static-leg route may be used."
+                    ),
+                    required_ticket="QUA-1115",
+                )
+            )
+        barrier_state = (
+            dynamic_features.get("barrier_state")
+            or dynamic_features.get("barrier_events")
+            or dynamic_features.get("knockout_condition")
+            or dynamic_features.get("knock_out")
+            or dynamic_features.get("knock_in")
+            or {}
+        )
+        if barrier_state:
+            blockers.append(
+                _admission_blocker(
+                    "conditional_range_accrual_barrier_state_pending",
+                    (
+                        "Barrier-style range accrual requires dynamic event-state "
+                        "admission before the checked static-leg route may be used."
+                    ),
+                    required_ticket="QUA-1115",
+                )
+            )
     if signed_leg.direction != "receive":
         blockers.append(
             _admission_blocker(
@@ -390,6 +449,11 @@ def conditional_range_accrual_admission_blockers(
             )
         )
     condition = leg.accrual_condition
+    support_blockers = (
+        _observable_support_admission_blockers(condition)
+        if condition is not None
+        else ()
+    )
     if not isinstance(condition, BetweenPredicate):
         blockers.append(
             _admission_blocker(
@@ -397,6 +461,9 @@ def conditional_range_accrual_admission_blockers(
                 "The checked range-accrual route admits a single between predicate.",
             )
         )
+        blockers.extend(support_blockers)
+    elif support_blockers:
+        blockers.extend(support_blockers)
     elif not isinstance(condition.observable, RateIndexObservable):
         blockers.append(
             _admission_blocker(

--- a/trellis/agent/static_leg_admission.py
+++ b/trellis/agent/static_leg_admission.py
@@ -220,6 +220,14 @@ def _metadata_mapping(value: object) -> dict[str, object]:
     return dict(value or {}) if isinstance(value, Mapping) else {}
 
 
+def _merged_metadata_mapping(*values: object) -> dict[str, object]:
+    merged: dict[str, object] = {}
+    for value in values:
+        if isinstance(value, Mapping):
+            merged.update(value)
+    return merged
+
+
 def _admission_blocker(
     blocker_id: str,
     reason: str,
@@ -293,7 +301,10 @@ def conditional_range_accrual_admission_blockers(
                 "Conditional accrual route admission is restricted to range_accrual legs.",
             )
         )
-    callability = leg_metadata.get("callability") or contract_metadata.get("callability") or {}
+    callability = _merged_metadata_mapping(
+        contract_metadata.get("callability"),
+        leg_metadata.get("callability"),
+    )
     if callability:
         blockers.append(
             _admission_blocker(
@@ -305,48 +316,46 @@ def conditional_range_accrual_admission_blockers(
                 required_ticket="QUA-1115",
             )
         )
-    dynamic_features = (
-        leg_metadata.get("dynamic_features")
-        or contract_metadata.get("dynamic_features")
+    dynamic_features = _merged_metadata_mapping(
+        contract_metadata.get("dynamic_features"),
+        leg_metadata.get("dynamic_features"),
+    )
+    interruption_events = (
+        dynamic_features.get("interruption_events")
+        or dynamic_features.get("interruptions")
+        or dynamic_features.get("accrual_interruptions")
+        or ()
+    )
+    if interruption_events:
+        blockers.append(
+            _admission_blocker(
+                "conditional_range_accrual_interruption_state_pending",
+                (
+                    "Interrupted range accrual requires dynamic event-state "
+                    "admission before the checked static-leg route may be used."
+                ),
+                required_ticket="QUA-1115",
+            )
+        )
+    barrier_state = (
+        dynamic_features.get("barrier_state")
+        or dynamic_features.get("barrier_events")
+        or dynamic_features.get("knockout_condition")
+        or dynamic_features.get("knock_out")
+        or dynamic_features.get("knock_in")
         or {}
     )
-    if isinstance(dynamic_features, Mapping):
-        interruption_events = (
-            dynamic_features.get("interruption_events")
-            or dynamic_features.get("interruptions")
-            or dynamic_features.get("accrual_interruptions")
-            or ()
-        )
-        if interruption_events:
-            blockers.append(
-                _admission_blocker(
-                    "conditional_range_accrual_interruption_state_pending",
-                    (
-                        "Interrupted range accrual requires dynamic event-state "
-                        "admission before the checked static-leg route may be used."
-                    ),
-                    required_ticket="QUA-1115",
-                )
+    if barrier_state:
+        blockers.append(
+            _admission_blocker(
+                "conditional_range_accrual_barrier_state_pending",
+                (
+                    "Barrier-style range accrual requires dynamic event-state "
+                    "admission before the checked static-leg route may be used."
+                ),
+                required_ticket="QUA-1115",
             )
-        barrier_state = (
-            dynamic_features.get("barrier_state")
-            or dynamic_features.get("barrier_events")
-            or dynamic_features.get("knockout_condition")
-            or dynamic_features.get("knock_out")
-            or dynamic_features.get("knock_in")
-            or {}
         )
-        if barrier_state:
-            blockers.append(
-                _admission_blocker(
-                    "conditional_range_accrual_barrier_state_pending",
-                    (
-                        "Barrier-style range accrual requires dynamic event-state "
-                        "admission before the checked static-leg route may be used."
-                    ),
-                    required_ticket="QUA-1115",
-                )
-            )
     if signed_leg.direction != "receive":
         blockers.append(
             _admission_blocker(

--- a/trellis/agent/static_leg_contract.py
+++ b/trellis/agent/static_leg_contract.py
@@ -17,7 +17,7 @@ from trellis.agent.contract_ir import CurveQuote, SurfaceQuote
 from trellis.agent.semantic_observables import (
     PredicateExpr,
     PredicateGrammarValidationError,
-    validate_conditional_accrual_predicate,
+    predicate_support_blockers,
 )
 
 
@@ -418,7 +418,7 @@ class ConditionalAccrualLeg:
         )
         if self.accrual_condition is not None:
             try:
-                validate_conditional_accrual_predicate(self.accrual_condition)
+                predicate_support_blockers(self.accrual_condition)
             except PredicateGrammarValidationError as exc:
                 raise StaticLegIRWellFormednessError(str(exc)) from exc
         object.__setattr__(self, "label", str(self.label or "").strip())

--- a/trellis/platform/services/trade_service.py
+++ b/trellis/platform/services/trade_service.py
@@ -611,6 +611,30 @@ class TradeService:
         return callability
 
     @staticmethod
+    def _structured_range_accrual_dynamic_features(
+        structured_trade: Mapping[str, object],
+    ) -> Mapping[str, object]:
+        """Return unsupported dynamic range-accrual hooks for fail-closed admission."""
+        dynamic_features = dict(structured_trade.get("dynamic_features") or {})
+        for source_key, target_key in (
+            ("interruption_events", "interruption_events"),
+            ("interruptions", "interruption_events"),
+            ("accrual_interruptions", "interruption_events"),
+            ("barrier_state", "barrier_state"),
+            ("barrier_events", "barrier_state"),
+            ("knockout_condition", "barrier_state"),
+            ("knock_out", "barrier_state"),
+            ("knock_in", "barrier_state"),
+        ):
+            if source_key not in structured_trade or target_key in dynamic_features:
+                continue
+            value = structured_trade.get(source_key)
+            if value is None or value == "":
+                continue
+            dynamic_features[target_key] = value
+        return dynamic_features
+
+    @staticmethod
     def _callable_bond_missing_fields(structured_trade: Mapping[str, object]) -> tuple[str, ...]:
         missing: list[str] = []
         if structured_trade.get("notional") in {None, ""}:
@@ -883,6 +907,9 @@ class TradeService:
                     range_condition=self._structured_range_condition(structured_trade),
                     settlement_profile=settlement_profile,
                     callability=self._structured_callability(structured_trade),
+                    dynamic_features=self._structured_range_accrual_dynamic_features(
+                        structured_trade
+                    ),
                     preferred_method=str(structured_trade.get("preferred_method", "analytical")).strip() or "analytical",
                 )
             except ValueError:


### PR DESCRIPTION
## Summary
- add static-leg admission blocker evidence to semantic blueprints, request metadata, and platform traces
- preserve unsupported conditional-accrual predicates in IR while failing route admission closed
- block callable, interrupted/barrier-state, CMS/spread, and multi-index range-accrual variants from the checked static route

## Validation
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_semantic_observable_predicates.py tests/test_agent/test_static_leg_admission.py tests/test_agent/test_platform_requests.py tests/test_agent/test_platform_traces.py tests/test_mcp/test_trade_service.py -q
- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_semantic_contracts.py tests/test_agent/test_dsl_integration.py -q
- git diff --check