### PR TITLE
QUA-1168: compose equity tree routes from primitives

### DIFF
--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -516,7 +516,12 @@ must compose the admitted single-state market resolver, GBM process, Monte Carlo
 engine, intrinsic payoff primitive, and Longstaff-Schwartz exercise control.
 The compatibility American LSM helper is excluded from generated target
 evidence, so the task tests the agent's composition rather than product-helper
-delegation. ``T15``
+delegation. Its ``crr_tree`` and ``high_step_tree_2000`` targets follow the same
+rule: generated code composes the neutral diffusion resolver with
+``equity_tree``, ``with_control``, ``compile_lattice_recipe``, ``build_lattice``,
+and ``price_on_lattice``. Bermudan variants map contract dates to exercise
+steps before attaching control. The product-level tree helper remains a
+compatibility/reference surface and is not admitted route evidence. ``T15``
 uses a bounded CEV European call contract for the CEVOperator PDE versus CEV
 tree comparison and binds ``cev_pde`` / ``cev_tree`` to deterministic local
 proof adapters. The PDE adapter must consume CEV parameters through

--- a/docs/quant/extending_trellis.rst
+++ b/docs/quant/extending_trellis.rst
@@ -77,13 +77,17 @@ products where routes otherwise drift on:
 The DSL and agent surfaces should map to these stable objects, not to raw
 ``generate_schedule(...)`` plus hand-built ``prev_date`` logic.
 
-When a route family has enough repeated structure, go one step further and
-expose a checked-in helper surface in ``trellis/models/``. For example,
-single-name CDS routes should prefer shared schedule and leg-pricing helpers
-over open-coded premium/protection loops inside generated adapters. The same
-pattern now applies to:
+When a route family has enough repeated structure, expose the smallest stable
+computational surface that carries the repeated mathematics. Prefer neutral
+resolvers, contract recipes, numerical kernels, and solver entry points over a
+product-and-method wrapper. Product helpers remain appropriate when the whole
+operation is itself a stable domain abstraction, as with CDS leg pricing.
+Current route guidance includes:
 
-- vanilla equity tree routes via ``trellis.models.equity_option_tree``
+- vanilla American/Bermudan equity trees via
+  ``resolve_single_state_diffusion_inputs(...)``, ``equity_tree(...)``,
+  ``with_control(...)``, ``compile_lattice_recipe(...)``,
+  ``build_lattice(...)``, and ``price_on_lattice(...)``
 - vanilla European equity PDE routes via ``trellis.models.equity_option_pde``
 - rate-style swaption analytics via ``trellis.models.rate_style_swaption``
 - zero-coupon bond option tree routes via ``trellis.models.zcb_option_tree``

--- a/docs/quant/lattice_algebra.rst
+++ b/docs/quant/lattice_algebra.rst
@@ -328,8 +328,28 @@ The lattice checks cover:
 - Numba-compatibility of compiled rollback shape
 - reporting and multicurrency limits
 
+Primitive-Composed Equity Exercise Routes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Generated American and Bermudan vanilla equity adapters use the general
+lattice algebra directly. The composition boundary is:
+
+#. resolve scalar spot, discount rate, dividend carry, volatility, maturity,
+   strike, and option type
+   with ``resolve_single_state_diffusion_inputs(...)``;
+#. declare ``equity_tree(...)`` and attach holder exercise through
+   ``with_control(...)``;
+#. map contractual Bermudan dates to explicit lattice steps when applicable;
+#. call ``compile_lattice_recipe(...)``, ``build_lattice(...)``, and
+   ``price_on_lattice(...)``.
+
+The generated adapter owns contract and market composition. The library owns
+tree probabilities, topology, and backward induction. The compatibility
+``price_vanilla_equity_option_tree(...)`` wrapper remains useful as a reference
+and migration surface, but it is not route authority for generated adapters.
+
 Current Helper-Backed Routes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The checked helper-backed lattice routes remain:
 

--- a/docs/user_guide/pricing.rst
+++ b/docs/user_guide/pricing.rst
@@ -275,9 +275,12 @@ product lattices. Legacy helpers such as ``build_rate_lattice(...)`` and
 ``build_spot_lattice(...)`` still work, but they are compatibility shims and
 emit deprecation warnings.
 
-For plain equity/rate pricing, prefer the helper routes or recipe compilers.
-For new lattice integrations, target ``LatticeRecipe`` and the unified builder
-instead of hand-assembling route-local tree logic.
+For American or Bermudan vanilla equity pricing, compose an ``equity_tree``
+recipe with ``with_control(...)``, compile it, and use the unified builder and
+pricing entry point. Map Bermudan dates to explicit lattice steps before
+attaching control. Product-level equity-tree helpers remain compatibility and
+reference surfaces; new integrations should target ``LatticeRecipe`` rather
+than hand-assembling route-local tree logic.
 
 Semantic Request Compilation
 ----------------------------

--- a/tests/test_agent/test_api_map.py
+++ b/tests/test_agent/test_api_map.py
@@ -22,7 +22,7 @@ def test_api_map_contains_expected_core_entries():
         api_map["rate_monte_carlo_composition"]["module"]
         == "trellis.models.monte_carlo.simulation_substrate"
     )
-    assert api_map["equity_tree"]["module"] == "trellis.models.equity_option_tree"
+    assert api_map["equity_tree"]["module"] == "trellis.models.trees.algebra"
     assert api_map["rate_lattice"]["module"] == "trellis.models.trees.lattice"
     assert "utilities" in api_map
 
@@ -97,6 +97,22 @@ def test_monte_carlo_api_map_prioritizes_american_lsm_primitives():
     assert "terminal_intrinsic_from_resolved" in text
     assert "longstaff_schwartz" in text
     assert "price_american_equity_option_lsm_monte_carlo" not in text
+
+
+def test_equity_tree_api_map_prioritizes_lattice_algebra_primitives():
+    section = get_api_map()["equity_tree"]
+    text = "\n".join((*section["key_imports"], *section["notes"]))
+
+    for symbol in (
+        "resolve_single_state_diffusion_inputs",
+        "equity_tree",
+        "with_control",
+        "compile_lattice_recipe",
+        "build_lattice",
+        "price_on_lattice",
+    ):
+        assert symbol in text
+    assert "price_vanilla_equity_option_tree" not in text
 
 
 def _assert_import_statements_valid(import_statements: list[str]) -> None:

--- a/tests/test_agent/test_backend_bindings.py
+++ b/tests/test_agent/test_backend_bindings.py
@@ -877,6 +877,57 @@ def test_exercise_monte_carlo_binding_resolves_american_equity_lsm_primitives():
     }
 
 
+def test_exercise_lattice_binding_resolves_american_equity_algebra_primitives():
+    catalog = load_backend_binding_catalog()
+    binding = find_backend_binding_by_route_id("exercise_lattice", catalog)
+    assert binding is not None
+
+    resolved = resolve_backend_binding_spec(
+        binding,
+        product_ir=ProductIR(
+            instrument="american_put",
+            payoff_family="vanilla_option",
+            exercise_style="american",
+            model_family="equity_diffusion",
+        ),
+    )
+
+    assert resolved.helper_refs == ()
+    assert resolved.exact_target_refs == ()
+    assert set(resolved.primitive_refs) == {
+        "trellis.models.resolution.single_state_diffusion.resolve_single_state_diffusion_inputs",
+        "trellis.models.resolution.single_state_diffusion.terminal_intrinsic_from_resolved",
+        "trellis.models.trees.algebra.equity_tree",
+        "trellis.models.trees.algebra.with_control",
+        "trellis.models.trees.algebra.compile_lattice_recipe",
+        "trellis.models.trees.algebra.build_lattice",
+        "trellis.models.trees.algebra.price_on_lattice",
+    }
+
+
+def test_exercise_lattice_binding_adds_bermudan_schedule_mapping_primitives():
+    catalog = load_backend_binding_catalog()
+    binding = find_backend_binding_by_route_id("exercise_lattice", catalog)
+    assert binding is not None
+
+    resolved = resolve_backend_binding_spec(
+        binding,
+        product_ir=ProductIR(
+            instrument="american_put",
+            payoff_family="vanilla_option",
+            exercise_style="bermudan",
+            model_family="equity_diffusion",
+        ),
+    )
+
+    assert resolved.helper_refs == ()
+    assert resolved.exact_target_refs == ()
+    assert {
+        "trellis.core.date_utils.year_fraction",
+        "trellis.models.monte_carlo.event_state.event_step_indices",
+    }.issubset(resolved.primitive_refs)
+
+
 def test_binding_catalog_cache_tracks_binding_catalog_freshness(monkeypatch):
     clear_backend_binding_catalog_cache()
 

