### PR TITLE
[codex] Add stochastic-vol computational problem IR

### DIFF
--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -357,6 +357,15 @@ you need to understand a failure or confirm a success. The batch runner now
 surfaces those packet paths directly on the task result so you do not have to
 reconstruct them from traces or summary files.
 
+Stochastic-volatility task runs also carry a ``computational_problem`` block
+when the task target is Heston, Bates, SLV/LSV, or a related unsupported
+path-dependent control shape. The block is copied into the task result,
+``runtime_contract``, comparison-target request metadata, and the diagnosis
+packet. It is meant for task triage and remediation: it records the
+computational bucket, model-parameter semantics, validation bundle, and any
+missing primitive or unsupported class before raw build exceptions dominate
+the failure story.
+
 That packet/checkpoint surface also now treats backend binding identity as the
 primary implementation provenance. Compatibility route aliases may still
 appear, but only as secondary metadata so replay, canary drift, and learning

--- a/docs/developer/task_diagnostics.rst
+++ b/docs/developer/task_diagnostics.rst
@@ -90,6 +90,11 @@ computational bucket:
 - ``slv_lsv``
 - ``unsupported_path_dependent_control``
 
+The top-level ``task_bucket`` is an aggregate over those target buckets. When
+one task compares multiple stochastic-volatility methods, the task-level value
+can be ``stochastic_vol_mixed`` even though each target still has one of the
+stable buckets above.
+
 The target entries also record model-parameter semantics. Heston pricing
 targets that already have model parameters treat a Black vol surface as market
 context, not as an implicit recalibration instruction. Calibration targets are

--- a/docs/developer/task_diagnostics.rst
+++ b/docs/developer/task_diagnostics.rst
@@ -73,6 +73,37 @@ If the dossier is still not enough, open the JSON packet next. The packet is
 the canonical structured record and should contain the same evidence in a
 machine-friendly shape.
 
+Computational problem evidence
+------------------------------
+
+For stochastic-volatility tasks, ``run_task(...)`` now attaches a
+``computational_problem`` block to the task result, runtime contract, and
+diagnosis packet. That block is an internal diagnostic IR, not a public pricing
+API. It classifies each concrete comparison target into one stable
+computational bucket:
+
+- ``stochastic_vol_transform``
+- ``stochastic_vol_monte_carlo``
+- ``stochastic_vol_pde``
+- ``calibration_to_surface``
+- ``affine_jump_stochastic_vol``
+- ``slv_lsv``
+- ``unsupported_path_dependent_control``
+
+The target entries also record model-parameter semantics. Heston pricing
+targets that already have model parameters treat a Black vol surface as market
+context, not as an implicit recalibration instruction. Calibration targets are
+the explicit bridge where a market surface is allowed to produce model
+parameters.
+
+When a task asks for a computational class Trellis does not yet implement, the
+same block carries a machine-readable ``repair_packet`` naming the missing
+primitive or unsupported class. Examples include
+``heston_andersen_qe_scheme``, ``bates_affine_jump_stochastic_vol_kernel``,
+``leverage_function_contract``, and
+``path_dependent_early_exercise_under_stochastic_vol``. Remediation tools
+should group these packets before falling back to raw exception text.
+
 Operational use
 ---------------
 

--- a/tests/test_agent/test_computational_problem_ir.py
+++ b/tests/test_agent/test_computational_problem_ir.py
@@ -105,6 +105,7 @@ def test_heston_parameter_semantics_distinguish_parameters_from_surface_bumps():
         "calibration_to_market_surface"
     )
     assert calibrated["model_parameter_semantics"]["requires_calibration_bridge"] is True
+    assert calibrated["market_bindings"]["requires_model_parameters"] is False
     assert calibrated["market_bindings"]["requires_black_vol_surface"] is True
 
 

