### PR TITLE
QUA-1152: deterministic canary replay lane

### DIFF
--- a/CANARY_TASKS.yaml
+++ b/CANARY_TASKS.yaml
@@ -10,15 +10,17 @@ source_corpora:
 canary_set:
   - id: T13
     engine_family: pde
-    canary_kind: legacy_replay
+    canary_kind: deterministic_replay
     complexity: simple
     core: true
     estimated_cost_usd: 0.12
-    record_cassette: true
-    rationale: Legacy replay-backed PDE canary retained for zero-token contract coverage.
+    record_cassette: false
+    replay_mode: deterministic_exact_binding
+    rationale: PDE canary retained for zero-token exact-binding contract coverage.
     covers:
       - pde
-      - replay
+      - deterministic_replay
+      - exact_binding
       - regression
 
   - id: T38

--- a/doc/plan/active__contract-backed-task-learning-repair.md
+++ b/doc/plan/active__contract-backed-task-learning-repair.md
@@ -71,6 +71,7 @@ Status mirror last synced: `2026-07-02`
 | --- | --- | --- |
 | `QUA-1131` | Agent learning: contract-backed intra-run repair | Todo |
 | `QUA-1138` | Agent learning: deterministic promotion loop | In Progress |
+| `QUA-1151` | Task learning: replay-safe self-learning closure | Todo |
 
 ### Ordered Implementation Queue
 
@@ -87,6 +88,8 @@ Status mirror last synced: `2026-07-02`
 | `QUA-1141` | Semantic validation: helper-backed primitive closure | In Progress | `QUA-1135` |
 | `QUA-1142` | Semantic contract: static exotic spec catalog | In Progress | `QUA-1134`, `QUA-1136` |
 | `QUA-1143` | Task learning: no-LLM scorecard and docs closeout | In Progress | `QUA-1139`, `QUA-1140`, `QUA-1141`, `QUA-1142` |
+| `QUA-1152` | Canary replay: deterministic exact-binding contract lane | In Progress | `QUA-1138` |
+| `QUA-1153` | Task learning: failure-seeded retry benchmark | Todo | `QUA-1152` |
 
 ## Validation Plan
 
@@ -288,3 +291,43 @@ token usage was zero; and bounded remediation reported `0` failures. The
 important interpretation is that the pack is now first-pass deterministic reuse
 of checked contracts rather than retry rescue: `successful_after_retry=0`,
 `first_attempt_successes=4`, and all pricing successes had shared context.
+
+### 2026-07-02 QUA-1152 deterministic canary replay lane
+
+Started `QUA-1152` after the stacked PRs failed `pr-gate-tier2-contracts`.
+The failing CI path was `T13` full-task canary replay.  Pricing had become
+deterministic, but the old full-task cassette still recorded generation and
+critic calls, so the replay failed on stale prompt hashes or unconsumed calls.
+
+The fix added a deterministic exact-binding replay lane to
+`scripts/run_canary.py`.  Canary entries with
+`replay_mode: deterministic_exact_binding` run the normal `run_task(...)`
+surface under the offline-local LLM guard, persist the same diagnosis packet
+and dossier artifacts, and mark the result with
+`execution_mode=deterministic_replay` plus `llm_cassette.used=false`.
+T13 now uses that lane.  Cassette replay remains strict for canaries that
+actually need recorded LLM calls.
+
+The same slice added deterministic exact-binding materialization for
+`price_vanilla_equity_option_pde(...)` comparison targets.  The generated
+wrapper maps `theta_0.5` to `theta=0.5` and `theta_1.0` to `theta=1.0`, then
+delegates to the checked helper instead of regenerating PDE code.
+
+Validation:
+
+```bash
+/Users/steveyang/miniforge3/bin/python3 -m pytest -q \
+  tests/test_agent/test_executor.py::test_deterministic_exact_binding_module_materializes_vanilla_equity_pde_helper_wrapper \
+  tests/test_agent/test_canary_runner.py::TestRunCanaries::test_run_canaries_deterministic_replay_uses_offline_local_scope_without_cassette \
+  tests/test_agent/test_canary_runner.py::TestCanaryFileValidity::test_real_canary_file_marks_t38_as_live_only_during_route_refactor \
+  tests/test_agent/test_canary_runner.py::TestCanaryFileValidity::test_real_canary_file_covers_canary_kinds \
+  tests/test_contracts/test_cassette_contract_helpers.py
+/Users/steveyang/miniforge3/bin/python3 -m pytest -q \
+  tests/test_contracts/test_canary_replay_contracts.py \
+  -m "tier2 and not freshness"
+make gate-tier2-contracts PYTHON=/Users/steveyang/miniforge3/bin/python3
+```
+
+The focused unit/manifest/contract-helper set reports `10 passed`; full
+canary replay reports `1 passed, 1 skipped`; and the local tier-2 contract
+shard reports `32 passed, 15 skipped, 7 deselected`.