--- a/tests/test_agent/test_codegen_guardrails.py
+++ b/tests/test_agent/test_codegen_guardrails.py
@@ -856,7 +856,7 @@ def test_pde_route_card_mentions_terminal_array_contract():
     assert "rannacher_timesteps" in card
 
 
-def test_american_option_route_card_mentions_equity_tree_helper():
+def test_american_option_route_card_describes_lattice_algebra_composition():
     from trellis.agent.knowledge.decompose import decompose_to_ir
 
     pricing_plan = PricingPlan(
@@ -881,14 +881,26 @@ def test_american_option_route_card_mentions_equity_tree_helper():
     assert plan.primitive_plan.route_family == "equity_tree"
     primitive_symbols = {primitive.symbol for primitive in plan.primitive_plan.primitives}
     primitive_modules = {primitive.module for primitive in plan.primitive_plan.primitives}
-    assert primitive_symbols == {"price_vanilla_equity_option_tree"}
-    assert primitive_modules == {"trellis.models.equity_option_tree"}
+    assert primitive_symbols == {
+        "resolve_single_state_diffusion_inputs",
+        "terminal_intrinsic_from_resolved",
+        "equity_tree",
+        "with_control",
+        "compile_lattice_recipe",
+        "build_lattice",
+        "price_on_lattice",
+    }
+    assert primitive_modules == {
+        "trellis.models.resolution.single_state_diffusion",
+        "trellis.models.trees.algebra",
+    }
     assert "Lane obligations:" in card
-    assert "Resolve a spec-like contract with `spot`, `strike`, `expiry_date`" in card
-    assert "price_vanilla_equity_option_tree(market_state, spec_like, model=\"crr\"|\"jarrow_rudd\", n_steps=...)" in card
+    assert "Resolve spot, strike, expiry, option type, and exercise style" in card
+    assert "Compile `equity_tree(...)`" in card
+    assert "Build the lattice with `build_lattice(...)`" in card
+    assert "price the compiled contract with `price_on_lattice(...)`" in card
     assert "build_rate_lattice" not in primitive_symbols
-    assert "price_vanilla_equity_option_tree" in card
-    assert "build_spot_lattice" in card
+    assert "price_vanilla_equity_option_tree" not in card
     assert "lsm_mc" not in card
 
 

--- a/tests/test_agent/test_executor.py
+++ b/tests/test_agent/test_executor.py
@@ -1216,6 +1216,71 @@ def test_deterministic_american_tree_maps_bermudan_dates_to_exercise_steps():
     assert captured["steps"] == event_step_indices(event_times, maturity, 12)
 
 
+def test_deterministic_american_tree_rejects_empty_bermudan_schedule_window():
+    from datetime import date as _date
+
+    import numpy as _np
+
+    from trellis.agent.executor import (
+        _generate_skeleton,
+        _materialize_deterministic_exact_binding_module,
+    )
+    from trellis.agent.planner import SPECIALIZED_SPECS
+    from trellis.core.market_state import MarketState
+
+    class _FlatDiscount:
+        def zero_rate(self, _t: float) -> float:
+            return 0.05
+
+        def discount(self, t: float) -> float:
+            return float(_np.exp(-0.05 * float(t)))
+
+    class _FlatBlackVol:
+        def black_vol(self, _t: float, _strike: float) -> float:
+            return 0.20
+
+    generation_plan = SimpleNamespace(
+        lane_exact_binding_refs=(),
+        primitive_plan=None,
+        method="rate_tree",
+        instrument_type="american_option",
+        lane_control_obligations=("exercise_style:bermudan",),
+    )
+    schema = SPECIALIZED_SPECS["american_put_tree"]
+    generated = _materialize_deterministic_exact_binding_module(
+        _generate_skeleton(
+            schema,
+            "Bermudan put primitive-composed tree",
+            generation_plan=generation_plan,
+        ),
+        generation_plan,
+        comparison_target="crr_tree",
+    )
+
+    assert generated is not None
+    namespace: dict = {}
+    exec(compile(generated.code, "<qua_1168_empty_bermudan>", "exec"), namespace)  # noqa: S102
+    payoff = namespace[schema.class_name](
+        namespace[schema.spec_name](
+            spot=100.0,
+            strike=100.0,
+            expiry_date=_date(2025, 1, 1),
+            exercise_style="bermudan",
+            exercise_dates=(_date(2023, 12, 1), _date(2025, 2, 1)),
+            tree_steps=12,
+        )
+    )
+    market = MarketState(
+        as_of=_date(2024, 1, 1),
+        settlement=_date(2024, 1, 1),
+        discount=_FlatDiscount(),
+        vol_surface=_FlatBlackVol(),
+    )
+
+    with pytest.raises(ValueError, match="within the pricing horizon"):
+        payoff.evaluate(market)
+
+
 def test_deterministic_american_tree_primitive_composition_executes():
     from datetime import date as _date
 

--- a/tests/test_agent/test_executor.py
+++ b/tests/test_agent/test_executor.py
@@ -1045,16 +1045,6 @@ def test_deterministic_exact_binding_module_materializes_vanilla_equity_pde_help
             "price_event_aware_equity_option_pde(",
             "from trellis.models.equity_option_pde import price_event_aware_equity_option_pde",
         ),
-        (
-            "crr_tree",
-            'float(getattr(spec, "notional", 1.0) or 1.0) * price_vanilla_equity_option_tree(',
-            "from trellis.models.equity_option_tree import price_vanilla_equity_option_tree",
-        ),
-        (
-            "high_step_tree_2000",
-            'float(getattr(spec, "notional", 1.0) or 1.0) * price_vanilla_equity_option_tree(',
-            "from trellis.models.equity_option_tree import price_vanilla_equity_option_tree",
-        ),
     ],
 )
 @pytest.mark.parametrize("instrument_type", ["american_put", "american_option"])
@@ -1093,6 +1083,198 @@ def test_deterministic_exact_binding_module_materializes_american_put_targets_wi
     assert expected_import in generated.code
     assert expected_fragment in generated.code
     assert EVALUATE_SENTINEL not in generated.code