--- a/tests/test_agent/test_computational_problem_ir.py
+++ b/tests/test_agent/test_computational_problem_ir.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import json
+
+
+def _legacy_tasks() -> dict[str, dict]:
+    from trellis.agent.task_manifests import load_task_manifest
+
+    return {
+        str(task["id"]): task
+        for task in load_task_manifest("TASKS_PROOF_LEGACY.yaml")
+    }
+
+
+def _target_buckets(report) -> dict[str, str]:
+    return {target.target_id: target.bucket for target in report.target_problems}
+
+
+def _target_payload(report, target_id: str) -> dict:
+    payload = report.to_payload()
+    for target in payload["targets"]:
+        if target["target_id"] == target_id:
+            return target
+    raise AssertionError(f"missing target {target_id}")
+
+
+def test_classifies_recent_stochastic_vol_task_pack_into_stable_buckets():
+    from trellis.agent.computational_problem_ir import classify_stochastic_vol_task
+
+    tasks = _legacy_tasks()
+    expected = {
+        "T20": {
+            "heston_adi_pde": "stochastic_vol_pde",
+            "heston_mc": "stochastic_vol_monte_carlo",
+        },
+        "T28": {
+            "euler_heston": "stochastic_vol_monte_carlo",
+            "qe_heston": "stochastic_vol_monte_carlo",
+            "heston_fft": "stochastic_vol_transform",
+        },
+        "T40": {
+            "heston_fft": "stochastic_vol_transform",
+            "heston_cos": "stochastic_vol_transform",
+            "heston_mc": "stochastic_vol_monte_carlo",
+        },
+        "T67": {
+            "calibrated_heston_fft": "calibration_to_surface",
+            "market_prices": "calibration_to_surface",
+        },
+        "T76": {
+            "heston_analytical": "stochastic_vol_transform",
+            "heston_mc": "stochastic_vol_monte_carlo",
+            "heston_pde": "stochastic_vol_pde",
+            "heston_fft": "stochastic_vol_transform",
+            "heston_cos": "stochastic_vol_transform",
+        },
+        "T114": {
+            "laguerre_heston": "stochastic_vol_transform",
+            "fft_heston": "stochastic_vol_transform",
+        },
+        "T44": {
+            "bates_fft": "affine_jump_stochastic_vol",
+            "bates_mc": "affine_jump_stochastic_vol",
+        },
+        "T60": {
+            "slv_mc": "slv_lsv",
+            "heston_mc": "stochastic_vol_monte_carlo",
+        },
+        "T117": {
+            "lsv_pde": "slv_lsv",
+            "lsv_mc": "slv_lsv",
+        },
+        "E27": {
+            "american_pathdep_pde": "unsupported_path_dependent_control",
+            "american_pathdep_mc": "unsupported_path_dependent_control",
+            "american_pathdep_fft": "unsupported_path_dependent_control",
+        },
+    }
+
+    for task_id, target_expectations in expected.items():
+        report = classify_stochastic_vol_task(tasks[task_id])
+        assert report is not None, task_id
+        assert _target_buckets(report) == target_expectations
+
+
+def test_heston_parameter_semantics_distinguish_parameters_from_surface_bumps():
+    from trellis.agent.computational_problem_ir import classify_stochastic_vol_task
+
+    tasks = _legacy_tasks()
+
+    t20 = classify_stochastic_vol_task(tasks["T20"])
+    heston_pde = _target_payload(t20, "heston_adi_pde")
+    assert heston_pde["model_parameter_semantics"] == {
+        "model_family": "heston",
+        "model_parameter_source": "explicit_model_parameters",
+        "black_vol_surface_role": "market_input_not_model_calibration",
+        "requires_calibration_bridge": False,
+    }
+    assert heston_pde["market_bindings"]["requires_model_parameters"] is True
+    assert heston_pde["market_bindings"]["requires_black_vol_surface"] is False
+
+    t67 = classify_stochastic_vol_task(tasks["T67"])
+    calibrated = _target_payload(t67, "calibrated_heston_fft")
+    assert calibrated["model_parameter_semantics"]["model_parameter_source"] == (
+        "calibration_to_market_surface"
+    )
+    assert calibrated["model_parameter_semantics"]["requires_calibration_bridge"] is True
+    assert calibrated["market_bindings"]["requires_black_vol_surface"] is True
+
+
+def test_repair_packets_name_missing_primitives_not_generated_text():
+    from trellis.agent.computational_problem_ir import classify_stochastic_vol_task
+
+    tasks = _legacy_tasks()
+
+    qe_packet = _target_payload(classify_stochastic_vol_task(tasks["T28"]), "qe_heston")[
+        "repair_packet"
+    ]
+    assert qe_packet["missing_primitive"] == "heston_andersen_qe_scheme"
+    assert "NameError" not in json.dumps(qe_packet)
+
+    bates_packet = _target_payload(classify_stochastic_vol_task(tasks["T44"]), "bates_fft")[
+        "repair_packet"
+    ]
+    assert bates_packet["missing_primitive"] == "bates_affine_jump_stochastic_vol_kernel"
+
+    slv_packet = _target_payload(classify_stochastic_vol_task(tasks["T117"]), "lsv_pde")[
+        "repair_packet"
+    ]
+    assert slv_packet["missing_primitive"] == "leverage_function_contract"
+
+    e27_packet = _target_payload(
+        classify_stochastic_vol_task(tasks["E27"]),
+        "american_pathdep_mc",
+    )["repair_packet"]
+    assert e27_packet["unsupported_class"] == (
+        "path_dependent_early_exercise_under_stochastic_vol"
+    )
+
+
+def test_stochastic_vol_problem_payload_is_json_stable():
+    from trellis.agent.computational_problem_ir import stochastic_vol_problem_payload
+
+    payload = stochastic_vol_problem_payload(_legacy_tasks()["T28"])
+
+    assert payload is not None
+    assert payload["task_id"] == "T28"
+    assert payload["task_bucket"] == "stochastic_vol_mixed"
+    assert json.loads(json.dumps(payload, sort_keys=True)) == payload
+
+
+def test_single_target_stochastic_vol_task_uses_construct_hint():
+    from trellis.agent.computational_problem_ir import classify_stochastic_vol_task
+
+    report = classify_stochastic_vol_task(
+        {
+            "id": "TX",
+            "title": "Heston equity option via 2D PDE",
+            "construct": "pde",
+            "new_component": "adi_2d_solver",
+        }
+    )
+
+    assert report is not None
+    assert report.task_bucket == "stochastic_vol_pde"
+    assert report.target_problems[0].solver_target == "pde_adi"