--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -227,13 +227,14 @@ That lets sparse manifest rows keep their normal task-inventory shape while
 the curated regression surface still carries the fuller descriptions or market
 blocks needed to exercise canonical comparison cases honestly.
 
-The same runner now also has a full-task replay mode for diagnosis-heavy
-canaries:
+The same runner now also has full-task replay modes for diagnosis-heavy
+canaries.  Cassette-backed replay is for canaries that still require recorded
+LLM calls:
 
 - record with
-  ``PYTHONHASHSEED=0 python3 scripts/record_cassettes.py --task T13``
+  ``PYTHONHASHSEED=0 python3 scripts/record_cassettes.py --task <task-id>``
 - replay with
-  ``PYTHONHASHSEED=0 python3 scripts/run_canary.py --task T13 --replay``
+  ``PYTHONHASHSEED=0 python3 scripts/run_canary.py --task <task-id> --replay``
 - full-task canary cassettes live under ``cassettes/full_task/``
 
 The hash seed matters because the replay contract hashes the full prompt text.
@@ -242,6 +243,14 @@ still depend on iteration order stay stable across processes.
 Run these commands with the repo-standard miniforge interpreter; if your shell
 ``python3`` resolves elsewhere, invoke the configured interpreter path from
 ``AGENTS.md`` directly.
+
+Canaries whose manifest entry sets
+``replay_mode: deterministic_exact_binding`` use a different zero-token replay
+lane.  The runner executes the real ``run_task(...)`` surface under the
+offline-local LLM guard and requires the task to complete through deterministic
+exact bindings.  No cassette calls are consumed, so prompt-hash drift in old
+recordings cannot block the replay.  If such a canary attempts a live LLM call,
+the offline guard fails the run.
 
 Unlike the older tier-2 pipeline cassettes, the full-task canary path replays
 the real ``run_task(...)`` surface. That means the replay still exercises the
@@ -494,11 +503,14 @@ primary implementation provenance. Compatibility route aliases may still
 appear, but only as secondary metadata so replay, canary drift, and learning
 artifacts no longer rely on route-primary checkpoint joins.
 
-For cassette-backed canary replays, the task result and persisted task-run
-record now carry explicit execution metadata:
+For canary replays, the task result and persisted task-run record now carry
+explicit execution metadata:
 
 - ``execution_mode`` is ``cassette_replay`` instead of ``live``
-- ``llm_cassette`` records the cassette name, path, and replay policy
+- ``execution_mode`` is ``deterministic_replay`` for exact-binding replay
+  canaries that do not consume cassette calls
+- ``llm_cassette`` records the cassette name, path, replay policy, and
+  ``used=false`` for deterministic replay
 
 That keeps replay runs obvious to humans and downstream tooling without
 changing the packet or task-result schema that remediation and canary summary

--- a/docs/developer/task_diagnostics.rst
+++ b/docs/developer/task_diagnostics.rst
@@ -45,14 +45,22 @@ Full-task canary replays now persist the same task-run and diagnosis artifacts
 as live runs, but they also mark the execution surface explicitly:
 
 - ``execution_mode`` is set to ``cassette_replay``