+
+
+@pytest.mark.parametrize("comparison_target", ["crr_tree", "high_step_tree_2000"])
+@pytest.mark.parametrize("instrument_type", ["american_put", "american_option"])
+def test_deterministic_exact_binding_materializes_american_tree_from_primitives(
+    instrument_type,
+    comparison_target,
+):
+    from trellis.agent.executor import (
+        EVALUATE_SENTINEL,
+        _generate_skeleton,
+        _materialize_deterministic_exact_binding_module,
+    )
+    from trellis.agent.planner import SPECIALIZED_SPECS
+
+    generation_plan = SimpleNamespace(
+        lane_exact_binding_refs=(),
+        primitive_plan=None,
+        method="rate_tree",
+        instrument_type=instrument_type,
+    )
+    generated = _materialize_deterministic_exact_binding_module(
+        _generate_skeleton(
+            SPECIALIZED_SPECS["american_put_tree"],
+            "American put primitive-composed tree",
+            generation_plan=generation_plan,
+        ),
+        generation_plan,
+        comparison_target=comparison_target,
+    )
+
+    assert generated is not None
+    for fragment in (
+        "from trellis.models.resolution.single_state_diffusion import (",
+        "resolve_single_state_diffusion_inputs",
+        "terminal_intrinsic_from_resolved",
+        "from trellis.models.trees.algebra import (",
+        "equity_tree",
+        "with_control",
+        "compile_lattice_recipe",
+        "build_lattice",
+        "price_on_lattice",
+        "dividend_yield=resolved.dividend_yield",
+    ):
+        assert fragment in generated.code
+    assert "event_step_indices(" not in generated.code
+    assert 'exercise_style == "bermudan"' not in generated.code
+    assert "price_vanilla_equity_option_tree" not in generated.code
+    assert EVALUATE_SENTINEL not in generated.code
+
+
+def test_deterministic_american_tree_maps_bermudan_dates_to_exercise_steps():
+    from datetime import date as _date
+
+    import numpy as _np
+
+    from trellis.agent.executor import (
+        _generate_skeleton,
+        _materialize_deterministic_exact_binding_module,
+    )
+    from trellis.agent.planner import SPECIALIZED_SPECS
+    from trellis.core.date_utils import year_fraction
+    from trellis.core.market_state import MarketState
+    from trellis.models.monte_carlo.event_state import event_step_indices
+
+    class _FlatDiscount:
+        def zero_rate(self, _t: float) -> float:
+            return 0.05
+
+        def discount(self, t: float) -> float:
+            return float(_np.exp(-0.05 * float(t)))
+
+    class _FlatBlackVol:
+        def black_vol(self, _t: float, _strike: float) -> float:
+            return 0.20
+
+    generation_plan = SimpleNamespace(
+        lane_exact_binding_refs=(),
+        primitive_plan=None,
+        method="rate_tree",
+        instrument_type="american_option",
+        lane_control_obligations=("exercise_style:bermudan",),
+    )
+    schema = SPECIALIZED_SPECS["american_put_tree"]
+    generated = _materialize_deterministic_exact_binding_module(
+        _generate_skeleton(
+            schema,
+            "Bermudan put primitive-composed tree",
+            generation_plan=generation_plan,
+        ),
+        generation_plan,
+        comparison_target="crr_tree",
+    )
+
+    assert generated is not None
+    assert "event_step_indices(" in generated.code
+    assert 'exercise_style == "bermudan"' in generated.code
+    namespace: dict = {}
+    exec(compile(generated.code, "<qua_1168_bermudan>", "exec"), namespace)  # noqa: S102
+    settle = _date(2024, 1, 1)
+    expiry = _date(2025, 1, 1)
+    exercise_dates = (_date(2024, 4, 1), _date(2024, 10, 1), expiry)
+    payoff = namespace[schema.class_name](
+        namespace[schema.spec_name](
+            spot=100.0,
+            strike=100.0,
+            expiry_date=expiry,
+            exercise_style="bermudan",
+            exercise_dates=exercise_dates,
+            tree_steps=12,
+        )
+    )
+    captured: dict[str, tuple[int, ...]] = {}
+    original_with_control = namespace["with_control"]
+
+    def _capture_control(recipe, control_kind, **control_params):
+        captured["steps"] = tuple(control_params.get("exercise_steps", ()))
+        return original_with_control(recipe, control_kind, **control_params)
+
+    namespace["with_control"] = _capture_control
+    market = MarketState(
+        as_of=settle,
+        settlement=settle,
+        discount=_FlatDiscount(),
+        vol_surface=_FlatBlackVol(),
+    )
+
+    assert float(payoff.evaluate(market)) > 0.0
+    maturity = year_fraction(settle, expiry)
+    event_times = tuple(year_fraction(settle, item) for item in exercise_dates)
+    assert captured["steps"] == event_step_indices(event_times, maturity, 12)
+
+
+def test_deterministic_american_tree_primitive_composition_executes():
+    from datetime import date as _date
+
+    import numpy as _np
+
+    from trellis.agent.executor import (
+        _generate_skeleton,
+        _materialize_deterministic_exact_binding_module,
+    )
+    from trellis.agent.planner import SPECIALIZED_SPECS
+    from trellis.core.market_state import MarketState
+
+    class _FlatDiscount:
+        def zero_rate(self, _t: float) -> float:
+            return 0.05
+
+        def discount(self, t: float) -> float:
+            return float(_np.exp(-0.05 * float(t)))
+
+    class _FlatBlackVol:
+        def black_vol(self, _t: float, _strike: float) -> float:
+            return 0.20
+
+    generation_plan = SimpleNamespace(
+        lane_exact_binding_refs=(),
+        primitive_plan=None,
+        method="rate_tree",
+        instrument_type="american_option",
+    )
+    schema = SPECIALIZED_SPECS["american_put_tree"]
+    generated = _materialize_deterministic_exact_binding_module(
+        _generate_skeleton(
+            schema,
+            "American put primitive-composed tree",
+            generation_plan=generation_plan,
+        ),
+        generation_plan,
+        comparison_target="crr_tree",
+    )
+
+    assert generated is not None
+    namespace: dict = {}
+    exec(compile(generated.code, "<qua_1168>", "exec"), namespace)  # noqa: S102
+    payoff = namespace[schema.class_name](
+        namespace[schema.spec_name](
+            spot=100.0,
+            strike=100.0,
+            expiry_date=_date(2025, 1, 1),
+            tree_steps=800,
+        )
+    )
+    market = MarketState(
+        as_of=_date(2024, 1, 1),
+        settlement=_date(2024, 1, 1),
+        discount=_FlatDiscount(),
+        vol_surface=_FlatBlackVol(),
+    )
+
+    assert float(payoff.evaluate(market)) == pytest.approx(6.09, abs=0.15)
 
 
 @pytest.mark.parametrize("instrument_type", ["american_put", "american_option"])

