### PR TITLE
QUA-1167: compose American LSM from primitives

### DIFF
--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -511,10 +511,12 @@ Sparse legacy proof rows can also carry a deterministic task-runtime contract
 bridge before generation. The bridge is intentionally small and auditable:
 ``T25``, ``T26``, ``T31``, and ``T32`` default to a European SPX call
 semantic contract for Monte Carlo numerical-method proof work. ``T14`` uses an
-American SPX put contract for the PDE/tree/LSM comparison and resolves
-``lsm_mc`` through the exact
-``price_american_equity_option_lsm_monte_carlo(...)`` helper, so the task tests
-route-helper binding rather than generated early-exercise branching. ``T15``
+American SPX put contract for the PDE/tree/LSM comparison. Its ``lsm_mc`` target
+must compose the admitted single-state market resolver, GBM process, Monte Carlo
+engine, intrinsic payoff primitive, and Longstaff-Schwartz exercise control.
+The compatibility American LSM helper is excluded from generated target
+evidence, so the task tests the agent's composition rather than product-helper
+delegation. ``T15``
 uses a bounded CEV European call contract for the CEVOperator PDE versus CEV
 tree comparison and binds ``cev_pde`` / ``cev_tree`` to deterministic local
 proof adapters. The PDE adapter must consume CEV parameters through

--- a/docs/developer/task_diagnostics.rst
+++ b/docs/developer/task_diagnostics.rst
@@ -415,13 +415,15 @@ reset-date GBM increments, local/global return clipping, antithetic sampling,
 and discounting to the checked helper. Ordinary Monte Carlo adapters still
 need to satisfy their compiled route-helper or primitive obligations directly.
 
-For vanilla American or Bermudan equity options, ``exercise_monte_carlo`` now
-has the same exact-helper shape. A comparison target such as ``lsm_mc`` may call
-``price_american_equity_option_lsm_monte_carlo(market_state, spec, ...)`` and
-let that helper own GBM path generation, Longstaff-Schwartz regression, exercise
-step construction, and notional scaling. Diagnostics should treat that as
-route-helper evidence, not as a failure to spell out ``GBM`` and
-``MonteCarloEngine`` inside the generated adapter.
+Vanilla American or Bermudan equity options are intentionally different. The
+``exercise_monte_carlo`` route is primitive-composed: an adapter resolves inputs
+with ``resolve_single_state_monte_carlo_inputs(...)``, constructs ``GBM`` and
+``MonteCarloEngine``, defines exercise steps and intrinsic payoff semantics, and
+calls ``longstaff_schwartz(...)``. Diagnostics must require evidence for those
+route primitives. A market-binding resolver is input evidence, not an exact
+pricing target, and a call to the compatibility helper
+``price_american_equity_option_lsm_monte_carlo(...)`` is not sufficient route
+evidence for generated task code.
 
 For CEV proof targets, diagnostics should check both the payoff family and the
 model family. ``cev_pde`` and ``cev_tree`` may delegate to

--- a/docs/quant/pricing_stack.rst
+++ b/docs/quant/pricing_stack.rst
@@ -184,10 +184,12 @@ The first migrated vanilla cases now use that boundary directly:
   ``trellis.models.resolution`` for settlement, maturity, spot, dividend,
   discount, vol, and characteristic-function binding
 - vanilla American/Bermudan equity Monte Carlo now resolves the
-  ``exercise_monte_carlo`` route to the exact helper
-  ``price_american_equity_option_lsm_monte_carlo(...)``. Thin adapters may
-  delegate to that helper for Longstaff-Schwartz path simulation and exercise
-  control instead of reimplementing GBM path construction in generated code.
+  ``exercise_monte_carlo`` route to a primitive composition. Generated adapters
+  use ``resolve_single_state_monte_carlo_inputs(...)`` for market and numerical
+  controls, build ``GBM`` and ``MonteCarloEngine`` paths, evaluate
+  ``terminal_intrinsic_from_resolved(...)``, and pass the paths and exercise
+  schedule to ``longstaff_schwartz(...)``. The product-level American LSM helper
+  remains a compatibility/reference surface, not route authority.
 - FX single-barrier options now have dedicated analytical and Monte Carlo
   helper-backed routes in ``trellis.models.fx_barrier_option``. These routes
   bind spot FX, domestic discounting, foreign discounting, and Black volatility

--- a/tests/test_agent/test_american_generation.py
+++ b/tests/test_agent/test_american_generation.py
@@ -71,6 +71,9 @@ def test_current_american_artifact_is_thin_lsm_adapter():
 
     assert "longstaff_schwartz" in source
     assert "LaguerreBasis" in source
+    assert "resolve_single_state_monte_carlo_inputs" in source
+    assert "terminal_intrinsic_from_resolved" in source
+    assert "price_american_equity_option_lsm_monte_carlo" not in source
     assert 'method="lsm"' not in source
     assert "engine.price(" not in source
     assert "engine.simulate(" in source

--- a/tests/test_agent/test_american_generation.py
+++ b/tests/test_agent/test_american_generation.py
@@ -73,6 +73,8 @@ def test_current_american_artifact_is_thin_lsm_adapter():
     assert "LaguerreBasis" in source
     assert "resolve_single_state_monte_carlo_inputs" in source
     assert "terminal_intrinsic_from_resolved" in source
+    assert "event_step_indices" in source
+    assert 'exercise_style == "bermudan"' in source
     assert "price_american_equity_option_lsm_monte_carlo" not in source
     assert 'method="lsm"' not in source
     assert "engine.price(" not in source

--- a/tests/test_agent/test_api_map.py
+++ b/tests/test_agent/test_api_map.py
@@ -89,6 +89,16 @@ def test_api_map_formatter_includes_all_canonical_utilities():
     assert "credit_curve" in text
 
 
+def test_monte_carlo_api_map_prioritizes_american_lsm_primitives():
+    section = get_api_map()["monte_carlo"]
+    text = "\n".join((*section["key_imports"], *section["notes"]))
+
+    assert "resolve_single_state_monte_carlo_inputs" in text
+    assert "terminal_intrinsic_from_resolved" in text
+    assert "longstaff_schwartz" in text
+    assert "price_american_equity_option_lsm_monte_carlo" not in text
+
+
 def _assert_import_statements_valid(import_statements: list[str]) -> None:
     for statement in import_statements:
         cleaned = statement.split("#", 1)[0].strip()

