### PR TITLE
Agent orientation: runtime quant and model-validator navigation contracts

### DIFF
--- a/doc/plan/active__semantic-task-synthesis-helper-retirement.md
+++ b/doc/plan/active__semantic-task-synthesis-helper-retirement.md
@@ -33,19 +33,17 @@ Status mirror last synced: `2026-07-12`
 | `QUA-1170` | Vanilla PDE: primitive-composed theta-method lane | Done |
 | `QUA-1171` | FX barrier: primitive-composed analytical and MC lanes | Done |
 | `QUA-1172` | FX vanilla: primitive-composed analytical and MC lanes | Done |
-| `QUA-1174` | Hybrid market binding: named underlier and volatility surfaces | In Progress |
-| `QUA-1173` | Quanto option: primitive-composed analytical and MC lanes | Backlog; blocked by `QUA-1174` |
-| `QUA-1175` | Agent orientation: runtime quant and model-validator navigation contracts | Backlog |
+| `QUA-1174` | Hybrid market binding: named underlier and volatility surfaces | Done |
+| `QUA-1173` | Quanto option: primitive-composed analytical and MC lanes | Backlog |
+| `QUA-1175` | Agent orientation: runtime quant and model-validator navigation contracts | In Progress |
 
 ## Current Sequence
 
-1. Complete `QUA-1174` so quanto pricing binds a named underlier, FX quote,
-   distinct implied-volatility surfaces, foreign curve, and correlation.
+1. Complete `QUA-1175` so quant and model-validator receive compact,
+   role-specific navigation contracts at runtime.
 2. Complete `QUA-1173` by composing analytical and Monte Carlo pricing from
    those bindings and generic numerical primitives without quanto helpers.
-3. Complete `QUA-1175` so quant and model-validator receive compact,
-   role-specific navigation contracts at runtime.
-4. Re-run the helper-authority audit and choose the next coherent product
+3. Re-run the helper-authority audit and choose the next coherent product
    family by remaining authority count and semantic risk.
 
 ## Completion Evidence

--- a/docs/agent/model_validator_agent.rst
+++ b/docs/agent/model_validator_agent.rst
@@ -1,0 +1,50 @@
+Model Validator Agent
+=====================
+
+The runtime model-validator agent reviews residual conceptual, calibration,
+numerical-model, and limitation risk after deterministic validation has
+executed. It does not repeat deterministic checks, select routes, rewrite
+generated code, review code style, or promote cookbook entries.
+
+Runtime Orientation
+-------------------
+
+The LLM review receives the versioned ``model-validator-runtime-navigation``
+card rendered from
+``trellis/agent/knowledge/canonical/agent_orientations.yaml``. Its navigation
+order starts with runtime evidence:
+
+#. the compiled validation contract
+#. the deterministic evidence packet
+#. the quant challenger packet
+#. admitted route, model-grammar, and method-requirement context
+#. cookbook patterns as read-only supporting evidence
+#. ``LIMITATIONS.md`` and the validation, calibration, quant, and audit docs
+
+This order matters. A deterministic route, binding, or validation-bundle
+failure is already concrete evidence and should not be converted into a second
+LLM opinion. The validator is useful when executed evidence leaves a genuine
+question about model suitability, calibration, numerical quality, or a support
+boundary.
+
+Review Policy
+-------------
+
+Build-time LLM model validation remains governed by the validation profile and
+risk policy. Skipped and completed lifecycle events both record the orientation
+contract identity, so an audit can establish which role contract governed a
+review without persisting the full prompt card.
+
+Implementation
+--------------
+
+.. autofunction:: trellis.agent.model_validator.validate_model
+
+See Also
+--------
+
+- :doc:`../developer/runtime_agent_orientation` for the shared orientation
+  contract
+- :doc:`../developer/audit_and_observability` for cycle-report evidence
+- :doc:`../mathematical/calibration` for calibration contracts and boundaries
+- :doc:`../quant/index` for the quantitative documentation index

--- a/docs/agent/quant_agent.rst
+++ b/docs/agent/quant_agent.rst
@@ -36,6 +36,8 @@ data, exercise style, state dependence, and model family become ``ProductIR``.
 The quant layer ranks the admitted candidates and emits a ``PricingPlan`` plus
 a ``QuantChallengerPacket``. Genuinely novel products may use bounded LLM
 decomposition, and that prompt receives the same orientation card.
+The selected method family is mapped to deterministic default construction
+modules in runtime code; the LLM is not asked to emit module or import paths.
 
 PricingPlan
 -----------

--- a/docs/agent/quant_agent.rst
+++ b/docs/agent/quant_agent.rst
@@ -1,51 +1,56 @@
 Quant Agent
 ===========
 
-The quant agent makes the **financial** decision: given an instrument,
-which computational method is appropriate and what market data does it need?
-It does NOT write code.
+The runtime quant agent makes the financial decision: given typed product
+semantics, which computational method is appropriate, what market data is
+required, and which residual model risks must be handed to validation? It does
+not write code, choose imports, run deterministic acceptance checks, or promote
+cookbook entries.
+
+Runtime Orientation
+-------------------
+
+The quant agent receives the versioned ``quant-runtime-navigation`` card at
+its LLM boundary. The card is rendered from
+``trellis/agent/knowledge/canonical/agent_orientations.yaml`` and points to the
+smallest useful navigation surface in this order:
+
+#. the runtime semantic contract, ``ProductIR``, and quant challenger packet
+#. canonical product decompositions and admitted route families
+#. the model grammar and method requirements
+#. the cookbook catalog as read-only pattern evidence
+#. the quant documentation index and model-grammar design reference
+
+The card deliberately omits exact symbol and import lookup. Existing routing
+context may still include the family-level API map, but exact symbol selection
+remains the builder's responsibility through the API map and import registry.
+This keeps method selection independent from whichever convenience helper
+happens to exist.
 
 Method Selection
 ----------------
 
-Static rules for 13 instrument types:
-
-.. list-table::
-   :header-rows: 1
-   :widths: 25 20 30
-
-   * - Instrument
-     - Method
-     - Data Requirements
-   * - Bond, Swap
-     - ``analytical``
-     - discount, forward_rate
-   * - Cap, Floor, Swaption
-     - ``analytical``
-     - discount, forward_rate, black_vol
-   * - Callable Bond, Puttable Bond
-     - ``rate_tree``
-     - discount, black_vol
-   * - Bermudan Swaption
-     - ``rate_tree``
-     - discount, forward_rate, black_vol
-   * - Barrier Option, Asian Option
-     - ``monte_carlo``
-     - discount, black_vol
-   * - CDO, Nth-to-Default
-     - ``copula``
-     - discount, credit
-   * - MBS
-     - ``monte_carlo``
-     - discount
-
-For unknown instruments, the quant agent falls back to an LLM call.
+Known products are decomposed through canonical typed knowledge, not a second
+table in ``quant.py``. Product features, method candidates, required market
+data, exercise style, state dependence, and model family become ``ProductIR``.
+The quant layer ranks the admitted candidates and emits a ``PricingPlan`` plus
+a ``QuantChallengerPacket``. Genuinely novel products may use bounded LLM
+decomposition, and that prompt receives the same orientation card.
 
 PricingPlan
 -----------
 
 .. autoclass:: trellis.agent.quant.PricingPlan
    :members:
+
+Quant Challenger Packet
+------------------------
+
+The packet records the selected method, rejected alternatives, assumption
+basis, market-data obligations, expected executable checks, requested
+measures, residual-risk handoff, and quant orientation identity. Downstream
+validation consumes this packet instead of reconstructing method-selection
+reasoning from prose.
 
 Early Data Check
 ----------------
@@ -64,3 +69,12 @@ Implementation
 
 .. autofunction:: trellis.agent.quant.select_pricing_method
 .. autofunction:: trellis.agent.quant.check_data_availability
+
+See Also
+--------
+
+- :doc:`../quant/index` for the quantitative documentation index
+- :doc:`../developer/runtime_agent_orientation` for contract loading, role
+  separation, and trace behavior
+- :doc:`../developer/task_and_eval_loops` for task execution and bounded
+  learning behavior

--- a/docs/developer/audit_and_observability.rst
+++ b/docs/developer/audit_and_observability.rst
@@ -216,6 +216,8 @@ The cycle report records:
 - stable stage statuses such as ``passed``, ``failed``, and ``skipped``
 - compact stage summaries and low-cardinality details suitable for replay,
   dashboards, and later promotion/adoption checks
+- the versioned runtime orientation identity for quant and model-validator
+  stages, without duplicating either role's full prompt card
 
 Use ``load_platform_trace_cycle_report(...)`` when code needs the typed
 ``CycleReport`` object for one trace. Use ``load_platform_traces(...)`` when a
@@ -227,6 +229,11 @@ the deterministic validation contract, executable checks, arbiter verdicts, and
 model-validator findings. The cycle report makes those stage outcomes stable
 and inspectable so downstream tooling no longer has to infer governance state
 from ad hoc event strings.
+
+The ``orientation_contract`` field contains only ``role``, ``contract_id``,
+and ``version``. Use it to establish which navigation and ownership contract
+governed a runtime role. See :doc:`runtime_agent_orientation` for the canonical
+manifest and the distinction from repository-level ``AGENTS.md`` guidance.
 
 Agent Cycle Result Surface
 --------------------------

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -19,6 +19,7 @@ Core Developer Topics
    overview
    hosting_and_configuration
    audit_and_observability
+   runtime_agent_orientation
    contract_ir_solver_compiler
    stochastic_vol_computational_ir
    task_and_eval_loops
@@ -47,6 +48,7 @@ Agent Architecture Reference
 
    ../agent/architecture
    ../agent/quant_agent
+   ../agent/model_validator_agent
    ../agent/builder_agent
    ../agent/critic_agent
 

--- a/docs/developer/runtime_agent_orientation.rst
+++ b/docs/developer/runtime_agent_orientation.rst
@@ -1,0 +1,66 @@
+Runtime Agent Orientation
+=========================
+
+Trellis uses two different orientation mechanisms for two different kinds of
+agent.
+
+``AGENTS.md`` applies to coding agents operating in a repository worktree. It
+defines ownership, implementation workflow, tests, and collaboration rules.
+Runtime quant and model-validator calls do not autonomously walk the worktree,
+so adding nested ``AGENTS.md`` files would not reliably orient those calls.
+
+Runtime roles instead receive compact, versioned orientation contracts at the
+prompt boundary. The canonical source is
+``trellis/agent/knowledge/canonical/agent_orientations.yaml`` and the typed
+loader is ``trellis.agent.role_orientation``.
+
+Contract Shape
+--------------
+
+Each role contract declares:
+
+- a stable contract id and positive version
+- a prompt-size budget
+- the decisions the role owns and explicitly does not own
+- an ordered list of runtime evidence, canonical knowledge, support contracts,
+  and official documentation targets
+
+The loader fails closed unless both ``quant`` and ``model_validator`` are
+present and every navigation order is consecutive. Tests also verify that all
+file-backed targets exist. Runtime targets use the ``runtime:`` prefix because
+their evidence is supplied by the compiled request rather than read from disk.
+
+Role Boundaries
+---------------
+
+The quant card begins with ``ProductIR`` and semantic-contract evidence, then
+points to decompositions, routes, model grammar, method requirements, the
+read-only cookbook catalog, and the quant docs index. It does not include the
+builder's import-selection surface.
+
+The model-validator card begins with the validation contract, deterministic
+evidence, and quant challenger packet. It then points to model and route
+contracts, the read-only cookbook catalog, current limitations, calibration
+documentation, and audit contracts. This preserves deterministic-first review
+ownership.
+
+Prompt And Trace Behavior
+-------------------------
+
+Only the role that makes an LLM call receives its rendered card. The quant
+card is injected into novel-product decomposition; the model-validator card is
+injected into residual conceptual review. Cards are bounded and are not a
+mechanism for loading every referenced file into a prompt.
+
+Lifecycle events and cycle reports persist only ``role``, ``contract_id``, and
+``version`` under ``orientation_contract``. That low-cardinality identity is
+enough for replay and drift review while avoiding duplicate prompt payloads in
+traces.
+
+Cookbook Authority
+------------------
+
+Both role cards expose ``canonical/cookbooks.yaml`` as read-only validated
+pattern evidence. Runtime calls cannot update or promote entries. Candidate
+learning remains ephemeral until the governed remediation and promotion path
+has independent validation evidence.

--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -35,6 +35,14 @@ catalogs should expose reusable primitives and binding surfaces; generated
 adapters still own product-specific payoff assembly unless a checked helper is
 explicitly selected as the exact backend binding.
 
+Runtime quant and model-validator calls are oriented by the versioned contracts
+described in :doc:`runtime_agent_orientation`. Repository ``AGENTS.md`` files
+govern coding-agent workflows; they are not assumed to be visible to hosted
+runtime calls. The quant contract points to semantic and method-selection
+indexes, while the model-validator contract starts from executed validation
+evidence. Both expose cookbook entries as read-only evidence and explicitly
+exclude runtime promotion authority.
+
 Current composition rules:
 
 - identity inference treats product names such as ``autocallable``,

--- a/tests/test_agent/test_build_loop.py
+++ b/tests/test_agent/test_build_loop.py
@@ -1351,10 +1351,24 @@ class TestBuildLoop:
                     max_retries=1,
                 )
 
-        failure_events = [details for event, details in events if event == "builder_attempt_failed"]
+        failure_events = [
+            details
+            for event, details in events
+            if event == "builder_attempt_failed"
+        ]
         assert failure_events
         assert failure_events[-1]["reason"] == "code_generation"
         assert failure_events[-1]["failure_count"] == 1