-- ``llm_cassette`` records the cassette name, path, and replay policy
+- ``execution_mode`` is set to ``deterministic_replay`` for canaries that run
+  under the offline-local exact-binding lane instead of consuming cassette
+  calls
+- ``llm_cassette`` records the cassette name, path, replay policy, and
+  ``used=false`` when deterministic replay bypasses the cassette
 
 That metadata is stored on the top-level task result and the persisted task-run
 record so diagnosis, remediation, and canary-summary tooling can tell live and
-cassette-backed runs apart without needing a separate artifact schema.
+cassette-backed or deterministic replay runs apart without needing a separate
+artifact schema.
 
 For replay stability, record and replay full-task canary cassettes with
 ``PYTHONHASHSEED=0`` and keep them under ``cassettes/full_task/``.
+Canaries that declare ``replay_mode: deterministic_exact_binding`` do not need
+their historical cassette refreshed; they must instead complete with zero live
+LLM calls through deterministic exact bindings.
 
 How to read one
 ---------------

--- a/docs/developer/task_diagnostics.rst
+++ b/docs/developer/task_diagnostics.rst
@@ -44,10 +44,10 @@ Replay marker
 Full-task canary replays now persist the same task-run and diagnosis artifacts
 as live runs, but they also mark the execution surface explicitly:
 
-- ``execution_mode`` is set to ``cassette_replay``
-- ``execution_mode`` is set to ``deterministic_replay`` for canaries that run
-  under the offline-local exact-binding lane instead of consuming cassette
-  calls
+- ``execution_mode`` is set to exactly one replay value:
+  ``cassette_replay`` for cassette-backed canaries or
+  ``deterministic_replay`` for canaries that run under the offline-local
+  exact-binding lane instead of consuming cassette calls
 - ``llm_cassette`` records the cassette name, path, replay policy, and
   ``used=false`` when deterministic replay bypasses the cassette
 