--- a/tests/test_agent/test_backend_bindings.py
+++ b/tests/test_agent/test_backend_bindings.py
@@ -851,7 +851,7 @@ def test_resolve_backend_binding_spec_uses_credit_loss_distribution_exact_helper
     )
 
 
-def test_exercise_monte_carlo_binding_resolves_american_equity_lsm_helper():
+def test_exercise_monte_carlo_binding_resolves_american_equity_lsm_primitives():
     catalog = load_backend_binding_catalog()
     binding = find_backend_binding_by_route_id("exercise_monte_carlo", catalog)
     assert binding is not None
@@ -865,15 +865,16 @@ def test_exercise_monte_carlo_binding_resolves_american_equity_lsm_helper():
 
     resolved = resolve_backend_binding_spec(binding, product_ir=product_ir)
 
-    assert resolved.binding_id == (
-        "trellis.models.equity_option_monte_carlo."
-        "price_american_equity_option_lsm_monte_carlo"
-    )
-    assert resolved.helper_refs == (
-        "trellis.models.equity_option_monte_carlo."
-        "price_american_equity_option_lsm_monte_carlo",
-    )
-    assert resolved.exact_target_refs == resolved.helper_refs
+    assert resolved.binding_id == "exercise:exercise:fallback"
+    assert resolved.helper_refs == ()
+    assert resolved.exact_target_refs == ()
+    assert set(resolved.primitive_refs) == {
+        "trellis.models.processes.gbm.GBM",
+        "trellis.models.monte_carlo.engine.MonteCarloEngine",
+        "trellis.models.monte_carlo.lsm.longstaff_schwartz",
+        "trellis.models.monte_carlo.single_state_diffusion.resolve_single_state_monte_carlo_inputs",
+        "trellis.models.resolution.single_state_diffusion.terminal_intrinsic_from_resolved",
+    }
 
 
 def test_binding_catalog_cache_tracks_binding_catalog_freshness(monkeypatch):

--- a/tests/test_agent/test_build_loop.py
+++ b/tests/test_agent/test_build_loop.py
@@ -227,8 +227,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import date
 
-from trellis.core.date_utils import year_fraction
-from trellis.core.differentiable import get_numpy
 from trellis.core.market_state import MarketState
 
 
@@ -237,6 +235,7 @@ class AmericanPutEquitySpec:
     spot: float
     strike: float
     expiry_date: date
+    notional: float = 1.0
     option_type: str = "put"
     exercise_style: str = "american"
 
@@ -257,34 +256,55 @@ class AmericanOptionPayoff:
         from trellis.models.monte_carlo.engine import MonteCarloEngine
         from trellis.models.monte_carlo.lsm import longstaff_schwartz
         from trellis.models.monte_carlo.schemes import LaguerreBasis
+        from trellis.models.monte_carlo.single_state_diffusion import resolve_single_state_monte_carlo_inputs
         from trellis.models.processes.gbm import GBM
+        from trellis.models.resolution.single_state_diffusion import terminal_intrinsic_from_resolved
 
         spec = self._spec
-        np = get_numpy()
-        T = year_fraction(market_state.settlement, spec.expiry_date)
-        if T <= 0:
-            return 0.0
+        resolved = resolve_single_state_monte_carlo_inputs(
+            market_state,
+            spec,
+            scheme="exact",
+            variance_reduction="none",
+            n_paths=4096,
+            n_steps=64,
+            seed=42,
+        )
+        if resolved.maturity <= 0.0:
+            return float(
+                resolved.notional
+                * terminal_intrinsic_from_resolved(resolved.spot, resolved)
+            )
 
-        r = float(market_state.discount.zero_rate(T))
-        sigma = float(market_state.vol_surface.black_vol(T, spec.strike))
-        process = GBM(mu=r, sigma=sigma)
-        engine = MonteCarloEngine(process, n_paths=4096, n_steps=64, seed=42, method="exact")
-        paths = engine.simulate(spec.spot, T)
-        dt = T / engine.n_steps
+        process = GBM(
+            mu=resolved.rate - resolved.dividend_yield,
+            sigma=resolved.sigma,
+        )
+        engine = MonteCarloEngine(
+            process,
+            n_paths=resolved.n_paths,
+            n_steps=resolved.n_steps,
+            seed=resolved.seed,
+            method="exact",
+        )
+        paths = engine.simulate(resolved.spot, resolved.maturity)
+        dt = resolved.maturity / engine.n_steps
         exercise_dates = list(range(1, engine.n_steps + 1))
-        basis = LaguerreBasis()
+        basis = LaguerreBasis(degree=2)
 
         def payoff_fn(spots):
-            return np.maximum(spec.strike - spots, 0.0)
+            return terminal_intrinsic_from_resolved(spots, resolved)
 