--- a/tests/test_agent/test_task_diagnostics.py
+++ b/tests/test_agent/test_task_diagnostics.py
@@ -326,6 +326,30 @@ def test_build_task_diagnosis_packet_summarizes_failure(tmp_path):
     assert "/tmp/t999_waits.jsonl" in rendered
 
 
+def test_build_task_diagnosis_packet_preserves_computational_problem(tmp_path):
+    from trellis.agent.task_diagnostics import build_task_diagnosis_packet
+
+    record = _sample_record(tmp_path)
+    record["result"]["computational_problem"] = {
+        "task_id": "T999",
+        "task_bucket": "stochastic_vol_monte_carlo",
+        "targets": [
+            {
+                "target_id": "qe_heston",
+                "bucket": "stochastic_vol_monte_carlo",
+                "repair_packet": {
+                    "missing_primitive": "heston_andersen_qe_scheme",
+                },
+            }
+        ],
+    }
+
+    packet = build_task_diagnosis_packet(record)
+
+    assert packet["computational_problem"]["task_bucket"] == "stochastic_vol_monte_carlo"
+    assert packet["computational_problem"]["targets"][0]["target_id"] == "qe_heston"
+
+
 def test_save_task_diagnosis_artifacts_writes_packet_and_dossier(tmp_path):
     from trellis.agent.task_diagnostics import save_task_diagnosis_artifacts
 

--- a/tests/test_agent/test_task_runtime.py
+++ b/tests/test_agent/test_task_runtime.py
@@ -1183,6 +1183,73 @@ def test_run_task_builds_each_construct_method_for_comparison_task():
     assert result["success"] is True
 
 