--- a/tests/test_agent/test_platform_requests.py
+++ b/tests/test_agent/test_platform_requests.py
@@ -388,7 +388,11 @@ def test_compile_build_request_emits_fallback_lane_plan_for_american_tree_route(
     assert compiled.generation_plan.primitive_plan is not None
     assert compiled.generation_plan.primitive_plan.route == "exercise_lattice"
     assert compiled.generation_plan.lane_family == "lattice"
-    assert "price_vanilla_equity_option_tree" in " ".join(compiled.generation_plan.lane_construction_steps)
+    construction = " ".join(compiled.generation_plan.lane_construction_steps)
+    assert "equity_tree" in construction
+    assert "build_lattice" in construction
+    assert "price_on_lattice" in construction
+    assert "price_vanilla_equity_option_tree" not in construction
 
 
 def test_compile_build_request_keeps_explicit_zcb_option_off_generic_vanilla_semantics():

--- a/tests/test_agent/test_primitive_planning.py
+++ b/tests/test_agent/test_primitive_planning.py
@@ -78,10 +78,21 @@ def test_builds_primitive_plan_for_american_put_tree_route():
     assert plan.primitive_plan.route_family == "equity_tree"
     primitive_symbols = {primitive.symbol for primitive in plan.primitive_plan.primitives}
     primitive_modules = {primitive.module for primitive in plan.primitive_plan.primitives}
-    assert primitive_symbols == {"price_vanilla_equity_option_tree"}
-    assert primitive_modules == {"trellis.models.equity_option_tree"}
+    assert primitive_symbols == {
+        "resolve_single_state_diffusion_inputs",
+        "terminal_intrinsic_from_resolved",
+        "equity_tree",
+        "with_control",
+        "compile_lattice_recipe",
+        "build_lattice",
+        "price_on_lattice",
+    }
+    assert primitive_modules == {
+        "trellis.models.resolution.single_state_diffusion",
+        "trellis.models.trees.algebra",
+    }
     assert "build_rate_lattice" not in primitive_symbols
-    assert any("price_vanilla_equity_option_tree" in note for note in plan.primitive_plan.notes)
+    assert all("price_vanilla_equity_option_tree" not in note for note in plan.primitive_plan.notes)
 
 
 def test_builds_pde_plan_for_barrier_option_uses_grid_and_operator():

--- a/tests/test_agent/test_prompts.py
+++ b/tests/test_agent/test_prompts.py
@@ -1592,16 +1592,40 @@ def test_evaluate_prompt_american_tree_surface_mentions_equity_tree_helper_and_l
             route_family="equity_tree",
             primitives=(
                 PrimitiveRef(
-                    "trellis.models.equity_option_tree",
-                    "price_vanilla_equity_option_tree",
-                    "route_helper",
+                    "trellis.models.resolution.single_state_diffusion",
+                    "resolve_single_state_diffusion_inputs",
+                    "market_binding",
+                ),
+                PrimitiveRef(
+                    "trellis.models.trees.algebra",
+                    "equity_tree",
+                    "contract_recipe",
+                ),
+                PrimitiveRef(
+                    "trellis.models.trees.algebra",
+                    "with_control",
+                    "exercise_control",
+                ),
+                PrimitiveRef(
+                    "trellis.models.trees.algebra",
+                    "compile_lattice_recipe",
+                    "contract_compiler",
+                ),
+                PrimitiveRef(
+                    "trellis.models.trees.algebra",
+                    "build_lattice",
+                    "lattice_builder",
+                ),
+                PrimitiveRef(
+                    "trellis.models.trees.algebra",
+                    "price_on_lattice",
+                    "backward_induction",
                 ),
             ),
             adapters=(),
             blockers=(),
             notes=(
-                "For American and Bermudan equity options, prefer `price_vanilla_equity_option_tree(...)` from `trellis.models.equity_option_tree`.",
-                "If you need the lower-level lattice path, use `build_spot_lattice(..., model=\"crr\"|\"jarrow_rudd\")` with `lattice_backward_induction(...)`.",
+                "Compose the neutral market resolver with the declarative lattice algebra.",
             ),
         ),
     )
@@ -1613,8 +1637,8 @@ def test_evaluate_prompt_american_tree_surface_mentions_equity_tree_helper_and_l
         pricing_plan=PricingPlan(
             method="rate_tree",
             method_modules=[
-                "trellis.models.equity_option_tree",
-                "trellis.models.trees.lattice",
+                "trellis.models.resolution.single_state_diffusion",
+                "trellis.models.trees.algebra",
             ],
             required_market_data={"discount_curve", "black_vol_surface"},
             model_to_build="american_option",
@@ -1625,12 +1649,15 @@ def test_evaluate_prompt_american_tree_surface_mentions_equity_tree_helper_and_l
         prompt_surface="compact",
     )
 
-    assert "price_vanilla_equity_option_tree" in prompt
-    assert "build_spot_lattice" in prompt
-    assert "lattice_backward_induction" in prompt
-    assert "trellis.models.equity_option_tree" in prompt
+    assert "resolve_single_state_diffusion_inputs" in prompt
+    assert "equity_tree" in prompt
+    assert "with_control" in prompt
+    assert "compile_lattice_recipe" in prompt
+    assert "build_lattice" in prompt
+    assert "price_on_lattice" in prompt
+    assert "price_vanilla_equity_option_tree" not in prompt
+    assert "trellis.models.trees.algebra" in prompt
     assert "Route family: `equity_tree`" in prompt
-    assert 'model="crr"' in prompt
     assert "longstaff_schwartz" in prompt
 
 

--- a/tests/test_agent/test_route_registry.py
+++ b/tests/test_agent/test_route_registry.py
@@ -1280,7 +1280,13 @@ class TestRateTreeRoutes:
         spec = [r for r in registry.routes if r.id == "exercise_lattice"][0]
         new_prims = resolve_route_primitives(spec, self.EQUITY_AMERICAN_IR)
         expected_prims = {
-            ("trellis.models.equity_option_tree", "price_vanilla_equity_option_tree", "route_helper"),
+            ("trellis.models.resolution.single_state_diffusion", "resolve_single_state_diffusion_inputs", "market_binding"),
+            ("trellis.models.resolution.single_state_diffusion", "terminal_intrinsic_from_resolved", "payoff_primitive"),
+            ("trellis.models.trees.algebra", "equity_tree", "contract_recipe"),
+            ("trellis.models.trees.algebra", "with_control", "exercise_control"),
+            ("trellis.models.trees.algebra", "compile_lattice_recipe", "contract_compiler"),
+            ("trellis.models.trees.algebra", "build_lattice", "lattice_builder"),
+            ("trellis.models.trees.algebra", "price_on_lattice", "backward_induction"),
         }
         assert _prim_set(new_prims) == expected_prims
 

--- a/tests/test_agent/test_semantic_validation.py
+++ b/tests/test_agent/test_semantic_validation.py
@@ -879,7 +879,7 @@ def test_accepts_helper_only_callable_route_without_low_level_lattice_contract()
     assert report.ok
 
 
