### PR TITLE
QUA-1169: Compose vanilla MC from terminal primitives

### DIFF
--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -510,7 +510,15 @@ of collapsing into a generic validation-failure bucket.
 Sparse legacy proof rows can also carry a deterministic task-runtime contract
 bridge before generation. The bridge is intentionally small and auditable:
 ``T25``, ``T26``, ``T31``, and ``T32`` default to a European SPX call
-semantic contract for Monte Carlo numerical-method proof work. ``T14`` uses an
+semantic contract for Monte Carlo numerical-method proof work. ``T25`` and
+``T26`` lower the European terminal claim to
+``price_single_state_terminal_claim_monte_carlo_result(...)`` plus an explicit
+``terminal_intrinsic_from_resolved(...)`` callback. Their generated targets
+bind Euler, Milstein, exact, log-Euler, antithetic, and control-variate choices
+at the adapter boundary; control-variate targets also provide the
+dividend-adjusted expected terminal spot. The product-level vanilla Monte
+Carlo wrapper is not admitted target evidence, and strict offline replay uses
+no LLM generation or recovery. ``T14`` uses an
 American SPX put contract for the PDE/tree/LSM comparison. Its ``lsm_mc`` target
 must compose the admitted single-state market resolver, GBM process, Monte Carlo
 engine, intrinsic payoff primitive, and Longstaff-Schwartz exercise control.

--- a/docs/quant/contract_algebra.rst
+++ b/docs/quant/contract_algebra.rst
@@ -440,9 +440,14 @@ The first vanilla migration slice is now checked in as well:
 
 - vanilla European Monte Carlo lowers as a terminal-only ``gbm_1d`` family
   instance with no synthetic event-replay timeline
-- the existing local-vol vanilla helper remains a compatibility surface, but
-  it now delegates into the generic event-aware Monte Carlo runtime rather than
-  owning a separate engine/payoff implementation
+- its lowering expression composes the selected terminal-payoff primitive with
+  ``price_single_state_terminal_claim_monte_carlo_result(...)`` rather than
+  lowering to a product-level pricing helper
+- generated adapters supply the derivative-specific payoff callback and bind
+  scheme and variance-reduction controls explicitly; the estimator owns the
+  checked single-state market binding and simulation machinery
+- the product-level vanilla Monte Carlo wrapper remains a compatibility and
+  reference surface, not route authority
 
 In the current tranche this is still a bounded 1D family surface. It makes the
 operator family and event-transform contract explicit before the generic

--- a/docs/quant/pricing_stack.rst
+++ b/docs/quant/pricing_stack.rst
@@ -179,7 +179,13 @@ The first migrated vanilla cases now use that boundary directly:
 - vanilla European Monte Carlo lowers onto ``EventAwareMonteCarloIR`` as a
   terminal-only ``gbm_1d`` family instance rather than a synthetic event-replay
   instance
-- the vanilla Monte Carlo and transform wrappers now both compose a shared
+- vanilla European Monte Carlo route authority is the product-neutral
+  ``price_single_state_terminal_claim_monte_carlo_result(...)`` estimator plus
+  an explicit terminal-payoff callback. Generated call/put adapters bind
+  ``terminal_intrinsic_from_resolved(...)`` and choose the requested scheme and
+  variance-reduction controls; the product-level wrapper is retained only for
+  compatibility and reference use
+- the vanilla Monte Carlo estimator and transform wrappers share the
   single-state diffusion resolver/GBM-support layer under
   ``trellis.models.resolution`` for settlement, maturity, spot, dividend,
   discount, vol, and characteristic-function binding

--- a/tests/test_agent/test_api_map.py
+++ b/tests/test_agent/test_api_map.py
@@ -99,6 +99,15 @@ def test_monte_carlo_api_map_prioritizes_american_lsm_primitives():
     assert "price_american_equity_option_lsm_monte_carlo" not in text
 
 
+def test_monte_carlo_api_map_prioritizes_terminal_claim_composition():
+    section = get_api_map()["monte_carlo"]
+    text = "\n".join((*section["key_imports"], *section["notes"]))
+
+    assert "price_single_state_terminal_claim_monte_carlo_result" in text
+    assert "terminal_intrinsic_from_resolved" in text
+    assert "price_vanilla_equity_option_monte_carlo" not in text
+
+
 def test_equity_tree_api_map_prioritizes_lattice_algebra_primitives():
     section = get_api_map()["equity_tree"]
     text = "\n".join((*section["key_imports"], *section["notes"]))

--- a/tests/test_agent/test_backend_bindings.py
+++ b/tests/test_agent/test_backend_bindings.py
@@ -261,6 +261,29 @@ def test_resolve_backend_binding_spec_uses_basket_option_exact_helpers():
     )
 
 
+def test_monte_carlo_binding_resolves_vanilla_terminal_claim_primitives():
+    catalog = load_backend_binding_catalog()
+    binding = find_backend_binding_by_route_id("monte_carlo_paths", catalog)
+    assert binding is not None
+
+    resolved = resolve_backend_binding_spec(
+        binding,
+        product_ir=ProductIR(
+            instrument="european_option",
+            payoff_family="vanilla_option",
+            exercise_style="european",
+            model_family="equity_diffusion",
+        ),
+    )
+
+    assert resolved.helper_refs == ()
+    assert resolved.exact_target_refs == ()
+    assert set(resolved.primitive_refs) == {
+        "trellis.models.monte_carlo.single_state_diffusion.price_single_state_terminal_claim_monte_carlo_result",
+        "trellis.models.resolution.single_state_diffusion.terminal_intrinsic_from_resolved",
+    }
+
+
 def test_resolve_backend_binding_spec_uses_heston_transform_helper():
     catalog = load_backend_binding_catalog()
     transform = find_backend_binding_by_route_id("transform_fft", catalog)

--- a/tests/test_agent/test_dsl_lowering.py
+++ b/tests/test_agent/test_dsl_lowering.py
@@ -335,21 +335,27 @@ def test_vanilla_option_monte_carlo_lowers_to_terminal_only_compilation_steps():
     assert isinstance(lowering.family_ir, EventAwareMonteCarloIR)
     assert lowering.family_ir.path_requirement_spec.requirement_kind == "terminal_only"
     assert lowering.family_ir.event_kinds == ()
