### PR TITLE
QUA-1173 Retire quanto helper construction authority

### DIFF
--- a/tests/test_agent/test_semantic_validators.py
+++ b/tests/test_agent/test_semantic_validators.py
@@ -654,6 +654,50 @@ def evaluate(self, market_state):
         findings = validator.validate(source, _make_plan("equity_quanto"), spec)
         assert any(f.category == "required_primitive_not_called" for f in findings)
 
+    @pytest.mark.parametrize(
+        "non_call_source",
+        [
+            "# black76_call(forward, strike, vol, T)",
+            '"""black76_call(forward, strike, vol, T)"""',
+            "def black76_call(forward, strike, vol, T):\n        return 0.0",
+        ],
+    )
+    def test_rejects_non_call_text_for_required_quanto_primitive(
+        self,
+        registry,
+        non_call_source,
+    ):
+        spec = [r for r in registry.routes if r.id == "equity_quanto"][0]
+        source = f'''
+def evaluate(self, market_state):
+    resolved = resolve_quanto_inputs(market_state, self._spec)
+    option_type = normalized_option_type(self._spec.option_type)
+    if resolved.T <= 0.0:
+        return terminal_intrinsic(option_type, spot=resolved.spot, strike=self._spec.strike)
+    forward = quanto_adjusted_forward(
+        spot=resolved.spot,
+        domestic_df=resolved.domestic_df,
+        foreign_df=resolved.foreign_df,
+        corr=resolved.corr,
+        sigma_underlier=resolved.sigma_underlier,
+        sigma_fx=resolved.sigma_fx,
+        T=resolved.T,
+    )
+    {non_call_source}
+    call = 0.0
+    put = black76_put(forward, self._spec.strike, resolved.sigma_underlier, resolved.T)
+    return discounted_value(call if option_type == "call" else put, resolved.domestic_df)
+'''
+        validator = AlgorithmContractValidator()
+
+        findings = validator.validate(source, _make_plan("equity_quanto"), spec)
+
+        assert any(
+            finding.category == "required_primitive_not_called"
+            and "'black76_call'" in finding.message
+            for finding in findings
+        )
+
     def test_accepts_complete_quanto_analytical_primitive_surface(self, registry):
         spec = [r for r in registry.routes if r.id == "equity_quanto"][0]
         source = '''

--- a/trellis/agent/semantic_validators/algorithm_contract.py
+++ b/trellis/agent/semantic_validators/algorithm_contract.py
@@ -10,7 +10,6 @@ Checks:
 from __future__ import annotations
 
 import ast
-import re
 
 from trellis.agent.codegen_guardrails import GenerationPlan
 from trellis.agent.route_registry import RouteSpec, resolve_route_primitives
@@ -511,8 +510,15 @@ _EXACT_HELPER_SIGNATURES = {
 
 
 def _calls_symbol(source: str, symbol: str) -> bool:
-    """Return whether ``source`` appears to call ``symbol`` as a function."""
-    return re.search(rf"\b{re.escape(symbol)}\s*\(", source) is not None
+    """Return whether a Python call node targets ``symbol``."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return False
+    return any(
+        isinstance(node, ast.Call) and _call_matches_symbol(node, symbol)
+        for node in ast.walk(tree)
+    )
 
 
 def _calls_checked_route_helper(


### PR DESCRIPTION
Retires product-helper authority from the bounded single-underlier quanto route. Analytical, Monte Carlo, and QMC artifacts now compose reusable primitives; target references and true helper authority are distinct across lowering, observability, guardrails, and semantic validation. Updates exact market binding, checked/fresh adapters, tests, and official docs. Validated with gate-pr, gate-release, and a strict offline T105 fresh-build replay with zero LLM calls or recovery.