--- a/scripts/run_canary.py
+++ b/scripts/run_canary.py
@@ -49,6 +49,7 @@ from trellis.agent.golden_traces import (
 CORE_FAMILIES = {"lattice", "monte_carlo", "pde", "credit"}
 CANARY_MAX_RETRIES = 3
 OPTIONAL_REPLAY_STAGES = ("critic", "unscoped")
+DETERMINISTIC_EXACT_BINDING_REPLAY = "deterministic_exact_binding"
 
 
 # ---------------------------------------------------------------------------
@@ -84,6 +85,16 @@ def filter_canaries(
             return explicitly_curated
         return [c for c in canaries if c.get("engine_family") in CORE_FAMILIES]
     return canaries
+
+
+def _canary_replay_mode(canary: dict) -> str:
+    """Return the replay mode requested by a canary manifest entry."""
+    return str(canary.get("replay_mode") or "cassette").strip().lower()
+
+
+def _uses_deterministic_replay(canary: dict) -> bool:
+    """Return whether replay should use deterministic exact bindings, not cassettes."""
+    return _canary_replay_mode(canary) == DETERMINISTIC_EXACT_BINDING_REPLAY
 
 
 # ---------------------------------------------------------------------------
@@ -173,7 +184,13 @@ def run_canaries(
     print(f"  Model: {model}")
     print(f"  Budget: ${budget:.2f}")
     if replay:
-        print(f"  Replay: cassette-backed ({cassette_root})")
+        replay_modes = sorted({_canary_replay_mode(canary) for canary in canaries})
+        if replay_modes == [DETERMINISTIC_EXACT_BINDING_REPLAY]:
+            print("  Replay: deterministic exact-binding")
+        elif replay_modes == ["cassette"]:
+            print(f"  Replay: cassette-backed ({cassette_root})")
+        else:
+            print(f"  Replay: mixed ({', '.join(replay_modes)})")
     print(f"  Started: {started_at.isoformat()}")
     print(f"{'=' * 65}")
 
@@ -192,11 +209,12 @@ def run_canaries(
             continue
         task = merge_canary_task_payload(task, canary)
         cassette_path = cassette_root / f"{task_id}.yaml"
+        deterministic_replay = replay and _uses_deterministic_replay(canary)
 
         start = time.time()
         print(f"\n  [{idx}/{len(canaries)}] {task_id:6s}  {canary.get('engine_family', '?'):14s}", end="", flush=True)
 
-        if replay and not canary.get("record_cassette", True):
+        if replay and not deterministic_replay and not canary.get("record_cassette", True):
             print("  SKIP — replay unsupported")
             results.append({
                 "canary_id": task_id,
@@ -207,7 +225,7 @@ def run_canaries(
             })
             continue
 
-        if replay and not cassette_path.exists():
+        if replay and not deterministic_replay and not cassette_path.exists():
             error = (
                 f"Missing cassette for {task_id} at {cassette_path}. "
                 f"Record it with scripts/record_cassettes.py --task {task_id}"
@@ -231,7 +249,25 @@ def run_canaries(
                 "max_retries": CANARY_MAX_RETRIES,
                 "knowledge_profile": "knowledge_light" if knowledge_light else None,
             }
-            if replay:
+            if deterministic_replay:
+                from trellis.agent.offline_agents import offline_local_agent_run_scope
+
+                with offline_local_agent_run_scope():
+                    result = run_task(
+                        task,
+                        market_state,
+                        **run_kwargs,
+                    )
+                result["execution_mode"] = "deterministic_replay"
+                result["offline_local_agents"] = True
+                result["llm_cassette"] = {
+                    "mode": "deterministic_replay",
+                    "name": task_id,
+                    "path": str(cassette_path),
+                    "stale_policy": cassette_stale_policy,
+                    "used": False,
+                }
+            elif replay:
                 from trellis.agent.cassette import llm_cassette_session
 
                 with llm_cassette_session(
@@ -259,7 +295,17 @@ def run_canaries(
                 "error": str(exc),
                 "elapsed_seconds": time.time() - start,
             }
-            if replay:
+            if deterministic_replay:
+                result["execution_mode"] = "deterministic_replay"
+                result["offline_local_agents"] = True
+                result["llm_cassette"] = {
+                    "mode": "deterministic_replay",
+                    "name": task_id,
+                    "path": str(cassette_path),
+                    "stale_policy": cassette_stale_policy,
+                    "used": False,
+                }
+            elif replay:
                 result["execution_mode"] = "cassette_replay"
                 result["llm_cassette"] = {
                     "mode": "replay",

--- a/tests/test_agent/test_canary_runner.py
+++ b/tests/test_agent/test_canary_runner.py
@@ -5,6 +5,7 @@ All tests use mocked task execution — no LLM calls, no tokens spent.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from datetime import datetime, timezone
 
@@ -460,6 +461,71 @@ class TestRunCanaries:
         assert results[0]["skipped"] is True
         assert results[0]["reason"] == "replay_unsupported"
 
+    def test_run_canaries_deterministic_replay_uses_offline_local_scope_without_cassette(
+        self, monkeypatch, tmp_path
+    ):
+        seen: dict[str, object] = {}
+
+        def fake_build_market_state():
+            return object()
+
+        def fake_load_tasks(*, status="pending", path=None):
+            return [{"id": "T13", "title": "European call: theta-method convergence order"}]
+
+        def fake_run_task(task, market_state, **kwargs):
+            seen["task_id"] = task["id"]
+            seen["force_rebuild"] = kwargs.get("force_rebuild")
+            seen["offline_env"] = os.environ.get("TRELLIS_OFFLINE_LOCAL_AGENTS")
+            return {
+                "task_id": task["id"],
+                "success": True,
+                "token_usage_summary": {"total_tokens": 0},
+            }
+
+        monkeypatch.setattr(
+            "trellis.agent.task_runtime.build_market_state",
+            fake_build_market_state,
+        )
+        monkeypatch.setattr(
+            "trellis.agent.task_runtime.load_tasks",
+            fake_load_tasks,
+        )
+        monkeypatch.setattr(
+            "trellis.agent.task_runtime.run_task",
+            fake_run_task,
+        )
+
+        results = run_canaries(
+            [
+                {
+                    "id": "T13",
+                    "engine_family": "pde",
+                    "complexity": "simple",
+                    "record_cassette": False,
+                    "replay_mode": "deterministic_exact_binding",
+                }
+            ],
+            {"total_budget_usd": 1.0},
+            replay=True,
+            cassette_dir=tmp_path,
+        )
+
+        assert seen == {
+            "task_id": "T13",
+            "force_rebuild": True,
+            "offline_env": "1",
+        }
+        assert results[0]["success"] is True
+        assert results[0]["execution_mode"] == "deterministic_replay"
+        assert results[0]["offline_local_agents"] is True
+        assert results[0]["llm_cassette"] == {
+            "mode": "deterministic_replay",
+            "name": "T13",
+            "path": str(tmp_path / "T13.yaml"),
+            "stale_policy": "error",
+            "used": False,
+        }
+
     def test_run_canaries_replay_mode_uses_full_task_cassette(self, monkeypatch, tmp_path):
         from trellis.agent.cassette import _prompt_hash
 
@@ -669,6 +735,7 @@ class TestCanaryFileValidity:
         assert "extension" in canary_kinds
         assert "negative" in canary_kinds
         assert "legacy_replay" in canary_kinds
+        assert "deterministic_replay" in canary_kinds
 
     def test_real_canary_ids_exist_in_active_task_manifests(self):
         from trellis.agent.task_manifests import load_active_task_lookup
@@ -691,8 +758,9 @@ class TestCanaryFileValidity:
         expected_ids = {"T13", "T38", "F001", "F002", "P003", "N001"}
         assert expected_ids <= set(canary_lookup)
 
-        assert canary_lookup["T13"]["canary_kind"] == "legacy_replay"
-        assert canary_lookup["T13"].get("record_cassette", True) is True
+        assert canary_lookup["T13"]["canary_kind"] == "deterministic_replay"
+        assert canary_lookup["T13"].get("record_cassette", True) is False
+        assert canary_lookup["T13"]["replay_mode"] == "deterministic_exact_binding"
         assert canary_lookup["T38"].get("record_cassette", True) is False
         assert canary_lookup["F001"]["canary_kind"] == "parity"
         assert canary_lookup["P003"]["canary_kind"] == "extension"

--- a/tests/test_agent/test_executor.py
+++ b/tests/test_agent/test_executor.py
@@ -782,6 +782,50 @@ def test_deterministic_exact_binding_module_materializes_vanilla_equity_mc_helpe
 @pytest.mark.parametrize(
     ("comparison_target", "expected_fragment"),
     [
+        ("theta_0.5", "price_vanilla_equity_option_pde(market_state, spec, theta=0.5)"),
+        ("theta_1.0", "price_vanilla_equity_option_pde(market_state, spec, theta=1.0)"),
+    ],
+)
+def test_deterministic_exact_binding_module_materializes_vanilla_equity_pde_helper_wrapper(
+    comparison_target,
+    expected_fragment,
+):
+    from trellis.agent.executor import (
+        EVALUATE_SENTINEL,
+        _generate_skeleton,
+        _materialize_deterministic_exact_binding_module,
+    )
+    from trellis.agent.planner import SPECIALIZED_SPECS
+
+    generation_plan = SimpleNamespace(
+        lane_exact_binding_refs=(
+            "trellis.models.equity_option_pde.price_vanilla_equity_option_pde",
+        ),
+        primitive_plan=SimpleNamespace(route="vanilla_equity_theta_pde"),
+        method="pde_solver",
+        instrument_type="european_option",
+    )
+
+    skeleton = _generate_skeleton(
+        SPECIALIZED_SPECS["european_option_analytical"],
+        "European call: theta-method convergence order measurement",
+        generation_plan=generation_plan,
+    )
+    generated = _materialize_deterministic_exact_binding_module(
+        skeleton,
+        generation_plan,
+        comparison_target=comparison_target,
+    )
+
+    assert generated is not None
+    assert "from trellis.models.equity_option_pde import price_vanilla_equity_option_pde" in generated.code
+    assert expected_fragment in generated.code
+    assert EVALUATE_SENTINEL not in generated.code
+
+
+@pytest.mark.parametrize(
+    ("comparison_target", "expected_fragment"),
+    [
         ("heston_mc", 'scheme="heston_qe"'),
         ("euler_heston", 'scheme="euler"'),
         ("qe_heston", 'scheme="heston_qe"'),

--- a/tests/test_contracts/conftest.py
+++ b/tests/test_contracts/conftest.py
@@ -2,7 +2,8 @@
 
 Provides cassette-aware fixtures and helpers for canary contract tests.
 Replay-backed contract tests run with cassette replay (zero tokens) by
-default, while tasks marked ``record_cassette=false`` opt out of replay.
+default, while tasks marked ``record_cassette=false`` opt out of cassette
+recording. Some canaries instead use deterministic exact-binding replay.
 """
 
 from __future__ import annotations
@@ -72,6 +73,16 @@ def cassette_recording_supported(task_id: str) -> bool:
     return canary is None or canary.get("record_cassette", True)
 
 
+def deterministic_full_task_replay_supported(task_id: str) -> bool:
+    """Return whether *task_id* uses deterministic full-task replay."""
+    canary = CANARY_META.get(task_id)
+    return (
+        canary is not None
+        and str(canary.get("replay_mode", "")).strip().lower()
+        == "deterministic_exact_binding"
+    )
+
+
 def cassette_skip_reason(task_id: str) -> str:
     """Explain why a cassette-backed contract test should skip for *task_id*."""
     if not cassette_recording_supported(task_id):
@@ -96,6 +107,8 @@ def full_task_cassette_path_for(task_id: str) -> Path:
 
 def full_task_cassette_skip_reason(task_id: str) -> str:
     """Explain why a full-task replay contract test should skip for *task_id*."""
+    if deterministic_full_task_replay_supported(task_id):
+        return f"{task_id} uses deterministic exact-binding replay."
     if not cassette_recording_supported(task_id):
         return (
             f"Full-task cassette replay disabled for {task_id}; "
@@ -109,6 +122,8 @@ def full_task_cassette_skip_reason(task_id: str) -> str:
 
 def full_task_cassette_available(task_id: str) -> bool:
     """Check whether a full-task cassette exists for *task_id*."""
+    if deterministic_full_task_replay_supported(task_id):
+        return True
     return (
         cassette_recording_supported(task_id)
         and full_task_cassette_path_for(task_id).exists()

--- a/tests/test_contracts/test_canary_replay_contracts.py
+++ b/tests/test_contracts/test_canary_replay_contracts.py
@@ -75,10 +75,17 @@ def _full_task_replay_test(task_id: str):
             assert len(results) == 1
             result = results[0]
             assert result["success"] is True
-            assert result["execution_mode"] == "cassette_replay"
-            assert result["llm_cassette"]["path"] == str(
-                FULL_TASK_CASSETTES_DIR / f"{task_id}.yaml"
+            expected_execution_mode = (
+                "deterministic_replay"
+                if canary.get("replay_mode") == "deterministic_exact_binding"
+                else "cassette_replay"
             )
+            assert result["execution_mode"] == expected_execution_mode
+            replay_meta = result["llm_cassette"]
+            assert replay_meta["path"] == str(FULL_TASK_CASSETTES_DIR / f"{task_id}.yaml")
+            if expected_execution_mode == "deterministic_replay":
+                assert replay_meta["used"] is False
+                assert result["offline_local_agents"] is True
             assert (result.get("token_usage_summary") or {}).get("total_tokens") == 0
             assert Path(result["task_diagnosis_packet_path"]).exists()
             assert Path(result["task_diagnosis_dossier_path"]).exists()

--- a/tests/test_contracts/test_cassette_contract_helpers.py
+++ b/tests/test_contracts/test_cassette_contract_helpers.py
@@ -63,3 +63,24 @@ class TestCassetteAvailabilityHelpers:
         )
 
         assert contract_conftest.full_task_cassette_available("T13") is True
+
+    def test_full_task_replay_available_for_deterministic_exact_binding_without_cassette(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setitem(
+            contract_conftest.CANARY_META,
+            "T13",
+            {
+                "id": "T13",
+                "record_cassette": False,
+                "replay_mode": "deterministic_exact_binding",
+            },
+        )
+        monkeypatch.setattr(
+            contract_conftest,
+            "full_task_cassette_path_for",
+            lambda task_id: tmp_path / f"{task_id}.yaml",
+        )
+
+        assert contract_conftest.cassette_recording_supported("T13") is False
+        assert contract_conftest.full_task_cassette_available("T13") is True

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -3430,6 +3430,16 @@ def _vanilla_equity_monte_carlo_helper_kwargs(comparison_target: str | None) -> 
     return ""
 
 
+def _vanilla_equity_pde_helper_kwargs(comparison_target: str | None) -> str:
+    """Return deterministic helper kwargs for vanilla-equity PDE comparison targets."""
+    target = str(comparison_target or "").strip().lower().replace("-", "_")
+    if target in {"theta_0.5", "theta_0_5", "crank_nicolson"}:
+        return ", theta=0.5"
+    if target in {"theta_1.0", "theta_1_0", "implicit"}:
+        return ", theta=1.0"
+    return ""
+
+
 def _heston_monte_carlo_helper_kwargs(comparison_target: str | None) -> str:
     """Return deterministic helper kwargs for Heston Monte Carlo comparison targets."""
     target = str(comparison_target or "").strip().lower().replace("-", "_")
@@ -3520,6 +3530,7 @@ def _deterministic_exact_binding_evaluate_body(
     refs = set(_exact_binding_refs(generation_plan))
     swaption_comparison_kwargs = _swaption_comparison_helper_kwargs(semantic_blueprint)
     vanilla_equity_mc_kwargs = _vanilla_equity_monte_carlo_helper_kwargs(comparison_target)
+    vanilla_equity_pde_kwargs = _vanilla_equity_pde_helper_kwargs(comparison_target)
     heston_mc_kwargs = _heston_monte_carlo_helper_kwargs(comparison_target)
     vanilla_equity_transform_kwargs = _vanilla_equity_transform_helper_kwargs(comparison_target)
     heston_transform_kwargs = _heston_transform_helper_kwargs(comparison_target)
@@ -3807,6 +3818,10 @@ def _deterministic_exact_binding_evaluate_body(
         "trellis.models.equity_option_monte_carlo.price_vanilla_equity_option_monte_carlo": (
             "return price_vanilla_equity_option_monte_carlo("
             f"market_state, spec{vanilla_equity_mc_kwargs})"
+        ),
+        "trellis.models.equity_option_pde.price_vanilla_equity_option_pde": (
+            "return price_vanilla_equity_option_pde("
+            f"market_state, spec{vanilla_equity_pde_kwargs})"
         ),
         "trellis.models.monte_carlo.stochastic_vol.price_heston_option_monte_carlo": (
             "return price_heston_option_monte_carlo("


### PR DESCRIPTION
## Summary
- add deterministic exact-binding canary replay mode for zero-token full-task replay
- move T13 from stale cassette replay to deterministic exact-binding replay
- materialize vanilla-equity PDE theta exact-binding wrappers for T13 targets
- document replay-mode metadata and update the active learning-repair plan

## Validation
- /Users/steveyang/miniforge3/bin/python3 -m pytest -q tests/test_agent/test_executor.py::test_deterministic_exact_binding_module_materializes_vanilla_equity_pde_helper_wrapper tests/test_agent/test_canary_runner.py::TestRunCanaries::test_run_canaries_deterministic_replay_uses_offline_local_scope_without_cassette tests/test_agent/test_canary_runner.py::TestCanaryFileValidity::test_real_canary_file_marks_t38_as_live_only_during_route_refactor tests/test_agent/test_canary_runner.py::TestCanaryFileValidity::test_real_canary_file_covers_canary_kinds tests/test_contracts/test_cassette_contract_helpers.py
- /Users/steveyang/miniforge3/bin/python3 -m pytest -q tests/test_contracts/test_canary_replay_contracts.py -m "tier2 and not freshness"
- make gate-tier2-contracts PYTHON=/Users/steveyang/miniforge3/bin/python3
- /Users/steveyang/miniforge3/bin/python3 -m py_compile scripts/run_canary.py trellis/agent/executor.py
- git diff --check for touched files