-    assert isinstance(lowering.normalized_expr, ContractAtom)
-    assert (
-        lowering.binding_id
-        == "trellis.models.equity_option_monte_carlo.price_vanilla_equity_option_monte_carlo"
-    )
-    assert lowering.normalized_expr.atom_id == (
-        "trellis.models.equity_option_monte_carlo.price_vanilla_equity_option_monte_carlo:"
-        "route_helper"
-    )
-    assert lowering.normalized_expr.primitive_ref == (
-        "trellis.models.equity_option_monte_carlo.price_vanilla_equity_option_monte_carlo"
+    assert isinstance(lowering.normalized_expr, ThenExpr)
+    assert lowering.binding_id == "monte_carlo:monte_carlo:fallback"
+    assert tuple(
+        term.primitive_ref for term in lowering.normalized_expr.terms
+    ) == (
+        "trellis.models.resolution.single_state_diffusion."
+        "terminal_intrinsic_from_resolved",
+        "trellis.models.monte_carlo.single_state_diffusion."
+        "price_single_state_terminal_claim_monte_carlo_result",
     )
     assert blueprint.lane_plan is not None
+    assert blueprint.lane_plan.exact_target_refs == (
+        "trellis.models.monte_carlo.single_state_diffusion."
+        "price_single_state_terminal_claim_monte_carlo_result",
+    )
     assert "spot" in blueprint.lane_plan.state_obligations
     assert "terminal_only" in blueprint.lane_plan.state_obligations
+    steps = " ".join(blueprint.lane_plan.construction_steps)
+    assert "payoff callback" in steps
+    assert "scheme" in steps
+    assert "variance-reduction" in steps
 
 
 def test_vanilla_option_analytical_lowers_to_checked_in_black76_kernel():

--- a/tests/test_agent/test_executor.py
+++ b/tests/test_agent/test_executor.py
@@ -958,7 +958,7 @@ def test_deterministic_exact_binding_module_materializes_callable_bond_pde_wrapp
         ("control_variate_mc", 'variance_reduction="control_variate"'),
     ],
 )