-        return float(
+        return float(resolved.notional) * float(
             longstaff_schwartz(
                 paths,
                 exercise_dates,
                 payoff_fn,
-                discount_rate=r,
+                discount_rate=resolved.rate,
                 dt=dt,
-                basis_fn=basis,
+                basis_fn=lambda spots: basis(
+                    spots / max(resolved.strike, 1e-12)
+                ),
             )
         )
 '''

--- a/tests/test_agent/test_executor.py
+++ b/tests/test_agent/test_executor.py
@@ -1055,12 +1055,6 @@ def test_deterministic_exact_binding_module_materializes_vanilla_equity_pde_help
             'float(getattr(spec, "notional", 1.0) or 1.0) * price_vanilla_equity_option_tree(',
             "from trellis.models.equity_option_tree import price_vanilla_equity_option_tree",
         ),
-        (
-            "lsm_mc",
-            "price_american_equity_option_lsm_monte_carlo(",
-            "from trellis.models.equity_option_monte_carlo import "
-            "price_american_equity_option_lsm_monte_carlo",
-        ),
     ],
 )
 @pytest.mark.parametrize("instrument_type", ["american_put", "american_option"])
@@ -1099,6 +1093,116 @@ def test_deterministic_exact_binding_module_materializes_american_put_targets_wi
     assert expected_import in generated.code
     assert expected_fragment in generated.code
     assert EVALUATE_SENTINEL not in generated.code
+
+
+@pytest.mark.parametrize("instrument_type", ["american_put", "american_option"])
+def test_deterministic_exact_binding_materializes_american_lsm_from_primitives(
+    instrument_type,
+):
+    from trellis.agent.executor import (
+        EVALUATE_SENTINEL,
+        _generate_skeleton,
+        _materialize_deterministic_exact_binding_module,
+    )
+    from trellis.agent.planner import SPECIALIZED_SPECS
+
+    generation_plan = SimpleNamespace(
+        lane_exact_binding_refs=(),
+        primitive_plan=None,
+        method="monte_carlo",
+        instrument_type=instrument_type,
+    )
+    skeleton = _generate_skeleton(
+        SPECIALIZED_SPECS["american_put_tree"],
+        "American put: PSOR vs tree vs LSM three-way",
+        generation_plan=generation_plan,
+    )
+
+    generated = _materialize_deterministic_exact_binding_module(
+        skeleton,
+        generation_plan,
+        comparison_target="lsm_mc",
+    )
+
+    assert generated is not None
+    for fragment in (
+        "from trellis.models.processes.gbm import GBM",
+        "from trellis.models.monte_carlo.engine import MonteCarloEngine",
+        "from trellis.models.monte_carlo.lsm import longstaff_schwartz",
+        "from trellis.models.monte_carlo.single_state_diffusion import resolve_single_state_monte_carlo_inputs",
+        "from trellis.models.resolution.single_state_diffusion import terminal_intrinsic_from_resolved",
+        "resolve_single_state_monte_carlo_inputs(",
+        "MonteCarloEngine(",
+        "longstaff_schwartz(",
+    ):
+        assert fragment in generated.code
+    assert "price_american_equity_option_lsm_monte_carlo" not in generated.code
+    assert EVALUATE_SENTINEL not in generated.code
+
+
+def test_deterministic_american_lsm_primitive_composition_executes():
+    from datetime import date as _date
+
+    import numpy as _np
+
+    from trellis.agent.executor import (
+        _generate_skeleton,
+        _materialize_deterministic_exact_binding_module,
+    )
+    from trellis.agent.planner import SPECIALIZED_SPECS
+    from trellis.core.market_state import MarketState
+
+    class _FlatDiscount:
+        def zero_rate(self, _t: float) -> float:
+            return 0.05
+
+        def discount(self, t: float) -> float:
+            return float(_np.exp(-0.05 * float(t)))
+
+    class _FlatBlackVol:
+        def black_vol(self, _t: float, _strike: float) -> float:
+            return 0.20
+
+    generation_plan = SimpleNamespace(
+        lane_exact_binding_refs=(),
+        primitive_plan=None,
+        method="monte_carlo",
+        instrument_type="american_option",
+    )
+    schema = SPECIALIZED_SPECS["american_put_tree"]
+    generated = _materialize_deterministic_exact_binding_module(
+        _generate_skeleton(
+            schema,
+            "American put primitive-composed LSM",
+            generation_plan=generation_plan,
+        ),
+        generation_plan,
+        comparison_target="lsm_mc",
+    )
+
+    assert generated is not None
+    namespace: dict = {}
+    exec(compile(generated.code, "<qua_1167>", "exec"), namespace)  # noqa: S102
+    payoff_cls = namespace[schema.class_name]
+    spec_cls = namespace[schema.spec_name]
+    payoff = payoff_cls(
+        spec_cls(
+            spot=100.0,
+            strike=100.0,
+            expiry_date=_date(2025, 1, 1),
+            n_paths=8_000,
+            n_steps=48,
+            seed=42,
+        )
+    )
+    market = MarketState(
+        as_of=_date(2024, 1, 1),
+        settlement=_date(2024, 1, 1),
+        discount=_FlatDiscount(),
+        vol_surface=_FlatBlackVol(),
+    )
+
+    assert float(payoff.evaluate(market)) == pytest.approx(6.08, abs=0.75)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_agent/test_executor.py
+++ b/tests/test_agent/test_executor.py
@@ -1134,10 +1134,93 @@ def test_deterministic_exact_binding_materializes_american_lsm_from_primitives(
         "resolve_single_state_monte_carlo_inputs(",
         "MonteCarloEngine(",
         "longstaff_schwartz(",
+        "event_step_indices(",
+        'exercise_style == "bermudan"',
+        "spec.exercise_dates",
     ):
         assert fragment in generated.code
     assert "price_american_equity_option_lsm_monte_carlo" not in generated.code
     assert EVALUATE_SENTINEL not in generated.code
+
+
+def test_deterministic_american_lsm_maps_bermudan_dates_to_exercise_steps():
+    from datetime import date as _date
+
+    import numpy as _np
+
+    from trellis.agent.executor import (
+        _generate_skeleton,
+        _materialize_deterministic_exact_binding_module,
+    )
+    from trellis.agent.planner import SPECIALIZED_SPECS
+    from trellis.core.date_utils import year_fraction
+    from trellis.core.market_state import MarketState
+    from trellis.models.monte_carlo.event_state import event_step_indices
+
+    class _FlatDiscount:
+        def zero_rate(self, _t: float) -> float:
+            return 0.05
+
+        def discount(self, t: float) -> float:
+            return float(_np.exp(-0.05 * float(t)))
+
+    class _FlatBlackVol:
+        def black_vol(self, _t: float, _strike: float) -> float:
+            return 0.20
+
+    generation_plan = SimpleNamespace(
+        lane_exact_binding_refs=(),
+        primitive_plan=None,
+        method="monte_carlo",
+        instrument_type="american_option",
+    )
+    schema = SPECIALIZED_SPECS["american_put_tree"]
+    generated = _materialize_deterministic_exact_binding_module(
+        _generate_skeleton(
+            schema,
+            "Bermudan put primitive-composed LSM",
+            generation_plan=generation_plan,
+        ),
+        generation_plan,
+        comparison_target="lsm_mc",
+    )
+
+    assert generated is not None
+    namespace: dict = {}
+    exec(compile(generated.code, "<qua_1167_bermudan>", "exec"), namespace)  # noqa: S102
+    settle = _date(2024, 1, 1)
+    expiry = _date(2025, 1, 1)
+    exercise_dates = (_date(2024, 4, 1), _date(2024, 10, 1), expiry)
+    payoff = namespace[schema.class_name](
+        namespace[schema.spec_name](
+            spot=100.0,
+            strike=100.0,
+            expiry_date=expiry,
+            exercise_style="bermudan",
+            exercise_dates=exercise_dates,
+            n_paths=32,
+            n_steps=12,
+            seed=42,
+        )
+    )
+    captured: dict[str, list[int]] = {}
+
+    def _capture_lsm(_paths, steps, _payoff_fn, **_kwargs):
+        captured["steps"] = list(steps)
+        return 6.0
+
+    namespace["longstaff_schwartz"] = _capture_lsm
+    market = MarketState(
+        as_of=settle,
+        settlement=settle,
+        discount=_FlatDiscount(),
+        vol_surface=_FlatBlackVol(),
+    )
+
+    assert payoff.evaluate(market) == 6.0
+    maturity = year_fraction(settle, expiry)
+    event_times = tuple(year_fraction(settle, item) for item in exercise_dates)
+    assert captured["steps"] == list(event_step_indices(event_times, maturity, 12))
 
 
 def test_deterministic_american_lsm_primitive_composition_executes():

--- a/tests/test_agent/test_planner.py
+++ b/tests/test_agent/test_planner.py
@@ -379,6 +379,7 @@ class TestPlanBuild:
             "expiry_date",
             "option_type",
             "exercise_style",
+            "exercise_dates",
             "day_count",
             "tree_steps",
             "n_paths",

--- a/tests/test_agent/test_primitive_planning.py
+++ b/tests/test_agent/test_primitive_planning.py
@@ -34,21 +34,21 @@ def test_builds_primitive_plan_for_american_put():
         "GBM",
         "MonteCarloEngine",
         "longstaff_schwartz",
-        "price_american_equity_option_lsm_monte_carlo",
+        "resolve_single_state_monte_carlo_inputs",
+        "terminal_intrinsic_from_resolved",
     }
     primitive_modules = {primitive.module for primitive in plan.primitive_plan.primitives}
     assert primitive_modules == {
-        "trellis.models.equity_option_monte_carlo",
         "trellis.models.monte_carlo.engine",
         "trellis.models.monte_carlo.lsm",
+        "trellis.models.monte_carlo.single_state_diffusion",
         "trellis.models.processes.gbm",
+        "trellis.models.resolution.single_state_diffusion",
     }
-    route_helper = next(
-        primitive
+    assert all(
+        primitive.role != "route_helper"
         for primitive in plan.primitive_plan.primitives
-        if primitive.role == "route_helper"
     )
-    assert route_helper.required is False
     assert "LaguerreBasis" not in primitive_symbols
     assert plan.primitive_plan.blockers == ()
 
@@ -950,7 +950,9 @@ def test_render_generation_plan_includes_primitive_plan_section():
     assert "Backend binding" in text
     assert "exercise_monte_carlo" in text
     assert "Route score" in text
-    assert "price_american_equity_option_lsm_monte_carlo" in text
+    assert "resolve_single_state_monte_carlo_inputs" in text
+    assert "terminal_intrinsic_from_resolved" in text
+    assert "price_american_equity_option_lsm_monte_carlo" not in text
 
 
 def test_build_generation_plan_uses_deterministic_cache():

--- a/tests/test_agent/test_route_registry.py
+++ b/tests/test_agent/test_route_registry.py
@@ -149,18 +149,18 @@ class TestRegistryValidation:
                 "exercise_control",
             ),
             (
-                "trellis.models.equity_option_monte_carlo",
-                "price_american_equity_option_lsm_monte_carlo",
-                "route_helper",
-            )
+                "trellis.models.monte_carlo.single_state_diffusion",
+                "resolve_single_state_monte_carlo_inputs",
+                "market_binding",
+            ),
+            (
+                "trellis.models.resolution.single_state_diffusion",
+                "terminal_intrinsic_from_resolved",
+                "payoff_primitive",
+            ),
         }
-        helper = next(primitive for primitive in primitives if primitive.role == "route_helper")
-        assert helper.required is False
-        assert all(
-            primitive.required
-            for primitive in primitives
-            if primitive.role != "route_helper"
-        )
+        assert all(primitive.required for primitive in primitives)
+        assert all(primitive.role != "route_helper" for primitive in primitives)
 
     def test_all_routes_promoted(self, registry):
         candidate_ids = {route.id for route in registry.routes if route.status == "candidate"}

--- a/tests/test_models/test_monte_carlo/test_equity_option_monte_carlo.py
+++ b/tests/test_models/test_monte_carlo/test_equity_option_monte_carlo.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from datetime import date
 
 import pytest
-
 from trellis.core.market_state import MarketState
 from trellis.curves.yield_curve import YieldCurve
 from trellis.models.black import black76_call, black76_put
@@ -11,6 +10,17 @@ from trellis.models.vol_surface import FlatVol
 
 
 SETTLE = date(2024, 11, 15)
+
+
+def test_equity_monte_carlo_preserves_legacy_single_state_resolver_reexport():
+    from trellis.models.equity_option_monte_carlo import (
+        resolve_single_state_terminal_claim_monte_carlo_inputs as product_legacy,
+    )
+    from trellis.models.monte_carlo.single_state_diffusion import (
+        resolve_single_state_terminal_claim_monte_carlo_inputs as core_legacy,
+    )
+
+    assert product_legacy is core_legacy
 
 
 class _Spec:

--- a/tests/test_models/test_monte_carlo/test_single_state_diffusion.py
+++ b/tests/test_models/test_monte_carlo/test_single_state_diffusion.py
@@ -57,6 +57,30 @@ def test_resolve_single_state_terminal_claim_monte_carlo_inputs_reads_market_and
     assert resolved.seed == 11
 
 
+def test_product_neutral_single_state_resolver_preserves_legacy_contract():
+    from trellis.models.monte_carlo.single_state_diffusion import (
+        resolve_single_state_monte_carlo_inputs,
+        resolve_single_state_terminal_claim_monte_carlo_inputs,
+    )
+
+    canonical = resolve_single_state_monte_carlo_inputs(
+        _market_state(vol=0.25, rate=0.03),
+        _Spec(),
+        n_paths=4000,
+        n_steps=48,
+        seed=13,
+    )
+    legacy = resolve_single_state_terminal_claim_monte_carlo_inputs(
+        _market_state(vol=0.25, rate=0.03),
+        _Spec(),
+        n_paths=4000,
+        n_steps=48,
+        seed=13,
+    )
+
+    assert canonical == legacy
+
+
 def test_build_single_state_terminal_claim_monte_carlo_problem_uses_terminal_only_event_aware_shape():
     from trellis.models.monte_carlo.single_state_diffusion import (
         build_single_state_terminal_claim_monte_carlo_problem_from_resolved,

--- a/trellis/agent/backend_bindings.py
+++ b/trellis/agent/backend_bindings.py
@@ -607,7 +607,6 @@ def _exact_target_refs_for(
         "numerical_evidence",
         "payoff_kernel",
         "engine",
-        "market_binding",
         "cashflow_engine",
     )
     refs_by_role = {
@@ -636,7 +635,6 @@ def _binding_id_for(
         "numerical_evidence",
         "payoff_kernel",
         "engine",
-        "market_binding",
         "cashflow_engine",
     )
     source_primitives = tuple(getattr(primitive_plan, "primitives", ()) or ()) or primitives

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -4052,11 +4052,33 @@ def _deterministic_exact_binding_evaluate_body(
         )
     if is_american_equity_option and normalized_target == "lsm_mc":
         return (
-            "return price_american_equity_option_lsm_monte_carlo("
-            "market_state, spec, "
-            'n_paths=getattr(spec, "n_paths", 50000), '
-            'n_steps=getattr(spec, "n_steps", 96), '
-            'seed=getattr(spec, "seed", 42))'
+            "resolved = resolve_single_state_monte_carlo_inputs(\n"
+            "    market_state, spec, scheme=\"exact\", variance_reduction=\"none\",\n"
+            '    n_paths=getattr(spec, "n_paths", 50000),\n'
+            '    n_steps=getattr(spec, "n_steps", 96),\n'
+            '    seed=getattr(spec, "seed", 42),\n'
+            ")\n"
+            "if resolved.maturity <= 0.0:\n"
+            "    return float(resolved.notional * terminal_intrinsic_from_resolved(\n"
+            "        resolved.spot, resolved\n"
+            "    ))\n"
+            "process = GBM(\n"
+            "    mu=resolved.rate - resolved.dividend_yield, sigma=resolved.sigma\n"
+            ")\n"
+            "engine = MonteCarloEngine(\n"
+            "    process, n_paths=resolved.n_paths, n_steps=resolved.n_steps,\n"
+            "    seed=resolved.seed, method=\"exact\",\n"
+            ")\n"
+            "paths = engine.simulate(resolved.spot, resolved.maturity)\n"
+            "exercise_steps = list(range(1, resolved.n_steps + 1))\n"
+            "basis = LaguerreBasis(degree=2)\n"
+            "payoff_fn = lambda spots: terminal_intrinsic_from_resolved(spots, resolved)\n"
+            "price = longstaff_schwartz(\n"
+            "    paths, exercise_steps, payoff_fn, discount_rate=resolved.rate,\n"
+            "    dt=resolved.maturity / resolved.n_steps,\n"
+            "    basis_fn=lambda spots: basis(spots / max(resolved.strike, 1e-12)),\n"
+            ")\n"
+            "return float(resolved.notional * price)"
         )
     if normalized_target == "cev_pde":
         return (
@@ -4970,11 +4992,24 @@ def _deterministic_exact_binding_import_lines(body: str) -> tuple[str, ...]:
         imports.append(
             "from trellis.models.equity_option_tree import price_cev_option_tree"
         )
-    if "price_american_equity_option_lsm_monte_carlo(" in body:
+    if "resolve_single_state_monte_carlo_inputs(" in body:
         imports.append(
-            "from trellis.models.equity_option_monte_carlo import "
-            "price_american_equity_option_lsm_monte_carlo"
+            "from trellis.models.monte_carlo.single_state_diffusion import "
+            "resolve_single_state_monte_carlo_inputs"
         )
+    if "terminal_intrinsic_from_resolved(" in body:
+        imports.append(
+            "from trellis.models.resolution.single_state_diffusion import "
+            "terminal_intrinsic_from_resolved"
+        )
+    if "GBM(" in body:
+        imports.append("from trellis.models.processes.gbm import GBM")
+    if "MonteCarloEngine(" in body:
+        imports.append("from trellis.models.monte_carlo.engine import MonteCarloEngine")
+    if "longstaff_schwartz(" in body:
+        imports.append("from trellis.models.monte_carlo.lsm import longstaff_schwartz")
+    if "LaguerreBasis(" in body:
+        imports.append("from trellis.models.monte_carlo.schemes import LaguerreBasis")
     return tuple(imports)
 
 

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -4070,7 +4070,30 @@ def _deterministic_exact_binding_evaluate_body(
             "    seed=resolved.seed, method=\"exact\",\n"
             ")\n"
             "paths = engine.simulate(resolved.spot, resolved.maturity)\n"
-            "exercise_steps = list(range(1, resolved.n_steps + 1))\n"
+            'exercise_style = str(getattr(spec, "exercise_style", "american")).strip().lower()\n'
+            'if exercise_style == "american":\n'
+            "    exercise_steps = list(range(1, resolved.n_steps + 1))\n"
+            'elif exercise_style == "bermudan":\n'
+            "    if not spec.exercise_dates:\n"
+            '        raise ValueError("Bermudan LSM requires spec.exercise_dates")\n'
+            "    settlement = market_state.settlement or market_state.as_of\n"
+            "    if settlement is None:\n"
+            '        raise ValueError("Bermudan LSM requires market settlement or as_of")\n'
+            "    event_times = []\n"
+            "    for exercise_date in spec.exercise_dates:\n"
+            "        exercise_time = float(year_fraction(settlement, exercise_date, spec.day_count))\n"
+            "        if 0.0 <= exercise_time <= resolved.maturity:\n"
+            "            event_times.append(exercise_time)\n"
+            "    if not event_times:\n"
+            '        raise ValueError("Bermudan LSM resolved no valid exercise dates")\n'
+            "    exercise_steps = list(event_step_indices(\n"
+            "        tuple(event_times), resolved.maturity, resolved.n_steps\n"
+            "    ))\n"
+            "    exercise_steps = sorted({max(int(step), 1) for step in exercise_steps})\n"
+            'elif exercise_style == "european":\n'
+            "    exercise_steps = [resolved.n_steps]\n"
+            "else:\n"
+            '    raise ValueError(f"Unsupported exercise_style {exercise_style!r}")\n'
             "basis = LaguerreBasis(degree=2)\n"
             "payoff_fn = lambda spots: terminal_intrinsic_from_resolved(spots, resolved)\n"
             "price = longstaff_schwartz(\n"
@@ -5010,6 +5033,10 @@ def _deterministic_exact_binding_import_lines(body: str) -> tuple[str, ...]:
         imports.append("from trellis.models.monte_carlo.lsm import longstaff_schwartz")
     if "LaguerreBasis(" in body:
         imports.append("from trellis.models.monte_carlo.schemes import LaguerreBasis")
+    if "event_step_indices(" in body:
+        imports.append(
+            "from trellis.models.monte_carlo.event_state import event_step_indices"
+        )
     return tuple(imports)
 
 

--- a/trellis/agent/knowledge/canonical/api_map.yaml
+++ b/trellis/agent/knowledge/canonical/api_map.yaml
@@ -85,7 +85,8 @@ monte_carlo:
   key_imports:
     - "from trellis.models.monte_carlo.engine import MonteCarloEngine"
     - "from trellis.models.monte_carlo.lsm import longstaff_schwartz, longstaff_schwartz_result"
-    - "from trellis.models.equity_option_monte_carlo import price_american_equity_option_lsm_monte_carlo"
+    - "from trellis.models.monte_carlo.single_state_diffusion import resolve_single_state_monte_carlo_inputs"
+    - "from trellis.models.resolution.single_state_diffusion import terminal_intrinsic_from_resolved"
     - "from trellis.models.monte_carlo.early_exercise import EarlyExercisePolicyResult, LeastSquaresContinuationEstimator"
     - "from trellis.models.monte_carlo.schemes import HestonQuadraticExponential, LaguerreBasis"
     - "from trellis.models.monte_carlo.stochastic_vol import price_heston_option_monte_carlo, price_heston_option_monte_carlo_result"
@@ -101,7 +102,7 @@ monte_carlo:
     - "from trellis.models.monte_carlo import antithetic, control_variate, sobol_normals"
     - "from trellis.models.processes.gbm import GBM"
   notes:
-    - "For American/Bermudan vanilla equity Monte Carlo, compose `GBM`, `MonteCarloEngine`, and `longstaff_schwartz` explicitly when writing a derivative adapter; `price_american_equity_option_lsm_monte_carlo(...)` is an optional compatibility/reference surface"
+    - "For American/Bermudan vanilla equity Monte Carlo, resolve the market contract with `resolve_single_state_monte_carlo_inputs(...)`, then compose `GBM`, `MonteCarloEngine`, `terminal_intrinsic_from_resolved(...)`, and `longstaff_schwartz(...)` explicitly"
     - "Autocallable MC routes should prefer `price_autocallable_monte_carlo_result(...)`; use `sampling='sobol'` only for QMC comparison targets"
     - "Double-barrier MC routes should use two barrier monitors or `double_barrier_state_payoff(...)` instead of adapting a one-barrier analytical formula"
     - "If the control primitive uses continuation regression, choose the estimator or basis explicitly; LaguerreBasis is optional, not mandatory"

--- a/trellis/agent/knowledge/canonical/backend_bindings.yaml
+++ b/trellis/agent/knowledge/canonical/backend_bindings.yaml
@@ -150,10 +150,12 @@ bindings:
           - module: trellis.models.monte_carlo.lsm
             symbol: longstaff_schwartz
             role: exercise_control
-          - module: trellis.models.equity_option_monte_carlo
-            symbol: price_american_equity_option_lsm_monte_carlo
-            role: route_helper
-            required: false
+          - module: trellis.models.monte_carlo.single_state_diffusion
+            symbol: resolve_single_state_monte_carlo_inputs
+            role: market_binding
+          - module: trellis.models.resolution.single_state_diffusion
+            symbol: terminal_intrinsic_from_resolved
+            role: payoff_primitive
 
   - route_id: monte_carlo_paths
     engine_family: monte_carlo

--- a/trellis/agent/knowledge/canonical/routes.yaml
+++ b/trellis/agent/knowledge/canonical/routes.yaml
@@ -308,10 +308,12 @@ routes:
           - module: trellis.models.monte_carlo.lsm
             symbol: longstaff_schwartz
             role: exercise_control
-          - module: trellis.models.equity_option_monte_carlo
-            symbol: price_american_equity_option_lsm_monte_carlo
-            role: route_helper
-            required: false
+          - module: trellis.models.monte_carlo.single_state_diffusion
+            symbol: resolve_single_state_monte_carlo_inputs
+            role: market_binding
+          - module: trellis.models.resolution.single_state_diffusion
+            symbol: terminal_intrinsic_from_resolved
+            role: payoff_primitive
     # QUA-880: adapters, static notes, and dynamic_notes retired onto the
     # lane-obligation surface.  `lane_obligations._control_obligations_for`
     # now emits `approved_exercise_policies` / `implemented_exercise_policies`

--- a/trellis/agent/planner.py
+++ b/trellis/agent/planner.py
@@ -575,6 +575,12 @@ SPECIALIZED_SPECS: dict[str, SpecSchema] = {
             FieldDef("expiry_date", "date", "Option expiry date"),
             FieldDef("option_type", "str", "Option type: 'call' or 'put'", "'put'"),
             FieldDef("exercise_style", "str", "Exercise style for the checked lattice helper", "'american'"),
+            FieldDef(
+                "exercise_dates",
+                "tuple[date, ...] | None",
+                "Bermudan exercise dates",
+                "None",
+            ),
             FieldDef("day_count", "DayCountConvention", "Day count convention", "DayCountConvention.ACT_365"),
             FieldDef("tree_steps", "int", "Tree steps for lattice comparison targets", "800"),
             FieldDef("n_paths", "int", "Monte Carlo paths for LSM comparison targets", "50000"),

--- a/trellis/instruments/_agent/americanputpayoff.py
+++ b/trellis/instruments/_agent/americanputpayoff.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import date
 
-from trellis.core.date_utils import year_fraction
-from trellis.core.differentiable import get_numpy
 from trellis.core.market_state import MarketState
 
 
@@ -16,6 +14,7 @@ class AmericanPutEquitySpec:
     spot: float
     strike: float
     expiry_date: date
+    notional: float = 1.0
     option_type: str = "put"
     exercise_style: str = "american"
 
@@ -41,34 +40,59 @@ class AmericanOptionPayoff:
         from trellis.models.monte_carlo.engine import MonteCarloEngine
         from trellis.models.monte_carlo.lsm import longstaff_schwartz
         from trellis.models.monte_carlo.schemes import LaguerreBasis
+        from trellis.models.monte_carlo.single_state_diffusion import (
+            resolve_single_state_monte_carlo_inputs,
+        )
         from trellis.models.processes.gbm import GBM
+        from trellis.models.resolution.single_state_diffusion import (
+            terminal_intrinsic_from_resolved,
+        )
 
         spec = self._spec
-        np = get_numpy()
-        T = year_fraction(market_state.settlement, spec.expiry_date)
-        if T <= 0:
-            return 0.0
+        resolved = resolve_single_state_monte_carlo_inputs(
+            market_state,
+            spec,
+            scheme="exact",
+            variance_reduction="none",
+            n_paths=4096,
+            n_steps=64,
+            seed=42,
+        )
+        if resolved.maturity <= 0.0:
+            return float(
+                resolved.notional
+                * terminal_intrinsic_from_resolved(resolved.spot, resolved)
+            )
 
-        r = float(market_state.discount.zero_rate(T))
-        sigma = float(market_state.vol_surface.black_vol(T, spec.strike))
-        process = GBM(mu=r, sigma=sigma)
-        engine = MonteCarloEngine(process, n_paths=4096, n_steps=64, seed=42, method="exact")
-        paths = engine.simulate(spec.spot, T)
-        dt = T / engine.n_steps
+        process = GBM(
+            mu=resolved.rate - resolved.dividend_yield,
+            sigma=resolved.sigma,
+        )
+        engine = MonteCarloEngine(
+            process,
+            n_paths=resolved.n_paths,
+            n_steps=resolved.n_steps,
+            seed=resolved.seed,
+            method="exact",
+        )
+        paths = engine.simulate(resolved.spot, resolved.maturity)
+        dt = resolved.maturity / engine.n_steps
         exercise_dates = list(range(1, engine.n_steps + 1))
-        basis = LaguerreBasis()
+        basis = LaguerreBasis(degree=2)
 
         def payoff_fn(spots):
             """Return intrinsic put values at the exercise spots used by LSM."""
-            return np.maximum(spec.strike - spots, 0.0)
+            return terminal_intrinsic_from_resolved(spots, resolved)
 
-        return float(
+        return float(resolved.notional) * float(
             longstaff_schwartz(
                 paths,
                 exercise_dates,
                 payoff_fn,
-                discount_rate=r,
+                discount_rate=resolved.rate,
                 dt=dt,
-                basis_fn=basis,
+                basis_fn=lambda spots: basis(
+                    spots / max(resolved.strike, 1e-12)
+                ),
             )
         )

--- a/trellis/instruments/_agent/americanputpayoff.py
+++ b/trellis/instruments/_agent/americanputpayoff.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import date
 
+from trellis.core.date_utils import year_fraction
 from trellis.core.market_state import MarketState
+from trellis.core.types import DayCountConvention
 
 
 @dataclass(frozen=True)
@@ -17,6 +19,8 @@ class AmericanPutEquitySpec:
     notional: float = 1.0
     option_type: str = "put"
     exercise_style: str = "american"
+    exercise_dates: tuple[date, ...] | None = None
+    day_count: DayCountConvention = DayCountConvention.ACT_365
 
 
 class AmericanOptionPayoff:
@@ -38,6 +42,7 @@ class AmericanOptionPayoff:
     def evaluate(self, market_state: MarketState) -> float:
         """Price the generated American put with Longstaff-Schwartz regression."""
         from trellis.models.monte_carlo.engine import MonteCarloEngine
+        from trellis.models.monte_carlo.event_state import event_step_indices
         from trellis.models.monte_carlo.lsm import longstaff_schwartz
         from trellis.models.monte_carlo.schemes import LaguerreBasis
         from trellis.models.monte_carlo.single_state_diffusion import (
@@ -77,7 +82,36 @@ class AmericanOptionPayoff:
         )
         paths = engine.simulate(resolved.spot, resolved.maturity)
         dt = resolved.maturity / engine.n_steps
-        exercise_dates = list(range(1, engine.n_steps + 1))
+        exercise_style = str(spec.exercise_style).strip().lower()
+        if exercise_style == "american":
+            exercise_steps = list(range(1, engine.n_steps + 1))
+        elif exercise_style == "bermudan":
+            if not spec.exercise_dates:
+                raise ValueError("Bermudan LSM requires spec.exercise_dates")
+            settlement = market_state.settlement or market_state.as_of
+            if settlement is None:
+                raise ValueError("Bermudan LSM requires market settlement or as_of")
+            event_times = []
+            for exercise_date in spec.exercise_dates:
+                exercise_time = float(
+                    year_fraction(settlement, exercise_date, spec.day_count)
+                )
+                if 0.0 <= exercise_time <= resolved.maturity:
+                    event_times.append(exercise_time)
+            if not event_times:
+                raise ValueError("Bermudan LSM resolved no valid exercise dates")
+            exercise_steps = list(
+                event_step_indices(
+                    tuple(event_times), resolved.maturity, resolved.n_steps
+                )
+            )
+            exercise_steps = sorted(
+                {max(int(step), 1) for step in exercise_steps}
+            )
+        elif exercise_style == "european":
+            exercise_steps = [resolved.n_steps]
+        else:
+            raise ValueError(f"Unsupported exercise_style {exercise_style!r}")
         basis = LaguerreBasis(degree=2)
 
         def payoff_fn(spots):
@@ -87,7 +121,7 @@ class AmericanOptionPayoff:
         return float(resolved.notional) * float(
             longstaff_schwartz(
                 paths,
-                exercise_dates,
+                exercise_steps,
                 payoff_fn,
                 discount_rate=resolved.rate,
                 dt=dt,

--- a/trellis/models/equity_option_monte_carlo.py
+++ b/trellis/models/equity_option_monte_carlo.py
@@ -15,7 +15,7 @@ from trellis.models.monte_carlo.single_state_diffusion import (
     SingleStateMonteCarloResult as VanillaEquityMonteCarloResult,
     build_single_state_terminal_claim_monte_carlo_problem,
     price_single_state_terminal_claim_monte_carlo_result,
-    resolve_single_state_terminal_claim_monte_carlo_inputs,
+    resolve_single_state_monte_carlo_inputs,
 )
 from trellis.models.monte_carlo.event_aware import EventAwareMonteCarloProblem
 from trellis.models.monte_carlo.engine import MonteCarloEngine
@@ -41,7 +41,7 @@ def resolve_vanilla_equity_monte_carlo_inputs(
     seed: int | None = None,
 ) -> ResolvedEquityMonteCarloInputs:
     """Resolve vanilla-equity MC inputs from market state and a product spec."""
-    return resolve_single_state_terminal_claim_monte_carlo_inputs(
+    return resolve_single_state_monte_carlo_inputs(
         market_state,
         spec,
         scheme=scheme,

--- a/trellis/models/equity_option_monte_carlo.py
+++ b/trellis/models/equity_option_monte_carlo.py
@@ -16,6 +16,7 @@ from trellis.models.monte_carlo.single_state_diffusion import (
     build_single_state_terminal_claim_monte_carlo_problem,
     price_single_state_terminal_claim_monte_carlo_result,
     resolve_single_state_monte_carlo_inputs,
+    resolve_single_state_terminal_claim_monte_carlo_inputs,
 )
 from trellis.models.monte_carlo.event_aware import EventAwareMonteCarloProblem
 from trellis.models.monte_carlo.engine import MonteCarloEngine
@@ -243,4 +244,5 @@ __all__ = [
     "price_vanilla_equity_option_monte_carlo",
     "price_vanilla_equity_option_monte_carlo_result",
     "resolve_vanilla_equity_monte_carlo_inputs",
+    "resolve_single_state_terminal_claim_monte_carlo_inputs",
 ]

--- a/trellis/models/monte_carlo/single_state_diffusion.py
+++ b/trellis/models/monte_carlo/single_state_diffusion.py
@@ -48,7 +48,7 @@ class SingleStateMonteCarloResult:
     control_variate_beta: float | None = None
 
 
-def resolve_single_state_terminal_claim_monte_carlo_inputs(
+def resolve_single_state_monte_carlo_inputs(
     market_state: SingleStateDiffusionMarketStateLike,
     spec: SingleStateDiffusionSpecLike,
     *,
@@ -58,7 +58,13 @@ def resolve_single_state_terminal_claim_monte_carlo_inputs(
     n_steps: int | None = None,
     seed: int | None = None,
 ) -> ResolvedSingleStateMonteCarloInputs:
-    """Resolve one bounded single-state Monte Carlo contract from semantics."""
+    """Resolve one bounded single-state Monte Carlo contract from semantics.
+
+    The resolved process and numerical controls are useful for terminal,
+    path-dependent, and early-exercise claims. Product-specific code should
+    compose the appropriate process, engine, and payoff/control primitives
+    from this neutral boundary.
+    """
     resolved_base = resolve_single_state_diffusion_inputs(market_state, spec)
     resolved_scheme = _normalized_scheme(
         scheme if scheme is not None else getattr(spec, "scheme", "exact")
@@ -76,6 +82,28 @@ def resolve_single_state_terminal_claim_monte_carlo_inputs(
         seed=seed if seed is not None else getattr(spec, "seed", 42),
         scheme=resolved_scheme,
         variance_reduction=resolved_variance_reduction,
+    )
+
+
+def resolve_single_state_terminal_claim_monte_carlo_inputs(
+    market_state: SingleStateDiffusionMarketStateLike,
+    spec: SingleStateDiffusionSpecLike,
+    *,
+    scheme: str | None = None,
+    variance_reduction: str | None = None,
+    n_paths: int | None = None,
+    n_steps: int | None = None,
+    seed: int | None = None,
+) -> ResolvedSingleStateMonteCarloInputs:
+    """Compatibility name for the product-neutral single-state MC resolver."""
+    return resolve_single_state_monte_carlo_inputs(
+        market_state,
+        spec,
+        scheme=scheme,
+        variance_reduction=variance_reduction,
+        n_paths=n_paths,
+        n_steps=n_steps,
+        seed=seed,
     )
 
 
@@ -127,7 +155,7 @@ def build_single_state_terminal_claim_monte_carlo_problem(
     local_vol_surface: Callable | None = None,
 ) -> tuple[ResolvedSingleStateMonteCarloInputs, EventAwareMonteCarloProblem]:
     """Resolve one single-state terminal claim and build its event-aware MC problem."""
-    resolved = resolve_single_state_terminal_claim_monte_carlo_inputs(
+    resolved = resolve_single_state_monte_carlo_inputs(
         market_state,
         spec,
         scheme=scheme,
@@ -336,5 +364,6 @@ __all__ = [
     "build_single_state_terminal_claim_monte_carlo_problem",
     "build_single_state_terminal_claim_monte_carlo_problem_from_resolved",
     "price_single_state_terminal_claim_monte_carlo_result",
+    "resolve_single_state_monte_carlo_inputs",
     "resolve_single_state_terminal_claim_monte_carlo_inputs",
 ]


### PR DESCRIPTION
## Summary
- replace American LSM product-helper authority with explicit resolver/GBM/engine/payoff/LSM composition
- prevent market-binding resolvers from being treated as exact pricing targets
- migrate the checked-in American adapter and agent-facing docs without changing cookbooks

## Validation
- T14/T27 offline replay: 2/2 passed, zero LLM calls
- T14 LSM deviation from high-step tree: 0.90%; all target code hashes distinct
- `NUMBA_CACHE_DIR=/tmp/trellis-numba-cache make gate-pr`
  - 4260 main tests passed
  - 32 tier-2 contract tests passed

Linear: QUA-1167