-def test_accepts_helper_only_equity_tree_route_without_low_level_tree_contract():
+def test_rejects_helper_only_equity_tree_route_without_required_algebra_primitives():
     from trellis.agent.semantic_validation import validate_semantics
 
     pricing_plan = PricingPlan(
@@ -908,8 +908,8 @@ def test_accepts_helper_only_equity_tree_route_without_low_level_tree_contract()
 
     issue_codes = {issue.code for issue in report.issues}
     assert "engine.family_incompatible_with_ir" not in issue_codes
-    assert "assembly.required_primitive_missing" not in issue_codes
-    assert report.ok
+    assert "assembly.required_primitive_missing" in issue_codes
+    assert not report.ok
 
 
 def test_accepts_helper_only_equity_pde_route_without_low_level_pde_contract():

--- a/tests/test_agent/test_semantic_validators.py
+++ b/tests/test_agent/test_semantic_validators.py
@@ -465,7 +465,7 @@ def evaluate(self, market_state):
         findings = validator.validate(source, _make_plan("analytical_black76"), spec)
         assert any(f.category == "missing_discount_application" for f in findings)
 
-    def test_flags_exact_helper_signature_mismatch(self, registry):
+    def test_equity_tree_compatibility_helper_is_not_exact_route_authority(self, registry):
         spec = [r for r in registry.routes if r.id == "exercise_lattice"][0]
         callable_ir = ProductIR(
             instrument="american_option",
@@ -489,7 +489,8 @@ def evaluate(self, market_state):
 '''
         validator = AlgorithmContractValidator()
         findings = validator.validate(source, _make_plan("exercise_lattice", "lattice"), spec)
-        assert any(f.category == "route_helper_signature_mismatch" for f in findings)
+        assert all(primitive.role != "route_helper" for primitive in spec.primitives)
+        assert not any(f.category == "route_helper_signature_mismatch" for f in findings)
 
     def test_flags_fx_exact_helper_signature_mismatch(self, registry):
         spec = [r for r in registry.routes if r.id == "analytical_garman_kohlhagen"][0]

--- a/tests/test_models/test_trees/test_lattice_algebra.py
+++ b/tests/test_models/test_trees/test_lattice_algebra.py
@@ -26,6 +26,25 @@ def _bs_call(spot: float, strike: float, rate: float, sigma: float, maturity: fl
     return spot * norm.cdf(d1) - strike * exp(-rate * maturity) * norm.cdf(d2)
 
 
+def _bs_call_with_dividend(
+    spot: float,
+    strike: float,
+    rate: float,
+    dividend_yield: float,
+    sigma: float,
+    maturity: float,
+) -> float:
+    d1 = (
+        log(spot / strike)
+        + (rate - dividend_yield + 0.5 * sigma * sigma) * maturity
+    ) / (sigma * sqrt(maturity))
+    d2 = d1 - sigma * sqrt(maturity)
+    return (
+        spot * exp(-dividend_yield * maturity) * norm.cdf(d1)
+        - strike * exp(-rate * maturity) * norm.cdf(d2)
+    )
+
+
 def test_tree_model_round_trips_to_lattice_model_spec():
     spec = MODEL_REGISTRY["hull_white"].as_lattice_model_spec()
 
@@ -110,6 +129,36 @@ def test_build_lattice_equity_matches_spot_builder_and_prices_call():
     assert lattice_backward_induction(built, payoff) == pytest.approx(
         _bs_call(100.0, 100.0, 0.05, 0.20, 1.0),
         rel=0.02,
+    )
+
+
+def test_build_lattice_equity_separates_dividend_carry_from_discounting():
+    from trellis.models.trees.algebra import (
+        BINOMIAL_1F_TOPOLOGY,
+        LATTICE_MODEL_REGISTRY,
+        LOG_SPOT_MESH,
+        NO_CALIBRATION_TARGET,
+    )
+
+    lattice = build_lattice(
+        BINOMIAL_1F_TOPOLOGY,
+        LOG_SPOT_MESH,
+        LATTICE_MODEL_REGISTRY["crr"],
+        calibration_target=NO_CALIBRATION_TARGET(),
+        spot=100.0,
+        rate=0.05,
+        dividend_yield=0.03,
+        sigma=0.20,
+        maturity=1.0,
+        n_steps=500,
+    )
+
+    def payoff(step, node, lattice_):
+        return max(float(lattice_.get_state(step, node)) - 100.0, 0.0)
+
+    assert lattice_backward_induction(lattice, payoff) == pytest.approx(
+        _bs_call_with_dividend(100.0, 100.0, 0.05, 0.03, 0.20, 1.0),
+        rel=0.01,
     )
 
 

--- a/trellis/agent/codegen_guardrails.py
+++ b/trellis/agent/codegen_guardrails.py
@@ -118,11 +118,15 @@ FAMILY_SUPPORT_MODULES = {
         "trellis.models.equity_option_pde",
         "trellis.models.equity_option_tree",
         "trellis.models.equity_option_monte_carlo",
+        "trellis.models.resolution.single_state_diffusion",
+        "trellis.models.trees.algebra",
     ),
     "american_option": (
         "trellis.models.equity_option_pde",
         "trellis.models.equity_option_tree",
         "trellis.models.equity_option_monte_carlo",
+        "trellis.models.resolution.single_state_diffusion",
+        "trellis.models.trees.algebra",
     ),
     "european_option": (
         "trellis.models.equity_option_pde",

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -3803,6 +3803,10 @@ def _american_equity_tree_primitive_body(
                     exercise_time = float(year_fraction(settlement, exercise_date, spec.day_count))
                     if 0.0 <= exercise_time <= resolved.maturity:
                         event_times.append(exercise_time)
+                if not event_times:
+                    raise ValueError(
+                        "Bermudan tree pricing requires an exercise date within the pricing horizon"
+                    )
                 exercise_steps = event_step_indices(
                     event_times, resolved.maturity, tree_steps
                 )

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -3759,6 +3759,80 @@ def _basket_option_helper_kwargs(comparison_target: str | None) -> str:
     return f', comparison_target="{target}"'
 
 
+def _american_equity_tree_primitive_body(
+    comparison_target: str,
+    *,
+    include_bermudan_schedule: bool,
+) -> str:
+    """Return explicit lattice-algebra composition for an early-exercise equity option."""
+    steps_expression = (
+        "2000"
+        if comparison_target == "high_step_tree_2000"
+        else 'max(int(getattr(spec, "tree_steps", 800)), 1)'
+    )
+    prefix = textwrap.dedent(
+        f"""\
+        resolved = resolve_single_state_diffusion_inputs(market_state, spec)
+        if resolved.maturity <= 0.0:
+            return float(resolved.notional * terminal_intrinsic_from_resolved(
+                resolved.spot, resolved
+            ))
+        tree_steps = {steps_expression}
+        recipe = equity_tree(
+            model_family="crr",
+            strike=resolved.strike,
+            option_type=resolved.option_type,
+        )
+        exercise_style = str(getattr(spec, "exercise_style", "american")).strip().lower()
+        if exercise_style == "american":
+            recipe = with_control(recipe, "american")
+        """
+    ).rstrip()
+    control_branches: list[str] = []
+    if include_bermudan_schedule:
+        control_branches.append(textwrap.dedent(
+            """\
+            elif exercise_style == "bermudan":
+                if not spec.exercise_dates:
+                    raise ValueError("Bermudan tree pricing requires spec.exercise_dates")
+                settlement = market_state.settlement or market_state.as_of
+                if settlement is None:
+                    raise ValueError("Bermudan tree pricing requires market settlement or as_of")
+                event_times = []
+                for exercise_date in spec.exercise_dates:
+                    exercise_time = float(year_fraction(settlement, exercise_date, spec.day_count))
+                    if 0.0 <= exercise_time <= resolved.maturity:
+                        event_times.append(exercise_time)
+                exercise_steps = event_step_indices(
+                    event_times, resolved.maturity, tree_steps
+                )
+                recipe = with_control(
+                    recipe, "bermudan", exercise_steps=exercise_steps
+                )
+            """
+        ).rstrip())
+    suffix = textwrap.dedent(
+        """\
+        elif exercise_style != "european":
+            raise ValueError(f"Unsupported exercise_style {exercise_style!r}")
+        topology, mesh, model, contract = compile_lattice_recipe(recipe)
+        lattice = build_lattice(
+            topology,
+            mesh,
+            model,
+            spot=resolved.spot,
+            rate=resolved.rate,
+            dividend_yield=resolved.dividend_yield,
+            sigma=resolved.sigma,
+            maturity=resolved.maturity,
+            n_steps=tree_steps,
+        )
+        return float(resolved.notional * price_on_lattice(lattice, contract))
+        """
+    ).rstrip()
+    return "\n".join((prefix, *control_branches, suffix))
+
+
 def _credit_default_swap_helper_body(refs: set[str]) -> str | None:
     """Return a thin deterministic CDS wrapper for analytical or MC exact bindings."""
     analytical_ref = "trellis.models.credit_default_swap.price_cds_analytical"
@@ -4038,17 +4112,20 @@ def _deterministic_exact_binding_evaluate_body(
             'n_t=getattr(spec, "n_t", 400))'
         )
     if is_american_equity_option and normalized_target == "crr_tree":
-        return (
-            'return float(getattr(spec, "notional", 1.0) or 1.0) * '
-            "price_vanilla_equity_option_tree("
-            'market_state, spec, model="crr", '
-            'n_steps=getattr(spec, "tree_steps", 800))'
+        control_obligations = tuple(
+            _generation_plan_field(generation_plan, "lane_control_obligations", ()) or ()
+        )
+        return _american_equity_tree_primitive_body(
+            normalized_target,
+            include_bermudan_schedule="exercise_style:bermudan" in control_obligations,
         )
     if is_american_equity_option and normalized_target == "high_step_tree_2000":
-        return (
-            'return float(getattr(spec, "notional", 1.0) or 1.0) * '
-            "price_vanilla_equity_option_tree("
-            'market_state, spec, model="crr", n_steps=2000)'
+        control_obligations = tuple(
+            _generation_plan_field(generation_plan, "lane_control_obligations", ()) or ()
+        )
+        return _american_equity_tree_primitive_body(
+            normalized_target,
+            include_bermudan_schedule="exercise_style:bermudan" in control_obligations,
         )
     if is_american_equity_option and normalized_target == "lsm_mc":
         return (
@@ -5020,10 +5097,27 @@ def _deterministic_exact_binding_import_lines(body: str) -> tuple[str, ...]:
             "from trellis.models.monte_carlo.single_state_diffusion import "
             "resolve_single_state_monte_carlo_inputs"
         )
-    if "terminal_intrinsic_from_resolved(" in body:
+    if "resolve_single_state_diffusion_inputs(" in body:
+        imports.append(
+            "from trellis.models.resolution.single_state_diffusion import (\n"
+            "    resolve_single_state_diffusion_inputs,\n"
+            "    terminal_intrinsic_from_resolved,\n"
+            ")"
+        )
+    elif "terminal_intrinsic_from_resolved(" in body:
         imports.append(
             "from trellis.models.resolution.single_state_diffusion import "
             "terminal_intrinsic_from_resolved"
+        )
+    if "equity_tree(" in body and "compile_lattice_recipe(" in body:
+        imports.append(
+            "from trellis.models.trees.algebra import (\n"
+            "    build_lattice,\n"
+            "    compile_lattice_recipe,\n"
+            "    equity_tree,\n"
+            "    price_on_lattice,\n"
+            "    with_control,\n"
+            ")"
         )
     if "GBM(" in body:
         imports.append("from trellis.models.processes.gbm import GBM")

--- a/trellis/agent/knowledge/canonical/api_map.yaml
+++ b/trellis/agent/knowledge/canonical/api_map.yaml
@@ -57,15 +57,15 @@ payoff:
 # Model imports — trees
 # ---------------------------------------------------------------------------
 equity_tree:
-  module: trellis.models.equity_option_tree
+  module: trellis.models.trees.algebra
   key_imports:
+    - "from trellis.models.resolution.single_state_diffusion import resolve_single_state_diffusion_inputs, terminal_intrinsic_from_resolved"
+    - "from trellis.models.trees.algebra import equity_tree, with_control, compile_lattice_recipe, build_lattice, price_on_lattice"
     - "from trellis.models.equity_option_tree import price_cev_option_tree"
-    - "from trellis.models.equity_option_tree import price_vanilla_equity_option_tree"
-    - "from trellis.models.trees.lattice import build_spot_lattice, lattice_backward_induction"
   notes:
-    - "American/Bermudan equity options should prefer the checked-in helper `price_vanilla_equity_option_tree(...)`"
+    - "American/Bermudan vanilla equity adapters should compose the neutral market resolver with the declarative lattice recipe, control, compiler, builder, and pricing primitives"
+    - "Bermudan adapters map contractual exercise dates to lattice steps before attaching control"
     - "CEV tree comparison targets should prefer the checked-in spot-lattice helper `price_cev_option_tree(...)`"
-    - "If you need the lower-level path, import the lattice builder/backward induction submodules directly"
 
 rate_lattice:
   module: trellis.models.trees.lattice

--- a/trellis/agent/knowledge/canonical/backend_bindings.yaml
+++ b/trellis/agent/knowledge/canonical/backend_bindings.yaml
@@ -407,11 +407,62 @@ bindings:
     conditional_primitives:
       - when:
           payoff_family: vanilla_option
-          exercise_style: [american, bermudan]
+          exercise_style: american
+          model_family: equity_diffusion
         primitives:
-          - module: trellis.models.equity_option_tree
-            symbol: price_vanilla_equity_option_tree
-            role: route_helper
+          - module: trellis.models.resolution.single_state_diffusion
+            symbol: resolve_single_state_diffusion_inputs
+            role: market_binding
+          - module: trellis.models.resolution.single_state_diffusion
+            symbol: terminal_intrinsic_from_resolved
+            role: payoff_primitive
+          - module: trellis.models.trees.algebra
+            symbol: equity_tree
+            role: contract_recipe
+          - module: trellis.models.trees.algebra
+            symbol: with_control
+            role: exercise_control
+          - module: trellis.models.trees.algebra
+            symbol: compile_lattice_recipe
+            role: contract_compiler
+          - module: trellis.models.trees.algebra
+            symbol: build_lattice
+            role: lattice_builder
+          - module: trellis.models.trees.algebra
+            symbol: price_on_lattice
+            role: backward_induction
+      - when:
+          payoff_family: vanilla_option
+          exercise_style: bermudan
+          model_family: equity_diffusion
+        primitives:
+          - module: trellis.models.resolution.single_state_diffusion
+            symbol: resolve_single_state_diffusion_inputs
+            role: market_binding
+          - module: trellis.models.resolution.single_state_diffusion
+            symbol: terminal_intrinsic_from_resolved
+            role: payoff_primitive
+          - module: trellis.models.trees.algebra
+            symbol: equity_tree
+            role: contract_recipe
+          - module: trellis.models.trees.algebra
+            symbol: with_control
+            role: exercise_control
+          - module: trellis.models.trees.algebra
+            symbol: compile_lattice_recipe
+            role: contract_compiler
+          - module: trellis.models.trees.algebra
+            symbol: build_lattice
+            role: lattice_builder
+          - module: trellis.models.trees.algebra
+            symbol: price_on_lattice
+            role: backward_induction
+          - module: trellis.core.date_utils
+            symbol: year_fraction
+            role: timeline_mapping
+          - module: trellis.models.monte_carlo.event_state
+            symbol: event_step_indices
+            role: schedule_mapping
       - when:
           payoff_family: [bond, callable_bond, callable_fixed_income]
           exercise_style: [issuer_call, holder_put, bermudan]

--- a/trellis/agent/knowledge/canonical/routes.yaml
+++ b/trellis/agent/knowledge/canonical/routes.yaml
@@ -812,17 +812,71 @@ routes:
     conditional_primitives:
       - when:
           payoff_family: vanilla_option
-          exercise_style: [american, bermudan]
+          exercise_style: american
+          model_family: equity_diffusion
         primitives:
-          - module: trellis.models.equity_option_tree
-            symbol: price_vanilla_equity_option_tree
-            role: route_helper
+          - module: trellis.models.resolution.single_state_diffusion
+            symbol: resolve_single_state_diffusion_inputs
+            role: market_binding
+          - module: trellis.models.resolution.single_state_diffusion
+            symbol: terminal_intrinsic_from_resolved
+            role: payoff_primitive
+          - module: trellis.models.trees.algebra
+            symbol: equity_tree
+            role: contract_recipe
+          - module: trellis.models.trees.algebra
+            symbol: with_control
+            role: exercise_control
+          - module: trellis.models.trees.algebra
+            symbol: compile_lattice_recipe
+            role: contract_compiler
+          - module: trellis.models.trees.algebra
+            symbol: build_lattice
+            role: lattice_builder
+          - module: trellis.models.trees.algebra
+            symbol: price_on_lattice
+            role: backward_induction
         adapters: []
         notes:
-          - "Use `trellis.models.equity_option_tree.price_vanilla_equity_option_tree(...)` directly inside `evaluate()` for vanilla American or Bermudan equity tree routes."
-          - "Treat equity-tree generation as a thin adapter over the checked-in helper; do not rebuild CRR step math, intrinsic payoff maps, or backward induction inline unless the shared helper is missing required functionality."
-          - "When you need a lower-level lattice entry point, call `build_spot_lattice(..., model=\"crr\"|\"jarrow_rudd\")` and `lattice_backward_induction(...)` from `trellis.models.trees.lattice`."
+          - "Resolve scalar market inputs, declare the vanilla claim with `equity_tree(...)`, attach American holder control with `with_control(...)`, then compile, build, and price through the lattice algebra."
+          - "Use the shipped recipe/compiler/builder/rollback primitives; do not reimplement CRR probabilities or backward induction inside the adapter."
           - "Do not invent `crr_tree`, `AMERICAN`, or a `method=\"lsm\"` fallback on the tree route."
+      - when:
+          payoff_family: vanilla_option
+          exercise_style: bermudan
+          model_family: equity_diffusion
+        primitives:
+          - module: trellis.models.resolution.single_state_diffusion
+            symbol: resolve_single_state_diffusion_inputs
+            role: market_binding
+          - module: trellis.models.resolution.single_state_diffusion
+            symbol: terminal_intrinsic_from_resolved
+            role: payoff_primitive
+          - module: trellis.models.trees.algebra
+            symbol: equity_tree
+            role: contract_recipe
+          - module: trellis.models.trees.algebra
+            symbol: with_control
+            role: exercise_control
+          - module: trellis.models.trees.algebra
+            symbol: compile_lattice_recipe
+            role: contract_compiler
+          - module: trellis.models.trees.algebra
+            symbol: build_lattice
+            role: lattice_builder
+          - module: trellis.models.trees.algebra
+            symbol: price_on_lattice
+            role: backward_induction
+          - module: trellis.core.date_utils
+            symbol: year_fraction
+            role: timeline_mapping
+          - module: trellis.models.monte_carlo.event_state
+            symbol: event_step_indices
+            role: schedule_mapping
+        adapters: []
+        notes:
+          - "Map the contractual Bermudan exercise dates to lattice steps, then pass those steps to `with_control(..., control_kind=\"bermudan\", exercise_steps=...)`."
+          - "Resolve, compile, build, and price through the same generic lattice algebra used by the American route."
       - when:
           payoff_family: [bond, callable_bond, callable_fixed_income]
           exercise_style: [issuer_call, holder_put, bermudan]

--- a/trellis/agent/lane_obligations.py
+++ b/trellis/agent/lane_obligations.py
@@ -675,18 +675,24 @@ def _fallback_construction_steps(
     primitive_plan: PrimitivePlan | None,
 ) -> tuple[str, ...]:
     """Emit constructive fallback steps for non-semantic builds."""
-    helper_symbols = {
+    required_symbols = {
         str(primitive.symbol)
         for primitive in (getattr(primitive_plan, "primitives", ()) or ())
         if bool(getattr(primitive, "required", True))
     }
     instrument = str(getattr(product_ir, "instrument", "") or instrument_type or "").strip().lower()
 
-    if "price_vanilla_equity_option_tree" in helper_symbols:
+    if {
+        "equity_tree",
+        "with_control",
+        "compile_lattice_recipe",
+        "build_lattice",
+        "price_on_lattice",
+    }.issubset(required_symbols):
         return (
-            "Resolve a spec-like contract with `spot`, `strike`, `expiry_date`, and the optional fields `option_type`, `exercise_style`, and `day_count`.",
-            "Call `price_vanilla_equity_option_tree(market_state, spec_like, model=\"crr\"|\"jarrow_rudd\", n_steps=...)`; do not invent `underlying=`, `exercise=`, or other bespoke helper keywords.",
-            "Let the checked equity-tree helper own rate, discounting, and vol resolution; keep the adapter thin and market-state explicit.",
+            "Resolve spot, strike, expiry, option type, and exercise style through `resolve_single_state_diffusion_inputs(...)`.",
+            "Compile `equity_tree(...)` and attach `with_control(...)`; for Bermudan exercise, map contractual dates to explicit lattice steps.",
+            "Build the lattice with `build_lattice(...)` using the compiled topology, mesh, model, and resolved inputs; price the compiled contract with `price_on_lattice(...)` without reimplementing transition probabilities or backward induction.",
         )
 
     if lane_family == "monte_carlo" and "fx_rates" in required_market_data:
@@ -700,7 +706,7 @@ def _fallback_construction_steps(
         return (
             "Resolve spot, strike, expiry, and exercise style explicitly before building the early-exercise contract.",
             "Keep discounting and volatility on the market-state side; do not invent alternate curve or vol accessors.",
-            "Prefer the smallest exact helper-backed adapter when a stable lattice backend exists; otherwise keep the rollback and early-exercise contract explicit.",
+            "Compose the declarative lattice recipe, exercise control, compiler, lattice builder, and pricing primitive explicitly.",
         )
 
     if lane_family == "monte_carlo":

--- a/trellis/agent/planner.py
+++ b/trellis/agent/planner.py
@@ -574,7 +574,7 @@ SPECIALIZED_SPECS: dict[str, SpecSchema] = {
             FieldDef("strike", "float", "Option strike price"),
             FieldDef("expiry_date", "date", "Option expiry date"),
             FieldDef("option_type", "str", "Option type: 'call' or 'put'", "'put'"),
-            FieldDef("exercise_style", "str", "Exercise style for the checked lattice helper", "'american'"),
+            FieldDef("exercise_style", "str", "Exercise style for lattice control", "'american'"),
             FieldDef(
                 "exercise_dates",
                 "tuple[date, ...] | None",

--- a/trellis/agent/prompts.py
+++ b/trellis/agent/prompts.py
@@ -335,7 +335,7 @@ defined in the skeleton.
 - Black76: `black76_call(F, K, sigma, T)`, `black76_put(F, K, sigma, T)` — undiscounted
 - Black76 digital: `black76_cash_or_nothing_call(F, K, sigma, T)`, `black76_cash_or_nothing_put(F, K, sigma, T)` — undiscounted cash-or-nothing digitals
 - For CDS / nth-to-default: use `market_state.credit_curve.survival_probability(t)` and `market_state.credit_curve.hazard_rate(t)` on an explicit payment/default schedule; do not route credit-default pricing through Black76 call/put primitives.
-- For equity trees: prefer `from trellis.models.equity_option_tree import price_vanilla_equity_option_tree`; the lower-level lattice path is `from trellis.models.trees.lattice import build_spot_lattice, lattice_backward_induction`
+- For equity trees: resolve scalar inputs with `resolve_single_state_diffusion_inputs`, declare the claim with `equity_tree`, attach `with_control`, then use `compile_lattice_recipe`, `build_lattice`, and `price_on_lattice`
 - For vanilla European PDE routes: prefer `from trellis.models.equity_option_pde import price_vanilla_equity_option_pde`; the lower-level fallback is `from trellis.models.pde.grid import Grid`, `from trellis.models.pde.operator import BlackScholesOperator`, and `from trellis.models.pde.theta_method import theta_method_1d`
 - For rate lattices: prefer helper surfaces such as `price_callable_bond_tree(...)`, `price_bermudan_swaption_tree(...)`, or `price_zcb_option_tree(...)`; the lower-level fallback is `from trellis.models.trees.lattice import build_rate_lattice, lattice_backward_induction`
 - For schedule-dependent rate lattices: `from trellis.models.trees.control import lattice_steps_from_timeline, resolve_lattice_exercise_policy`
@@ -448,10 +448,10 @@ def _render_family_route_guidance(
         lines.append("## Family Route Guidance")
         if method == "rate_tree":
             lines.extend([
-                "- For American/Bermudan equity tree routes, prefer `price_vanilla_equity_option_tree(market_state, self._spec, model=\"crr\")` from `trellis.models.equity_option_tree`.",
-                "- If you need the lower-level lattice path, build `build_spot_lattice(..., model=\"crr\"|\"jarrow_rudd\")` and then call `lattice_backward_induction(..., exercise_policy=resolve_lattice_exercise_policy(\"american\"|\"bermudan\"))`.",
+                "- For American/Bermudan equity tree routes, compose `resolve_single_state_diffusion_inputs`, `equity_tree`, `with_control`, `compile_lattice_recipe`, `build_lattice`, and `price_on_lattice`.",
+                "- Map Bermudan exercise dates to lattice steps before passing `exercise_steps` to `with_control`; American control remains open at every rollback step.",
                 "- Do not invent a `crr_tree` symbol, an `AMERICAN` constant, or a `method=\"lsm\"` fallback on the tree route.",
-                "- Keep the early-exercise logic on the tree side and treat the checked-in helper as the default adapter surface.",
+                "- Use the lattice algebra for transition probabilities and backward induction; keep the generated adapter focused on contract and market composition.",
             ])
         elif method == "pde_solver":
             lines.extend([

--- a/trellis/instruments/_agent/buildapayoff.py
+++ b/trellis/instruments/_agent/buildapayoff.py
@@ -1,6 +1,6 @@
 """Agent-generated payoff: Build a pricer for: American put: equity tree knowledge-light proving
 
-Build a thin adapter for a vanilla American put on an equity underlier. Use the checked lattice helper for the pricing engine rather than open-coding the rollback.
+Build a thin adapter for a vanilla American put on an equity underlier by composing the shared lattice algebra.
 
 Construct methods: rate_tree
 Comparison targets: rate_tree (rate_tree)."""
@@ -12,8 +12,17 @@ from datetime import date
 
 from trellis.core.market_state import MarketState
 from trellis.core.types import DayCountConvention
-from trellis.models.equity_option_tree import price_vanilla_equity_option_tree
-from trellis.models.trees.lattice import build_spot_lattice, lattice_backward_induction
+from trellis.models.resolution.single_state_diffusion import (
+    resolve_single_state_diffusion_inputs,
+    terminal_intrinsic_from_resolved,
+)
+from trellis.models.trees.algebra import (
+    build_lattice,
+    compile_lattice_recipe,
+    equity_tree,
+    price_on_lattice,
+    with_control,
+)
 
 
 
@@ -21,7 +30,7 @@ from trellis.models.trees.lattice import build_spot_lattice, lattice_backward_in
 class AmericanPutEquityTreeSpec:
     """Specification for Build a pricer for: American put: equity tree knowledge-light proving
 
-Build a thin adapter for a vanilla American put on an equity underlier. Use the checked lattice helper for the pricing engine rather than open-coding the rollback.
+Build a thin adapter for a vanilla American put on an equity underlier by composing the shared lattice algebra.
 
 Construct methods: rate_tree
 Comparison targets: rate_tree (rate_tree)."""
@@ -32,13 +41,14 @@ Comparison targets: rate_tree (rate_tree)."""
     notional: float
     rate_index: str | None
     num_steps: int = 100
+    option_type: str = "put"
     day_count: DayCountConvention = DayCountConvention.ACT_365
 
 
 class AmericanPutEquityTreePayoff:
     """Build a pricer for: American put: equity tree knowledge-light proving
 
-Build a thin adapter for a vanilla American put on an equity underlier. Use the checked lattice helper for the pricing engine rather than open-coding the rollback.
+Build a thin adapter for a vanilla American put on an equity underlier by composing the shared lattice algebra.
 
 Construct methods: rate_tree
 Comparison targets: rate_tree (rate_tree)."""
@@ -56,12 +66,31 @@ Comparison targets: rate_tree (rate_tree)."""
 
     def evaluate(self, market_state: MarketState) -> float:
         spec = self._spec
+        resolved = resolve_single_state_diffusion_inputs(market_state, spec)
+        if resolved.maturity <= 0.0:
+            return float(
+                resolved.notional
+                * terminal_intrinsic_from_resolved(resolved.spot, resolved)
+            )
 
-        raw_price = price_vanilla_equity_option_tree(
-            market_state,
-            spec,
-            model="crr",
-            n_steps=spec.num_steps,
+        recipe = with_control(
+            equity_tree(
+                model_family="crr",
+                strike=resolved.strike,
+                option_type=resolved.option_type,
+            ),
+            "american",
         )
-
-        return float(spec.notional * raw_price)
+        topology, mesh, model, contract = compile_lattice_recipe(recipe)
+        lattice = build_lattice(
+            topology,
+            mesh,
+            model,
+            spot=resolved.spot,
+            rate=resolved.rate,
+            dividend_yield=resolved.dividend_yield,
+            sigma=resolved.sigma,
+            maturity=resolved.maturity,
+            n_steps=max(int(spec.num_steps), 1),
+        )
+        return float(resolved.notional * price_on_lattice(lattice, contract))

--- a/trellis/models/trees/algebra.py
+++ b/trellis/models/trees/algebra.py
@@ -125,14 +125,16 @@ def _uniform_additive_step_size(step: int, params: Mapping[str, object]) -> floa
 def _log_spot_coordinate(step: int, node: int, params: Mapping[str, object]) -> float:
     spot = float(params.get("spot", params.get("S0", 1.0)))
     rate = float(params.get("rate", params.get("r", 0.0)))
+    dividend_yield = float(params.get("dividend_yield", 0.0))
     sigma = float(params.get("sigma", 0.0))
     maturity = float(params.get("maturity", params.get("T", 0.0)))
     n_steps = max(int(params.get("n_steps", 1)), 1)
     dt = maturity / n_steps
     model = str(params.get("model", "crr")).strip().lower()
     if model in {"jarrow_rudd", "jr"}:
-        u = exp((rate - 0.5 * sigma * sigma) * dt + sigma * sqrt(dt))
-        d = exp((rate - 0.5 * sigma * sigma) * dt - sigma * sqrt(dt))
+        carry_rate = rate - dividend_yield
+        u = exp((carry_rate - 0.5 * sigma * sigma) * dt + sigma * sqrt(dt))
+        d = exp((carry_rate - 0.5 * sigma * sigma) * dt - sigma * sqrt(dt))
     else:
         u = exp(sigma * sqrt(dt))
         d = 1.0 / max(u, 1e-12)
@@ -610,6 +612,7 @@ class AnalyticalCalibration:
             maturity,
             int(params["n_steps"]),
             model=model.name,
+            dividend_yield=float(params.get("dividend_yield", 0.0)),
         )
         diagnostics = CalibrationDiagnostics(
             residuals={},

--- a/trellis/models/trees/lattice.py
+++ b/trellis/models/trees/lattice.py
@@ -822,6 +822,7 @@ def _build_spot_lattice_impl(
     n_steps: int,
     *,
     model: str = "crr",
+    dividend_yield: float = 0.0,
 ) -> RecombiningLattice:
     """Build a recombining spot-price lattice for low-dimensional equity trees.
 
@@ -836,14 +837,15 @@ def _build_spot_lattice_impl(
         - ``"jarrow_rudd"`` / ``"jr"``
     """
     dt = T / n_steps
+    carry_rate = float(r) - float(dividend_yield)
     model_key = str(model).strip().lower()
     if model_key in {"crr", "cox_ross_rubinstein"}:
         u = raw_np.exp(sigma * raw_np.sqrt(dt))
         d = 1.0 / u
-        p = (raw_np.exp(r * dt) - d) / (u - d)
+        p = (raw_np.exp(carry_rate * dt) - d) / (u - d)
     elif model_key in {"jarrow_rudd", "jr"}:
-        u = raw_np.exp((r - 0.5 * sigma ** 2) * dt + sigma * raw_np.sqrt(dt))
-        d = raw_np.exp((r - 0.5 * sigma ** 2) * dt - sigma * raw_np.sqrt(dt))
+        u = raw_np.exp((carry_rate - 0.5 * sigma ** 2) * dt + sigma * raw_np.sqrt(dt))
+        d = raw_np.exp((carry_rate - 0.5 * sigma ** 2) * dt - sigma * raw_np.sqrt(dt))
         p = 0.5
     else:
         raise ValueError(


### PR DESCRIPTION
## Summary
- replace American/Bermudan equity-tree product-helper authority with neutral resolver and lattice algebra primitives
- preserve contract-specific Bermudan schedule mapping and migrate the checked-in proof adapter
- separate dividend carry from discounting in generic CRR/Jarrow-Rudd construction
- document generated-adapter versus compatibility-helper boundaries

## Validation
- targeted current-tree suite: 731 passed
- T14 strict offline replay: green, zero LLM calls; CRR deviation 0.0177% vs 2,000-step reference
- T27 strict offline replay: green, zero LLM calls
- make gate-pr: 4,276 main passed; 32 tier-2 passed; 15 optional skips
- Sphinx parsed/rendered changed pages; repository-wide -W remains red on pre-existing warnings and offline intersphinx lookups

## Tracking
- QUA-1168