### PR TITLE
QUA-1171: compose FX barrier routes from primitives

### DIFF
--- a/TASKS_PROOF_LEGACY.yaml
+++ b/TASKS_PROOF_LEGACY.yaml
@@ -1415,10 +1415,26 @@ tasks:
   status: pending
 - id: T109
   title: 'FX barrier option: analytical vs MC'
+  instrument_type: barrier_option
   construct:
   - analytical
   - monte_carlo
   new_component: fx_barrier_analytical
+  market_scenario_id: fx_barrier_smile
+  validation_policy: invariants_and_cross_method
+  extension_contract:
+    product: fx_barrier_option
+    option_type: call
+    barrier_type: down_and_in
+    strike: 1.1
+    barrier: 1.02
+    spot: 1.1
+    expiry_years: 1.0
+    domestic_rate: 0.045
+    foreign_rate: 0.025
+    volatility: 0.14
+    notional: 1000000.0
+    currency_pair: EURUSD
   cross_validate:
     internal:
     - fx_barrier_analytical

--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -529,7 +529,18 @@ rule: generated code composes the neutral diffusion resolver with
 ``equity_tree``, ``with_control``, ``compile_lattice_recipe``, ``build_lattice``,
 and ``price_on_lattice``. Bermudan variants map contract dates to exercise
 steps before attaching control. The product-level tree helper remains a
-compatibility/reference surface and is not admitted route evidence. ``T15``
+compatibility/reference surface and is not admitted route evidence. ``P003``
+and legacy ``T109`` apply the same artifact-coherence
+rule to FX single-barrier comparison: the analytical target resolves the FX
+market contract and calls the scalar barrier kernel, while the Monte Carlo
+target constructs GBM simulation plus an explicit reduced-state barrier
+monitor and terminal payoff. Neither target may count a product-level FX
+barrier wrapper as method evidence. The wrappers remain available to ordinary
+callers as compatibility/reference APIs, and cookbook promotion remains owned
+by quant/model-validator evidence rather than the route lowering. Legacy
+``T109`` declares the nondegenerate FX barrier terms and market scenario in its
+task manifest, so generic task-contract materialization supplies both targets
+without a task-id-specific runtime patch. ``T15``
 uses a bounded CEV European call contract for the CEVOperator PDE versus CEV
 tree comparison and binds ``cev_pde`` / ``cev_tree`` to deterministic local
 proof adapters. The PDE adapter must consume CEV parameters through

--- a/docs/quant/pricing_stack.rst
+++ b/docs/quant/pricing_stack.rst
@@ -196,13 +196,17 @@ The first migrated vanilla cases now use that boundary directly:
   ``terminal_intrinsic_from_resolved(...)``, and pass the paths and exercise
   schedule to ``longstaff_schwartz(...)``. The product-level American LSM helper
   remains a compatibility/reference surface, not route authority.
-- FX single-barrier options now have dedicated analytical and Monte Carlo
-  helper-backed routes in ``trellis.models.fx_barrier_option``. These routes
-  bind spot FX, domestic discounting, foreign discounting, and Black volatility
-  explicitly instead of passing FX barrier tasks through the vanilla
-  Garman-Kohlhagen adapters. When an observation frequency is not supplied, the
-  FX analytical helper uses the Monte Carlo grid's effective monitoring
-  frequency for task-level cross-method parity.
+- FX single-barrier analytical routes now compose
+  ``resolve_fx_barrier_inputs(...)`` with the scalar
+  ``barrier_option_price(...)`` kernel. Monte Carlo routes compose the same
+  resolved contract with ``GBM``, ``MonteCarloEngine``, ``BarrierMonitor``,
+  ``MonteCarloPathRequirement``, ``StateAwarePayoff``, and
+  ``terminal_intrinsic(...)``. The MC path contract stores terminal state and a
+  barrier-hit flag rather than retaining full paths. Product-level FX barrier
+  wrappers remain compatibility/reference surfaces, not route authority.
+  When an observation frequency is not supplied, resolution derives it from
+  the Monte Carlo grid so analytical and MC monitoring contracts remain
+  aligned for task-level comparison.
 - equity variance-swap comparison targets now have a checked Monte Carlo
   realised-variance route in ``trellis.models.variance_swap``. The MC helper
   simulates annualised log-return variance under the market state's GBM