+def test_run_task_carries_stochastic_vol_problem_metadata_for_comparison_task(monkeypatch, tmp_path):
+    from trellis.agent.task_manifests import load_task_manifest
+    from trellis.agent.task_runtime import run_task
+
+    task = next(
+        task
+        for task in load_task_manifest("TASKS_PROOF_LEGACY.yaml")
+        if task["id"] == "T28"
+    )
+    calls: list[dict] = []
+    price_map = {
+        "euler_heston": 10.00,
+        "qe_heston": 10.01,
+        "heston_fft": 10.00,
+    }
+
+    class FakeResult:
+        def __init__(self, target: str):
+            self.success = True
+            self.attempts = 1
+            self.gap_confidence = 0.9
+            self.knowledge_gaps = []
+            self.payoff_cls = type(f"{target.title()}Payoff", (), {"price": price_map[target]})
+            self.failures = []
+            self.reflection = {}
+
+    def fake_build(**kwargs):
+        calls.append(kwargs)
+        return FakeResult(kwargs["comparison_target"])
+
+    monkeypatch.setattr(
+        "trellis.agent.task_run_store.persist_task_run_record",
+        lambda *_args, **_kwargs: {
+            "history_path": str(tmp_path / "history.json"),
+            "latest_path": str(tmp_path / "latest.json"),
+            "latest_index_path": str(tmp_path / "latest-index.json"),
+        },
+    )
+
+    result = run_task(
+        task,
+        market_state=object(),
+        build_fn=fake_build,
+        payoff_factory=lambda payoff_cls, _spec_schema, _settle: payoff_cls(),
+        price_fn=lambda payoff, _market_state: payoff.price,
+        task_run_storage_root=tmp_path,
+        task_run_storage_layout="standalone",
+    )
+
+    problem = result["computational_problem"]
+    assert problem["task_bucket"] == "stochastic_vol_mixed"
+    assert [target["target_id"] for target in problem["targets"]] == [
+        "euler_heston",
+        "qe_heston",
+        "heston_fft",
+    ]
+    assert result["runtime_contract"]["computational_problem"]["task_bucket"] == (
+        "stochastic_vol_mixed"
+    )
+    assert calls[1]["request_metadata"]["computational_problem_target"]["target_id"] == (
+        "qe_heston"
+    )
+    assert calls[1]["request_metadata"]["computational_problem_target"]["repair_packet"][
+        "missing_primitive"
+    ] == "heston_andersen_qe_scheme"
+
+
 def test_cross_validate_comparison_task_prices_reused_fx_modules():
     from trellis.agent.task_runtime import (
         ComparisonBuildTarget,

--- a/trellis/agent/computational_problem_ir.py
+++ b/trellis/agent/computational_problem_ir.py
@@ -304,7 +304,7 @@ def _market_bindings(
     process_family: str,
 ) -> MarketBindingSemantics:
     return MarketBindingSemantics(
-        requires_model_parameters=True,
+        requires_model_parameters=bucket != CALIBRATION_TO_SURFACE,
         requires_black_vol_surface=(
             bucket in {CALIBRATION_TO_SURFACE, SLV_LSV}
             or process_family == "slv_lsv"

--- a/trellis/agent/computational_problem_ir.py
+++ b/trellis/agent/computational_problem_ir.py
@@ -1,0 +1,524 @@
+"""Typed computational problem IR for stochastic-volatility task diagnostics."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+
+STOCHASTIC_VOL_TRANSFORM = "stochastic_vol_transform"
+STOCHASTIC_VOL_MONTE_CARLO = "stochastic_vol_monte_carlo"
+STOCHASTIC_VOL_PDE = "stochastic_vol_pde"
+CALIBRATION_TO_SURFACE = "calibration_to_surface"
+AFFINE_JUMP_STOCHASTIC_VOL = "affine_jump_stochastic_vol"
+SLV_LSV = "slv_lsv"
+UNSUPPORTED_PATH_DEPENDENT_CONTROL = "unsupported_path_dependent_control"
+STOCHASTIC_VOL_MIXED = "stochastic_vol_mixed"
+
+
+@dataclass(frozen=True)
+class RepairPacket:
+    """Machine-readable repair hint for a missing computational primitive."""
+
+    packet_type: str
+    summary: str
+    missing_primitive: str | None = None
+    unsupported_class: str | None = None
+    suggested_action: str = "open_remediation_packet"
+    evidence: tuple[str, ...] = ()
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "packet_type": self.packet_type,
+            "summary": self.summary,
+            "missing_primitive": self.missing_primitive,
+            "unsupported_class": self.unsupported_class,
+            "suggested_action": self.suggested_action,
+            "evidence": list(self.evidence),
+        }
+
+
+@dataclass(frozen=True)
+class MarketBindingSemantics:
+    """Market-input requirements implied by the computational problem class."""
+
+    requires_model_parameters: bool
+    requires_black_vol_surface: bool
+    requires_local_vol_surface: bool = False
+    requires_jump_parameters: bool = False
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "requires_model_parameters": self.requires_model_parameters,
+            "requires_black_vol_surface": self.requires_black_vol_surface,
+            "requires_local_vol_surface": self.requires_local_vol_surface,
+            "requires_jump_parameters": self.requires_jump_parameters,
+        }
+
+
+@dataclass(frozen=True)
+class ModelParameterSemantics:
+    """How stochastic-vol model parameters relate to market vol surfaces."""
+
+    model_family: str
+    model_parameter_source: str
+    black_vol_surface_role: str
+    requires_calibration_bridge: bool
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "model_family": self.model_family,
+            "model_parameter_source": self.model_parameter_source,
+            "black_vol_surface_role": self.black_vol_surface_role,
+            "requires_calibration_bridge": self.requires_calibration_bridge,
+        }
+
+
+@dataclass(frozen=True)
+class StochasticVolTargetProblem:
+    """Computational class for one concrete comparison/build target."""
+
+    target_id: str
+    bucket: str
+    solver_target: str
+    process_family: str
+    payoff_class: str
+    model_parameter_semantics: ModelParameterSemantics
+    market_bindings: MarketBindingSemantics
+    validation_bundle: str
+    unsupported_features: tuple[str, ...] = ()
+    repair_packet: RepairPacket | None = None
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "target_id": self.target_id,
+            "bucket": self.bucket,
+            "solver_target": self.solver_target,
+            "process_family": self.process_family,
+            "payoff_class": self.payoff_class,
+            "model_parameter_semantics": self.model_parameter_semantics.to_payload(),
+            "market_bindings": self.market_bindings.to_payload(),
+            "validation_bundle": self.validation_bundle,
+            "unsupported_features": list(self.unsupported_features),
+            "repair_packet": (
+                self.repair_packet.to_payload()
+                if self.repair_packet is not None
+                else None
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class StochasticVolTaskProblemReport:
+    """Computational problem report for a stochastic-vol task."""
+
+    task_id: str
+    task_title: str
+    task_bucket: str
+    target_problems: tuple[StochasticVolTargetProblem, ...]
+
+    @property
+    def repair_packets(self) -> tuple[dict[str, Any], ...]:
+        packets: list[dict[str, Any]] = []
+        for target in self.target_problems:
+            if target.repair_packet is None:
+                continue
+            packet = target.repair_packet.to_payload()
+            packet["target_id"] = target.target_id
+            packet["bucket"] = target.bucket
+            packets.append(packet)
+        return tuple(packets)
+
+    @property
+    def is_supported_now(self) -> bool:
+        return not self.repair_packets
+
+    def target_payload(self, target_id: str) -> dict[str, Any] | None:
+        for target in self.target_problems:
+            if target.target_id == target_id:
+                return target.to_payload()
+        return None
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": 1,
+            "task_id": self.task_id,
+            "task_title": self.task_title,
+            "task_bucket": self.task_bucket,
+            "is_supported_now": self.is_supported_now,
+            "targets": [target.to_payload() for target in self.target_problems],
+            "repair_packets": list(self.repair_packets),
+        }
+
+
+def classify_stochastic_vol_task(
+    task: Mapping[str, Any],
+) -> StochasticVolTaskProblemReport | None:
+    """Classify a task into stochastic-vol computational buckets when applicable."""
+    task_id = str(task.get("id") or "").strip()
+    task_title = str(task.get("title") or task_id).strip()
+    targets = _task_target_ids(task)
+    if not targets:
+        targets = ("task",)
+    if not _looks_stochastic_vol_task(task, targets):
+        return None
+
+    target_problems = tuple(
+        _classify_target(task, target_id)
+        for target_id in targets
+    )
+    return StochasticVolTaskProblemReport(
+        task_id=task_id,
+        task_title=task_title,
+        task_bucket=_task_bucket(target_problems),
+        target_problems=target_problems,
+    )
+
+
+def stochastic_vol_problem_payload(task: Mapping[str, Any]) -> dict[str, Any] | None:
+    """Return a JSON-stable stochastic-vol computational problem payload."""
+    report = classify_stochastic_vol_task(task)
+    if report is None:
+        return None
+    return report.to_payload()
+
+
+def _classify_target(
+    task: Mapping[str, Any],
+    target_id: str,
+) -> StochasticVolTargetProblem:
+    target_text = _target_route_text(task, target_id)
+    context_text = _text_blob(task, target_id)
+    bucket = _target_bucket(target_text)
+    process_family = _process_family(context_text, bucket)
+    semantics = _model_parameter_semantics(bucket, process_family)
+    bindings = _market_bindings(bucket, process_family)
+    repair_packet = _repair_packet(bucket, target_id=target_id, text=target_text)
+    unsupported = _unsupported_features(bucket, repair_packet)
+    return StochasticVolTargetProblem(
+        target_id=target_id,
+        bucket=bucket,
+        solver_target=_solver_target(target_text, bucket),
+        process_family=process_family,
+        payoff_class=_payoff_class(context_text),
+        model_parameter_semantics=semantics,
+        market_bindings=bindings,
+        validation_bundle=_validation_bundle(bucket, process_family),
+        unsupported_features=unsupported,
+        repair_packet=repair_packet,
+    )
+
+
+def _target_bucket(text: str) -> str:
+    if _has_any(text, ("american_pathdep", "american path", "asian barrier")):
+        return UNSUPPORTED_PATH_DEPENDENT_CONTROL
+    if _has_any(text, ("slv", "lsv", "stochastic local vol", "local-stochastic vol")):
+        return SLV_LSV
+    if "bates" in text:
+        return AFFINE_JUMP_STOCHASTIC_VOL
+    if _has_any(text, ("calibrat", "market_prices", "market prices")):
+        return CALIBRATION_TO_SURFACE
+    if _has_any(text, ("pde", "adi")):
+        return STOCHASTIC_VOL_PDE
+    if _has_any(text, ("mc", "monte", "euler", "qe")):
+        return STOCHASTIC_VOL_MONTE_CARLO
+    return STOCHASTIC_VOL_TRANSFORM
+
+
+def _solver_target(text: str, bucket: str) -> str:
+    if bucket == UNSUPPORTED_PATH_DEPENDENT_CONTROL:
+        if "pde" in text:
+            return "path_dependent_control_pde"
+        if _has_any(text, ("mc", "monte")):
+            return "path_dependent_control_monte_carlo"
+        return "path_dependent_control_transform"
+    if bucket == SLV_LSV:
+        if "pde" in text:
+            return "leverage_function_pde"
+        if _has_any(text, ("mc", "monte")):
+            return "leverage_function_monte_carlo"
+        return "leverage_function_calibration"
+    if bucket == AFFINE_JUMP_STOCHASTIC_VOL:
+        if _has_any(text, ("mc", "monte")):
+            return "affine_jump_monte_carlo"
+        return "affine_jump_transform"
+    if bucket == CALIBRATION_TO_SURFACE:
+        return "surface_calibration"
+    if bucket == STOCHASTIC_VOL_PDE:
+        if "adi" in text:
+            return "pde_adi"
+        return "pde"
+    if bucket == STOCHASTIC_VOL_MONTE_CARLO:
+        if "qe" in text:
+            return "monte_carlo_qe"
+        if "euler" in text:
+            return "monte_carlo_euler"
+        return "monte_carlo"
+    if "cos" in text:
+        return "cos_transform"
+    if "laguerre" in text:
+        return "gauss_laguerre_quadrature"
+    if "fft" in text:
+        return "fft_transform"
+    return "semi_analytical_transform"
+
+
+def _process_family(text: str, bucket: str) -> str:
+    if bucket == SLV_LSV:
+        return "slv_lsv"
+    if bucket == AFFINE_JUMP_STOCHASTIC_VOL:
+        return "bates"
+    if "rough" in text:
+        return "rough_heston"
+    return "heston"
+
+
+def _payoff_class(text: str) -> str:
+    if _has_any(text, ("american_pathdep", "american path", "asian barrier")):
+        return "path_dependent_early_exercise"
+    return "vanilla_option"
+
+
+def _model_parameter_semantics(
+    bucket: str,
+    process_family: str,
+) -> ModelParameterSemantics:
+    if bucket == CALIBRATION_TO_SURFACE:
+        return ModelParameterSemantics(
+            model_family=process_family,
+            model_parameter_source="calibration_to_market_surface",
+            black_vol_surface_role="calibration_target",
+            requires_calibration_bridge=True,
+        )
+    return ModelParameterSemantics(
+        model_family=process_family,
+        model_parameter_source="explicit_model_parameters",
+        black_vol_surface_role="market_input_not_model_calibration",
+        requires_calibration_bridge=False,
+    )
+
+
+def _market_bindings(
+    bucket: str,
+    process_family: str,
+) -> MarketBindingSemantics:
+    return MarketBindingSemantics(
+        requires_model_parameters=True,
+        requires_black_vol_surface=(
+            bucket in {CALIBRATION_TO_SURFACE, SLV_LSV}
+            or process_family == "slv_lsv"
+        ),
+        requires_local_vol_surface=process_family == "slv_lsv",
+        requires_jump_parameters=process_family == "bates",
+    )
+
+
+def _validation_bundle(bucket: str, process_family: str) -> str:
+    if bucket == STOCHASTIC_VOL_TRANSFORM:
+        return f"{process_family}:transform"
+    if bucket == STOCHASTIC_VOL_MONTE_CARLO:
+        return f"{process_family}:monte_carlo"
+    if bucket == STOCHASTIC_VOL_PDE:
+        return f"{process_family}:pde"
+    if bucket == CALIBRATION_TO_SURFACE:
+        return f"{process_family}:calibration_to_surface"
+    if bucket == AFFINE_JUMP_STOCHASTIC_VOL:
+        return "bates:affine_jump_stochastic_vol"
+    if bucket == SLV_LSV:
+        return "slv_lsv:leverage_function"
+    return "heston:path_dependent_control"
+
+
+def _repair_packet(bucket: str, *, target_id: str, text: str) -> RepairPacket | None:
+    evidence = tuple(item for item in (target_id, _short_text_evidence(text)) if item)
+    if bucket == AFFINE_JUMP_STOCHASTIC_VOL:
+        return RepairPacket(
+            packet_type="missing_affine_jump_stochastic_vol_kernel",
+            missing_primitive="bates_affine_jump_stochastic_vol_kernel",
+            summary=(
+                "Bates targets need an affine Heston-plus-jump characteristic "
+                "function and matching MC process contract."
+            ),
+            evidence=evidence,
+        )
+    if bucket == SLV_LSV:
+        return RepairPacket(
+            packet_type="missing_slv_lsv_leverage_contract",
+            missing_primitive="leverage_function_contract",
+            summary=(
+                "SLV/LSV targets need an explicit leverage-function contract "
+                "before route binding can select PDE or MC engines."
+            ),
+            evidence=evidence,
+        )
+    if bucket == UNSUPPORTED_PATH_DEPENDENT_CONTROL:
+        return RepairPacket(
+            packet_type="unsupported_path_dependent_control",
+            missing_primitive="path_dependent_heston_control_kernel",
+            unsupported_class="path_dependent_early_exercise_under_stochastic_vol",
+            summary=(
+                "Path-dependent early-exercise under stochastic volatility is a "
+                "composite control problem and should block honestly until a "
+                "dedicated kernel exists."
+            ),
+            evidence=evidence,
+        )
+    if bucket == STOCHASTIC_VOL_MONTE_CARLO and "qe" in text:
+        return RepairPacket(
+            packet_type="missing_heston_qe_scheme",
+            missing_primitive="heston_andersen_qe_scheme",
+            summary=(
+                "The target asks for Andersen QE Heston simulation; route binding "
+                "must not silently fall back to Euler semantics."
+            ),
+            evidence=evidence,
+        )
+    return None
+
+
+def _unsupported_features(
+    bucket: str,
+    repair_packet: RepairPacket | None,
+) -> tuple[str, ...]:
+    if repair_packet is not None and repair_packet.unsupported_class:
+        return (repair_packet.unsupported_class,)
+    if bucket in {AFFINE_JUMP_STOCHASTIC_VOL, SLV_LSV}:
+        return (bucket,)
+    return ()
+
+
+def _task_bucket(targets: Sequence[StochasticVolTargetProblem]) -> str:
+    buckets = tuple(dict.fromkeys(target.bucket for target in targets))
+    if not buckets:
+        return STOCHASTIC_VOL_MIXED
+    if len(buckets) == 1:
+        return buckets[0]
+    if UNSUPPORTED_PATH_DEPENDENT_CONTROL in buckets:
+        return UNSUPPORTED_PATH_DEPENDENT_CONTROL
+    if SLV_LSV in buckets:
+        return SLV_LSV
+    if AFFINE_JUMP_STOCHASTIC_VOL in buckets:
+        return AFFINE_JUMP_STOCHASTIC_VOL
+    return STOCHASTIC_VOL_MIXED
+
+
+def _task_target_ids(task: Mapping[str, Any]) -> tuple[str, ...]:
+    cross_validate = task.get("cross_validate")
+    if not isinstance(cross_validate, Mapping):
+        return ()
+    raw_targets: list[Any] = []
+    raw_targets.extend(_as_list(cross_validate.get("internal")))
+    raw_targets.extend(_as_list(cross_validate.get("analytical")))
+    return tuple(
+        dict.fromkeys(
+            str(target).strip()
+            for target in raw_targets
+            if str(target).strip()
+        )
+    )
+
+
+def _looks_stochastic_vol_task(
+    task: Mapping[str, Any],
+    target_ids: Sequence[str],
+) -> bool:
+    text = _text_blob(task, *target_ids)
+    return _has_any(
+        text,
+        (
+            "heston",
+            "bates",
+            "stochastic vol",
+            "stochastic local vol",
+            "local-stochastic vol",
+            "slv",
+            "lsv",
+            "rough heston",
+        ),
+    )
+
+
+def _text_blob(task: Mapping[str, Any], *target_ids: str) -> str:
+    pieces: list[str] = [
+        str(task.get("id") or ""),
+        str(task.get("title") or ""),
+        str(task.get("description") or ""),
+    ]
+    pieces.extend(target_ids)
+    pieces.extend(str(item) for item in _as_list(task.get("construct")))
+    pieces.extend(str(item) for item in _as_list(task.get("new_component")))
+    market = task.get("market")
+    if isinstance(market, Mapping):
+        pieces.extend(str(value) for value in market.values())
+    assertions = task.get("market_assertions")
+    if isinstance(assertions, Mapping):
+        pieces.extend(_flatten_strings(assertions))
+    return " ".join(pieces).replace("_", " ").lower()
+
+
+def _target_text(target_id: str) -> str:
+    return str(target_id or "").replace("_", " ").lower()
+
+
+def _target_route_text(task: Mapping[str, Any], target_id: str) -> str:
+    text = _target_text(target_id)
+    if target_id != "task":
+        return text
+    pieces = [text, str(task.get("title") or "")]
+    pieces.extend(str(item) for item in _as_list(task.get("construct")))
+    pieces.extend(str(item) for item in _as_list(task.get("new_component")))
+    return " ".join(pieces).replace("_", " ").lower()
+
+
+def _short_text_evidence(text: str) -> str:
+    words = text.split()
+    return " ".join(words[:18])
+
+
+def _has_any(text: str, needles: Sequence[str]) -> bool:
+    return any(needle in text for needle in needles)
+
+
+def _as_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return list(value)
+    if isinstance(value, tuple):
+        return list(value)
+    return [value]
+
+
+def _flatten_strings(value: Any) -> list[str]:
+    if isinstance(value, Mapping):
+        items: list[str] = []
+        for key, inner in value.items():
+            items.append(str(key))
+            items.extend(_flatten_strings(inner))
+        return items
+    if isinstance(value, (list, tuple)):
+        items = []
+        for inner in value:
+            items.extend(_flatten_strings(inner))
+        return items
+    return [str(value)]
+
+
+__all__ = [
+    "AFFINE_JUMP_STOCHASTIC_VOL",
+    "CALIBRATION_TO_SURFACE",
+    "MarketBindingSemantics",
+    "ModelParameterSemantics",
+    "RepairPacket",
+    "SLV_LSV",
+    "STOCHASTIC_VOL_MIXED",
+    "STOCHASTIC_VOL_MONTE_CARLO",
+    "STOCHASTIC_VOL_PDE",
+    "STOCHASTIC_VOL_TRANSFORM",
+    "StochasticVolTargetProblem",
+    "StochasticVolTaskProblemReport",
+    "UNSUPPORTED_PATH_DEPENDENT_CONTROL",
+    "classify_stochastic_vol_task",
+    "stochastic_vol_problem_payload",
+]

--- a/trellis/agent/task_diagnostics.py
+++ b/trellis/agent/task_diagnostics.py
@@ -38,6 +38,11 @@ def build_task_diagnosis_packet(record: Mapping[str, Any]) -> dict[str, Any]:
     framework = dict(record.get("framework") or {})
     telemetry = _telemetry_section(record)
     runtime_controls = dict(result.get("runtime_controls") or {})
+    computational_problem = dict(
+        result.get("computational_problem")
+        or record.get("computational_problem")
+        or {}
+    )
     method_runs = dict(record.get("method_runs") or {})
     post_build = dict(record.get("post_build") or {})
     traces = list(record.get("trace_summaries") or [])
@@ -84,7 +89,7 @@ def build_task_diagnosis_packet(record: Mapping[str, Any]) -> dict[str, Any]:
     model_audit = _model_audit_section(method_runs, record)
     consolidated_validation = _consolidated_validation_section(method_runs)
 
-    return {
+    packet = {
         "schema_version": DIAGNOSIS_SCHEMA_VERSION,
         "task": {
             "id": record.get("task_id"),
@@ -121,6 +126,9 @@ def build_task_diagnosis_packet(record: Mapping[str, Any]) -> dict[str, Any]:
         "consolidated_validation": consolidated_validation,
         "storage": storage,
     }
+    if computational_problem:
+        packet["computational_problem"] = computational_problem
+    return packet
 
 
 def _diagnosis_failure_bucket(

--- a/trellis/agent/task_runtime.py
+++ b/trellis/agent/task_runtime.py
@@ -34,6 +34,7 @@ from trellis.agent.benchmark_contracts import (
     canonical_benchmark_instrument_type,
 )
 from trellis.agent.benchmark_greek_fallback import compute_bump_and_reprice_greeks
+from trellis.agent.computational_problem_ir import classify_stochastic_vol_task
 from trellis.agent.financepy_parity import align_market_state_for_financepy_parity
 from trellis.agent.instrument_identity import (
     InstrumentIdentityResolution,
@@ -1103,6 +1104,12 @@ def run_task(
     construct_methods = _task_construct_methods(task)
     comparison_targets = _task_comparison_targets(task, construct_methods)
     comparison_task = len(comparison_targets) > 1
+    computational_problem_report = classify_stochastic_vol_task(task)
+    computational_problem_payload = (
+        computational_problem_report.to_payload()
+        if computational_problem_report is not None
+        else None
+    )
     cassette_context = current_llm_cassette_context()
     execution_mode = (
         f"cassette_{cassette_context['mode']}"
@@ -1150,6 +1157,8 @@ def run_task(
         "task_definition_manifest": str(task.get("task_definition_manifest") or ""),
         "market_scenario_id": str(task.get("market_scenario_id") or ""),
     }
+    if computational_problem_payload is not None:
+        result_data["computational_problem"] = computational_problem_payload
     if cassette_context is not None:
         result_data["llm_cassette"] = cassette_context
 
@@ -1164,6 +1173,8 @@ def run_task(
             semantic_contract=semantic_contract,
             market_context=market_context,
         )
+        if computational_problem_payload is not None:
+            runtime_contract["computational_problem"] = computational_problem_payload
         task_benchmark_spec_overrides = benchmark_spec_overrides(task)
         base_request_metadata = {
             "task_id": task_id,
@@ -1181,6 +1192,8 @@ def run_task(
             from trellis.agent.semantic_contracts import semantic_contract_summary
 
             base_request_metadata["semantic_contract"] = semantic_contract_summary(semantic_contract)
+        if computational_problem_payload is not None:
+            base_request_metadata["computational_problem"] = computational_problem_payload
         result_data["market_context"] = market_context
         result_data["runtime_contract"] = runtime_contract
         if comparison_task:
@@ -1204,6 +1217,10 @@ def run_task(
                     "force_rebuild": force_rebuild,
                     "fresh_build": fresh_build,
                 }
+                if computational_problem_report is not None:
+                    target_payload = computational_problem_report.target_payload(target.target_id)
+                    if target_payload is not None:
+                        build_kwargs["request_metadata"]["computational_problem_target"] = target_payload
                 result = build_fn(**build_kwargs)
                 live_results[target.target_id] = result
                 method_results[target.target_id] = _build_result_payload(
@@ -1352,6 +1369,12 @@ def run_task(
                 "force_rebuild": force_rebuild,
                 "fresh_build": fresh_build,
             }
+            if computational_problem_report is not None and comparison_targets:
+                target_payload = computational_problem_report.target_payload(
+                    comparison_targets[0].target_id
+                )
+                if target_payload is not None:
+                    build_kwargs["request_metadata"]["computational_problem_target"] = target_payload
             if preferred_method is not None:
                 build_kwargs["preferred_method"] = preferred_method
             if task.get("cross_validate") and comparison_targets:


### PR DESCRIPTION
## Summary

- add an internal stochastic-vol computational problem IR for Heston/Bates/SLV/LSV task targets
- classify comparison targets into stable computational buckets and emit repair packets for missing primitives or unsupported classes
- carry the computational problem payload through run_task metadata, runtime contracts, and diagnosis packets
- document the diagnostic payload and Heston model-parameter vs Black-vol-surface boundary

## Validation

- /Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_computational_problem_ir.py tests/test_agent/test_task_runtime.py::test_run_task_carries_stochastic_vol_problem_metadata_for_comparison_task tests/test_agent/test_task_diagnostics.py tests/test_agent/test_blocker_planning.py -q

## Notes

This slice does not add stochastic-vol numerical kernels. QE, Bates, SLV/LSV, and path-dependent early-exercise Heston gaps are represented as repair packets for follow-on QUA-1121 tickets.