+        quant_event = next(
+            details
+            for event, details in events
+            if event == "quant_selected_method"
+        )
+        assert quant_event["orientation_contract"] == {
+            "role": "quant",
+            "contract_id": "quant-runtime-navigation",
+            "version": 1,
+        }
 
     @patch(
         "trellis.agent.executor._materialize_deterministic_exact_binding_module",

--- a/tests/test_agent/test_lite_review.py
+++ b/tests/test_agent/test_lite_review.py
@@ -1356,9 +1356,12 @@ def test_validate_build_passes_quant_selected_method_to_model_validator(monkeypa
         "trellis.agent.executor._make_test_payoff",
         lambda *args, **kwargs: object(),
     )
+    events: list[tuple[str, dict[str, object]]] = []
     monkeypatch.setattr(
         "trellis.agent.executor._record_platform_event",
-        lambda *args, **kwargs: None,
+        lambda compiled_request, event, **kwargs: events.append(
+            (event, kwargs.get("details", {}))
+        ),
     )
     monkeypatch.setattr(
         "trellis.agent.executor._should_run_reference_oracle",
@@ -1428,6 +1431,16 @@ def test_validate_build_passes_quant_selected_method_to_model_validator(monkeypa
     assert failures == []
     assert captured["method"] == "analytical"
     assert captured["run_llm_review"] is False
+    skipped = next(
+        details
+        for event, details in events
+        if event == "model_validator_llm_review_skipped"
+    )
+    assert skipped["orientation_contract"] == {
+        "role": "model_validator",
+        "contract_id": "model-validator-runtime-navigation",
+        "version": 1,
+    }
 
 
 def test_format_validation_failure_feedback_includes_structured_diagnostics():

--- a/tests/test_agent/test_model_validator.py
+++ b/tests/test_agent/test_model_validator.py
@@ -221,6 +221,9 @@ def test_llm_conceptual_review_includes_shared_knowledge(monkeypatch):
     )
 
     assert findings == []
+    assert "model-validator-runtime-navigation@1" in captured["prompt"]
+    assert "deterministic_evidence_packet" in captured["prompt"]
+    assert "quant-runtime-navigation" not in captured["prompt"]
     assert "Shared Review Principles" in captured["prompt"]
     assert "Check calibration first." in captured["prompt"]
 

--- a/tests/test_agent/test_platform_traces.py
+++ b/tests/test_agent/test_platform_traces.py
@@ -198,6 +198,11 @@ def test_platform_trace_persists_cycle_report_from_lifecycle_events(tmp_path):
         details={
             "method": "analytical",
             "selection_reason": "exact_binding",
+            "orientation_contract": {
+                "role": "quant",
+                "contract_id": "quant-runtime-navigation",
+                "version": 1,
+            },
             "challenger_packet": {
                 "selected_method": "analytical",
                 "method_identity": "analytical",
@@ -261,7 +266,14 @@ def test_platform_trace_persists_cycle_report_from_lifecycle_events(tmp_path):
         compiled,
         "model_validator_skipped",
         status="info",
-        details={"validation": "standard"},
+        details={
+            "validation": "standard",
+            "orientation_contract": {
+                "role": "model_validator",
+                "contract_id": "model-validator-runtime-navigation",
+                "version": 1,
+            },
+        },
         root=tmp_path,
     )
     append_platform_trace_event(
@@ -304,6 +316,19 @@ def test_platform_trace_persists_cycle_report_from_lifecycle_events(tmp_path):
     assert quant_stage["details"]["challenger_packet"]["candidate_methods"][1][
         "method"
     ] == "monte_carlo"
+    assert quant_stage["details"]["orientation_contract"]["contract_id"] == (
+        "quant-runtime-navigation"
+    )
+    model_validator_stage = next(
+        stage
+        for stage in cycle_report["stages"]
+        if stage["stage"] == "model_validator"
+    )
+    assert model_validator_stage["details"]["orientation_contract"] == {
+        "role": "model_validator",
+        "contract_id": "model-validator-runtime-navigation",
+        "version": 1,
+    }
     arbiter_stage = next(
         stage for stage in cycle_report["stages"] if stage["stage"] == "arbiter"
     )

--- a/tests/test_agent/test_quant.py
+++ b/tests/test_agent/test_quant.py
@@ -301,6 +301,11 @@ class TestPricingPlan:
         assert "deterministic_validation_bundle" in summary["expected_executable_checks"]
         assert "alternative_method_challenge" in summary["expected_executable_checks"]
         assert "quant:multiple_valid_methods_available" in summary["residual_risk_handoff"]
+        assert summary["orientation_contract"] == {
+            "role": "quant",
+            "contract_id": "quant-runtime-navigation",
+            "version": 1,
+        }
 
     def test_product_ir_sensitivity_request_prefers_rate_tree_for_callable_bond(self):
         from trellis.agent.knowledge.decompose import decompose_to_ir

--- a/tests/test_agent/test_role_orientation.py
+++ b/tests/test_agent/test_role_orientation.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_load_role_orientations_exposes_required_runtime_roles():
+    from trellis.agent.role_orientation import load_role_orientations
+
+    orientations = load_role_orientations()
+
+    assert set(orientations) == {"quant", "model_validator"}
+    assert orientations["quant"].contract_id == "quant-runtime-navigation"
+    assert orientations["model_validator"].contract_id == (
+        "model-validator-runtime-navigation"
+    )
+    assert all(orientation.version == 1 for orientation in orientations.values())
+    assert all(orientation.navigation for orientation in orientations.values())
+
+
+def test_role_orientation_cards_are_bounded_and_role_separated():
+    from trellis.agent.role_orientation import (
+        get_role_orientation,
+        render_role_orientation_card,
+    )
+
+    quant = get_role_orientation("quant")
+    quant_card = render_role_orientation_card("quant")
+    validator = get_role_orientation("model_validator")
+    validator_card = render_role_orientation_card("model_validator")
+
+    assert len(quant_card) <= quant.max_render_chars
+    assert len(validator_card) <= validator.max_render_chars
+    assert "`quant-runtime-navigation@1`" in quant_card
+    assert "canonical/decompositions.yaml" in quant_card
+    assert "canonical/model_grammar.yaml" in quant_card
+    assert "canonical/cookbooks.yaml" in quant_card
+    assert "docs/quant/index.rst" in quant_card
+    assert "Do not generate code or select import paths" in quant_card
+    assert "deterministic_evidence_packet" not in quant_card
+
+    assert "`model-validator-runtime-navigation@1`" in validator_card
+    assert "deterministic_evidence_packet" in validator_card
+    assert "docs/mathematical/calibration.rst" in validator_card
+    assert "canonical/cookbooks.yaml" in validator_card
+    assert "LIMITATIONS.md" in validator_card
+    assert "Do not repeat deterministic checks" in validator_card
+    assert "canonical/decompositions.yaml" not in validator_card
+
+
+def test_role_orientation_summary_is_trace_safe():
+    from trellis.agent.role_orientation import role_orientation_summary
+
+    assert role_orientation_summary("quant") == {
+        "role": "quant",
+        "contract_id": "quant-runtime-navigation",
+        "version": 1,
+    }
+    assert role_orientation_summary("model_validator") == {
+        "role": "model_validator",
+        "contract_id": "model-validator-runtime-navigation",
+        "version": 1,
+    }
+
+
+def test_role_orientation_file_navigation_targets_exist():
+    from trellis.agent.role_orientation import load_role_orientations
+
+    for orientation in load_role_orientations().values():
+        for resource in orientation.navigation:
+            if resource.path.startswith("runtime:"):
+                continue
+            assert (ROOT / resource.path).is_file(), (
+                f"{orientation.identity} references missing {resource.path}"
+            )
+
+
+def test_load_role_orientations_rejects_incomplete_manifest(tmp_path):
+    from trellis.agent.role_orientation import load_role_orientations
+
+    canonical = yaml.safe_load(
+        (ROOT / "trellis/agent/knowledge/canonical/agent_orientations.yaml").read_text()
+    )
+    canonical["orientations"].pop("model_validator")
+    path = tmp_path / "agent_orientations.yaml"
+    path.write_text(yaml.safe_dump(canonical, sort_keys=False))
+
+    with pytest.raises(ValueError, match="quant.*model_validator"):
+        load_role_orientations(path)
+
+
+def test_unknown_runtime_role_fails_closed():
+    from trellis.agent.role_orientation import get_role_orientation
+
+    with pytest.raises(ValueError, match="Unsupported runtime agent role"):
+        get_role_orientation("builder")
+
+
+def test_quant_llm_decomposition_prompt_includes_only_quant_orientation(monkeypatch):
+    from trellis.agent.knowledge import get_store
+    from trellis.agent.knowledge.decompose import _decompose_via_llm
+
+    captured: dict[str, str] = {}
+
+    monkeypatch.setattr("trellis.agent.config.load_env", lambda: None)
+
+    def fake_generate(prompt, model=None):
+        captured["prompt"] = prompt
+        return {
+            "features": ["discounting"],
+            "method": "analytical",
+            "method_modules": [],
+            "required_market_data": ["discount_curve"],
+            "reasoning": "bounded test",
+        }
+
+    monkeypatch.setattr("trellis.agent.config.llm_generate_json", fake_generate)
+
+    result = _decompose_via_llm(
+        "Novel bounded derivative",
+        "novel_bounded_derivative",
+        get_store(),
+        "fake-model",
+    )
+
+    assert result.method == "analytical"
+    assert "quant-runtime-navigation@1" in captured["prompt"]
+    assert "canonical/decompositions.yaml" in captured["prompt"]
+    assert "model-validator-runtime-navigation" not in captured["prompt"]
+    assert '"method_modules"' not in captured["prompt"]

--- a/tests/test_agent/test_role_orientation.py
+++ b/tests/test_agent/test_role_orientation.py
@@ -68,6 +68,30 @@ def test_role_orientation_summary_is_trace_safe():
     }
 
 
+def test_default_role_orientation_manifest_is_cached():
+    from trellis.agent.role_orientation import load_role_orientations
+
+    assert load_role_orientations() is load_role_orientations()
+
+
+def test_custom_role_orientation_manifest_is_reloaded(tmp_path):
+    from trellis.agent.role_orientation import load_role_orientations
+
+    canonical = yaml.safe_load(
+        (ROOT / "trellis/agent/knowledge/canonical/agent_orientations.yaml").read_text()
+    )
+    path = tmp_path / "agent_orientations.yaml"
+    path.write_text(yaml.safe_dump(canonical, sort_keys=False))
+    first = load_role_orientations(path)
+
+    canonical["orientations"]["quant"]["version"] = 2
+    path.write_text(yaml.safe_dump(canonical, sort_keys=False))
+    second = load_role_orientations(path)
+
+    assert first["quant"].version == 1
+    assert second["quant"].version == 2
+
+
 def test_role_orientation_file_navigation_targets_exist():
     from trellis.agent.role_orientation import load_role_orientations
 
@@ -94,6 +118,20 @@ def test_load_role_orientations_rejects_incomplete_manifest(tmp_path):
         load_role_orientations(path)
 
 
+def test_load_role_orientations_rejects_card_over_budget(tmp_path):
+    from trellis.agent.role_orientation import load_role_orientations
+
+    canonical = yaml.safe_load(
+        (ROOT / "trellis/agent/knowledge/canonical/agent_orientations.yaml").read_text()
+    )
+    canonical["orientations"]["quant"]["max_render_chars"] = 10
+    path = tmp_path / "agent_orientations.yaml"
+    path.write_text(yaml.safe_dump(canonical, sort_keys=False))
+
+    with pytest.raises(ValueError, match="above its 10-char budget"):
+        load_role_orientations(path)
+
+
 def test_unknown_runtime_role_fails_closed():
     from trellis.agent.role_orientation import get_role_orientation
 
@@ -102,8 +140,10 @@ def test_unknown_runtime_role_fails_closed():
 
 
 def test_quant_llm_decomposition_prompt_includes_only_quant_orientation(monkeypatch):
+    from trellis.agent.codegen_guardrails import build_generation_plan
     from trellis.agent.knowledge import get_store
     from trellis.agent.knowledge.decompose import _decompose_via_llm
+    from trellis.agent.quant import _plan_from_decomposition
 
     captured: dict[str, str] = {}
 
@@ -113,8 +153,7 @@ def test_quant_llm_decomposition_prompt_includes_only_quant_orientation(monkeypa
         captured["prompt"] = prompt
         return {
             "features": ["discounting"],
-            "method": "analytical",
-            "method_modules": [],
+            "method": "monte_carlo",
             "required_market_data": ["discount_curve"],
             "reasoning": "bounded test",
         }
@@ -128,8 +167,43 @@ def test_quant_llm_decomposition_prompt_includes_only_quant_orientation(monkeypa
         "fake-model",
     )
 
-    assert result.method == "analytical"
+    assert result.method == "monte_carlo"
+    assert result.method_modules == ("trellis.models.monte_carlo.engine",)
     assert "quant-runtime-navigation@1" in captured["prompt"]
     assert "canonical/decompositions.yaml" in captured["prompt"]
     assert "model-validator-runtime-navigation" not in captured["prompt"]
     assert '"method_modules"' not in captured["prompt"]
+
+    pricing_plan = _plan_from_decomposition(result)
+    generation_plan = build_generation_plan(
+        pricing_plan=pricing_plan,
+        instrument_type="novel_bounded_derivative",
+        inspected_modules=tuple(pricing_plan.method_modules),
+        primitive_plan_override=None,
+    )
+    assert pricing_plan.method_modules == ["trellis.models.monte_carlo.engine"]
+    assert "quant_plan_has_no_explicit_method_modules" not in (
+        generation_plan.uncertainty_flags
+    )
+
+
+def test_quant_llm_decomposition_failure_uses_deterministic_modules(monkeypatch):
+    from trellis.agent.knowledge import get_store
+    from trellis.agent.knowledge.decompose import _decompose_via_llm
+
+    monkeypatch.setattr("trellis.agent.config.load_env", lambda: None)
+
+    def fail_generate(*args, **kwargs):
+        raise RuntimeError("provider down")
+
+    monkeypatch.setattr("trellis.agent.config.llm_generate_json", fail_generate)
+
+    result = _decompose_via_llm(
+        "Novel bounded derivative",
+        "novel_bounded_derivative",
+        get_store(),
+        "fake-model",
+    )
+
+    assert result.method == "analytical"
+    assert result.method_modules == ("trellis.models.black",)

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -961,6 +961,7 @@ def build_payoff(
         )
     )
     quant_challenger_packet = quant_challenger_packet_summary(pricing_plan)
+    # Keep identity queryable without decoding the nested challenger packet.
     quant_orientation = role_orientation_summary("quant")
     _record_platform_event(
         compiled_request,

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -37,6 +37,7 @@ from trellis.agent.semantic_validation import validate_semantics
 from trellis.agent.builder import write_module, run_tests
 from trellis.agent.knowledge.import_registry import resolve_import_candidates
 from trellis.agent.knowledge.api_map import format_api_map_for_prompt
+from trellis.agent.role_orientation import role_orientation_summary
 
 
 # Sentinel in the skeleton that gets replaced by the LLM-generated body.
@@ -960,6 +961,7 @@ def build_payoff(
         )
     )
     quant_challenger_packet = quant_challenger_packet_summary(pricing_plan)
+    quant_orientation = role_orientation_summary("quant")
     _record_platform_event(
         compiled_request,
         "quant_selected_method",
@@ -975,6 +977,7 @@ def build_payoff(
             "selection_reason": pricing_plan.selection_reason,
             "assumption_summary": list(pricing_plan.assumption_summary),
             "required_market_data": sorted(pricing_plan.required_market_data),
+            "orientation_contract": quant_orientation,
             "challenger_packet": quant_challenger_packet,
             "sensitivity_support": (
                 pricing_plan.sensitivity_support.to_dict()
@@ -996,6 +999,7 @@ def build_payoff(
                 artifact_kind="PricingPlan",
             ),
             "required_market_data": sorted(pricing_plan.required_market_data),
+            "orientation_contract": quant_orientation,
             "method_modules": list(pricing_plan.method_modules),
             "reasoning": pricing_plan.reasoning,
             "selection_reason": pricing_plan.selection_reason,
@@ -1377,7 +1381,10 @@ def build_payoff(
             compiled_request,
             "model_validator_skipped",
             status="info",
-            details={"validation": validation},
+            details={
+                "validation": validation,
+                "orientation_contract": role_orientation_summary("model_validator"),
+            },
         )
 
     # Retrieve all relevant knowledge for this task (single call)
@@ -2589,6 +2596,9 @@ def _validate_build(
                         ),
                         "risk_level": review_policy.risk_level,
                         "reason": review_policy.model_validator_reason,
+                        "orientation_contract": role_orientation_summary(
+                            "model_validator"
+                        ),
                     },
                 )
                 report = validate_model(
@@ -2650,6 +2660,9 @@ def _validate_build(
                         executed=review_policy.run_model_validator_llm,
                     ),
                     "finding_count": len(report.findings),
+                    "orientation_contract": role_orientation_summary(
+                        "model_validator"
+                    ),
                     "blocker_count": len(blocker_findings),
                     "approved": report.approved,
                     "llm_review": review_policy.run_model_validator_llm,
@@ -2690,6 +2703,9 @@ def _validate_build(
             details={
                 "risk_level": review_policy.risk_level,
                 "reason": deterministic_review_block_reason,
+                "orientation_contract": role_orientation_summary(
+                    "model_validator"
+                ),
                 "failure_count": len(failures),
                 "deterministic_evidence": model_validation_evidence_packet,
             },

--- a/trellis/agent/knowledge/canonical/agent_orientations.yaml
+++ b/trellis/agent/knowledge/canonical/agent_orientations.yaml
@@ -1,0 +1,133 @@
+schema_version: 1
+orientations:
+  quant:
+    contract_id: quant-runtime-navigation
+    version: 1
+    title: Quant Runtime Orientation
+    purpose: Select and challenge pricing methods from typed product semantics and canonical quantitative knowledge.
+    max_render_chars: 3600
+    owns:
+      - Interpret ProductIR and semantic contract assumptions for method selection.
+      - Rank candidate method families and state rejected alternatives.
+      - Declare required market-data capabilities and residual model-risk handoff.
+    excludes:
+      - Do not generate code or select import paths; builder owns API-map and import-registry construction.
+      - Do not invent deterministic validation checks or override compiled route admissibility.
+      - Do not write or promote cookbook entries during task execution.
+    navigation:
+      - order: 1
+        resource_id: quant_runtime_packet
+        kind: runtime_contract
+        path: runtime:semantic_contract_product_ir_and_quant_challenger_packet
+        purpose: Start from typed product meaning, requested measures, assumptions, and already-ranked method evidence.
+      - order: 2
+        resource_id: product_decompositions
+        kind: canonical_knowledge
+        path: trellis/agent/knowledge/canonical/decompositions.yaml
+        purpose: Resolve known product features, candidate methods, required data, and modeling requirements.
+      - order: 3
+        resource_id: admitted_routes
+        kind: canonical_knowledge
+        path: trellis/agent/knowledge/canonical/routes.yaml
+        purpose: Check which method families are admitted for the typed product; do not choose implementation symbols.
+      - order: 4
+        resource_id: model_grammar
+        kind: canonical_knowledge
+        path: trellis/agent/knowledge/canonical/model_grammar.yaml
+        purpose: Compare model dynamics, state variables, calibration targets, and numerical families.
+      - order: 5
+        resource_id: method_requirements
+        kind: canonical_knowledge
+        path: trellis/agent/knowledge/canonical/method_requirements.yaml
+        purpose: Apply method-level assumptions and market-data obligations.
+      - order: 6
+        resource_id: cookbook_catalog
+        kind: read_only_pattern_index
+        path: trellis/agent/knowledge/canonical/cookbooks.yaml
+        purpose: Consult validated pattern evidence only after typed decomposition; never promote or let it override semantics.
+      - order: 7
+        resource_id: quant_docs_index
+        kind: official_docs_index
+        path: docs/quant/index.rst
+        purpose: Navigate pricing-stack, ContractIR, DSL, numerical, and knowledge-maintenance documentation.
+      - order: 8
+        resource_id: model_grammar_design
+        kind: official_docs
+        path: docs/unified_pricing_engine_model_grammar.md
+        purpose: Use the maintained model-layer grammar when canonical entries need conceptual interpretation.
+
+  model_validator:
+    contract_id: model-validator-runtime-navigation
+    version: 1
+    title: Model Validator Runtime Orientation
+    purpose: Review only residual conceptual, calibration, numerical-model, and limitation risks after deterministic evidence.
+    max_render_chars: 4200
+    owns:
+      - Assess residual conceptual soundness and calibration adequacy named by the validation contract.
+      - Challenge model assumptions using the quant packet, route contract, and executed evidence.
+      - Record bounded model-risk findings and limitations with specific evidence.
+    excludes:
+      - Do not repeat deterministic checks already owned by deterministic_evidence_packet and arbiter verdicts.
+      - Do not select routes, rewrite generated code, or review code style.
+      - Do not write or promote cookbook entries during validation.
+    navigation:
+      - order: 1
+        resource_id: validation_contract
+        kind: runtime_contract
+        path: runtime:validation_contract
+        purpose: Start from deterministic checks, residual risks, exact validation identity, and review policy.
+      - order: 2
+        resource_id: deterministic_evidence
+        kind: runtime_evidence
+        path: runtime:deterministic_evidence_packet
+        purpose: Treat executed validation, reference-oracle, and arbiter claims as already owned evidence.
+      - order: 3
+        resource_id: quant_challenger_packet
+        kind: runtime_evidence
+        path: runtime:quant_challenger_packet
+        purpose: Review the selected method, rejected alternatives, assumptions, and residual-risk handoff without reconstructing quant reasoning.
+      - order: 4
+        resource_id: admitted_routes
+        kind: canonical_knowledge
+        path: trellis/agent/knowledge/canonical/routes.yaml
+        purpose: Inspect declared route assumptions and validation expectations as read-only context.
+      - order: 5
+        resource_id: model_grammar
+        kind: canonical_knowledge
+        path: trellis/agent/knowledge/canonical/model_grammar.yaml
+        purpose: Evaluate dynamics, factors, calibration targets, and numerical-method compatibility.
+      - order: 6
+        resource_id: method_requirements
+        kind: canonical_knowledge
+        path: trellis/agent/knowledge/canonical/method_requirements.yaml
+        purpose: Check method-level conceptual and calibration obligations.
+      - order: 7
+        resource_id: cookbook_catalog
+        kind: read_only_pattern_index
+        path: trellis/agent/knowledge/canonical/cookbooks.yaml
+        purpose: Use validated patterns only as supporting model evidence, never as validation or promotion authority.
+      - order: 8
+        resource_id: limitations
+        kind: support_contract
+        path: LIMITATIONS.md
+        purpose: Bound findings against current supported and unsupported behavior.
+      - order: 9
+        resource_id: validation_loop_design
+        kind: official_docs
+        path: docs/design_validation_contract_loop.md
+        purpose: Preserve deterministic-first ownership and residual-review boundaries.
+      - order: 10
+        resource_id: calibration_reference
+        kind: official_docs
+        path: docs/mathematical/calibration.rst
+        purpose: Review calibration targets, solve diagnostics, provenance, and known workflow boundaries.
+      - order: 11
+        resource_id: quant_docs_index
+        kind: official_docs_index
+        path: docs/quant/index.rst
+        purpose: Navigate mathematical and computational references without loading all documents.
+      - order: 12
+        resource_id: audit_contract
+        kind: official_docs
+        path: docs/developer/audit_and_observability.rst
+        purpose: Align findings with cycle-report, trace, and model-risk evidence contracts.

--- a/trellis/agent/knowledge/decompose.py
+++ b/trellis/agent/knowledge/decompose.py
@@ -3837,6 +3837,7 @@ def _decompose_via_llm(
     from trellis.agent.knowledge.retrieval import (
         format_decomposition_knowledge_for_prompt,
     )
+    from trellis.agent.role_orientation import render_role_orientation_card
     load_env()
 
     # Build feature taxonomy context
@@ -3863,8 +3864,11 @@ def _decompose_via_llm(
     knowledge_section = ""
     if knowledge_text:
         knowledge_section = f"\n\n## Shared Knowledge\n{knowledge_text}"
+    orientation_card = render_role_orientation_card("quant")
 
-    prompt = f"""You are a quantitative finance expert decomposing a financial instrument
+    prompt = f"""{orientation_card}
+
+You are a quantitative finance expert decomposing a financial instrument
 into its constituent features for a pricing library.
 
 ## Available Features
@@ -3886,7 +3890,6 @@ Return JSON:
 {{
     "features": ["feature1", "feature2", ...],
     "method": "pricing_method",
-    "method_modules": ["trellis.models.module1", ...],
     "required_market_data": ["discount_curve", "black_vol_surface", ...],
     "reasoning": "Brief explanation of why this decomposition and method",
     "notes": "Any known complexities or edge cases"

--- a/trellis/agent/knowledge/decompose.py
+++ b/trellis/agent/knowledge/decompose.py
@@ -51,6 +51,7 @@ from trellis.agent.contract_ir import (
     ZeroRateTenor,
     canonicalize,
 )
+from trellis.agent.knowledge.methods import default_method_modules
 from trellis.agent.dynamic_contract_ir import (
     ActionSpec,
     AutomaticTerminationEvent,
@@ -3903,15 +3904,17 @@ Return JSON:
             instrument=key,
             features=("discounting",),
             method=normalize_method("analytical"),
+            method_modules=default_method_modules("analytical"),
             reasoning="LLM decomposition failed — falling back to analytical.",
             learned=True,
         )
 
+    method = normalize_method(data.get("method", "analytical"))
     return ProductDecomposition(
         instrument=key,
         features=tuple(data.get("features", ["discounting"])),
-        method=normalize_method(data.get("method", "analytical")),
-        method_modules=tuple(data.get("method_modules", [])),
+        method=method,
+        method_modules=default_method_modules(method),
         required_market_data=frozenset(data.get("required_market_data", ["discount_curve"])),
         reasoning=data.get("reasoning", ""),
         notes=data.get("notes", ""),

--- a/trellis/agent/knowledge/methods.py
+++ b/trellis/agent/knowledge/methods.py
@@ -19,6 +19,17 @@ CANONICAL_METHODS = frozenset({
     "waterfall",
 })
 
+_DEFAULT_METHOD_MODULES = {
+    "analytical": ("trellis.models.black",),
+    "rate_tree": ("trellis.models.trees.lattice",),
+    "monte_carlo": ("trellis.models.monte_carlo.engine",),
+    "qmc": ("trellis.models.qmc",),
+    "fft_pricing": ("trellis.models.transforms.fft_pricer",),
+    "pde_solver": ("trellis.models.pde.theta_method",),
+    "copula": ("trellis.models.copulas.gaussian",),
+    "waterfall": ("trellis.models.cashflow_engine.waterfall",),
+}
+
 _METHOD_ALIASES = {
     "analytic": "analytical",
     "analytics": "analytical",
@@ -79,3 +90,8 @@ def aliases_for_method(method: str | None) -> tuple[str, ...]:
 def is_known_method(method: str | None) -> bool:
     """Return whether *method* resolves to a known canonical method family."""
     return normalize_method(method) in CANONICAL_METHODS
+
+
+def default_method_modules(method: str | None) -> tuple[str, ...]:
+    """Return deterministic construction modules for a canonical method family."""
+    return _DEFAULT_METHOD_MODULES.get(normalize_method(method), ())

--- a/trellis/agent/model_validator.py
+++ b/trellis/agent/model_validator.py
@@ -159,6 +159,7 @@ def _llm_conceptual_review(
 ) -> list[ValidationFinding]:
     """LLM-based model validation — conceptual soundness review."""
     from trellis.agent.config import llm_generate_json, get_default_model
+    from trellis.agent.role_orientation import render_role_orientation_card
 
     model = model or get_default_model()
 
@@ -199,7 +200,10 @@ def _llm_conceptual_review(
 
         route_contract_section = "\n" + render_review_contract_card(generation_plan) + "\n"
 
-    prompt = f"""You are a model validation analyst at a quantitative finance firm.
+    orientation_card = render_role_orientation_card("model_validator")
+    prompt = f"""{orientation_card}
+
+You are a model validation analyst at a quantitative finance firm.
 Your role is to independently assess whether a pricing model is conceptually
 sound, correctly calibrated, and produces reasonable risk measures.
 

--- a/trellis/agent/platform_traces.py
+++ b/trellis/agent/platform_traces.py
@@ -1071,6 +1071,7 @@ def _cycle_stage_details(stage: str, details: dict[str, Any]) -> dict[str, Any]:
             "selection_reason",
             "assumption_summary",
             "required_market_data",
+            "orientation_contract",
             "challenger_packet",
         ),
         "validation_bundle": (
@@ -1093,6 +1094,7 @@ def _cycle_stage_details(stage: str, details: dict[str, Any]) -> dict[str, Any]:
             "approved",
             "llm_review",
             "risk_level",
+            "orientation_contract",
             "residual_risks",
             "finding_classification",
             "reason",

--- a/trellis/agent/quant.py
+++ b/trellis/agent/quant.py
@@ -15,7 +15,11 @@ import re
 
 from trellis.agent.knowledge import get_store
 from trellis.agent.knowledge.decompose import decompose, decompose_to_ir
-from trellis.agent.knowledge.methods import CANONICAL_METHODS, normalize_method
+from trellis.agent.knowledge.methods import (
+    CANONICAL_METHODS,
+    default_method_modules,
+    normalize_method,
+)
 from trellis.agent.role_orientation import role_orientation_summary
 from trellis.agent.sensitivity_support import (
     SensitivitySupport,
@@ -78,17 +82,6 @@ class PricingPlan:
     assumption_summary: tuple[str, ...] = ()
     challenger_packet: QuantChallengerPacket | Mapping[str, object] | None = None
 
-
-_DEFAULT_METHOD_MODULES = {
-    "analytical": ["trellis.models.black"],
-    "rate_tree": ["trellis.models.trees.lattice"],
-    "monte_carlo": ["trellis.models.monte_carlo.engine"],
-    "qmc": ["trellis.models.qmc"],
-    "fft_pricing": ["trellis.models.transforms.fft_pricer"],
-    "pde_solver": ["trellis.models.pde.theta_method"],
-    "copula": ["trellis.models.copulas.gaussian"],
-    "waterfall": ["trellis.models.cashflow_engine.waterfall"],
-}
 
 # Legacy _FAMILY_BLUEPRINT_ROUTE_MODULES removed.
 # Route → module mappings are now sourced from the route registry
@@ -677,7 +670,7 @@ def select_pricing_method_for_product_ir(
     requirements_entry = store._load_requirements(method)
     plan = PricingPlan(
         method=method,
-        method_modules=list(_DEFAULT_METHOD_MODULES.get(method, ())),
+        method_modules=list(default_method_modules(method)),
         required_market_data=normalize_market_data_requirements(
             getattr(product_ir, "required_market_data", ()) or ()
         ),
@@ -878,7 +871,7 @@ def _apply_heston_transform_overrides(
 
     method = "fft_pricing"
     method_modules = list(
-        _DEFAULT_METHOD_MODULES.get(method, ())
+        default_method_modules(method)
         if plan.method == "analytical"
         else plan.method_modules
     )
@@ -951,7 +944,7 @@ def _apply_local_vol_overrides(
     if method == "analytical":
         method = "monte_carlo"
 
-    method_modules = list(_DEFAULT_METHOD_MODULES.get(method, plan.method_modules))
+    method_modules = list(default_method_modules(method) or plan.method_modules)
     if method == "monte_carlo":
         for module_path in (
             "trellis.models.monte_carlo.local_vol",

--- a/trellis/agent/quant.py
+++ b/trellis/agent/quant.py
@@ -16,6 +16,7 @@ import re
 from trellis.agent.knowledge import get_store
 from trellis.agent.knowledge.decompose import decompose, decompose_to_ir
 from trellis.agent.knowledge.methods import CANONICAL_METHODS, normalize_method
+from trellis.agent.role_orientation import role_orientation_summary
 from trellis.agent.sensitivity_support import (
     SensitivitySupport,
     normalize_requested_measures,
@@ -467,6 +468,7 @@ def quant_challenger_packet_summary(
         )
     if validation_contract_id:
         payload["validation_contract_id"] = validation_contract_id
+    payload["orientation_contract"] = role_orientation_summary("quant")
     return payload
 
 

--- a/trellis/agent/role_orientation.py
+++ b/trellis/agent/role_orientation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import cache
 from pathlib import Path
 from types import MappingProxyType
 from typing import Mapping
@@ -58,6 +59,8 @@ def _required_text(payload: Mapping[str, object], key: str, *, context: str) -> 
 
 
 def _string_tuple(values: object, *, context: str) -> tuple[str, ...]:
+    if values is None:
+        raise ValueError(f"{context} is missing")
     if not isinstance(values, list) or not values:
         raise ValueError(f"{context} requires a non-empty list")
     normalized = tuple(str(value or "").strip() for value in values)
@@ -100,7 +103,7 @@ def _parse_orientation(role: str, payload: object) -> RoleOrientation:
     max_render_chars = int(payload.get("max_render_chars") or 0)
     if version <= 0 or max_render_chars <= 0:
         raise ValueError(f"{context} requires positive version and max_render_chars")
-    return RoleOrientation(
+    orientation = RoleOrientation(
         role=role,
         contract_id=_required_text(payload, "contract_id", context=context),
         version=version,
@@ -114,13 +117,13 @@ def _parse_orientation(role: str, payload: object) -> RoleOrientation:
         ),
         navigation=tuple(navigation),
     )
+    _render_orientation_card(orientation)
+    return orientation
 
 
-def load_role_orientations(
-    path: str | Path | None = None,
+def _load_role_orientations_from_path(
+    manifest_path: Path,
 ) -> Mapping[str, RoleOrientation]:
-    """Load and validate the canonical runtime role-orientation manifest."""
-    manifest_path = Path(path) if path is not None else _MANIFEST_PATH
     payload = yaml.safe_load(manifest_path.read_text())
     if not isinstance(payload, Mapping) or int(payload.get("schema_version") or 0) != 1:
         raise ValueError("Agent orientation manifest requires schema_version 1")
@@ -137,6 +140,20 @@ def load_role_orientations(
         for role in sorted(_REQUIRED_ROLES)
     }
     return MappingProxyType(orientations)
+
+
+@cache
+def _load_default_role_orientations() -> Mapping[str, RoleOrientation]:
+    return _load_role_orientations_from_path(_MANIFEST_PATH)
+
+
+def load_role_orientations(
+    path: str | Path | None = None,
+) -> Mapping[str, RoleOrientation]:
+    """Load and validate canonical or explicitly supplied role orientations."""
+    if path is None:
+        return _load_default_role_orientations()
+    return _load_role_orientations_from_path(Path(path))
 
 
 def get_role_orientation(role: str) -> RoleOrientation:
@@ -157,9 +174,7 @@ def role_orientation_summary(role: str) -> dict[str, object]:
     }
 
 
-def render_role_orientation_card(role: str) -> str:
-    """Render one compact role card without loading referenced documents."""
-    orientation = get_role_orientation(role)
+def _render_orientation_card(orientation: RoleOrientation) -> str:
     lines = [
         f"## {orientation.title}",
         f"- Contract: `{orientation.identity}`",
@@ -181,3 +196,8 @@ def render_role_orientation_card(role: str) -> str:
             f"above its {orientation.max_render_chars}-char budget"
         )
     return card
+
+
+def render_role_orientation_card(role: str) -> str:
+    """Render one compact role card without loading referenced documents."""
+    return _render_orientation_card(get_role_orientation(role))

--- a/trellis/agent/role_orientation.py
+++ b/trellis/agent/role_orientation.py
@@ -1,0 +1,183 @@
+"""Typed runtime orientation contracts for bounded agent roles."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from types import MappingProxyType
+from typing import Mapping
+
+import yaml
+
+
+_MANIFEST_PATH = (
+    Path(__file__).resolve().parent
+    / "knowledge"
+    / "canonical"
+    / "agent_orientations.yaml"
+)
+_REQUIRED_ROLES = frozenset({"quant", "model_validator"})
+
+
+@dataclass(frozen=True)
+class OrientationResource:
+    """One ordered machine-readable or documentation navigation target."""
+
+    order: int
+    resource_id: str
+    kind: str
+    path: str
+    purpose: str
+
+
+@dataclass(frozen=True)
+class RoleOrientation:
+    """One versioned runtime role-orientation contract."""
+
+    role: str
+    contract_id: str
+    version: int
+    title: str
+    purpose: str
+    max_render_chars: int
+    owns: tuple[str, ...]
+    excludes: tuple[str, ...]
+    navigation: tuple[OrientationResource, ...]
+
+    @property
+    def identity(self) -> str:
+        """Return the compact contract identity used in prompts and traces."""
+        return f"{self.contract_id}@{self.version}"
+
+
+def _required_text(payload: Mapping[str, object], key: str, *, context: str) -> str:
+    value = str(payload.get(key) or "").strip()
+    if not value:
+        raise ValueError(f"{context} requires non-empty {key!r}")
+    return value
+
+
+def _string_tuple(values: object, *, context: str) -> tuple[str, ...]:
+    if not isinstance(values, list) or not values:
+        raise ValueError(f"{context} requires a non-empty list")
+    normalized = tuple(str(value or "").strip() for value in values)
+    if any(not value for value in normalized):
+        raise ValueError(f"{context} cannot contain empty values")
+    return normalized
+
+
+def _parse_orientation(role: str, payload: object) -> RoleOrientation:
+    if not isinstance(payload, Mapping):
+        raise ValueError(f"Role orientation {role!r} must be a mapping")
+    context = f"Role orientation {role!r}"
+    navigation_payload = payload.get("navigation")
+    if not isinstance(navigation_payload, list) or not navigation_payload:
+        raise ValueError(f"{context} requires non-empty navigation")
+
+    navigation: list[OrientationResource] = []
+    for item in navigation_payload:
+        if not isinstance(item, Mapping):
+            raise ValueError(f"{context} navigation entries must be mappings")
+        order = int(item.get("order") or 0)
+        navigation.append(
+            OrientationResource(
+                order=order,
+                resource_id=_required_text(item, "resource_id", context=context),
+                kind=_required_text(item, "kind", context=context),
+                path=_required_text(item, "path", context=context),
+                purpose=_required_text(item, "purpose", context=context),
+            )
+        )
+    navigation.sort(key=lambda item: item.order)
+    expected_order = list(range(1, len(navigation) + 1))
+    if [item.order for item in navigation] != expected_order:
+        raise ValueError(f"{context} navigation order must be consecutive from 1")
+    resource_ids = [item.resource_id for item in navigation]
+    if len(resource_ids) != len(set(resource_ids)):
+        raise ValueError(f"{context} navigation resource ids must be unique")
+
+    version = int(payload.get("version") or 0)
+    max_render_chars = int(payload.get("max_render_chars") or 0)
+    if version <= 0 or max_render_chars <= 0:
+        raise ValueError(f"{context} requires positive version and max_render_chars")
+    return RoleOrientation(
+        role=role,
+        contract_id=_required_text(payload, "contract_id", context=context),
+        version=version,
+        title=_required_text(payload, "title", context=context),
+        purpose=_required_text(payload, "purpose", context=context),
+        max_render_chars=max_render_chars,
+        owns=_string_tuple(payload.get("owns"), context=f"{context} owns"),
+        excludes=_string_tuple(
+            payload.get("excludes"),
+            context=f"{context} excludes",
+        ),
+        navigation=tuple(navigation),
+    )
+
+
+def load_role_orientations(
+    path: str | Path | None = None,
+) -> Mapping[str, RoleOrientation]:
+    """Load and validate the canonical runtime role-orientation manifest."""
+    manifest_path = Path(path) if path is not None else _MANIFEST_PATH
+    payload = yaml.safe_load(manifest_path.read_text())
+    if not isinstance(payload, Mapping) or int(payload.get("schema_version") or 0) != 1:
+        raise ValueError("Agent orientation manifest requires schema_version 1")
+    raw_orientations = payload.get("orientations")
+    if not isinstance(raw_orientations, Mapping):
+        raise ValueError("Agent orientation manifest requires an orientations mapping")
+    roles = {str(role).strip() for role in raw_orientations}
+    if roles != _REQUIRED_ROLES:
+        raise ValueError(
+            "Agent orientation manifest requires exactly quant and model_validator roles"
+        )
+    orientations = {
+        role: _parse_orientation(role, raw_orientations[role])
+        for role in sorted(_REQUIRED_ROLES)
+    }
+    return MappingProxyType(orientations)
+
+
+def get_role_orientation(role: str) -> RoleOrientation:
+    """Return one supported runtime role orientation or fail closed."""
+    normalized = str(role or "").strip().lower().replace("-", "_")
+    if normalized not in _REQUIRED_ROLES:
+        raise ValueError(f"Unsupported runtime agent role {role!r}")
+    return load_role_orientations()[normalized]
+
+
+def role_orientation_summary(role: str) -> dict[str, object]:
+    """Return the low-cardinality orientation identity persisted in traces."""
+    orientation = get_role_orientation(role)
+    return {
+        "role": orientation.role,
+        "contract_id": orientation.contract_id,
+        "version": orientation.version,
+    }
+
+
+def render_role_orientation_card(role: str) -> str:
+    """Render one compact role card without loading referenced documents."""
+    orientation = get_role_orientation(role)
+    lines = [
+        f"## {orientation.title}",
+        f"- Contract: `{orientation.identity}`",
+        f"- Purpose: {orientation.purpose}",
+        "### Owns",
+        *(f"- {item}" for item in orientation.owns),
+        "### Does Not Own",
+        *(f"- {item}" for item in orientation.excludes),
+        "### Navigation Order",
+        *(
+            f"{item.order}. [{item.kind}] `{item.path}`: {item.purpose}"
+            for item in orientation.navigation
+        ),
+    ]
+    card = "\n".join(lines)
+    if len(card) > orientation.max_render_chars:
+        raise ValueError(
+            f"Role orientation {orientation.identity} renders to {len(card)} chars, "
+            f"above its {orientation.max_render_chars}-char budget"
+        )
+    return card


### PR DESCRIPTION
## Summary
- add typed, versioned runtime orientation contracts for quant and model-validator
- inject role-separated cards at the actual LLM boundaries and persist contract identity in cycle traces
- remove quant authority to request implementation module paths; keep cookbook evidence read-only
- document runtime orientation versus repository AGENTS.md guidance

## Validation
- 229 targeted agent/knowledge tests passed
- 36 focused orientation/quant tests passed after self-review
- make gate-pr: 4,329 ordinary tests passed; 32 tier-2 contract tests passed; 15 optional tests skipped
- strict Sphinx build rendered the new pages without ticket-specific warnings; repository-wide strict docs remain blocked by pre-existing documentation errors

Linear: QUA-1175