--- a/tests/test_agent/test_backend_bindings.py
+++ b/tests/test_agent/test_backend_bindings.py
@@ -439,24 +439,27 @@ def test_resolve_backend_binding_spec_uses_single_barrier_exact_helpers(
 
 
 @pytest.mark.parametrize(
-    "route_id,method,expected_ref",
+    "route_id,method,expected_ref,expected_market_binding",
     [
         (
             "analytical_fx_barrier",
             "analytical",
-            "trellis.models.fx_barrier_option.price_fx_barrier_option_analytical",
+            "trellis.models.analytical.barrier.barrier_option_price",
+            "trellis.models.fx_barrier_option.resolve_fx_barrier_inputs",
         ),
         (
             "monte_carlo_fx_barrier",
             "monte_carlo",
-            "trellis.models.fx_barrier_option.price_fx_barrier_option_monte_carlo",
+            "trellis.models.monte_carlo.engine.MonteCarloEngine",
+            "trellis.models.fx_barrier_option.resolve_fx_barrier_inputs",
         ),
     ],
 )
-def test_resolve_backend_binding_spec_uses_fx_barrier_exact_helpers(
+def test_resolve_backend_binding_spec_uses_fx_barrier_primitive_composition(
     route_id,
     method,
     expected_ref,
+    expected_market_binding,
 ):
     catalog = load_backend_binding_catalog()
     binding = find_backend_binding_by_route_id(route_id, catalog)
@@ -478,7 +481,8 @@ def test_resolve_backend_binding_spec_uses_fx_barrier_exact_helpers(
 
     assert resolved.binding_id == expected_ref
     assert resolved.exact_target_refs == (expected_ref,)
-    assert resolved.helper_refs == (expected_ref,)
+    assert resolved.market_binding_refs == (expected_market_binding,)
+    assert resolved.helper_refs == ()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_agent/test_executor.py
+++ b/tests/test_agent/test_executor.py
@@ -1263,6 +1263,218 @@ def test_admitted_european_analytical_adapter_honors_dividend_yield():
 
 
 @pytest.mark.parametrize(
+    ("schema_id", "method", "exact_ref", "required_fragments", "excluded_fragments"),
+    [
+        (
+            "fx_barrier_option_analytical",
+            "analytical",
+            "trellis.models.analytical.barrier.barrier_option_price",
+            (
+                "resolve_fx_barrier_inputs(",
+                "barrier_option_price(",
+                "q=resolved.foreign_rate",
+            ),
+            ("price_fx_barrier_option_analytical(",),
+        ),
+        (
+            "fx_barrier_option_monte_carlo",
+            "monte_carlo",
+            "trellis.models.monte_carlo.engine.MonteCarloEngine",
+            (
+                "resolve_fx_barrier_inputs(",
+                "GBM(",
+                "MonteCarloEngine(",
+                "BarrierMonitor(",
+                "MonteCarloPathRequirement(",
+                "StateAwarePayoff(",
+                "terminal_intrinsic(",
+                "return_paths=False",
+            ),
+            (
+                "price_fx_barrier_option_monte_carlo(",
+                "price_fx_barrier_option_monte_carlo_result(",
+            ),
+        ),
+    ],
+)
+def test_deterministic_fx_barrier_targets_use_primitive_composition(
+    schema_id,
+    method,
+    exact_ref,
+    required_fragments,
+    excluded_fragments,
+):
+    from trellis.agent.executor import (
+        EVALUATE_SENTINEL,
+        _generate_skeleton,
+        _materialize_deterministic_exact_binding_module,
+    )
+    from trellis.agent.planner import SPECIALIZED_SPECS
+
+    route_primitives = ()
+    if method == "monte_carlo":
+        route_primitives = (
+            SimpleNamespace(
+                module="trellis.models.monte_carlo.path_state",
+                symbol="BarrierMonitor",
+                role="event_monitor",
+                required=True,
+            ),
+            SimpleNamespace(
+                module="trellis.models.monte_carlo.path_state",
+                symbol="MonteCarloPathRequirement",
+                role="path_requirement",
+                required=True,
+            ),
+            SimpleNamespace(
+                module="trellis.models.monte_carlo.path_state",
+                symbol="StateAwarePayoff",
+                role="payoff_primitive",
+                required=True,
+            ),
+        )
+    generation_plan = SimpleNamespace(
+        lane_exact_binding_refs=(exact_ref,),
+        primitive_plan=SimpleNamespace(
+            route=f"{method}_fx_barrier" if method == "analytical" else "monte_carlo_fx_barrier",
+            primitives=route_primitives,
+        ),
+        method=method,
+        instrument_type="barrier_option",
+    )
+    generated = _materialize_deterministic_exact_binding_module(
+        _generate_skeleton(
+            SPECIALIZED_SPECS[schema_id],
+            "FX barrier primitive composition",
+            generation_plan=generation_plan,
+        ),
+        generation_plan,
+        comparison_target=method,
+    )
+
+    assert generated is not None
+    compile(generated.code, "<qua_1171_source>", "exec")
+    for fragment in required_fragments:
+        assert fragment in generated.code
+    for fragment in excluded_fragments:
+        assert fragment not in generated.code
+    if method == "monte_carlo":
+        assert generated.code.count(
+            "from trellis.models.monte_carlo.path_state import"
+        ) == 1
+    assert EVALUATE_SENTINEL not in generated.code
+
+
+def test_generated_fx_barrier_analytical_and_mc_agree():
+    from datetime import date as _date
+    from math import exp
+
+    from trellis.agent.executor import (
+        _generate_skeleton,
+        _materialize_deterministic_exact_binding_module,
+    )
+    from trellis.agent.planner import SPECIALIZED_SPECS
+    from trellis.core.market_state import MarketState
+    from trellis.curves.yield_curve import YieldCurve
+    from trellis.instruments.fx import FXRate
+    from trellis.models.vol_surface import FlatVol
+
+    def materialize(schema_id, method, exact_ref, route):
+        plan = SimpleNamespace(
+            lane_exact_binding_refs=(exact_ref,),
+            primitive_plan=SimpleNamespace(route=route),
+            method=method,
+            instrument_type="barrier_option",
+        )
+        schema = SPECIALIZED_SPECS[schema_id]
+        generated = _materialize_deterministic_exact_binding_module(
+            _generate_skeleton(
+                schema,
+                "FX barrier generated parity",
+                generation_plan=plan,
+            ),
+            plan,
+            comparison_target=method,
+        )
+        assert generated is not None
+        namespace: dict = {}
+        exec(compile(generated.code, f"<qua_1171_{method}>", "exec"), namespace)  # noqa: S102
+        return schema, namespace
+
+    analytical_schema, analytical_ns = materialize(
+        "fx_barrier_option_analytical",
+        "analytical",
+        "trellis.models.analytical.barrier.barrier_option_price",
+        "analytical_fx_barrier",
+    )
+    mc_schema, mc_ns = materialize(
+        "fx_barrier_option_monte_carlo",
+        "monte_carlo",
+        "trellis.models.monte_carlo.engine.MonteCarloEngine",
+        "monte_carlo_fx_barrier",
+    )
+    terms = dict(
+        notional=1_000_000.0,
+        strike=1.10,
+        barrier=1.02,
+        expiry_date=_date(2025, 11, 15),
+        fx_pair="EURUSD",
+        foreign_discount_key="EUR-DISC",
+        option_type="call",
+        barrier_type="down_and_in",
+    )
+    analytical = analytical_ns[analytical_schema.class_name](
+        analytical_ns[analytical_schema.spec_name](**terms)
+    )
+    mc = mc_ns[mc_schema.class_name](
+        mc_ns[mc_schema.spec_name](**terms, n_paths=20_000, n_steps=252)
+    )
+    market = MarketState(
+        as_of=_date(2024, 11, 15),
+        settlement=_date(2024, 11, 15),
+        discount=YieldCurve.flat(0.045),
+        forecast_curves={"EUR-DISC": YieldCurve.flat(0.025)},
+        fx_rates={"EURUSD": FXRate(spot=1.10, domestic="USD", foreign="EUR")},
+        vol_surface=FlatVol(0.14),
+    )
+
+    analytical_price = float(analytical.evaluate(market))
+    mc_price = float(mc.evaluate(market))
+
+    assert analytical_price > 0.0
+    assert mc_price == pytest.approx(analytical_price, rel=0.08, abs=2_000.0)
+
+    immediate_knock_in = mc_ns[mc_schema.class_name](
+        mc_ns[mc_schema.spec_name](
+            **{
+                **terms,
+                "strike": 1.0,
+                "barrier": 1.11,
+            },
+            observations_per_year=1,
+            n_paths=1_000,
+            n_steps=4,
+        )
+    )
+    deterministic_market = MarketState(
+        as_of=_date(2024, 11, 15),
+        settlement=_date(2024, 11, 15),
+        discount=YieldCurve.flat(0.02),
+        forecast_curves={"EUR-DISC": YieldCurve.flat(0.0)},
+        fx_rates={"EURUSD": FXRate(spot=1.10, domestic="USD", foreign="EUR")},
+        vol_surface=FlatVol(0.0),
+    )
+
+    expected_vanilla = 1_000_000.0 * (
+        1.10 - exp(-0.02) * 1.0
+    )
+    assert immediate_knock_in.evaluate(deterministic_market) == pytest.approx(
+        expected_vanilla,
+        rel=1e-12,
+    )
+
+
+@pytest.mark.parametrize(
     ("comparison_target", "expected_fragment", "expected_import"),
     [
         (

--- a/tests/test_agent/test_import_registry.py
+++ b/tests/test_agent/test_import_registry.py
@@ -369,6 +369,21 @@ def test_fx_barrier_helpers_are_visible_to_import_registry():
     assert "price_fx_barrier_option_analytical" in registry_text
 
 
+def test_fx_barrier_path_state_primitives_are_in_static_import_registry():
+    module = "trellis.models.monte_carlo.path_state"
+    symbols = {
+        "BarrierMonitor",
+        "MonteCarloPathRequirement",
+        "StateAwarePayoff",
+    }
+
+    static_registry = import_registry._parse_static_registry(
+        import_registry._STATIC_REGISTRY
+    )
+
+    assert symbols <= set(static_registry[module])
+
+
 def test_resolve_import_candidates_handles_known_and_unknown_symbols():
     candidates = resolve_import_candidates(["theta_method_1d", "definitely_not_real"])
     assert "trellis.models.pde.theta_method" in candidates["theta_method_1d"]

--- a/tests/test_agent/test_platform_requests.py
+++ b/tests/test_agent/test_platform_requests.py
@@ -475,8 +475,21 @@ def test_compile_build_request_selects_fx_barrier_monte_carlo_route():
     assert compiled.generation_plan.primitive_plan is not None
     assert compiled.generation_plan.primitive_plan.route == "monte_carlo_fx_barrier"
     assert compiled.generation_plan.lane_exact_binding_refs == (
-        "trellis.models.fx_barrier_option.price_fx_barrier_option_monte_carlo",
+        "trellis.models.monte_carlo.engine.MonteCarloEngine",
     )
+    primitive_symbols = {
+        primitive.symbol
+        for primitive in compiled.generation_plan.primitive_plan.primitives
+    }
+    assert {
+        "resolve_fx_barrier_inputs",
+        "GBM",
+        "MonteCarloEngine",
+        "BarrierMonitor",
+        "MonteCarloPathRequirement",
+        "StateAwarePayoff",
+        "terminal_intrinsic",
+    } <= primitive_symbols
 
 
 def test_compile_build_request_respects_quanto_preferred_monte_carlo_route():

--- a/tests/test_agent/test_primitive_planning.py
+++ b/tests/test_agent/test_primitive_planning.py
@@ -611,7 +611,7 @@ def test_builds_fx_barrier_plan_for_knock_in_fx_context():
     assert plan.primitive_plan is not None
     assert plan.primitive_plan.route == "analytical_fx_barrier"
     primitive_symbols = {primitive.symbol for primitive in plan.primitive_plan.primitives}
-    assert primitive_symbols == {"price_fx_barrier_option_analytical"}
+    assert primitive_symbols == {"resolve_fx_barrier_inputs", "barrier_option_price"}
     assert plan.primitive_plan.adapters == ()
     assert plan.primitive_plan.blockers == ()
 

--- a/tests/test_agent/test_route_registry.py
+++ b/tests/test_agent/test_route_registry.py
@@ -2043,7 +2043,8 @@ class TestFXBarrierRoutes:
         spec = [r for r in registry.routes if r.id == "analytical_fx_barrier"][0]
         new_prims = resolve_route_primitives(spec, self.FX_BARRIER_IR)
         expected_prims = {
-            ("trellis.models.fx_barrier_option", "price_fx_barrier_option_analytical", "route_helper"),
+            ("trellis.models.fx_barrier_option", "resolve_fx_barrier_inputs", "market_binding"),
+            ("trellis.models.analytical.barrier", "barrier_option_price", "pricing_kernel"),
         }
         assert _prim_set(new_prims) == expected_prims
 
@@ -2065,7 +2066,13 @@ class TestFXBarrierRoutes:
         spec = [r for r in registry.routes if r.id == "monte_carlo_fx_barrier"][0]
         new_prims = resolve_route_primitives(spec, self.FX_BARRIER_IR)
         expected_prims = {
-            ("trellis.models.fx_barrier_option", "price_fx_barrier_option_monte_carlo", "route_helper"),
+            ("trellis.models.fx_barrier_option", "resolve_fx_barrier_inputs", "market_binding"),
+            ("trellis.models.processes.gbm", "GBM", "state_process"),
+            ("trellis.models.monte_carlo.engine", "MonteCarloEngine", "engine"),
+            ("trellis.models.monte_carlo.path_state", "BarrierMonitor", "event_monitor"),
+            ("trellis.models.monte_carlo.path_state", "MonteCarloPathRequirement", "path_requirement"),
+            ("trellis.models.monte_carlo.path_state", "StateAwarePayoff", "payoff_primitive"),
+            ("trellis.models.analytical", "terminal_intrinsic", "terminal_payoff"),
         }
         assert _prim_set(new_prims) == expected_prims
 

--- a/tests/test_agent/test_semantic_validation.py
+++ b/tests/test_agent/test_semantic_validation.py
@@ -168,6 +168,22 @@ def build_price(self, market_state):
 """
 
 
+HELPER_ONLY_FX_BARRIER_SOURCE = """\
+from __future__ import annotations
+
+from trellis.models.fx_barrier_option import (
+    price_fx_barrier_option_analytical,
+    price_fx_barrier_option_monte_carlo,
+)
+
+
+def build_price(self, market_state, method="analytical"):
+    if method == "monte_carlo":
+        return float(price_fx_barrier_option_monte_carlo(market_state, self._spec))
+    return float(price_fx_barrier_option_analytical(market_state, self._spec))
+"""
+
+
 AUTOCALLABLE_HELPER_SOURCE = """\
 from __future__ import annotations
 
@@ -979,6 +995,48 @@ def test_rejects_helper_only_equity_monte_carlo_without_terminal_claim_primitive
 
     report = validate_semantics(
         HELPER_ONLY_EQUITY_MONTE_CARLO_SOURCE,
+        product_ir=product_ir,
+        generation_plan=generation_plan,
+    )
+
+    issue_codes = {issue.code for issue in report.issues}
+    assert "assembly.required_primitive_missing" in issue_codes
+    assert not report.ok
+
+
+@pytest.mark.parametrize("method", ["analytical", "monte_carlo"])
+def test_rejects_helper_only_fx_barrier_without_required_composition(method):
+    from trellis.agent.semantic_validation import validate_semantics
+
+    product_ir = decompose_to_ir(
+        "Price an FX knock-in call with domestic/foreign discounting.",
+        instrument_type="barrier_option",
+    )
+    pricing_plan = PricingPlan(
+        method=method,
+        method_modules=[
+            "trellis.models.fx_barrier_option",
+            "trellis.models.monte_carlo.engine",
+        ],
+        required_market_data={
+            "discount_curve",
+            "forward_curve",
+            "black_vol_surface",
+            "fx_rates",
+            "spot",
+        },
+        model_to_build="barrier_option",
+        reasoning="test",
+    )
+    generation_plan = build_generation_plan(
+        pricing_plan=pricing_plan,
+        instrument_type="barrier_option",
+        inspected_modules=tuple(pricing_plan.method_modules),
+        product_ir=product_ir,
+    )
+
+    report = validate_semantics(
+        HELPER_ONLY_FX_BARRIER_SOURCE,
         product_ir=product_ir,
         generation_plan=generation_plan,
     )

--- a/tests/test_agent/test_task_runtime.py
+++ b/tests/test_agent/test_task_runtime.py
@@ -1720,6 +1720,47 @@ def test_task_runtime_bridges_sparse_proof_mc_rows_to_vanilla_option_contract():
         assert summary["methods"]["preferred_method"] == "monte_carlo"
 
 
+def test_t109_declares_non_degenerate_fx_barrier_runtime_contract():
+    from trellis.agent.task_manifests import load_task_manifest
+    from trellis.agent.task_runtime import benchmark_spec_overrides
+
+    task = next(
+        task
+        for task in load_task_manifest("TASKS_PROOF_LEGACY.yaml")
+        if task["id"] == "T109"
+    )
+
+    assert task["market_scenario_id"] == "fx_barrier_smile"
+    assert task["instrument_type"] == "barrier_option"
+    assert task["extension_contract"] == {
+        "product": "fx_barrier_option",
+        "option_type": "call",
+        "barrier_type": "down_and_in",
+        "strike": pytest.approx(1.10),
+        "barrier": pytest.approx(1.02),
+        "spot": pytest.approx(1.10),
+        "expiry_years": pytest.approx(1.0),
+        "domestic_rate": pytest.approx(0.045),
+        "foreign_rate": pytest.approx(0.025),
+        "volatility": pytest.approx(0.14),
+        "notional": pytest.approx(1_000_000.0),
+        "currency_pair": "EURUSD",
+    }
+    assert benchmark_spec_overrides(task) == {
+        "notional": pytest.approx(1_000_000.0),
+        "spot": pytest.approx(1.10),
+        "strike": pytest.approx(1.10),
+        "option_type": "call",
+        "barrier": pytest.approx(1.02),
+        "barrier_type": "down_and_in",
+        "currency_pair": "EURUSD",
+        "fx_pair": "EURUSD",
+        "expiry_date": date(2025, 11, 15),
+        "foreign_discount_key": "EUR-DISC",
+        "rebate": pytest.approx(0.0),
+    }
+
+
 def test_task_runtime_bridges_sparse_cev_row_to_cev_route_contract():
     from trellis.agent.semantic_contracts import semantic_contract_summary
     from trellis.agent.task_manifests import load_task_manifest

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -4001,6 +4001,137 @@ def _deterministic_exact_binding_evaluate_body(
         normalized_target=normalized_target,
         route_free_exact_binding=route_free_exact_binding,
     )
+    primitive_plan = _generation_plan_field(generation_plan, "primitive_plan")
+    primitive_route = str(getattr(primitive_plan, "route", "") or "").strip()
+    if (
+        primitive_route == "analytical_fx_barrier"
+        and "trellis.models.analytical.barrier.barrier_option_price" in refs
+    ):
+        return textwrap.dedent(
+            """\
+            resolved = resolve_fx_barrier_inputs(market_state, self._spec)
+            unit_price = barrier_option_price(
+                resolved.spot,
+                resolved.strike,
+                resolved.barrier,
+                resolved.domestic_rate,
+                resolved.sigma,
+                resolved.maturity,
+                barrier_type=resolved.barrier_type,
+                option_type=resolved.option_type,
+                rebate=resolved.rebate,
+                q=resolved.foreign_rate,
+                observations_per_year=resolved.observations_per_year,
+            )
+            return float(resolved.notional) * float(unit_price)
+            """
+        ).rstrip()
+    if (
+        primitive_route == "monte_carlo_fx_barrier"
+        and "trellis.models.monte_carlo.engine.MonteCarloEngine" in refs
+    ):
+        return textwrap.dedent(
+            """\
+            resolved = resolve_fx_barrier_inputs(market_state, self._spec)
+            direction = "down" if resolved.barrier_type.startswith("down") else "up"
+            knock = "in" if resolved.barrier_type.endswith("_in") else "out"
+            initial_touched = (
+                resolved.spot <= resolved.barrier
+                if direction == "down"
+                else resolved.spot >= resolved.barrier
+            )
+            if resolved.maturity <= 0.0:
+                active = initial_touched if knock == "in" else not initial_touched
+                intrinsic = terminal_intrinsic(
+                    resolved.option_type,
+                    spot=resolved.spot,
+                    strike=resolved.strike,
+                )
+                payoff_at_expiry = intrinsic if active else resolved.rebate
+                return float(resolved.notional * payoff_at_expiry)
+
+            observation_steps = ()
+            if resolved.observations_per_year is not None:
+                observation_count = max(
+                    int(round(resolved.maturity * resolved.observations_per_year)),
+                    1,
+                )
+                observation_steps = (
+                    0,
+                    *tuple(
+                        sorted(
+                            {
+                                max(
+                                    1,
+                                    min(
+                                        resolved.n_steps,
+                                        int(round(index * resolved.n_steps / observation_count)),
+                                    ),
+                                )
+                                for index in range(1, observation_count + 1)
+                            }
+                        )
+                    ),
+                )
+            monitor = BarrierMonitor(
+                name="barrier",
+                level=resolved.barrier,
+                direction=direction,
+                observation_steps=observation_steps,
+            )
+            requirement = MonteCarloPathRequirement(barrier_monitors=(monitor,))
+
+            def apply_barrier(terminal, touched):
+                intrinsic = terminal_intrinsic(
+                    resolved.option_type,
+                    spot=terminal,
+                    strike=resolved.strike,
+                )
+                active = touched if knock == "in" else ~touched
+                return resolved.notional * raw_np.where(active, intrinsic, resolved.rebate)
+
+            def evaluate_paths(paths):
+                observed = paths[:, observation_steps] if observation_steps else paths
+                touched = (
+                    raw_np.any(observed <= resolved.barrier, axis=1)
+                    if direction == "down"
+                    else raw_np.any(observed >= resolved.barrier, axis=1)
+                )
+                return apply_barrier(paths[:, -1], touched)
+
+            def evaluate_state(state):
+                return apply_barrier(
+                    state.terminal_values,
+                    state.barrier_hit(monitor.name),
+                )
+
+            payoff = StateAwarePayoff(
+                path_requirement=requirement,
+                evaluate_paths_fn=evaluate_paths,
+                evaluate_state_fn=evaluate_state,
+                name="fx_single_barrier",
+            )
+            process = GBM(
+                mu=resolved.domestic_rate - resolved.foreign_rate,
+                sigma=resolved.sigma,
+            )
+            engine = MonteCarloEngine(
+                process,
+                n_paths=resolved.n_paths,
+                n_steps=resolved.n_steps,
+                seed=resolved.seed,
+                method="exact",
+            )
+            result = engine.price(
+                resolved.spot,
+                resolved.maturity,
+                payoff,
+                discount_rate=resolved.domestic_rate,
+                return_paths=False,
+            )
+            return float(result["price"])
+            """
+        ).rstrip()
 
     if instrument_type in {"credit_default_swap", "cds"} and normalized_target in {"mc_cds", "cds_mc"}:
         cds_body = _credit_default_swap_helper_body(
@@ -5186,6 +5317,25 @@ def _deterministic_exact_binding_import_lines(body: str) -> tuple[str, ...]:
         imports.append(
             "from trellis.models.fx_barrier_option import price_fx_barrier_option_monte_carlo"
         )
+    if "resolve_fx_barrier_inputs(" in body:
+        imports.append(
+            "from trellis.models.fx_barrier_option import resolve_fx_barrier_inputs"
+        )
+    if "barrier_option_price(" in body:
+        imports.append(
+            "from trellis.models.analytical.barrier import barrier_option_price"
+        )
+    if "BarrierMonitor(" in body:
+        imports.append(
+            "from trellis.models.monte_carlo.path_state import "
+            "BarrierMonitor, MonteCarloPathRequirement, StateAwarePayoff"
+        )
+    if "terminal_intrinsic(" in body:
+        imports.append(
+            "from trellis.models.analytical import terminal_intrinsic"
+        )
+    if "raw_np." in body:
+        imports.append("import numpy as raw_np")
     if "price_vanilla_equity_option_tree(" in body:
         imports.append(
             "from trellis.models.equity_option_tree import price_vanilla_equity_option_tree"

--- a/trellis/agent/knowledge/canonical/api_map.yaml
+++ b/trellis/agent/knowledge/canonical/api_map.yaml
@@ -91,6 +91,8 @@ monte_carlo:
     - "from trellis.models.monte_carlo.schemes import HestonQuadraticExponential, LaguerreBasis"
     - "from trellis.models.monte_carlo.stochastic_vol import price_heston_option_monte_carlo, price_heston_option_monte_carlo_result"
     - "from trellis.models.monte_carlo.path_state import BarrierMonitor, MonteCarloPathRequirement, StateAwarePayoff"
+    - "from trellis.models.fx_barrier_option import resolve_fx_barrier_inputs"
+    - "from trellis.models.analytical import terminal_intrinsic"
     - "from trellis.models.autocallable import AutocallableMonteCarloConfig, price_autocallable_monte_carlo_result, resolve_autocallable_inputs"
     - "from trellis.models.single_barrier_option import SingleBarrierMonteCarloConfig, price_single_barrier_option_monte_carlo_result, resolve_single_barrier_inputs"
     - "from trellis.models.analytical.support.barriers import DoubleBarrierSpec, double_barrier_state_payoff, resolve_double_barrier_inputs"
@@ -104,6 +106,7 @@ monte_carlo:
   notes:
     - "For European single-state terminal claims, supply an explicit payoff callback to `price_single_state_terminal_claim_monte_carlo_result(...)` and bind scheme/variance-reduction controls at the adapter boundary"
     - "For American/Bermudan vanilla equity Monte Carlo, resolve the market contract with `resolve_single_state_monte_carlo_inputs(...)`, then compose `GBM`, `MonteCarloEngine`, `terminal_intrinsic_from_resolved(...)`, and `longstaff_schwartz(...)` explicitly"
+    - "For FX single-barrier Monte Carlo, compose `resolve_fx_barrier_inputs(...)`, `GBM`, `MonteCarloEngine`, `BarrierMonitor`, `MonteCarloPathRequirement`, `StateAwarePayoff`, and `terminal_intrinsic(...)`; use reduced barrier-hit state and domestic discounting"
     - "Autocallable MC routes should prefer `price_autocallable_monte_carlo_result(...)`; use `sampling='sobol'` only for QMC comparison targets"
     - "Double-barrier MC routes should use two barrier monitors or `double_barrier_state_payoff(...)` instead of adapting a one-barrier analytical formula"
     - "If the control primitive uses continuation regression, choose the estimator or basis explicitly; LaguerreBasis is optional, not mandatory"
@@ -197,7 +200,11 @@ analytical:
     - "from trellis.models.analytical.jamshidian import ResolvedJamshidianInputs, zcb_option_hw_raw"
     - "from trellis.models.analytical import zcb_option_hw"
     - "from trellis.models.analytical import terminal_vanilla_from_basis"
+    - "from trellis.models.fx_barrier_option import resolve_fx_barrier_inputs"
+    - "from trellis.models.analytical.barrier import barrier_option_price"
     - "from trellis.models.rate_style_swaption import ResolvedSwaptionBlack76Inputs, resolve_swaption_black76_inputs, price_swaption_black76_raw, price_bermudan_swaption_black76_lower_bound"
+  notes:
+    - "For FX single-barrier analytics, resolve FX spot, domestic/foreign rates, volatility, monitoring, and payoff terms, then call `barrier_option_price(...)` with foreign rate as `q` and apply notional"
 
 # ---------------------------------------------------------------------------
 # Model imports — calibration

--- a/trellis/agent/knowledge/canonical/backend_bindings.yaml
+++ b/trellis/agent/knowledge/canonical/backend_bindings.yaml
@@ -356,8 +356,26 @@ bindings:
     route_family: monte_carlo
     primitives:
       - module: trellis.models.fx_barrier_option
-        symbol: price_fx_barrier_option_monte_carlo
-        role: route_helper
+        symbol: resolve_fx_barrier_inputs
+        role: market_binding
+      - module: trellis.models.processes.gbm
+        symbol: GBM
+        role: state_process
+      - module: trellis.models.monte_carlo.engine
+        symbol: MonteCarloEngine
+        role: engine
+      - module: trellis.models.monte_carlo.path_state
+        symbol: BarrierMonitor
+        role: event_monitor
+      - module: trellis.models.monte_carlo.path_state
+        symbol: MonteCarloPathRequirement
+        role: path_requirement
+      - module: trellis.models.monte_carlo.path_state
+        symbol: StateAwarePayoff
+        role: payoff_primitive
+      - module: trellis.models.analytical
+        symbol: terminal_intrinsic
+        role: terminal_payoff
 
   - route_id: monte_carlo_fx_vanilla
     engine_family: monte_carlo
@@ -851,8 +869,11 @@ bindings:
     route_family: analytical
     primitives:
       - module: trellis.models.fx_barrier_option
-        symbol: price_fx_barrier_option_analytical
-        role: route_helper
+        symbol: resolve_fx_barrier_inputs
+        role: market_binding
+      - module: trellis.models.analytical.barrier
+        symbol: barrier_option_price
+        role: pricing_kernel
 
   - route_id: analytical_garman_kohlhagen
     engine_family: analytical

--- a/trellis/agent/knowledge/canonical/routes.yaml
+++ b/trellis/agent/knowledge/canonical/routes.yaml
@@ -611,11 +611,29 @@ routes:
       supports_calibration: false
     primitives:
       - module: trellis.models.fx_barrier_option
-        symbol: price_fx_barrier_option_monte_carlo
-        role: route_helper
+        symbol: resolve_fx_barrier_inputs
+        role: market_binding
+      - module: trellis.models.processes.gbm
+        symbol: GBM
+        role: state_process
+      - module: trellis.models.monte_carlo.engine
+        symbol: MonteCarloEngine
+        role: engine
+      - module: trellis.models.monte_carlo.path_state
+        symbol: BarrierMonitor
+        role: event_monitor
+      - module: trellis.models.monte_carlo.path_state
+        symbol: MonteCarloPathRequirement
+        role: path_requirement
+      - module: trellis.models.monte_carlo.path_state
+        symbol: StateAwarePayoff
+        role: payoff_primitive
+      - module: trellis.models.analytical
+        symbol: terminal_intrinsic
+        role: terminal_payoff
     adapters: []
     notes:
-      - "Use the FX barrier helper for FX knock-in/knock-out tasks; vanilla FX helpers intentionally ignore barrier events."
+      - "Resolve domestic/foreign carry and FX spot explicitly, then compose GBM, reduced barrier-hit state, terminal intrinsic, in/out activation, rebate, and domestic discounting."
     market_data_access:
       required:
         discount_curve: [market_state.discount]
@@ -1582,11 +1600,14 @@ routes:
       supports_calibration: false
     primitives:
       - module: trellis.models.fx_barrier_option
-        symbol: price_fx_barrier_option_analytical
-        role: route_helper
+        symbol: resolve_fx_barrier_inputs
+        role: market_binding
+      - module: trellis.models.analytical.barrier
+        symbol: barrier_option_price
+        role: pricing_kernel
     adapters: []
     notes:
-      - "Use the FX barrier helper for FX knock-in/knock-out tasks; pass foreign carry as the analytical barrier `q` input."
+      - "Resolve FX spot, domestic/foreign rates, volatility, monitoring, and payoff terms, then call `barrier_option_price(...)` with foreign rate as `q` and apply notional."
     market_data_access:
       required:
         discount_curve: [market_state.discount]

--- a/trellis/agent/knowledge/import_registry.py
+++ b/trellis/agent/knowledge/import_registry.py
@@ -553,7 +553,7 @@ from trellis.curves.credit_curve import CreditCurve
 
 ### Models — Analytical
 from trellis.models.black import black76_call, black76_put, black76_asset_or_nothing_call, black76_asset_or_nothing_put, black76_cash_or_nothing_call, black76_cash_or_nothing_put
-from trellis.models.analytical import terminal_vanilla_from_basis
+from trellis.models.analytical import terminal_intrinsic, terminal_vanilla_from_basis
 from trellis.models.analytical.jamshidian import zcb_option_hw
 from trellis.models.analytical.barrier import barrier_option_price, down_and_out_call, down_and_in_call
 from trellis.models.analytical.support.barriers import DoubleBarrierSpec, double_barrier_hit_mask, double_barrier_path_payoff, double_barrier_state_payoff, resolve_double_barrier_inputs, terminal_double_barrier_payoff

--- a/trellis/agent/knowledge/import_registry.py
+++ b/trellis/agent/knowledge/import_registry.py
@@ -577,6 +577,7 @@ from trellis.models.trees.backward_induction import backward_induction
 
 ### Models — Monte Carlo
 from trellis.models.monte_carlo.engine import MonteCarloEngine
+from trellis.models.monte_carlo.path_state import BarrierMonitor, MonteCarloPathRequirement, StateAwarePayoff
 from trellis.models.monte_carlo.basket_state import build_basket_path_requirement, evaluate_ranked_observation_basket_paths, evaluate_ranked_observation_basket_state, observation_step_indices
 from trellis.models.monte_carlo.profiling import MonteCarloPathKernelBenchmark, benchmark_path_kernel
 from trellis.models.monte_carlo.lsm import longstaff_schwartz, laguerre_basis

--- a/trellis/agent/lane_obligations.py
+++ b/trellis/agent/lane_obligations.py
@@ -99,6 +99,7 @@ def compile_lane_construction_plan(
         for binding in reusable_bindings
         if binding.role
         in {
+            "engine",
             "monte_carlo_estimator",
             "route_helper",
             "pricing_kernel",
@@ -168,6 +169,7 @@ def compile_fallback_lane_construction_plan(
         for binding in reusable_bindings
         if binding.role
         in {
+            "engine",
             "monte_carlo_estimator",
             "route_helper",
             "pricing_kernel",
@@ -287,7 +289,7 @@ def _binding_kind_for_role(role: str) -> str:
     """Classify lowering bindings for prompt rendering."""
     if role == "market_binding":
         return "market_binding"
-    if role in {"route_helper", "pricing_kernel", "schedule_builder"}:
+    if role in {"engine", "route_helper", "pricing_kernel", "schedule_builder"}:
         return "exact_backend"
     return "reusable_primitive"
 


### PR DESCRIPTION
## Summary
- replace analytical and MC FX barrier helper authority with resolver/kernel/engine/path-state composition
- make legacy T109 declare a nondegenerate FX barrier contract and market scenario
- reject helper-only route artifacts while retaining public wrappers as compatibility/reference APIs
- document the primitive-composed lanes without editing cookbooks

## Validation
- affected agent/runtime suite: 759 passed
- make gate-pr: 4,300 passed, 5 deselected; tier-2 32 passed, 15 optional skips, 7 deselected
- post-review targeted suite: 5 passed
- strict offline P003/T109 replay: 2/2 green, 0 LLM calls, 0 retries, 0 lessons, 0 cookbook changes

## Review notes
- local self-review fixed inception monitoring for discrete barriers
- generated MC source emits one canonical path-state import

Linear: QUA-1171