-def test_deterministic_exact_binding_module_materializes_vanilla_equity_mc_helper_wrapper(
+def test_deterministic_exact_binding_module_materializes_vanilla_equity_mc_from_primitives(
     comparison_target,
     expected_fragment,
 ):
@@ -970,7 +970,10 @@ def test_deterministic_exact_binding_module_materializes_vanilla_equity_mc_helpe
     from trellis.agent.planner import SPECIALIZED_SPECS
 
     generation_plan = SimpleNamespace(
-        lane_exact_binding_refs=("trellis.models.equity_option_monte_carlo.price_vanilla_equity_option_monte_carlo",),
+        lane_exact_binding_refs=(
+            "trellis.models.monte_carlo.single_state_diffusion."
+            "price_single_state_terminal_claim_monte_carlo_result",
+        ),
         primitive_plan=None,
         method="monte_carlo",
         instrument_type="european_option",
@@ -988,9 +991,100 @@ def test_deterministic_exact_binding_module_materializes_vanilla_equity_mc_helpe
     )
 
     assert generated is not None
-    assert "price_vanilla_equity_option_monte_carlo(market_state, spec" in generated.code
+    assert "price_single_state_terminal_claim_monte_carlo_result(" in generated.code
+    assert "terminal_intrinsic_from_resolved(terminal, resolved)" in generated.code
+    assert "price_vanilla_equity_option_monte_carlo" not in generated.code
     assert expected_fragment in generated.code
+    if comparison_target == "control_variate_mc":
+        assert "control_variate_values=" in generated.code
+        assert "control_variate_expected=" in generated.code
+        assert "from math import exp" in generated.code
+    else:
+        assert "control_variate_values=" not in generated.code
+        assert "control_variate_expected=" not in generated.code
+        assert "from math import exp" not in generated.code
     assert EVALUATE_SENTINEL not in generated.code
+
+
+@pytest.mark.parametrize("comparison_target", ["exact", "control_variate_mc"])
+def test_deterministic_vanilla_equity_mc_primitive_composition_executes(
+    comparison_target,
+):
+    from datetime import date as _date
+
+    import numpy as _np
+
+    from trellis.agent.executor import (
+        _generate_skeleton,
+        _materialize_deterministic_exact_binding_module,
+    )
+    from trellis.agent.planner import SPECIALIZED_SPECS
+    from trellis.core.market_state import MarketState
+
+    class _FlatDiscount:
+        def zero_rate(self, _t: float) -> float:
+            return 0.05
+
+        def discount(self, t: float) -> float:
+            return float(_np.exp(-0.05 * float(t)))
+
+    class _FlatBlackVol:
+        def black_vol(self, _t: float, _strike: float) -> float:
+            return 0.20
+
+    generation_plan = SimpleNamespace(
+        lane_exact_binding_refs=(
+            "trellis.models.monte_carlo.single_state_diffusion."
+            "price_single_state_terminal_claim_monte_carlo_result",
+        ),
+        primitive_plan=None,
+        method="monte_carlo",
+        instrument_type="european_option",
+    )
+    schema = SPECIALIZED_SPECS["european_option_monte_carlo"]
+    generated = _materialize_deterministic_exact_binding_module(
+        _generate_skeleton(
+            schema,
+            "European option primitive-composed Monte Carlo",
+            generation_plan=generation_plan,
+        ),
+        generation_plan,
+        comparison_target=comparison_target,
+    )
+
+    assert generated is not None
+    namespace: dict = {}
+    exec(compile(generated.code, "<qua_1169>", "exec"), namespace)  # noqa: S102
+    payoff = namespace[schema.class_name](
+        namespace[schema.spec_name](
+            notional=1.0,
+            spot=100.0,
+            strike=100.0,
+            expiry_date=_date(2025, 1, 1),
+            option_type="call",
+            n_paths=30_000,
+            n_steps=64,
+        )
+    )
+    market = MarketState(
+        as_of=_date(2024, 1, 1),
+        settlement=_date(2024, 1, 1),
+        discount=_FlatDiscount(),
+        vol_surface=_FlatBlackVol(),
+    )
+
+    assert float(payoff.evaluate(market)) == pytest.approx(10.45, abs=0.25)
+
+
+def test_admitted_vanilla_equity_mc_adapter_uses_terminal_claim_primitives():
+    source = (
+        Path(__file__).resolve().parents[2]
+        / "trellis/instruments/_agent/europeanoptionmontecarlo.py"
+    ).read_text()
+
+    assert "price_single_state_terminal_claim_monte_carlo_result(" in source
+    assert "terminal_intrinsic_from_resolved(" in source
+    assert "price_vanilla_equity_option_monte_carlo" not in source
 
 
 @pytest.mark.parametrize(

--- a/tests/test_agent/test_family_lowering_ir.py
+++ b/tests/test_agent/test_family_lowering_ir.py
@@ -356,7 +356,7 @@ def test_vanilla_option_monte_carlo_compiles_to_terminal_only_event_aware_family
     assert family_ir.route_id == "monte_carlo_paths"
     assert family_ir.product_instrument == "european_option"
     assert family_ir.payoff_family == "vanilla_option"
-    assert family_ir.helper_symbol == "price_vanilla_equity_option_monte_carlo"
+    assert family_ir.helper_symbol == ""
     assert family_ir.state_spec.state_variable == "spot"
     assert family_ir.process_spec.process_family == "gbm_1d"
     assert family_ir.path_requirement_spec.requirement_kind == "terminal_only"

--- a/tests/test_agent/test_lane_obligations.py
+++ b/tests/test_agent/test_lane_obligations.py
@@ -22,7 +22,12 @@ from trellis.agent.family_lowering_ir import (
     TransformPricingIR,
     TransformStateSpec,
 )
-from trellis.agent.lane_obligations import compile_lane_construction_plan
+from trellis.agent.codegen_guardrails import PrimitivePlan, PrimitiveRef
+from trellis.agent.knowledge.schema import ProductIR
+from trellis.agent.lane_obligations import (
+    compile_fallback_lane_construction_plan,
+    compile_lane_construction_plan,
+)
 
 
 def test_event_aware_monte_carlo_lane_plan_emits_process_path_and_event_contracts():
@@ -125,6 +130,53 @@ def test_event_aware_monte_carlo_lane_plan_emits_process_path_and_event_contract
     assert "measure_family:risk_neutral" in plan.control_obligations
     assert any("hull_white_1f" in step for step in plan.construction_steps)
     assert any("event_replay" in step for step in plan.construction_steps)
+
+
+def test_terminal_claim_monte_carlo_fallback_emits_payoff_and_control_steps():
+    primitive_plan = PrimitivePlan(
+        route="monte_carlo_paths",
+        route_family="monte_carlo",
+        engine_family="monte_carlo",
+        primitives=(
+            PrimitiveRef(
+                module="trellis.models.monte_carlo.single_state_diffusion",
+                symbol="price_single_state_terminal_claim_monte_carlo_result",
+                role="monte_carlo_estimator",
+            ),
+            PrimitiveRef(
+                module="trellis.models.resolution.single_state_diffusion",
+                symbol="terminal_intrinsic_from_resolved",
+                role="payoff_primitive",
+            ),
+        ),
+        adapters=(),
+        blockers=(),
+    )
+    product_ir = ProductIR(
+        instrument="european_option",
+        payoff_family="vanilla_option",
+        exercise_style="european",
+        model_family="equity_diffusion",
+    )
+
+    plan = compile_fallback_lane_construction_plan(
+        preferred_method="monte_carlo",
+        required_market_data=("discount_curve", "black_vol_surface"),
+        primitive_plan=primitive_plan,
+        product_ir=product_ir,
+        instrument_type="european_option",
+    )
+
+    assert plan is not None
+    assert plan.exact_target_refs == (
+        "trellis.models.monte_carlo.single_state_diffusion."
+        "price_single_state_terminal_claim_monte_carlo_result",
+    )
+    steps = " ".join(plan.construction_steps)
+    assert "terminal_intrinsic_from_resolved" in steps
+    assert "payoff callback" in steps
+    assert "scheme" in steps
+    assert "variance-reduction" in steps
 
 
 def test_transform_lane_plan_emits_terminal_characteristic_contract():

--- a/tests/test_agent/test_lite_review.py
+++ b/tests/test_agent/test_lite_review.py
@@ -561,6 +561,80 @@ def price(spec, market_state):
     assert "lite.monte_carlo_paths_black_vol_surface_access_missing" in issue_codes
 
 
+def test_lite_review_accepts_checked_terminal_claim_estimator_market_binding():
+    from trellis.agent.codegen_guardrails import (
+        GenerationPlan,
+        PrimitivePlan,
+        PrimitiveRef,
+    )
+    from trellis.agent.lite_review import review_generated_code
+    from trellis.agent.quant import PricingPlan
+
+    source = """\
+from trellis.models.monte_carlo.single_state_diffusion import price_single_state_terminal_claim_monte_carlo_result
+from trellis.models.resolution.single_state_diffusion import terminal_intrinsic_from_resolved
+
+def price(spec, market_state):
+    result = price_single_state_terminal_claim_monte_carlo_result(
+        market_state,
+        spec,
+        terminal_payoff=lambda terminal, resolved: terminal_intrinsic_from_resolved(terminal, resolved),
+        scheme="exact",
+        variance_reduction="none",
+    )
+    return float(result.price)
+"""
+    plan = GenerationPlan(
+        method="monte_carlo",
+        instrument_type="european_option",
+        inspected_modules=("trellis.models.monte_carlo.single_state_diffusion",),
+        approved_modules=(
+            "trellis.models.monte_carlo.single_state_diffusion",
+            "trellis.models.resolution.single_state_diffusion",
+        ),
+        symbols_to_reuse=(
+            "price_single_state_terminal_claim_monte_carlo_result",
+            "terminal_intrinsic_from_resolved",
+        ),
+        proposed_tests=("tests/test_agent/test_build_loop.py",),
+        primitive_plan=PrimitivePlan(
+            route="monte_carlo_paths",
+            engine_family="monte_carlo",
+            primitives=(
+                PrimitiveRef(
+                    "trellis.models.monte_carlo.single_state_diffusion",
+                    "price_single_state_terminal_claim_monte_carlo_result",
+                    "monte_carlo_estimator",
+                ),
+                PrimitiveRef(
+                    "trellis.models.resolution.single_state_diffusion",
+                    "terminal_intrinsic_from_resolved",
+                    "payoff_primitive",
+                ),
+            ),
+            adapters=(),
+            blockers=(),
+        ),
+    )
+    pricing_plan = PricingPlan(
+        method="monte_carlo",
+        method_modules=["trellis.models.monte_carlo.single_state_diffusion"],
+        required_market_data={"discount_curve", "black_vol_surface"},
+        model_to_build="european_option",
+        reasoning="test",
+    )
+
+    report = review_generated_code(
+        source,
+        pricing_plan=pricing_plan,
+        generation_plan=plan,
+    )
+
+    issue_codes = {issue.code for issue in report.issues}
+    assert "lite.monte_carlo_paths_discount_curve_access_missing" not in issue_codes
+    assert "lite.monte_carlo_paths_black_vol_surface_access_missing" not in issue_codes
+
+
 def test_lite_review_rejects_rate_tree_route_without_market_access():
     from trellis.agent.codegen_guardrails import GenerationPlan, PrimitivePlan
     from trellis.agent.lite_review import review_generated_code

--- a/tests/test_agent/test_route_registry.py
+++ b/tests/test_agent/test_route_registry.py
@@ -861,9 +861,14 @@ class TestMonteCarloPathsRoutes:
         new_prims = resolve_route_primitives(spec, self.EUROPEAN_IR)
         expected_prims = {
             (
-                "trellis.models.equity_option_monte_carlo",
-                "price_vanilla_equity_option_monte_carlo",
-                "route_helper",
+                "trellis.models.monte_carlo.single_state_diffusion",
+                "price_single_state_terminal_claim_monte_carlo_result",
+                "monte_carlo_estimator",
+            ),
+            (
+                "trellis.models.resolution.single_state_diffusion",
+                "terminal_intrinsic_from_resolved",
+                "payoff_primitive",
             ),
         }
         assert _prim_set(new_prims) == expected_prims

--- a/tests/test_agent/test_semantic_validation.py
+++ b/tests/test_agent/test_semantic_validation.py
@@ -157,6 +157,17 @@ def build_price(self, market_state):
 """
 
 
+HELPER_ONLY_EQUITY_MONTE_CARLO_SOURCE = """\
+from __future__ import annotations
+
+from trellis.models.equity_option_monte_carlo import price_vanilla_equity_option_monte_carlo
+
+
+def build_price(self, market_state):
+    return float(price_vanilla_equity_option_monte_carlo(market_state, self._spec))
+"""
+
+
 AUTOCALLABLE_HELPER_SOURCE = """\
 from __future__ import annotations
 
@@ -943,6 +954,38 @@ def test_accepts_helper_only_equity_pde_route_without_low_level_pde_contract():
     assert "engine.family_incompatible_with_ir" not in issue_codes
     assert "assembly.required_primitive_missing" not in issue_codes
     assert report.ok
+
+
+def test_rejects_helper_only_equity_monte_carlo_without_terminal_claim_primitives():
+    from trellis.agent.semantic_validation import validate_semantics
+
+    pricing_plan = PricingPlan(
+        method="monte_carlo",
+        method_modules=["trellis.models.monte_carlo.single_state_diffusion"],
+        required_market_data={"discount_curve", "black_vol_surface"},
+        model_to_build="european_option",
+        reasoning="test",
+    )
+    product_ir = decompose_to_ir(
+        "European call option on equity",
+        instrument_type="european_option",
+    )
+    generation_plan = build_generation_plan(
+        pricing_plan=pricing_plan,
+        instrument_type="european_option",
+        inspected_modules=("trellis.models.monte_carlo.single_state_diffusion",),
+        product_ir=product_ir,
+    )
+
+    report = validate_semantics(
+        HELPER_ONLY_EQUITY_MONTE_CARLO_SOURCE,
+        product_ir=product_ir,
+        generation_plan=generation_plan,
+    )
+
+    issue_codes = {issue.code for issue in report.issues}
+    assert "assembly.required_primitive_missing" in issue_codes
+    assert not report.ok
 
 
 def test_accepts_helper_backed_autocallable_route():

--- a/tests/test_agent/test_semantic_validators.py
+++ b/tests/test_agent/test_semantic_validators.py
@@ -558,7 +558,7 @@ def evaluate(self, market_state):
         findings = validator.validate(source, _make_plan("transform_fft", "fft_pricing"), spec)
         assert not any(f.category == "route_helper_signature_mismatch" for f in findings)
 
-    def test_flags_vanilla_equity_monte_carlo_helper_signature_mismatch(self, registry):
+    def test_vanilla_equity_monte_carlo_helper_is_not_exact_route_authority(self, registry):
         spec = [r for r in registry.routes if r.id == "monte_carlo_paths"][0]
         vanilla_ir = ProductIR(
             instrument="european_option",
@@ -579,9 +579,10 @@ def evaluate(self, market_state):
 '''
         validator = AlgorithmContractValidator()
         findings = validator.validate(source, _make_plan("monte_carlo_paths", "monte_carlo"), spec)
-        assert any(f.category == "route_helper_signature_mismatch" for f in findings)
+        assert all(primitive.role != "route_helper" for primitive in spec.primitives)
+        assert not any(f.category == "route_helper_signature_mismatch" for f in findings)
 
-    def test_accepts_vanilla_equity_monte_carlo_helper_surface(self, registry):
+    def test_vanilla_equity_monte_carlo_compatibility_helper_has_no_route_signature_contract(self, registry):
         spec = [r for r in registry.routes if r.id == "monte_carlo_paths"][0]
         vanilla_ir = ProductIR(
             instrument="european_option",

--- a/trellis/agent/dsl_lowering.py
+++ b/trellis/agent/dsl_lowering.py
@@ -733,6 +733,64 @@ def _build_event_aware_monte_carlo_expr_from_family_ir(
         )
         return helper_atom, ()
 
+    terminal_estimator = next(
+        (
+            binding
+            for binding in bindings
+            if binding.role == "monte_carlo_estimator"
+        ),
+        None,
+    )
+    terminal_payoff = next(
+        (
+            binding
+            for binding in bindings
+            if binding.role in {"payoff_primitive", "terminal_payoff"}
+        ),
+        None,
+    )
+    path_requirement = str(
+        family_ir.path_requirement_spec.requirement_kind or ""
+    ).strip().lower()
+    if path_requirement == "terminal_only" and terminal_estimator is not None:
+        if terminal_payoff is None:
+            return None, (
+                _missing_primitive_message(
+                    route_id,
+                    binding_id,
+                    "terminal payoff",
+                ),
+            )
+        payoff_atom = ContractAtom(
+            atom_id=_binding_atom_id(route_id, binding_id, "payoff_primitive"),
+            primitive_ref=terminal_payoff.primitive_ref,
+            description=(
+                "Bind the derivative-specific terminal payoff as a callback over "
+                "resolved single-state diffusion inputs."
+            ),
+            signature=ContractSignature(
+                inputs=market_signature.inputs,
+                outputs=("terminal_payoff_callback:state",),
+                timeline_roles=market_signature.timeline_roles,
+                market_data_requirements=market_signature.market_data_requirements,
+            ),
+        )
+        estimator_atom = ContractAtom(
+            atom_id=_binding_atom_id(route_id, binding_id, "monte_carlo_estimator"),
+            primitive_ref=terminal_estimator.primitive_ref,
+            description=(
+                "Evaluate the terminal claim with explicit simulation scheme and "
+                "variance-reduction controls."
+            ),
+            signature=ContractSignature(
+                inputs=("terminal_payoff_callback:state",),
+                outputs=("price:scalar",),
+                timeline_roles=market_signature.timeline_roles,
+                market_data_requirements=market_signature.market_data_requirements,
+            ),
+        )
+        return ThenExpr(terms=(payoff_atom, estimator_atom)), ()
+
     process_binding = next(
         (
             binding

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -3952,6 +3952,20 @@ def _deterministic_exact_binding_evaluate_body(
     refs = set(_exact_binding_refs(generation_plan))
     swaption_comparison_kwargs = _swaption_comparison_helper_kwargs(semantic_blueprint)
     vanilla_equity_mc_kwargs = _vanilla_equity_monte_carlo_helper_kwargs(comparison_target)
+    vanilla_equity_mc_call_kwargs = (
+        vanilla_equity_mc_kwargs.lstrip(", ")
+        or 'scheme="exact", variance_reduction="none"'
+    )
+    vanilla_equity_mc_control_kwargs = ""
+    if 'variance_reduction="control_variate"' in vanilla_equity_mc_call_kwargs:
+        vanilla_equity_mc_control_kwargs = (
+            "    control_variate_values=lambda terminal, _resolved: terminal,\n"
+            "    control_variate_expected=lambda resolved: float(\n"
+            "        resolved.spot * exp(\n"
+            "            (resolved.rate - resolved.dividend_yield) * resolved.maturity\n"
+            "        )\n"
+            "    ),\n"
+        )
     vanilla_equity_pde_kwargs = _vanilla_equity_pde_helper_kwargs(comparison_target)
     heston_mc_kwargs = _heston_monte_carlo_helper_kwargs(comparison_target)
     vanilla_equity_transform_kwargs = _vanilla_equity_transform_helper_kwargs(comparison_target)
@@ -4492,9 +4506,16 @@ def _deterministic_exact_binding_evaluate_body(
             "market_state, spec, n_paths=20000, seed=42"
             f"{swaption_comparison_kwargs})"
         ),
-        "trellis.models.equity_option_monte_carlo.price_vanilla_equity_option_monte_carlo": (
-            "return price_vanilla_equity_option_monte_carlo("
-            f"market_state, spec{vanilla_equity_mc_kwargs})"
+        "trellis.models.monte_carlo.single_state_diffusion.price_single_state_terminal_claim_monte_carlo_result": (
+            "result = price_single_state_terminal_claim_monte_carlo_result(\n"
+            "    market_state,\n"
+            "    spec,\n"
+            "    terminal_payoff=lambda terminal, resolved: "
+            "terminal_intrinsic_from_resolved(terminal, resolved),\n"
+            f"    {vanilla_equity_mc_call_kwargs},\n"
+            f"{vanilla_equity_mc_control_kwargs}"
+            ")\n"
+            "return float(result.price)"
         ),
         "trellis.models.equity_option_pde.price_vanilla_equity_option_pde": (
             "return price_vanilla_equity_option_pde("
@@ -4944,6 +4965,8 @@ def _deterministic_exact_binding_import_lines(body: str) -> tuple[str, ...]:
     ordinary generated modules.
     """
     imports: list[str] = []
+    if "control_variate_expected=lambda resolved:" in body:
+        imports.append("from math import exp")
     if "year_fraction(" in body:
         imports.append("from trellis.core.date_utils import year_fraction")
     if "price_heston_option_monte_carlo(" in body:
@@ -5100,6 +5123,11 @@ def _deterministic_exact_binding_import_lines(body: str) -> tuple[str, ...]:
         imports.append(
             "from trellis.models.monte_carlo.single_state_diffusion import "
             "resolve_single_state_monte_carlo_inputs"
+        )
+    if "price_single_state_terminal_claim_monte_carlo_result(" in body:
+        imports.append(
+            "from trellis.models.monte_carlo.single_state_diffusion import "
+            "price_single_state_terminal_claim_monte_carlo_result"
         )
     if "resolve_single_state_diffusion_inputs(" in body:
         imports.append(

--- a/trellis/agent/family_lowering_ir.py
+++ b/trellis/agent/family_lowering_ir.py
@@ -804,7 +804,6 @@ _MC_MARKET_MAPPINGS = {
 
 
 _MC_HELPER_BINDINGS = {
-    ("gbm_1d", "vanilla_option", "european"): "price_vanilla_equity_option_monte_carlo",
     ("heston", "vanilla_option", "european"): "price_heston_option_monte_carlo",
     ("hull_white_1f", "period_rate_option_strip", ""): "price_rate_cap_floor_strip_monte_carlo",
     ("hull_white_1f", "swaption", ""): "price_swaption_monte_carlo",
@@ -1098,6 +1097,11 @@ def _binding_supports_event_aware_monte_carlo(
     binding_spec is None` fallback has been retired.
     """
     del route_id
+    if _binding_has_role(binding_spec, "monte_carlo_estimator") and _binding_has_role(
+        binding_spec,
+        "payoff_primitive",
+    ):
+        return True
     if _binding_has_role(binding_spec, "path_simulation") and _binding_has_role(binding_spec, "state_process"):
         return True
     if _binding_has_any_symbol(

--- a/trellis/agent/knowledge/canonical/api_map.yaml
+++ b/trellis/agent/knowledge/canonical/api_map.yaml
@@ -85,7 +85,7 @@ monte_carlo:
   key_imports:
     - "from trellis.models.monte_carlo.engine import MonteCarloEngine"
     - "from trellis.models.monte_carlo.lsm import longstaff_schwartz, longstaff_schwartz_result"
-    - "from trellis.models.monte_carlo.single_state_diffusion import resolve_single_state_monte_carlo_inputs"
+    - "from trellis.models.monte_carlo.single_state_diffusion import resolve_single_state_monte_carlo_inputs, price_single_state_terminal_claim_monte_carlo_result"
     - "from trellis.models.resolution.single_state_diffusion import terminal_intrinsic_from_resolved"
     - "from trellis.models.monte_carlo.early_exercise import EarlyExercisePolicyResult, LeastSquaresContinuationEstimator"
     - "from trellis.models.monte_carlo.schemes import HestonQuadraticExponential, LaguerreBasis"
@@ -102,6 +102,7 @@ monte_carlo:
     - "from trellis.models.monte_carlo import antithetic, control_variate, sobol_normals"
     - "from trellis.models.processes.gbm import GBM"
   notes:
+    - "For European single-state terminal claims, supply an explicit payoff callback to `price_single_state_terminal_claim_monte_carlo_result(...)` and bind scheme/variance-reduction controls at the adapter boundary"
     - "For American/Bermudan vanilla equity Monte Carlo, resolve the market contract with `resolve_single_state_monte_carlo_inputs(...)`, then compose `GBM`, `MonteCarloEngine`, `terminal_intrinsic_from_resolved(...)`, and `longstaff_schwartz(...)` explicitly"
     - "Autocallable MC routes should prefer `price_autocallable_monte_carlo_result(...)`; use `sampling='sobol'` only for QMC comparison targets"
     - "Double-barrier MC routes should use two barrier monitors or `double_barrier_state_payoff(...)` instead of adapting a one-barrier analytical formula"

--- a/trellis/agent/knowledge/canonical/backend_bindings.yaml
+++ b/trellis/agent/knowledge/canonical/backend_bindings.yaml
@@ -320,9 +320,12 @@ bindings:
           exercise_style: [european]
           model_family: [generic, equity, equity_diffusion]
         primitives:
-          - module: trellis.models.equity_option_monte_carlo
-            symbol: price_vanilla_equity_option_monte_carlo
-            role: route_helper
+          - module: trellis.models.monte_carlo.single_state_diffusion
+            symbol: price_single_state_terminal_claim_monte_carlo_result
+            role: monte_carlo_estimator
+          - module: trellis.models.resolution.single_state_diffusion
+            symbol: terminal_intrinsic_from_resolved
+            role: payoff_primitive
       - when:
           payoff_family: period_rate_option_strip
           model_family: [interest_rate, short_rate]

--- a/trellis/agent/knowledge/canonical/routes.yaml
+++ b/trellis/agent/knowledge/canonical/routes.yaml
@@ -550,9 +550,12 @@ routes:
           exercise_style: [european]
           model_family: [generic, equity, equity_diffusion]
         primitives:
-          - module: trellis.models.equity_option_monte_carlo
-            symbol: price_vanilla_equity_option_monte_carlo
-            role: route_helper
+          - module: trellis.models.monte_carlo.single_state_diffusion
+            symbol: price_single_state_terminal_claim_monte_carlo_result
+            role: monte_carlo_estimator
+          - module: trellis.models.resolution.single_state_diffusion
+            symbol: terminal_intrinsic_from_resolved
+            role: payoff_primitive
         adapters: []
         notes: []
       - when:

--- a/trellis/agent/lane_obligations.py
+++ b/trellis/agent/lane_obligations.py
@@ -97,7 +97,13 @@ def compile_lane_construction_plan(
     exact_target_refs = tuple(
         binding.primitive_ref
         for binding in reusable_bindings
-        if binding.role in {"route_helper", "pricing_kernel", "schedule_builder"}
+        if binding.role
+        in {
+            "monte_carlo_estimator",
+            "route_helper",
+            "pricing_kernel",
+            "schedule_builder",
+        }
     )
     timeline_roles = _timeline_roles_for(family_ir)
     state_obligations = _state_obligations_for(family_ir)
@@ -160,7 +166,13 @@ def compile_fallback_lane_construction_plan(
     exact_target_refs = tuple(
         binding.primitive_ref
         for binding in reusable_bindings
-        if binding.role in {"route_helper", "pricing_kernel", "schedule_builder"}
+        if binding.role
+        in {
+            "monte_carlo_estimator",
+            "route_helper",
+            "pricing_kernel",
+            "schedule_builder",
+        }
     )
     timeline_roles = _fallback_timeline_roles(product_ir)
     state_obligations = _fallback_state_obligations(
@@ -487,11 +499,18 @@ def _construction_steps_for(*, lane_family: str, family_ir) -> tuple[str, ...]:
         process_family = family_ir.process_spec.process_family or "generic_state_process"
         path_kind = family_ir.path_requirement_spec.requirement_kind or "terminal_only"
         reducer_kind = family_ir.payoff_reducer_spec.reducer_kind or "path_payoff"
-        steps = [
-            f"Assemble a one-factor `{process_family}` simulation over `{family_ir.state_spec.state_variable or 'state'}`.",
-            f"Bind the reduced-state requirement `{path_kind}` and event kinds `{', '.join(family_ir.event_kinds) or 'none'}` before path generation.",
-            f"Aggregate the payoff through `{reducer_kind}` under the `{family_ir.measure_spec.measure_family}` measure before discount-consistent readout.",
-        ]
+        if path_kind == "terminal_only" and not family_ir.event_kinds:
+            steps = [
+                "Bind the derivative-specific terminal payoff as an explicit payoff callback over resolved state.",
+                f"Evaluate the one-factor `{process_family}` terminal claim with the selected Monte Carlo estimator; bind the requested scheme and variance-reduction controls explicitly.",
+                f"Return the discounted `{reducer_kind}` result under the `{family_ir.measure_spec.measure_family}` measure without delegating to a product-level pricing wrapper.",
+            ]
+        else:
+            steps = [
+                f"Assemble a one-factor `{process_family}` simulation over `{family_ir.state_spec.state_variable or 'state'}`.",
+                f"Bind the reduced-state requirement `{path_kind}` and event kinds `{', '.join(family_ir.event_kinds) or 'none'}` before path generation.",
+                f"Aggregate the payoff through `{reducer_kind}` under the `{family_ir.measure_spec.measure_family}` measure before discount-consistent readout.",
+            ]
         # QUA-880: early-exercise MC routes (control_style == holder_max /
         # issuer_min) used to carry three adapters on the route card --
         # exercise-date derivation, spot-to-exercise-payoff callback, and
@@ -693,6 +712,16 @@ def _fallback_construction_steps(
             "Resolve spot, strike, expiry, option type, and exercise style through `resolve_single_state_diffusion_inputs(...)`.",
             "Compile `equity_tree(...)` and attach `with_control(...)`; for Bermudan exercise, map contractual dates to explicit lattice steps.",
             "Build the lattice with `build_lattice(...)` using the compiled topology, mesh, model, and resolved inputs; price the compiled contract with `price_on_lattice(...)` without reimplementing transition probabilities or backward induction.",
+        )
+
+    if {
+        "price_single_state_terminal_claim_monte_carlo_result",
+        "terminal_intrinsic_from_resolved",
+    }.issubset(required_symbols):
+        return (
+            "Bind `terminal_intrinsic_from_resolved(...)` as the derivative-specific terminal payoff callback over resolved state.",
+            "Call `price_single_state_terminal_claim_monte_carlo_result(...)` with the requested simulation scheme and variance-reduction controls explicitly selected.",
+            "For control variates, provide both the pathwise control value and its model-consistent expectation; otherwise leave control callbacks absent.",
         )
 
     if lane_family == "monte_carlo" and "fx_rates" in required_market_data:

--- a/trellis/agent/lite_review.py
+++ b/trellis/agent/lite_review.py
@@ -34,6 +34,9 @@ _CHECKED_ROUTE_HELPER_SYMBOLS = frozenset({
     "price_heston_option_monte_carlo",
     "price_equity_cliquet_option_monte_carlo",
 })
+_CHECKED_MARKET_BINDING_OWNER_SYMBOLS = frozenset({
+    "price_single_state_terminal_claim_monte_carlo_result",
+})
 
 # Legacy _ROUTE_REQUIRED_ACCESSES and _ROUTE_ACCESS_ERROR_CODES removed.
 # Market-data access requirements are now sourced from the route registry
@@ -386,11 +389,13 @@ def _has_market_binding_primitive_call(signals: LiteReviewSignals, primitive_pla
     for primitive in getattr(primitive_plan, "primitives", ()) or ():
         if not getattr(primitive, "required", True):
             continue
-        if str(getattr(primitive, "role", "") or "").strip() not in binding_roles:
+        symbol = str(getattr(primitive, "symbol", "") or "")
+        role = str(getattr(primitive, "role", "") or "").strip()
+        if role not in binding_roles and symbol not in _CHECKED_MARKET_BINDING_OWNER_SYMBOLS:
             continue
         if _call_names_include_symbol(
             signals.call_names,
-            str(getattr(primitive, "symbol", "") or ""),
+            symbol,
             module=str(getattr(primitive, "module", "") or "") or None,
         ):
             return True

--- a/trellis/instruments/_agent/europeanoptionmontecarlo.py
+++ b/trellis/instruments/_agent/europeanoptionmontecarlo.py
@@ -1,33 +1,4 @@
-"""Agent-generated payoff: Build a pricer for: Heston smile: FFT vs COS vs MC implied vol surface
-
-Extract the implied volatility smile surface under the Heston
-stochastic volatility model for SPX.
-Use the market snapshot (as_of 2024-11-15) which provides:
-  - SPX spot (S=5890)
-  - Heston parameters: kappa=2.0, theta=0.04, xi=0.48, rho=-0.68, v0=0.04
-  - USD OIS discount curve
-  - A reference implied vol smile surface (6 expiries x 7 strikes)
-Price European calls across strikes K=[5400, 5600, 5800, 5900, 6000,
-6200, 6400] and maturities T=[0.25, 0.5, 1.0, 2.0] years.
-Method 1: Heston FFT (Carr-Madan with the Heston characteristic function).
-Method 2: Heston COS method.
-Method 3: Heston MC (QE scheme, 200k paths).
-From each set of prices, extract the implied vol surface by inverting
-Black-Scholes.  All three surfaces should agree within 0.5 vol points.
-The resulting smile should show negative skew (lower strikes have
-higher IV) consistent with rho=-0.68.
-
-Construct methods: fft_pricing, monte_carlo
-Comparison targets: heston_fft (fft_pricing), heston_cos (fft_pricing), heston_mc (monte_carlo)
-Cross-validation harness:
-  internal targets: heston_fft, heston_cos, heston_mc
-  external targets: quantlib
-New component: implied_vol_surface_extraction
-
-Implementation target: heston_mc
-Preferred method family: monte_carlo
-
-Implementation target: heston_mc."""
+"""Admitted adapter for a European single-state terminal claim."""
 
 from __future__ import annotations
 
@@ -36,83 +7,30 @@ from datetime import date
 
 from trellis.core.market_state import MarketState
 from trellis.core.types import DayCountConvention
-from trellis.models.equity_option_monte_carlo import price_vanilla_equity_option_monte_carlo
-
+from trellis.models.monte_carlo.single_state_diffusion import (
+    price_single_state_terminal_claim_monte_carlo_result,
+)
+from trellis.models.resolution.single_state_diffusion import (
+    terminal_intrinsic_from_resolved,
+)
 
 
 @dataclass(frozen=True)
 class EuropeanOptionSpec:
-    """Specification for Build a pricer for: Heston smile: FFT vs COS vs MC implied vol surface
+    """Minimal European call/put terms consumed by the generic MC estimator."""
 
-Extract the implied volatility smile surface under the Heston
-stochastic volatility model for SPX.
-Use the market snapshot (as_of 2024-11-15) which provides:
-  - SPX spot (S=5890)
-  - Heston parameters: kappa=2.0, theta=0.04, xi=0.48, rho=-0.68, v0=0.04
-  - USD OIS discount curve
-  - A reference implied vol smile surface (6 expiries x 7 strikes)
-Price European calls across strikes K=[5400, 5600, 5800, 5900, 6000,
-6200, 6400] and maturities T=[0.25, 0.5, 1.0, 2.0] years.
-Method 1: Heston FFT (Carr-Madan with the Heston characteristic function).
-Method 2: Heston COS method.
-Method 3: Heston MC (QE scheme, 200k paths).
-From each set of prices, extract the implied vol surface by inverting
-Black-Scholes.  All three surfaces should agree within 0.5 vol points.
-The resulting smile should show negative skew (lower strikes have
-higher IV) consistent with rho=-0.68.
-
-Construct methods: fft_pricing, monte_carlo
-Comparison targets: heston_fft (fft_pricing), heston_cos (fft_pricing), heston_mc (monte_carlo)
-Cross-validation harness:
-  internal targets: heston_fft, heston_cos, heston_mc
-  external targets: quantlib
-New component: implied_vol_surface_extraction
-
-Implementation target: heston_mc
-Preferred method family: monte_carlo
-
-Implementation target: heston_mc."""
     notional: float
     spot: float
     strike: float
     expiry_date: date
-    option_type: str = "'call'"
+    option_type: str = "call"
     day_count: DayCountConvention = DayCountConvention.ACT_365
     n_paths: int = 50000
     n_steps: int = 252
 
 
 class EuropeanOptionMonteCarloPayoff:
-    """Build a pricer for: Heston smile: FFT vs COS vs MC implied vol surface
-
-Extract the implied volatility smile surface under the Heston
-stochastic volatility model for SPX.
-Use the market snapshot (as_of 2024-11-15) which provides:
-  - SPX spot (S=5890)
-  - Heston parameters: kappa=2.0, theta=0.04, xi=0.48, rho=-0.68, v0=0.04
-  - USD OIS discount curve
-  - A reference implied vol smile surface (6 expiries x 7 strikes)
-Price European calls across strikes K=[5400, 5600, 5800, 5900, 6000,
-6200, 6400] and maturities T=[0.25, 0.5, 1.0, 2.0] years.
-Method 1: Heston FFT (Carr-Madan with the Heston characteristic function).
-Method 2: Heston COS method.
-Method 3: Heston MC (QE scheme, 200k paths).
-From each set of prices, extract the implied vol surface by inverting
-Black-Scholes.  All three surfaces should agree within 0.5 vol points.
-The resulting smile should show negative skew (lower strikes have
-higher IV) consistent with rho=-0.68.
-
-Construct methods: fft_pricing, monte_carlo
-Comparison targets: heston_fft (fft_pricing), heston_cos (fft_pricing), heston_mc (monte_carlo)
-Cross-validation harness:
-  internal targets: heston_fft, heston_cos, heston_mc
-  external targets: quantlib
-New component: implied_vol_surface_extraction
-
-Implementation target: heston_mc
-Preferred method family: monte_carlo
-
-Implementation target: heston_mc."""
+    """Compose a vanilla terminal payoff with the single-state MC estimator."""
 
     def __init__(self, spec: EuropeanOptionSpec):
         self._spec = spec
@@ -126,5 +44,14 @@ Implementation target: heston_mc."""
         return {"black_vol_surface", "discount_curve"}
 
     def evaluate(self, market_state: MarketState) -> float:
-        spec = self._spec
-        return float(price_vanilla_equity_option_monte_carlo(market_state, spec))
+        result = price_single_state_terminal_claim_monte_carlo_result(
+            market_state,
+            self._spec,
+            terminal_payoff=lambda terminal, resolved: terminal_intrinsic_from_resolved(
+                terminal,
+                resolved,
+            ),
+            scheme="exact",
+            variance_reduction="none",
+        )
+        return float(result.price)

--- a/trellis/models/monte_carlo/single_state_diffusion.py
+++ b/trellis/models/monte_carlo/single_state_diffusion.py
@@ -196,7 +196,7 @@ def price_single_state_terminal_claim_monte_carlo_result(
     | None = None,
     control_variate_expected: Callable[[ResolvedSingleStateMonteCarloInputs], float] | None = None,
 ) -> SingleStateMonteCarloResult:
-    """Price one bounded single-state terminal claim through the generic MC family helper."""
+    """Estimate one bounded single-state terminal claim from an explicit payoff callback."""
     resolved, problem = build_single_state_terminal_claim_monte_carlo_problem(
         market_state,
         spec,


### PR DESCRIPTION
## Summary
- replace European vanilla Monte Carlo helper authority with the generic terminal-claim estimator and explicit payoff primitive
- lower the lane through typed DSL/compiler obligations and enforce the composition in semantic/lite review
- preserve T25/T26 scheme and variance-reduction targets without cookbook edits

## Validation
- affected agent/model suites: 678 passed
- T25 strict offline replay: green, 0 LLM calls
- T26 strict offline replay: green, 0 LLM calls
- NUMBA_CACHE_DIR=/tmp/trellis-numba-cache make gate-pr: 4285 main passed; 32 tier2 passed; 15 optional skipped
- make -C docs html: succeeded with 96 pre-existing repository warnings

Linear: QUA-1169