### PR TITLE
QUA-1177: compose cliquet routes from primitives

### DIFF
--- a/doc/plan/active__contract-backed-task-learning-repair.md
+++ b/doc/plan/active__contract-backed-task-learning-repair.md
@@ -509,6 +509,12 @@ route-helper gates now recognize the checked cliquet MC helper as satisfying
 the lower-level `monte_carlo_paths` route obligation for `cliquet_option`,
 without relaxing ordinary missing-helper checks.
 
+This records the original `P007` repair. `QUA-1177` supersedes its construction
+authority: current cliquet routes compose the generic observation-return,
+Black-76, bounded-expectation, GBM, and Monte Carlo primitives directly. The
+retained analytical and Monte Carlo cliquet functions are comparison references
+only, and the semantic/lite-review exemptions described above have been removed.
+
 Validation:
 
 ```bash

--- a/doc/plan/active__semantic-task-synthesis-helper-retirement.md
+++ b/doc/plan/active__semantic-task-synthesis-helper-retirement.md
@@ -37,7 +37,7 @@ Status mirror last synced: `2026-07-13`
 | `QUA-1173` | Quanto option: primitive-composed analytical and MC lanes | Done |
 | `QUA-1175` | Agent orientation: runtime quant and model-validator navigation contracts | Done |
 | `QUA-1176` | Observation returns: reusable bounded accumulation primitives | Done |
-| `QUA-1177` | Cliquet pricing: primitive-composed analytical and Monte Carlo lanes | Backlog |
+| `QUA-1177` | Cliquet pricing: primitive-composed analytical and Monte Carlo lanes | In Progress |
 
 ## Current Sequence
 

--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -43,6 +43,13 @@ indexes, while the model-validator contract starts from executed validation
 evidence. Both expose cookbook entries as read-only evidence and explicitly
 exclude runtime promotion authority.
 
+Stage-aware builder retrieval also preserves the compiled generation route.
+Every live refresh scopes shared knowledge by pricing method, exact route id,
+and declared route families before replacing the trace summary. A retry may
+therefore refresh relevant evidence, but it cannot silently broaden a compiled
+``analytical_black76`` request into an unrelated exact-helper hint from another
+analytical route.
+
 Current composition rules:
 
 - identity inference treats product names such as ``autocallable``,
@@ -904,14 +911,18 @@ a multi-method path-dependent option; and fixed-lookback MC targets bind to
 text may use cross-validation target names to recover product identity, but the
 runtime still fails closed if the resolved contract and exact helper disagree.
 
-Capped/floored cliquet comparisons follow a bounded version of that contract.
-The analytical target can use the checked capped/floored reset-return
-quadrature path, and the Monte Carlo target should call
-``price_equity_cliquet_option_monte_carlo(market_state, spec, ...)`` instead of
-rebuilding reset-date GBM path generation inline. The generic volatility
-monotonicity invariant is not enforced for ``cliquet_option`` because
-local/global caps and floors can make the capped return value non-monotone in
-Black volatility; volatility sensitivity remains part of the validation pack.
+Capped/floored cliquet comparisons are now a primitive-composed task lane. The
+analytical target builds an ``ObservationReturnContract`` and combines bounded
+return accumulation with a node-budgeted product expectation; the unbounded
+reset form instead assembles explicit Black-76 optionlets. The Monte Carlo
+target combines the same contract with ``observation_return_payoff``, ``GBM``,
+and ``MonteCarloEngine`` using reduced-state execution. Fresh generated source
+must show those obligations directly. Retained cliquet pricing functions are
+comparison references and do not count as route implementation evidence. The
+generic volatility monotonicity invariant is not enforced for
+``cliquet_option`` because local/global caps and floors can make the capped
+return value non-monotone in Black volatility; volatility sensitivity remains
+part of the validation pack.
 
 The ADI helper also owns its variance-grid domain. The grid upper bound is
 based on the CIR variance-process dispersion, not a raw ``xi * sqrt(T)`` move;

--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -915,8 +915,10 @@ Capped/floored cliquet comparisons are now a primitive-composed task lane. The
 analytical target builds an ``ObservationReturnContract`` and combines bounded
 return accumulation with a node-budgeted product expectation; the unbounded
 reset form instead assembles explicit Black-76 optionlets. The Monte Carlo
-target combines the same contract with ``observation_return_payoff``, ``GBM``,
-and ``MonteCarloEngine`` using reduced-state execution. Fresh generated source
+target combines the same contract with ``observation_return_payoff``,
+``PiecewiseConstantGBM``, and ``MonteCarloEngine`` using reduced-state
+execution. Each reset interval keeps its own drift and Black volatility instead
+of flattening the final-maturity quote across the path. Fresh generated source
 must show those obligations directly. Retained cliquet pricing functions are
 comparison references and do not count as route implementation evidence. The
 generic volatility monotonicity invariant is not enforced for

--- a/docs/developer/task_diagnostics.rst
+++ b/docs/developer/task_diagnostics.rst
@@ -410,9 +410,10 @@ remain a route-helper contract failure.
 Scheduled observation-return routes are primitive-composed. Their diagnosis
 packets should require ``ObservationReturnContract`` plus the selected
 analytical or Monte Carlo primitives. For Monte Carlo, that means
-``observation_return_payoff``, ``GBM``, and ``MonteCarloEngine`` with an exact
-observation grid and reduced-state execution. For bounded analytical work, it
-means ``bounded_observation_return_sum`` inside
+``observation_return_payoff``, ``PiecewiseConstantGBM``, and
+``MonteCarloEngine`` with interval-specific drift and volatility, an exact
+observation grid, and reduced-state execution. For bounded analytical work,
+it means ``bounded_observation_return_sum`` inside
 ``gauss_hermite_product_expectation``; unbounded reset optionlets additionally
 use the Black-76 call or put kernels. A call to a retained product-level cliquet
 pricing function does not subsume these obligations and should produce a

--- a/docs/developer/task_diagnostics.rst
+++ b/docs/developer/task_diagnostics.rst
@@ -407,13 +407,16 @@ internals to the checked helper.  If the adapter omits that helper or passes an
 invented surface such as raw ``spot`` or barrier keywords, the diagnosis should
 remain a route-helper contract failure.
 
-The same distinction applies to the capped/floored cliquet Monte Carlo helper.
-When the product identity is ``cliquet_option`` and the route is
-``monte_carlo_paths``, a thin adapter that calls
-``price_equity_cliquet_option_monte_carlo(market_state, spec, ...)`` delegates
-reset-date GBM increments, local/global return clipping, antithetic sampling,
-and discounting to the checked helper. Ordinary Monte Carlo adapters still
-need to satisfy their compiled route-helper or primitive obligations directly.
+Scheduled observation-return routes are primitive-composed. Their diagnosis
+packets should require ``ObservationReturnContract`` plus the selected
+analytical or Monte Carlo primitives. For Monte Carlo, that means
+``observation_return_payoff``, ``GBM``, and ``MonteCarloEngine`` with an exact
+observation grid and reduced-state execution. For bounded analytical work, it
+means ``bounded_observation_return_sum`` inside
+``gauss_hermite_product_expectation``; unbounded reset optionlets additionally
+use the Black-76 call or put kernels. A call to a retained product-level cliquet
+pricing function does not subsume these obligations and should produce a
+structured missing-primitive or route-contract failure.
 
 Vanilla American or Bermudan equity options are intentionally different. The
 ``exercise_monte_carlo`` route is primitive-composed: an adapter resolves inputs

--- a/docs/mathematical/processes.rst
+++ b/docs/mathematical/processes.rst
@@ -14,6 +14,16 @@ GBM
 Exact: :math:`S_T = S_0\exp[(\mu-\sigma^2/2)T + \sigma\sqrt{T}Z]`.
 Moments: :math:`\mathbb{E}[S_T] = S_0 e^{\mu T}`.
 
+Piecewise-Constant GBM
+----------------------
+
+``PiecewiseConstantGBM`` keeps deterministic drift and volatility pairs on an
+ordered time grid. Its exact transition integrates drift and variance across
+every interval crossed by a simulation step, so the numerical grid need not
+coincide with parameter boundaries. This is useful for scheduled-return
+composition when each observation interval binds a different market quote; it
+does not infer a local-volatility process from an implied-volatility surface.
+
 Vasicek
 -------
 
@@ -204,6 +214,8 @@ Implementation
 --------------
 
 .. autoclass:: trellis.models.processes.gbm.GBM
+   :members:
+.. autoclass:: trellis.models.processes.gbm.PiecewiseConstantGBM
    :members:
 .. autoclass:: trellis.models.processes.heston.Heston
    :members:

--- a/docs/quant/pricing_stack.rst
+++ b/docs/quant/pricing_stack.rst
@@ -405,7 +405,8 @@ The first migrated vanilla cases now use that boundary directly:
   ``black76_put`` and explicit carry and discounting. A locally or globally
   bounded analytical lane evaluates ``bounded_observation_return_sum`` inside
   ``gauss_hermite_product_expectation``. The Monte Carlo lane combines
-  ``observation_return_payoff``, ``GBM``, and ``MonteCarloEngine`` with
+  ``observation_return_payoff``, ``PiecewiseConstantGBM``, and
+  ``MonteCarloEngine`` with one drift/volatility pair per reset interval and
   ``return_paths=False`` so only the previous level and accumulated return are
   retained. The product-level cliquet pricing functions remain independent
   comparison and compatibility references; calling one does not satisfy a

--- a/docs/quant/pricing_stack.rst
+++ b/docs/quant/pricing_stack.rst
@@ -399,13 +399,17 @@ The first migrated vanilla cases now use that boundary directly:
   forward spread, strike spread, spread volatility, index annuity, discounting,
   and loss convention. This is a spread-option task helper, not an index-loss
   curve, tranche, or base-correlation model.
-- capped/floored equity cliquet comparisons now have bounded analytical and
-  Monte Carlo helper surfaces: the analytical path integrates reset returns
-  with local/global caps and floors, while the Monte Carlo path delegates
-  reset-date GBM increments, clipping, antithetic sampling, and discounting to
-  ``trellis.models.monte_carlo.event_aware.price_equity_cliquet_option_monte_carlo``.
-  These helpers support the explicit capped/floored comparison task surface;
-  they do not imply arbitrary cliquet-book or path-contract coverage.
+- scheduled equity reset-return comparisons now assemble from
+  ``ObservationReturnContract`` and product-neutral numerical primitives. An
+  unbounded analytical lane prices each reset interval with ``black76_call`` or
+  ``black76_put`` and explicit carry and discounting. A locally or globally
+  bounded analytical lane evaluates ``bounded_observation_return_sum`` inside
+  ``gauss_hermite_product_expectation``. The Monte Carlo lane combines
+  ``observation_return_payoff``, ``GBM``, and ``MonteCarloEngine`` with
+  ``return_paths=False`` so only the previous level and accumulated return are
+  retained. The product-level cliquet pricing functions remain independent
+  comparison and compatibility references; calling one does not satisfy a
+  generated route's construction contract.
 
 The developer-facing notation and task-triage lifecycle for these
 stochastic-volatility buckets is maintained in
@@ -557,11 +561,12 @@ branches, Heston ADI diagnostic scaffold, double-barrier payoff primitives,
 and vanilla-equity transform helper keep backend binding, admissibility, and
 validation ownership explicit. Exact-helper validation enforces the thin
 ``(market_state, spec, ...)`` call surface only for true checked route helpers;
-primitive-only supports, including vanilla theta-method PDE and the analytical,
-Monte Carlo, and QMC quanto lanes, require agent-written route assembly rather
-than a product/method wrapper. Their lowering records primitive targets
-separately from true ``route_helper`` bindings so generic resolvers and kernels
-are not mislabeled as helper authority in prompts or traces.
+primitive-only supports, including vanilla theta-method PDE, the analytical,
+Monte Carlo, and QMC quanto lanes, and scheduled observation-return lanes,
+require agent-written route assembly rather than a product/method wrapper.
+Their lowering records primitive targets separately from true ``route_helper``
+bindings so generic resolvers and kernels are not mislabeled as helper authority
+in prompts or traces.
 
 For schedule-driven cap/floor strips lowered onto ``analytical_black76``, the
 typed schedule state now carries admissibility directly. Structural

--- a/docs/user_guide/pricing.rst
+++ b/docs/user_guide/pricing.rst
@@ -147,7 +147,7 @@ return:
        ObservationReturnContract,
        observation_return_payoff,
    )
-   from trellis.models.processes.gbm import GBM
+   from trellis.models.processes.gbm import PiecewiseConstantGBM
 
    terms = ObservationReturnContract(
        observation_times=(0.25, 0.5, 0.75, 1.0),
@@ -164,7 +164,11 @@ return:
        n_steps=252,
    )
    result = MonteCarloEngine(
-       GBM(mu=0.03, sigma=0.20),
+       PiecewiseConstantGBM(
+           interval_ends=terms.observation_times,
+           mus=(0.03, 0.03, 0.03, 0.03),
+           sigmas=(0.18, 0.19, 0.20, 0.21),
+       ),
        n_paths=100_000,
        n_steps=252,
        seed=42,

--- a/docs/user_guide/pricing.rst
+++ b/docs/user_guide/pricing.rst
@@ -184,6 +184,15 @@ can reuse the same ``ObservationReturnContract`` and
 standard normals. Correlated returns, stochastic-volatility state, or
 nonpositive observables require a different model-specific composition.
 
+For an unbounded reset-style option, compose each observation interval as a
+unit-strike Black-76 call or put on the forward return and apply carry and
+discounting explicitly. For local or global bounds, use the contract and
+bounded accumulator inside the product expectation shown above. The retained
+``price_equity_cliquet_option_analytical`` and
+``price_equity_cliquet_option_monte_carlo`` functions are useful independent
+references for these supported cases, but generated adapters are expected to
+assemble the public primitives directly.
+
 The P001 Bermudan best-of-two rainbow proof is also exposed this way for
 task compatibility. Its checked-in ``_agent`` adapter delegates to the
 ``trellis.execution`` Bermudan best-of basket shim, which reuses the route-free

--- a/tests/test_agent/test_api_map.py
+++ b/tests/test_agent/test_api_map.py
@@ -128,6 +128,7 @@ def test_api_map_exposes_product_neutral_observation_return_composition():
         "observation_return_payoff",
         "gauss_hermite_product_expectation",
         "MonteCarloEngine",
+        "PiecewiseConstantGBM",
     ):
         assert symbol in text
     assert "cliquet" not in text.lower()

--- a/tests/test_agent/test_autonomous.py
+++ b/tests/test_agent/test_autonomous.py
@@ -312,6 +312,95 @@ def test_build_with_tracking_forwards_retry_overlays_to_build_payoff(monkeypatch
     ]
 
 
+def test_build_with_tracking_scopes_live_knowledge_to_compiled_route(monkeypatch):
+    from trellis.agent.knowledge.autonomous import _build_with_tracking
+    from trellis.agent.knowledge.gap_check import GapReport
+    from trellis.agent.knowledge.schema import ProductDecomposition
+
+    observed: list[dict[str, object]] = []
+    decomposition = ProductDecomposition(
+        instrument="cliquet_option",
+        features=("scheduled_observation_returns",),
+        method="analytical",
+        learned=False,
+    )
+    product_ir = SimpleNamespace(
+        instrument="cliquet_option",
+        route_families=("analytical",),
+    )
+
+    monkeypatch.setattr(
+        "trellis.agent.knowledge.autonomous._reset_deterministic_planning_caches",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "trellis.agent.knowledge.retrieve_for_product_ir",
+        lambda *args, **kwargs: [],
+    )
+
+    def fake_shared_payload(knowledge, **kwargs):
+        observed.append(dict(kwargs))
+        route_ids = tuple(kwargs.get("route_ids") or ())
+        scoped = route_ids == ("analytical_black76",)
+        text = "scoped primitive knowledge" if scoped else "unscoped SABR helper"
+        selected_ids = ["principle:P10"] if scoped else [
+            "route_hint:sabr_hagan_analytical:route-helper"
+        ]
+        return {
+            "summary": {"selected_artifact_ids": selected_ids},
+            "builder_text_distilled": text,
+            "builder_text": text,
+            "builder_text_expanded": text,
+            "review_text_distilled": text,
+            "review_text_expanded": text,
+        }
+
+    monkeypatch.setattr(
+        "trellis.agent.knowledge.build_shared_knowledge_payload",
+        fake_shared_payload,
+    )
+
+    def fake_build_payoff(*args, **kwargs):
+        generation_plan = SimpleNamespace(
+            lowering_route_id=None,
+            primitive_plan=SimpleNamespace(route="analytical_black76"),
+        )
+        request = SimpleNamespace(
+            audience="builder",
+            knowledge_surface="compact",
+            prompt_surface="compact",
+            pricing_method="analytical",
+            product_ir=product_ir,
+            compiled_request=SimpleNamespace(generation_plan=generation_plan),
+        )
+        assert kwargs["knowledge_retriever"](request) == "scoped primitive knowledge"
+        return type("FakeCliquetPayoff", (), {})
+
+    monkeypatch.setattr("trellis.agent.executor.build_payoff", fake_build_payoff)
+
+    payoff_cls, meta = _build_with_tracking(
+        description="Cliquet option",
+        instrument_type="cliquet_option",
+        decomposition=decomposition,
+        product_ir=product_ir,
+        gap_report=GapReport(confidence=0.8, retrieved_lesson_ids=[]),
+        model="test-model",
+        market_state=None,
+        max_retries=1,
+        validation="standard",
+        force_rebuild=True,
+        preferred_method="analytical",
+    )
+
+    assert payoff_cls.__name__ == "FakeCliquetPayoff"
+    assert observed[-1] == {
+        "pricing_method": "analytical",
+        "route_ids": ("analytical_black76",),
+        "route_families": ("analytical",),
+    }
+    assert meta["knowledge_summary"]["selected_artifact_ids"] == ["principle:P10"]
+
+
 def test_build_with_knowledge_preserves_platform_trace_metadata_on_failure(monkeypatch):
     from trellis.agent.knowledge.gap_check import GapReport
     from trellis.agent.knowledge.schema import ProductDecomposition

--- a/tests/test_agent/test_backend_bindings.py
+++ b/tests/test_agent/test_backend_bindings.py
@@ -678,22 +678,6 @@ def test_resolve_backend_binding_spec_uses_quanto_primitive_composition(
         ),
         pytest.param(
             ProductIR(
-                instrument="cliquet_option",
-                payoff_family="cliquet_option",
-                payoff_traits=("vanilla_option",),
-                exercise_style="european",
-                state_dependence="terminal_markov",
-                model_family="equity_diffusion",
-            ),
-            "analytical",
-            (
-                "trellis.models.analytical.equity_exotics.price_equity_cliquet_option_analytical",
-            ),
-            (),
-            id="cliquet",
-        ),
-        pytest.param(
-            ProductIR(
                 instrument="variance_swap",
                 payoff_family="variance_swap",
                 payoff_traits=(
@@ -733,6 +717,35 @@ def test_resolve_backend_binding_spec_uses_exact_helpers_for_absorbed_black76_eq
     assert resolved.route_family == expected_route_family
     assert resolved.helper_refs == expected_helper_refs
     assert resolved.pricing_kernel_refs == expected_kernel_refs
+
+
+def test_resolve_backend_binding_spec_uses_cliquet_primitive_composition():
+    catalog = load_backend_binding_catalog()
+    analytical = find_backend_binding_by_route_id("analytical_black76", catalog)
+
+    assert analytical is not None
+
+    resolved = resolve_backend_binding_spec(
+        analytical,
+        product_ir=ProductIR(
+            instrument="cliquet_option",
+            payoff_family="cliquet_option",
+            payoff_traits=("vanilla_option",),
+            exercise_style="european",
+            state_dependence="path_dependent",
+            schedule_dependence=True,
+            model_family="equity_diffusion",
+        ),
+    )
+
+    assert resolved.helper_refs == ()
+    assert resolved.pricing_kernel_refs == (
+        "trellis.models.black.black76_call",
+        "trellis.models.black.black76_put",
+        "trellis.models.analytical.support.expectations.gauss_hermite_product_expectation",
+    )
+    assert "trellis.models.observation_returns.ObservationReturnContract" in resolved.primitive_refs
+    assert "trellis.models.observation_returns.bounded_observation_return_sum" in resolved.primitive_refs
 
 
 def test_resolve_backend_binding_spec_uses_variance_swap_monte_carlo_helper():

--- a/tests/test_agent/test_benchmark_contracts.py
+++ b/tests/test_agent/test_benchmark_contracts.py
@@ -26,6 +26,13 @@ def _benchmark_tasks() -> dict[str, dict]:
     }
 
 
+def _extension_tasks() -> dict[str, dict]:
+    return {
+        task["id"]: task
+        for task in load_task_manifest("TASKS_EXTENSION.yaml", root=ROOT)
+    }
+
+
 def test_canonical_benchmark_instrument_type_maps_broad_runtime_families():
     tasks = _benchmark_tasks()
 
@@ -216,6 +223,12 @@ def test_benchmark_spec_overrides_cover_fx_rates_cap_and_swaption_contracts():
     )
     assert cliquet["day_count"] is DayCountConvention.THIRTY_E_360
     assert cliquet["time_day_count"] is DayCountConvention.ACT_365
+
+    bounded_cliquet = benchmark_spec_overrides(_extension_tasks()["P007"], root=ROOT)
+    assert bounded_cliquet["local_cap"] == pytest.approx(0.08)
+    assert bounded_cliquet["local_floor"] == pytest.approx(0.0)
+    assert bounded_cliquet["global_cap"] == pytest.approx(0.20)
+    assert bounded_cliquet["global_floor"] == pytest.approx(0.0)
 
     variance_swap = benchmark_spec_overrides(tasks["F015"], root=ROOT)
     assert variance_swap["strike_variance"] == pytest.approx(0.04)

--- a/tests/test_agent/test_executor.py
+++ b/tests/test_agent/test_executor.py
@@ -2288,7 +2288,8 @@ def test_deterministic_exact_binding_module_does_not_materialize_learning_target
     assert generated is None
 
 
-def test_deterministic_exact_binding_module_materializes_cliquet_monte_carlo_helper():
+def test_deterministic_exact_binding_module_composes_observation_return_monte_carlo():
+    from trellis.agent.codegen_guardrails import PrimitiveRef
     from trellis.agent.executor import (
         EVALUATE_SENTINEL,
         _generate_skeleton,
@@ -2298,7 +2299,36 @@ def test_deterministic_exact_binding_module_materializes_cliquet_monte_carlo_hel
 
     generation_plan = SimpleNamespace(
         lane_exact_binding_refs=(),
-        primitive_plan=None,
+        primitive_plan=SimpleNamespace(
+            route="monte_carlo_paths",
+            primitives=(
+                PrimitiveRef(
+                    "trellis.models.observation_returns",
+                    "ObservationReturnContract",
+                    "payoff_contract",
+                ),
+                PrimitiveRef(
+                    "trellis.models.observation_returns",
+                    "observation_return_payoff",
+                    "payoff_primitive",
+                ),
+                PrimitiveRef(
+                    "trellis.models.processes.gbm",
+                    "GBM",
+                    "state_process",
+                ),
+                PrimitiveRef(
+                    "trellis.models.monte_carlo.engine",
+                    "MonteCarloEngine",
+                    "path_simulation",
+                ),
+                PrimitiveRef(
+                    "trellis.core.date_utils",
+                    "year_fraction",
+                    "time_measure",
+                ),
+            ),
+        ),
         method="monte_carlo",
         instrument_type="cliquet_option",
     )
@@ -2315,10 +2345,188 @@ def test_deterministic_exact_binding_module_materializes_cliquet_monte_carlo_hel
     )
 
     assert generated is not None
-    assert "from trellis.models.monte_carlo.event_aware import price_equity_cliquet_option_monte_carlo" in generated.code
-    assert "price_equity_cliquet_option_monte_carlo(" in generated.code
-    assert 'n_paths=getattr(spec, "n_paths", 120000)' in generated.code
+    assert "ObservationReturnContract(" in generated.code
+    assert "observation_return_payoff(" in generated.code
+    assert "GBM(" in generated.code
+    assert "MonteCarloEngine(" in generated.code
+    assert "return_paths=False" in generated.code
+    assert "price_equity_cliquet_option_monte_carlo" not in generated.code
+    assert "price_equity_cliquet_option_analytical" not in generated.code
     assert EVALUATE_SENTINEL not in generated.code
+
+
+def test_generated_observation_return_lanes_match_retained_references():
+    from dataclasses import fields
+
+    from trellis.agent.codegen_guardrails import PrimitiveRef
+    from trellis.agent.executor import (
+        _generate_skeleton,
+        _materialize_deterministic_exact_binding_module,
+    )
+    from trellis.agent.planner import STATIC_SPECS
+    from trellis.agent.task_manifests import load_task_manifest
+    from trellis.agent.task_runtime import benchmark_spec_overrides, build_market_state_for_task
+    from trellis.models.analytical import price_equity_cliquet_option_analytical
+
+    analytical_primitives = (
+        PrimitiveRef(
+            "trellis.models.observation_returns",
+            "ObservationReturnContract",
+            "payoff_contract",
+        ),
+        PrimitiveRef(
+            "trellis.models.observation_returns",
+            "bounded_observation_return_sum",
+            "payoff_primitive",
+        ),
+        PrimitiveRef("trellis.models.black", "black76_call", "pricing_kernel"),
+        PrimitiveRef("trellis.models.black", "black76_put", "pricing_kernel"),
+        PrimitiveRef(
+            "trellis.models.analytical.support.expectations",
+            "gauss_hermite_product_expectation",
+            "pricing_kernel",
+        ),
+        PrimitiveRef("trellis.core.date_utils", "year_fraction", "time_measure"),
+    )
+    monte_carlo_primitives = (
+        PrimitiveRef(
+            "trellis.models.observation_returns",
+            "ObservationReturnContract",
+            "payoff_contract",
+        ),
+        PrimitiveRef(
+            "trellis.models.observation_returns",
+            "observation_return_payoff",
+            "payoff_primitive",
+        ),
+        PrimitiveRef("trellis.models.processes.gbm", "GBM", "state_process"),
+        PrimitiveRef(
+            "trellis.models.monte_carlo.engine",
+            "MonteCarloEngine",
+            "path_simulation",
+        ),
+        PrimitiveRef("trellis.core.date_utils", "year_fraction", "time_measure"),
+    )
+
+    def materialize(method, route, primitives):
+        generation_plan = SimpleNamespace(
+            lane_exact_binding_refs=(),
+            primitive_plan=SimpleNamespace(route=route, primitives=primitives),
+            method=method,
+            instrument_type="cliquet_option",
+        )
+        schema = STATIC_SPECS["cliquet_option"]
+        generated = _materialize_deterministic_exact_binding_module(
+            _generate_skeleton(
+                schema,
+                "Scheduled bounded observation returns",
+                generation_plan=generation_plan,
+            ),
+            generation_plan,
+            comparison_target=method,
+        )
+        assert generated is not None
+        namespace: dict = {}
+        exec(compile(generated.code, f"<qua_1177_{method}>", "exec"), namespace)  # noqa: S102
+        return schema, namespace, generated.code
+
+    analytical_schema, analytical_ns, analytical_source = materialize(
+        "analytical",
+        "analytical_black76",
+        analytical_primitives,
+    )
+    mc_schema, mc_ns, mc_source = materialize(
+        "monte_carlo",
+        "monte_carlo_paths",
+        monte_carlo_primitives,
+    )
+    tasks = {
+        task["id"]: task
+        for manifest in ("TASKS_BENCHMARK_FINANCEPY.yaml", "TASKS_EXTENSION.yaml")
+        for task in load_task_manifest(manifest)
+        if task["id"] in {"F014", "P007"}
+    }
+
+    def payoff(schema, namespace, overrides, **extra):
+        spec_type = namespace[schema.spec_name]
+        spec_fields = {field.name for field in fields(spec_type)}
+        terms = {key: value for key, value in overrides.items() if key in spec_fields}
+        terms.update({key: value for key, value in extra.items() if key in spec_fields})
+        return namespace[schema.class_name](spec_type(**terms))
+
+    for task_id in ("F014", "P007"):
+        task = tasks[task_id]
+        market_state, _ = build_market_state_for_task(task)
+        overrides = benchmark_spec_overrides(task)
+        analytical = payoff(analytical_schema, analytical_ns, overrides)
+        analytical_price = float(analytical.evaluate(market_state))
+        reference_price = float(
+            price_equity_cliquet_option_analytical(market_state, analytical.spec)
+        )
+        assert analytical_price == pytest.approx(reference_price, rel=1e-10, abs=1e-10)
+
+        if task_id == "P007":
+            monte_carlo = payoff(
+                mc_schema,
+                mc_ns,
+                overrides,
+                n_paths=30_000,
+                seed=17,
+            )
+            monte_carlo_price = float(monte_carlo.evaluate(market_state))
+            assert monte_carlo_price == pytest.approx(
+                analytical_price,
+                rel=0.05,
+                abs=0.10,
+            )
+
+    for source in (analytical_source, mc_source):
+        assert "price_equity_cliquet_option_analytical" not in source
+        assert "price_equity_cliquet_option_monte_carlo" not in source
+        assert "ObservationReturnContract(" in source
+    assert "bounded_observation_return_sum(" in analytical_source
+    assert "gauss_hermite_product_expectation(" in analytical_source
+    assert "observation_return_payoff(" in mc_source
+    assert "MonteCarloEngine(" in mc_source
+    assert "return_paths=False" in mc_source
+
+
+def test_checked_cliquet_adapter_composes_primitives_without_product_pricer():
+    from dataclasses import fields
+    from pathlib import Path
+
+    from trellis.agent.task_manifests import load_task_manifest
+    from trellis.agent.task_runtime import benchmark_spec_overrides, build_market_state_for_task
+    from trellis.instruments._agent.cliquetoption import CliquetOptionPayoff, CliquetOptionSpec
+    from trellis.models.analytical import price_equity_cliquet_option_analytical
+
+    source = Path("trellis/instruments/_agent/cliquetoption.py").read_text()
+    assert "price_equity_cliquet_option_analytical" not in source
+    assert "price_equity_cliquet_option_monte_carlo" not in source
+    assert "ObservationReturnContract(" in source
+    assert "bounded_observation_return_sum(" in source
+    assert "gauss_hermite_product_expectation(" in source
+
+    tasks = {
+        task["id"]: task
+        for manifest in ("TASKS_BENCHMARK_FINANCEPY.yaml", "TASKS_EXTENSION.yaml")
+        for task in load_task_manifest(manifest)
+        if task["id"] in {"F014", "P007"}
+    }
+    spec_fields = {field.name for field in fields(CliquetOptionSpec)}
+    for task_id in ("F014", "P007"):
+        task = tasks[task_id]
+        market_state, _ = build_market_state_for_task(task)
+        overrides = benchmark_spec_overrides(task)
+        spec = CliquetOptionSpec(
+            **{key: value for key, value in overrides.items() if key in spec_fields}
+        )
+
+        composed_price = float(CliquetOptionPayoff(spec).evaluate(market_state))
+        reference_price = float(
+            price_equity_cliquet_option_analytical(market_state, spec)
+        )
+        assert composed_price == pytest.approx(reference_price, rel=1e-10, abs=1e-10)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_agent/test_executor.py
+++ b/tests/test_agent/test_executor.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, timedelta
 from contextlib import contextmanager
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
@@ -2314,7 +2314,7 @@ def test_deterministic_exact_binding_module_composes_observation_return_monte_ca
                 ),
                 PrimitiveRef(
                     "trellis.models.processes.gbm",
-                    "GBM",
+                    "PiecewiseConstantGBM",
                     "state_process",
                 ),
                 PrimitiveRef(
@@ -2347,7 +2347,8 @@ def test_deterministic_exact_binding_module_composes_observation_return_monte_ca
     assert generated is not None
     assert "ObservationReturnContract(" in generated.code
     assert "observation_return_payoff(" in generated.code
-    assert "GBM(" in generated.code
+    assert "PiecewiseConstantGBM(" in generated.code
+    assert "black_vol(max(tau, 1e-6)" in generated.code
     assert "MonteCarloEngine(" in generated.code
     assert "return_paths=False" in generated.code
     assert "price_equity_cliquet_option_monte_carlo" not in generated.code
@@ -2367,6 +2368,9 @@ def test_generated_observation_return_lanes_match_retained_references():
     from trellis.agent.task_manifests import load_task_manifest
     from trellis.agent.task_runtime import benchmark_spec_overrides, build_market_state_for_task
     from trellis.models.analytical import price_equity_cliquet_option_analytical
+    from trellis.models.monte_carlo.event_aware import (
+        price_equity_cliquet_option_monte_carlo,
+    )
 
     analytical_primitives = (
         PrimitiveRef(
@@ -2399,7 +2403,11 @@ def test_generated_observation_return_lanes_match_retained_references():
             "observation_return_payoff",
             "payoff_primitive",
         ),
-        PrimitiveRef("trellis.models.processes.gbm", "GBM", "state_process"),
+        PrimitiveRef(
+            "trellis.models.processes.gbm",
+            "PiecewiseConstantGBM",
+            "state_process",
+        ),
         PrimitiveRef(
             "trellis.models.monte_carlo.engine",
             "MonteCarloEngine",
@@ -2480,6 +2488,58 @@ def test_generated_observation_return_lanes_match_retained_references():
                 abs=0.10,
             )
 
+    from trellis.core.market_state import MarketState
+    from trellis.curves.yield_curve import YieldCurve
+
+    class _IntervalVolSurface:
+        def black_vol(self, expiry, _strike):
+            return 0.05 if float(expiry) < 0.20 else 0.40
+
+    settlement = date(2025, 1, 1)
+    observation_dates = (
+        settlement + timedelta(days=30),
+        settlement + timedelta(days=120),
+    )
+    term_market = MarketState(
+        as_of=settlement,
+        settlement=settlement,
+        discount=YieldCurve.flat(0.03),
+        vol_surface=_IntervalVolSurface(),
+        model_parameters={"underlier_carry_rates": {"equity": 0.01}},
+    )
+    term_overrides = {
+        "notional": 1.0,
+        "spot": 100.0,
+        "expiry_date": observation_dates[-1],
+        "observation_dates": observation_dates,
+        "option_type": "call",
+        "local_floor": 0.0,
+        "local_cap": 0.05,
+        "global_floor": 0.0,
+        "global_cap": 0.08,
+    }
+    term_monte_carlo = payoff(
+        mc_schema,
+        mc_ns,
+        term_overrides,
+        n_paths=50_000,
+        seed=23,
+    )
+    term_monte_carlo_price = float(term_monte_carlo.evaluate(term_market))
+    term_reference_price = float(
+        price_equity_cliquet_option_monte_carlo(
+            term_market,
+            term_monte_carlo.spec,
+            n_paths=50_000,
+            seed=23,
+        )
+    )
+    assert term_monte_carlo_price == pytest.approx(
+        term_reference_price,
+        rel=0.01,
+        abs=0.03,
+    )
+
     for source in (analytical_source, mc_source):
         assert "price_equity_cliquet_option_analytical" not in source
         assert "price_equity_cliquet_option_monte_carlo" not in source
@@ -2527,6 +2587,29 @@ def test_checked_cliquet_adapter_composes_primitives_without_product_pricer():
             price_equity_cliquet_option_analytical(market_state, spec)
         )
         assert composed_price == pytest.approx(reference_price, rel=1e-10, abs=1e-10)
+
+
+def test_checked_cliquet_adapter_rejects_missing_observation_dates_cleanly():
+    from trellis.core.market_state import MarketState
+    from trellis.curves.yield_curve import YieldCurve
+    from trellis.instruments._agent.cliquetoption import CliquetOptionPayoff, CliquetOptionSpec
+    from trellis.models.vol_surface import FlatVol
+
+    spec = CliquetOptionSpec(
+        notional=1.0,
+        spot=100.0,
+        expiry_date=date(2026, 1, 1),
+        observation_dates=None,  # type: ignore[arg-type]
+    )
+    market_state = MarketState(
+        as_of=date(2025, 1, 1),
+        settlement=date(2025, 1, 1),
+        discount=YieldCurve.flat(0.02),
+        vol_surface=FlatVol(0.20),
+    )
+
+    with pytest.raises(ValueError, match="require observation dates"):
+        CliquetOptionPayoff(spec).evaluate(market_state)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_agent/test_import_registry.py
+++ b/tests/test_agent/test_import_registry.py
@@ -58,6 +58,12 @@ def test_observation_return_primitives_are_visible_to_import_registry():
     assert expectation_symbol in list_module_exports(expectation_module)
     assert expectation_module in find_symbol_modules(expectation_symbol)
 
+    process_module = "trellis.models.processes.gbm"
+    process_symbol = "PiecewiseConstantGBM"
+    assert process_symbol in list_module_exports(process_module)
+    assert process_module in find_symbol_modules(process_symbol)
+    assert is_valid_import(process_module, process_symbol)
+
 
 def test_quoted_observable_helpers_are_visible_to_import_registry():
     module = "trellis.models.quoted_observable"

--- a/tests/test_agent/test_import_registry.py
+++ b/tests/test_agent/test_import_registry.py
@@ -74,7 +74,7 @@ def test_quoted_observable_helpers_are_visible_to_import_registry():
     assert "price_curve_quote_spread_analytical" in registry_text
 
 
-def test_cliquet_monte_carlo_helper_is_visible_to_import_registry():
+def test_retained_cliquet_monte_carlo_reference_is_visible_to_import_registry():
     module = "trellis.models.monte_carlo.event_aware"
     symbol = "price_equity_cliquet_option_monte_carlo"
 

--- a/tests/test_agent/test_ir_retrieval.py
+++ b/tests/test_agent/test_ir_retrieval.py
@@ -210,7 +210,7 @@ def test_autonomous_build_tracking_refreshes_knowledge_between_attempts(monkeypa
         retrieval_calls["count"] += 1
         return {"marker": retrieval_calls["count"]}
 
-    def fake_build_shared_payload(knowledge):
+    def fake_build_shared_payload(knowledge, **kwargs):
         marker = knowledge["marker"]
         return {
             "builder_text_distilled": f"distilled {marker}",

--- a/tests/test_agent/test_lite_review.py
+++ b/tests/test_agent/test_lite_review.py
@@ -975,7 +975,7 @@ def price(self, market_state):
     assert "lite.monte_carlo_paths_route_helper_missing" in issue_codes
 
 
-def test_lite_review_accepts_checked_cliquet_helper_for_monte_carlo_paths():
+def test_lite_review_does_not_let_retired_cliquet_helper_own_market_binding():
     from trellis.agent.codegen_guardrails import GenerationPlan, PrimitivePlan, PrimitiveRef
     from trellis.agent.lite_review import review_generated_code
     from trellis.agent.quant import PricingPlan
@@ -1023,7 +1023,8 @@ def price(self, market_state):
     )
 
     issue_codes = {issue.code for issue in report.issues}
-    assert "lite.monte_carlo_paths_route_helper_missing" not in issue_codes
+    assert "lite.monte_carlo_paths_discount_curve_access_missing" in issue_codes
+    assert "lite.monte_carlo_paths_black_vol_surface_access_missing" in issue_codes
 
 
 def test_builder_prompt_surface_uses_semantic_repair_for_lite_review():

--- a/tests/test_agent/test_platform_requests.py
+++ b/tests/test_agent/test_platform_requests.py
@@ -893,11 +893,6 @@ def test_semantic_blueprint_summary_preserves_range_accrual_callability_blockers
             "trellis.models.analytical.equity_exotics.price_equity_compound_option_analytical",
         ),
         (
-            "F014",
-            "analytical",
-            "trellis.models.analytical.equity_exotics.price_equity_cliquet_option_analytical",
-        ),
-        (
             "F015",
             "analytical",
             "trellis.models.analytical.equity_exotics.price_equity_variance_swap_analytical",
@@ -930,6 +925,41 @@ def test_compile_build_request_preserves_exact_absorbed_black76_binding_for_fina
 
     if task_id == "F009":
         assert set(compiled.product_ir.candidate_engine_families) >= {"analytical", "pde"}
+
+
+def test_compile_build_request_uses_cliquet_primitive_composition_for_f014():
+    from trellis.agent.benchmark_contracts import benchmark_request_description
+    from trellis.agent.platform_requests import compile_build_request
+
+    task = _financepy_benchmark_task("F014")
+    compiled = compile_build_request(
+        benchmark_request_description(task),
+        instrument_type=task["instrument_type"],
+        preferred_method="analytical",
+    )
+
+    assert compiled.generation_plan is not None
+    primitive_plan = compiled.generation_plan.primitive_plan
+    assert primitive_plan is not None
+    primitive_refs = {
+        f"{primitive.module}.{primitive.symbol}"
+        for primitive in primitive_plan.primitives
+    }
+    assert {
+        "trellis.models.observation_returns.ObservationReturnContract",
+        "trellis.models.observation_returns.bounded_observation_return_sum",
+        "trellis.models.black.black76_call",
+        "trellis.models.black.black76_put",
+        (
+            "trellis.models.analytical.support.expectations."
+            "gauss_hermite_product_expectation"
+        ),
+    } <= primitive_refs
+    assert not any("price_equity_cliquet_option" in ref for ref in primitive_refs)
+    assert not any(
+        "price_equity_cliquet_option" in ref
+        for ref in compiled.generation_plan.backend_exact_target_refs
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_agent/test_prompts.py
+++ b/tests/test_agent/test_prompts.py
@@ -553,6 +553,47 @@ def test_prompt_skill_selection_skips_helper_hint_for_primitive_route_branch():
     }
 
 
+def test_helper_hint_resolution_normalizes_pricing_method(monkeypatch):
+    from types import SimpleNamespace
+
+    from trellis.agent.knowledge.schema import ProductIR
+    from trellis.agent.knowledge.skills import _resolved_route_accepts_helper_hint
+
+    observed = {}
+    route = SimpleNamespace(id="method_keyed_route")
+    monkeypatch.setattr(
+        "trellis.agent.route_registry.load_route_registry",
+        lambda: SimpleNamespace(routes=(route,)),
+    )
+
+    def resolve_route_primitives(_route, _product_ir, *, method):
+        observed["method"] = method
+        return ()
+
+    monkeypatch.setattr(
+        "trellis.agent.route_registry.resolve_route_primitives",
+        resolve_route_primitives,
+    )
+    record = SimpleNamespace(
+        skill_id="route_hint:method_keyed_route:route-helper",
+        source_artifact="method_keyed_route",
+    )
+
+    assert not _resolved_route_accepts_helper_hint(
+        record,
+        product_ir=ProductIR(
+            instrument="cliquet_option",
+            payoff_family="cliquet_option",
+            exercise_style="european",
+            state_dependence="path_dependent",
+            schedule_dependence=True,
+        ),
+        pricing_method="Monte Carlo",
+        route_ids=("method_keyed_route",),
+    )
+    assert observed["method"] == "monte_carlo"
+
+
 def test_prompt_skill_selection_prefers_hard_constraints_over_exact_route_note_matches(monkeypatch):
     from trellis.agent.knowledge.skills import select_prompt_skill_artifacts
 

--- a/tests/test_agent/test_prompts.py
+++ b/tests/test_agent/test_prompts.py
@@ -522,6 +522,37 @@ def test_prompt_skill_selection_rejects_route_tagged_sibling_hints(monkeypatch):
     ]
 
 
+def test_prompt_skill_selection_skips_helper_hint_for_primitive_route_branch():
+    from trellis.agent.knowledge.schema import ProductIR
+    from trellis.agent.knowledge.skills import select_prompt_skill_artifacts
+
+    product_ir = ProductIR(
+        instrument="cliquet_option",
+        payoff_family="cliquet_option",
+        payoff_traits=("scheduled_observation_returns",),
+        exercise_style="european",
+        state_dependence="path_dependent",
+        schedule_dependence=True,
+        model_family="equity_diffusion",
+        route_families=("monte_carlo",),
+    )
+
+    artifacts = select_prompt_skill_artifacts(
+        "Capped and floored cliquet option under Monte Carlo",
+        audience="builder",
+        stage="initial_build",
+        instrument_type="cliquet_option",
+        pricing_method="monte_carlo",
+        route_ids=("monte_carlo_paths",),
+        route_families=("monte_carlo",),
+        product_ir=product_ir,
+    )
+
+    assert "route_hint:monte_carlo_paths:route-helper" not in {
+        artifact["id"] for artifact in artifacts
+    }
+
+
 def test_prompt_skill_selection_prefers_hard_constraints_over_exact_route_note_matches(monkeypatch):
     from trellis.agent.knowledge.skills import select_prompt_skill_artifacts
 

--- a/tests/test_agent/test_route_registry.py
+++ b/tests/test_agent/test_route_registry.py
@@ -1805,7 +1805,11 @@ class TestAnalyticalRoutes:
                 "observation_return_payoff",
                 "payoff_primitive",
             ),
-            ("trellis.models.processes.gbm", "GBM", "state_process"),
+            (
+                "trellis.models.processes.gbm",
+                "PiecewiseConstantGBM",
+                "state_process",
+            ),
             (
                 "trellis.models.monte_carlo.engine",
                 "MonteCarloEngine",

--- a/tests/test_agent/test_route_registry.py
+++ b/tests/test_agent/test_route_registry.py
@@ -1765,16 +1765,53 @@ class TestAnalyticalRoutes:
             ),
         }
 
-    def test_cliquet_primitives_use_exact_helper(self, registry):
+    def test_cliquet_analytical_primitives_use_observation_return_composition(self, registry):
         spec = [r for r in registry.routes if r.id == "analytical_black76"][0]
         new_prims = resolve_route_primitives(spec, self.CLIQUET_IR)
         assert resolve_route_family(spec, self.CLIQUET_IR) == "analytical"
         assert _prim_set(new_prims) == {
             (
-                "trellis.models.analytical.equity_exotics",
-                "price_equity_cliquet_option_analytical",
-                "route_helper",
+                "trellis.models.observation_returns",
+                "ObservationReturnContract",
+                "payoff_contract",
             ),
+            (
+                "trellis.models.observation_returns",
+                "bounded_observation_return_sum",
+                "payoff_primitive",
+            ),
+            (
+                "trellis.models.analytical.support.expectations",
+                "gauss_hermite_product_expectation",
+                "pricing_kernel",
+            ),
+            ("trellis.models.black", "black76_call", "pricing_kernel"),
+            ("trellis.models.black", "black76_put", "pricing_kernel"),
+            ("trellis.core.date_utils", "year_fraction", "time_measure"),
+        }
+
+    def test_cliquet_monte_carlo_primitives_use_reduced_observation_state(self, registry):
+        spec = [r for r in registry.routes if r.id == "monte_carlo_paths"][0]
+        new_prims = resolve_route_primitives(spec, self.CLIQUET_IR)
+        assert resolve_route_family(spec, self.CLIQUET_IR) == "monte_carlo"
+        assert _prim_set(new_prims) == {
+            (
+                "trellis.models.observation_returns",
+                "ObservationReturnContract",
+                "payoff_contract",
+            ),
+            (
+                "trellis.models.observation_returns",
+                "observation_return_payoff",
+                "payoff_primitive",
+            ),
+            ("trellis.models.processes.gbm", "GBM", "state_process"),
+            (
+                "trellis.models.monte_carlo.engine",
+                "MonteCarloEngine",
+                "path_simulation",
+            ),
+            ("trellis.core.date_utils", "year_fraction", "time_measure"),
         }
 
     def test_variance_swap_primitives_use_exact_helper_and_output_kernel(self, registry):

--- a/tests/test_agent/test_semantic_validation.py
+++ b/tests/test_agent/test_semantic_validation.py
@@ -1137,7 +1137,7 @@ def test_accepts_helper_backed_autocallable_route():
     assert report.ok
 
 
-def test_accepts_helper_backed_cliquet_monte_carlo_route():
+def test_rejects_retired_helper_backed_cliquet_monte_carlo_route():
     from trellis.agent.semantic_validation import validate_semantics
 
     pricing_plan = PricingPlan(
@@ -1165,8 +1165,8 @@ def test_accepts_helper_backed_cliquet_monte_carlo_route():
     )
 
     issue_codes = {issue.code for issue in report.issues}
-    assert "assembly.required_primitive_missing" not in issue_codes
-    assert report.ok
+    assert "assembly.required_primitive_missing" in issue_codes
+    assert not report.ok
 
 
 @pytest.mark.parametrize(

--- a/tests/test_agent/test_semantic_validators.py
+++ b/tests/test_agent/test_semantic_validators.py
@@ -230,7 +230,7 @@ def evaluate(self, market_state):
         )
         assert any(f.category == "route_helper_not_called" for f in findings)
 
-    def test_accepts_checked_cliquet_helper_for_monte_carlo_paths(self, registry):
+    def test_rejects_retired_cliquet_helper_for_monte_carlo_paths(self, registry):
         spec = [r for r in registry.routes if r.id == "monte_carlo_paths"][0]
         source = '''
 from trellis.models.monte_carlo.event_aware import price_equity_cliquet_option_monte_carlo
@@ -255,8 +255,7 @@ def evaluate(self, market_state):
             ),
             spec,
         )
-        assert not any(f.category == "route_helper_not_called" for f in findings)
-        assert not any(f.category == "engine_family_mismatch" for f in findings)
+        assert any(f.category == "route_helper_not_called" for f in findings)
 
     def test_rejects_double_barrier_terminal_payoff_without_pde_engine(self, registry):
         spec = [r for r in registry.routes if r.id == "pde_theta_1d"][0]

--- a/tests/test_models/test_processes/test_processes.py
+++ b/tests/test_models/test_processes/test_processes.py
@@ -8,7 +8,7 @@ from trellis.core.market_state import MarketState
 from trellis.curves.yield_curve import YieldCurve
 from trellis.data.resolver import resolve_market_snapshot
 from trellis.models.processes.base import StochasticProcess
-from trellis.models.processes.gbm import GBM
+from trellis.models.processes.gbm import GBM, PiecewiseConstantGBM
 from trellis.models.processes.correlated_gbm import CorrelatedGBM
 from trellis.models.processes.vasicek import Vasicek
 from trellis.models.processes.cir import CIR
@@ -61,6 +61,30 @@ class TestGBM:
         gbm = GBM(mu=0.05, sigma=0.20)
         assert gbm.drift(100.0, 0) == pytest.approx(5.0)
         assert gbm.diffusion(100.0, 0) == pytest.approx(20.0)
+
+
+class TestPiecewiseConstantGBM:
+    def test_exact_sample_integrates_across_parameter_intervals(self):
+        process = PiecewiseConstantGBM(
+            interval_ends=(0.25, 1.0),
+            mus=(0.01, 0.03),
+            sigmas=(0.10, 0.30),
+        )
+
+        sampled = process.exact_sample(100.0, 0.20, 0.10, 0.0)
+
+        integrated_mu = 0.01 * 0.05 + 0.03 * 0.05
+        integrated_variance = 0.10**2 * 0.05 + 0.30**2 * 0.05
+        expected = 100.0 * raw_np.exp(integrated_mu - 0.5 * integrated_variance)
+        assert sampled == pytest.approx(expected, rel=1e-12)
+
+    def test_rejects_inconsistent_parameter_grid(self):
+        with pytest.raises(ValueError, match="same length"):
+            PiecewiseConstantGBM(
+                interval_ends=(0.25, 1.0),
+                mus=(0.01,),
+                sigmas=(0.10, 0.30),
+            )
 
 
 class TestCorrelatedGBM:

--- a/trellis/agent/benchmark_contracts.py
+++ b/trellis/agent/benchmark_contracts.py
@@ -1200,6 +1200,10 @@ def _cliquet_option_overrides(contract: Mapping[str, Any], *, valuation_date: da
         "option_type": str(contract.get("option_type") or "call").strip().lower(),
         "day_count": _day_count(contract.get("day_count")) or DayCountConvention.THIRTY_E_360,
         "time_day_count": _day_count(contract.get("time_day_count")) or DayCountConvention.ACT_365,
+        "local_cap": _float_or_none(contract.get("local_cap")),
+        "local_floor": _float_or_none(contract.get("local_floor")),
+        "global_cap": _float_or_none(contract.get("global_cap")),
+        "global_floor": _float_or_none(contract.get("global_floor")),
     }
 
 

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -3992,6 +3992,240 @@ def _nth_to_default_helper_body(refs: set[str]) -> str | None:
     ).rstrip()
 
 
+def _declared_primitive_refs(generation_plan) -> set[str]:
+    """Return every concrete primitive declared by the selected route."""
+    primitive_plan = _generation_plan_field(generation_plan, "primitive_plan")
+    return {
+        f"{primitive.module}.{primitive.symbol}"
+        for primitive in getattr(primitive_plan, "primitives", ()) or ()
+        if getattr(primitive, "module", "") and getattr(primitive, "symbol", "")
+    }
+
+
+def _scheduled_observation_return_evaluate_body(
+    refs: set[str],
+    *,
+    normalized_target: str,
+    generation_method: str,
+) -> str | None:
+    """Compose scheduled-return valuation from product-neutral primitives."""
+    analytical_refs = {
+        "trellis.models.observation_returns.ObservationReturnContract",
+        "trellis.models.observation_returns.bounded_observation_return_sum",
+        "trellis.models.analytical.support.expectations.gauss_hermite_product_expectation",
+        "trellis.models.black.black76_call",
+        "trellis.models.black.black76_put",
+    }
+    monte_carlo_refs = {
+        "trellis.models.observation_returns.ObservationReturnContract",
+        "trellis.models.observation_returns.observation_return_payoff",
+        "trellis.models.processes.gbm.GBM",
+        "trellis.models.monte_carlo.engine.MonteCarloEngine",
+    }
+    use_monte_carlo = normalized_target == "monte_carlo" or (
+        not normalized_target and generation_method == "monte_carlo"
+    )
+    if use_monte_carlo and monte_carlo_refs.issubset(refs):
+        return textwrap.dedent(
+            """\
+            settlement = market_state.settlement or market_state.as_of
+            if settlement is None:
+                raise ValueError("scheduled observation returns require settlement or as_of")
+            if market_state.discount is None:
+                raise ValueError("scheduled observation returns require market_state.discount")
+            if market_state.vol_surface is None:
+                raise ValueError("scheduled observation returns require market_state.vol_surface")
+
+            raw_times = getattr(spec, "observation_times", None)
+            observation_dates = tuple(sorted(getattr(spec, "observation_dates", ()) or ()))
+            time_day_count = (
+                getattr(spec, "time_day_count", None)
+                or getattr(spec, "day_count", DayCountConvention.ACT_365)
+            )
+            if raw_times:
+                observation_times = tuple(sorted(float(time) for time in raw_times))
+            else:
+                observation_times = tuple(
+                    float(year_fraction(settlement, observation_date, time_day_count))
+                    for observation_date in observation_dates
+                )
+            if not observation_times:
+                raise ValueError("scheduled observation returns require observation dates or times")
+
+            option_type = str(getattr(spec, "option_type", "call") or "call").strip().lower()
+            if option_type not in {"call", "put"}:
+                raise ValueError(f"unsupported observation-return direction {option_type!r}")
+            local_floor = getattr(spec, "local_floor", None)
+            local_cap = getattr(spec, "local_cap", None)
+            global_floor = getattr(spec, "global_floor", None)
+            global_cap = getattr(spec, "global_cap", None)
+            contract = ObservationReturnContract(
+                observation_times=observation_times,
+                direction="up" if option_type == "call" else "down",
+                local_floor=0.0 if local_floor is None else float(local_floor),
+                local_cap=float("inf") if local_cap is None else float(local_cap),
+                global_floor=float("-inf") if global_floor is None else float(global_floor),
+                global_cap=float("inf") if global_cap is None else float(global_cap),
+                payoff_scale=float(spec.notional) * float(spec.spot),
+            )
+            maturity = observation_times[-1]
+            if observation_dates:
+                default_steps = max((observation_dates[-1] - settlement).days, 1)
+            else:
+                default_steps = max(int(round(maturity * 365.0)), 1)
+            n_steps = max(int(getattr(spec, "n_steps", default_steps) or default_steps), 1)
+
+            carry = getattr(spec, "dividend_yield", None)
+            if carry is None:
+                carry = getattr(spec, "dividend_rate", None)
+            if carry is None:
+                params = dict(getattr(market_state, "model_parameters", None) or {})
+                carry_rates = dict(params.get("underlier_carry_rates") or {})
+                carry = next(iter(carry_rates.values()), 0.0)
+            carry = float(carry)
+            rate = float(market_state.discount.zero_rate(max(maturity, 1e-6)))
+            sigma = float(market_state.vol_surface.black_vol(max(maturity, 1e-6), float(spec.spot)))
+            process = GBM(mu=rate - carry, sigma=sigma)
+            engine = MonteCarloEngine(
+                process,
+                n_paths=max(int(getattr(spec, "n_paths", 120000) or 120000), 2),
+                n_steps=n_steps,
+                seed=getattr(spec, "seed", 42),
+                method="exact",
+            )
+            payoff = observation_return_payoff(
+                contract,
+                maturity=maturity,
+                n_steps=n_steps,
+            )
+            result = engine.price(
+                float(spec.spot),
+                maturity,
+                payoff,
+                discount_rate=rate,
+                return_paths=False,
+            )
+            return float(result["price"])
+            """
+        ).rstrip()
+
+    use_analytical = normalized_target in {"", "analytical"} and generation_method in {
+        "",
+        "analytical",
+    }
+    if not use_analytical or not analytical_refs.issubset(refs):
+        return None
+    return textwrap.dedent(
+        """\
+        settlement = market_state.settlement or market_state.as_of
+        if settlement is None:
+            raise ValueError("scheduled observation returns require settlement or as_of")
+        if market_state.discount is None:
+            raise ValueError("scheduled observation returns require market_state.discount")
+        if market_state.vol_surface is None:
+            raise ValueError("scheduled observation returns require market_state.vol_surface")
+
+        raw_times = getattr(spec, "observation_times", None)
+        observation_dates = tuple(sorted(getattr(spec, "observation_dates", ()) or ()))
+        time_day_count = (
+            getattr(spec, "time_day_count", None)
+            or getattr(spec, "day_count", DayCountConvention.ACT_365)
+        )
+        if raw_times:
+            observation_times = tuple(sorted(float(time) for time in raw_times))
+        else:
+            observation_times = tuple(
+                float(year_fraction(settlement, observation_date, time_day_count))
+                for observation_date in observation_dates
+            )
+        if not observation_times:
+            raise ValueError("scheduled observation returns require observation dates or times")
+
+        option_type = str(getattr(spec, "option_type", "call") or "call").strip().lower()
+        if option_type not in {"call", "put"}:
+            raise ValueError(f"unsupported observation-return direction {option_type!r}")
+        local_floor = getattr(spec, "local_floor", None)
+        local_cap = getattr(spec, "local_cap", None)
+        global_floor = getattr(spec, "global_floor", None)
+        global_cap = getattr(spec, "global_cap", None)
+        contract = ObservationReturnContract(
+            observation_times=observation_times,
+            direction="up" if option_type == "call" else "down",
+            local_floor=0.0 if local_floor is None else float(local_floor),
+            local_cap=float("inf") if local_cap is None else float(local_cap),
+            global_floor=float("-inf") if global_floor is None else float(global_floor),
+            global_cap=float("inf") if global_cap is None else float(global_cap),
+        )
+        carry = getattr(spec, "dividend_yield", None)
+        if carry is None:
+            carry = getattr(spec, "dividend_rate", None)
+        if carry is None:
+            params = dict(getattr(market_state, "model_parameters", None) or {})
+            carry_rates = dict(params.get("underlier_carry_rates") or {})
+            carry = next(iter(carry_rates.values()), 0.0)
+        carry = float(carry)
+        notional = float(spec.notional)
+        spot = float(spec.spot)
+
+        has_explicit_bounds = any(
+            value is not None
+            for value in (local_floor, local_cap, global_floor, global_cap)
+        )
+        if not has_explicit_bounds:
+            total = 0.0
+            previous_time = 0.0
+            for observation_time in observation_times:
+                tau = observation_time - previous_time
+                rate = float(market_state.discount.zero_rate(max(observation_time, 1e-6)))
+                sigma = float(market_state.vol_surface.black_vol(max(tau, 1e-6), spot))
+                forward_ratio = exp((rate - carry) * tau)
+                if option_type == "call":
+                    optionlet = black76_call(forward_ratio, 1.0, sigma, tau)
+                else:
+                    optionlet = black76_put(forward_ratio, 1.0, sigma, tau)
+                total += (
+                    spot
+                    * exp(-carry * previous_time)
+                    * exp(-rate * tau)
+                    * optionlet
+                )
+                previous_time = observation_time
+            return float(notional * total)
+
+        period_inputs = []
+        previous_time = 0.0
+        for observation_time in observation_times:
+            tau = observation_time - previous_time
+            rate = float(market_state.discount.zero_rate(max(observation_time, 1e-6)))
+            sigma = float(market_state.vol_surface.black_vol(max(tau, 1e-6), spot))
+            period_inputs.append((tau, rate, sigma))
+            previous_time = observation_time
+
+        def interval_payoff(normals):
+            gross_returns = [
+                exp(
+                    (rate - carry - 0.5 * sigma * sigma) * tau
+                    + sigma * sqrt(tau) * float(normal)
+                )
+                for normal, (tau, rate, sigma) in zip(normals, period_inputs)
+            ]
+            return bounded_observation_return_sum(gross_returns, contract)
+
+        expected_return = gauss_hermite_product_expectation(
+            interval_payoff,
+            dimension=len(period_inputs),
+            order=max(int(getattr(spec, "quadrature_order", 21) or 21), 3),
+            max_nodes=max(
+                int(getattr(spec, "max_quadrature_nodes", 2000000) or 2000000),
+                1,
+            ),
+        )
+        discount_factor = float(market_state.discount.discount(observation_times[-1]))
+        return float(notional * spot * discount_factor * expected_return)
+        """
+    ).rstrip()
+
+
 def _deterministic_exact_binding_evaluate_body(
     generation_plan,
     *,
@@ -4002,6 +4236,7 @@ def _deterministic_exact_binding_evaluate_body(
     """Return a deterministic evaluate body for supported exact-bound routes."""
     metadata = dict(request_metadata or {})
     refs = set(_exact_binding_refs(generation_plan))
+    refs.update(_declared_primitive_refs(generation_plan))
     swaption_comparison_kwargs = _swaption_comparison_helper_kwargs(semantic_blueprint)
     vanilla_equity_mc_kwargs = _vanilla_equity_monte_carlo_helper_kwargs(comparison_target)
     vanilla_equity_mc_call_kwargs = (
@@ -4058,6 +4293,13 @@ def _deterministic_exact_binding_evaluate_body(
     generation_method = str(
         _generation_plan_field(generation_plan, "method", "") or ""
     ).strip().lower().replace("-", "_")
+    scheduled_return_body = _scheduled_observation_return_evaluate_body(
+        refs,
+        normalized_target=normalized_target,
+        generation_method=generation_method,
+    )
+    if scheduled_return_body is not None:
+        return scheduled_return_body
     if (
         primitive_route == "equity_quanto"
         and {
@@ -4606,13 +4848,6 @@ def _deterministic_exact_binding_evaluate_body(
             'n_x=getattr(spec, "tree_grid_size", 301))'
         )
 
-    if comparison_target == "monte_carlo" and instrument_type == "cliquet_option":
-        return (
-            "return price_equity_cliquet_option_monte_carlo("
-            "market_state, spec, "
-            'n_paths=getattr(spec, "n_paths", 120000), '
-            'seed=getattr(spec, "seed", 42))'
-        )
     if (
         normalized_target in {"cn_rannacher", "cn_standard"}
         and "trellis.models.equity_option_pde.price_equity_digital_option_pde" in refs
@@ -5080,15 +5315,6 @@ def _deterministic_exact_binding_evaluate_body(
         "trellis.models.analytical.equity_exotics.price_equity_compound_option_analytical": (
             "return price_equity_compound_option_analytical(market_state, spec)"
         ),
-        "trellis.models.analytical.equity_exotics.price_equity_cliquet_option_analytical": (
-            "return price_equity_cliquet_option_analytical(market_state, spec)"
-        ),
-        "trellis.models.monte_carlo.event_aware.price_equity_cliquet_option_monte_carlo": (
-            "return price_equity_cliquet_option_monte_carlo("
-            "market_state, spec, "
-            'n_paths=getattr(spec, "n_paths", 120000), '
-            'seed=getattr(spec, "seed", 42))'
-        ),
         "trellis.models.analytical.equity_exotics.price_equity_variance_swap_analytical": (
             "return price_equity_variance_swap_analytical(market_state, spec)"
         ),
@@ -5426,6 +5652,8 @@ def _deterministic_exact_binding_import_lines(body: str) -> tuple[str, ...]:
     imports: list[str] = []
     if "exp(" in body:
         imports.append("from math import exp")
+    if "sqrt(" in body:
+        imports.append("from math import sqrt")
     if "year_fraction(" in body:
         imports.append("from trellis.core.date_utils import year_fraction")
     if "price_heston_option_monte_carlo(" in body:
@@ -5525,11 +5753,6 @@ def _deterministic_exact_binding_import_lines(body: str) -> tuple[str, ...]:
         imports.append(
             "from trellis.instruments.nth_to_default import price_nth_to_default_basket"
         )
-    if "price_equity_cliquet_option_monte_carlo(" in body:
-        imports.append(
-            "from trellis.models.monte_carlo.event_aware import "
-            "price_equity_cliquet_option_monte_carlo"
-        )
     if "price_event_aware_equity_option_pde(" in body:
         imports.append(
             "from trellis.models.equity_option_pde import price_event_aware_equity_option_pde"
@@ -5591,6 +5814,21 @@ def _deterministic_exact_binding_import_lines(body: str) -> tuple[str, ...]:
     if "MonteCarloEngine(" in body:
         imports.append(
             "from trellis.models.monte_carlo.engine import MonteCarloEngine"
+        )
+    if "ObservationReturnContract(" in body:
+        observation_symbols = ["ObservationReturnContract"]
+        if "bounded_observation_return_sum(" in body:
+            observation_symbols.append("bounded_observation_return_sum")
+        if "observation_return_payoff(" in body:
+            observation_symbols.append("observation_return_payoff")
+        imports.append(
+            "from trellis.models.observation_returns import "
+            + ", ".join(observation_symbols)
+        )
+    if "gauss_hermite_product_expectation(" in body:
+        imports.append(
+            "from trellis.models.analytical.support.expectations import "
+            "gauss_hermite_product_expectation"
         )
     if "resolve_quanto_inputs(" in body:
         imports.append(

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -4019,7 +4019,7 @@ def _scheduled_observation_return_evaluate_body(
     monte_carlo_refs = {
         "trellis.models.observation_returns.ObservationReturnContract",
         "trellis.models.observation_returns.observation_return_payoff",
-        "trellis.models.processes.gbm.GBM",
+        "trellis.models.processes.gbm.PiecewiseConstantGBM",
         "trellis.models.monte_carlo.engine.MonteCarloEngine",
     }
     use_monte_carlo = normalized_target == "monte_carlo" or (
@@ -4083,9 +4083,26 @@ def _scheduled_observation_return_evaluate_body(
                 carry_rates = dict(params.get("underlier_carry_rates") or {})
                 carry = next(iter(carry_rates.values()), 0.0)
             carry = float(carry)
+            interval_mus = []
+            interval_sigmas = []
+            previous_time = 0.0
+            for observation_time in observation_times:
+                tau = observation_time - previous_time
+                interval_rate = float(
+                    market_state.discount.zero_rate(max(observation_time, 1e-6))
+                )
+                interval_sigma = float(
+                    market_state.vol_surface.black_vol(max(tau, 1e-6), float(spec.spot))
+                )
+                interval_mus.append(interval_rate - carry)
+                interval_sigmas.append(interval_sigma)
+                previous_time = observation_time
             rate = float(market_state.discount.zero_rate(max(maturity, 1e-6)))
-            sigma = float(market_state.vol_surface.black_vol(max(maturity, 1e-6), float(spec.spot)))
-            process = GBM(mu=rate - carry, sigma=sigma)
+            process = PiecewiseConstantGBM(
+                interval_ends=observation_times,
+                mus=tuple(interval_mus),
+                sigmas=tuple(interval_sigmas),
+            )
             engine = MonteCarloEngine(
                 process,
                 n_paths=max(int(getattr(spec, "n_paths", 120000) or 120000), 2),

--- a/trellis/agent/knowledge/autonomous.py
+++ b/trellis/agent/knowledge/autonomous.py
@@ -573,20 +573,47 @@ def _build_with_tracking(
             overlay_payloads
         )
 
-    def _retrieve_live_payload() -> dict[str, Any]:
-        """Render a fresh shared-knowledge payload for each retry attempt."""
-        if product_ir is not None:
+    def _retrieve_live_payload(request=None) -> dict[str, Any]:
+        """Render route-scoped shared knowledge for each build or retry attempt."""
+        request_product_ir = getattr(request, "product_ir", None) or product_ir
+        pricing_method = (
+            getattr(request, "pricing_method", None)
+            or preferred_method
+            or decomposition.method
+        )
+        if request_product_ir is not None:
             latest_knowledge = retrieve_for_product_ir(
-                product_ir,
-                preferred_method=preferred_method or decomposition.method,
+                request_product_ir,
+                preferred_method=pricing_method,
             )
         else:
             latest_knowledge = retrieve_for_task(
-                method=decomposition.method,
+                method=pricing_method,
                 features=list(decomposition.features),
                 instrument=decomposition.instrument,
             )
-        return build_shared_knowledge_payload(latest_knowledge)
+
+        compiled_request = getattr(request, "compiled_request", None)
+        generation_plan = getattr(compiled_request, "generation_plan", None)
+        primitive_plan = getattr(generation_plan, "primitive_plan", None)
+        route_ids = tuple(
+            dict.fromkeys(
+                route_id
+                for route_id in (
+                    getattr(generation_plan, "lowering_route_id", None),
+                    getattr(primitive_plan, "route", None),
+                )
+                if isinstance(route_id, str) and route_id.strip()
+            )
+        )
+        return build_shared_knowledge_payload(
+            latest_knowledge,
+            pricing_method=pricing_method,
+            route_ids=route_ids,
+            route_families=tuple(
+                getattr(request_product_ir, "route_families", ()) or ()
+            ),
+        )
 
     import trellis.agent.executor as executor
     original_record_platform_event = executor._record_platform_event
@@ -594,9 +621,13 @@ def _build_with_tracking(
     def _stage_aware_knowledge_retriever(request) -> str:
         """Serve fresh knowledge with audience/surface awareness on every attempt."""
         try:
-            payload = _retrieve_live_payload()
+            payload = _retrieve_live_payload(request)
         except Exception:
             payload = knowledge_payload
+
+        meta.setdefault("knowledge_summary", {}).update(
+            dict(payload.get("summary") or {})
+        )
 
         audience = getattr(request, "audience", "builder")
         knowledge_surface = getattr(request, "knowledge_surface", "compact")

--- a/trellis/agent/knowledge/canonical/api_map.yaml
+++ b/trellis/agent/knowledge/canonical/api_map.yaml
@@ -129,7 +129,7 @@ monte_carlo:
     - "from trellis.models.variance_swap import price_equity_variance_swap_monte_carlo, price_equity_variance_swap_monte_carlo_result, equity_variance_swap_outputs_monte_carlo"
     - "from trellis.models.monte_carlo import euler_maruyama, milstein, brownian_bridge"
     - "from trellis.models.monte_carlo import antithetic, control_variate, sobol_normals"
-    - "from trellis.models.processes.gbm import GBM"
+    - "from trellis.models.processes.gbm import GBM, PiecewiseConstantGBM"
   notes:
     - "For European single-state terminal claims, supply an explicit payoff callback to `price_single_state_terminal_claim_monte_carlo_result(...)` and bind scheme/variance-reduction controls at the adapter boundary"
     - "For American/Bermudan vanilla equity Monte Carlo, resolve the market contract with `resolve_single_state_monte_carlo_inputs(...)`, then compose `GBM`, `MonteCarloEngine`, `terminal_intrinsic_from_resolved(...)`, and `longstaff_schwartz(...)` explicitly"
@@ -147,11 +147,11 @@ observation_return_composition:
     - "from trellis.models.observation_returns import ObservationReturnContract, bounded_observation_return_sum, build_observation_return_reducer, observation_return_payoff, simple_observation_returns"
     - "from trellis.models.analytical.support.expectations import gauss_hermite_product_expectation"
     - "from trellis.models.monte_carlo.engine import MonteCarloEngine"
-    - "from trellis.models.processes.gbm import GBM"
+    - "from trellis.models.processes.gbm import GBM, PiecewiseConstantGBM"
   notes:
     - "Start with ObservationReturnContract: declare ordered positive observation times, up/down return direction, local bounds, global bounds, and payoff scale; its observation_steps(...) method fails closed when the uniform simulation grid aliases or cannot exactly represent contractual observations"
     - "Analytical lane: map independent standard normals to interval gross returns, evaluate bounded_observation_return_sum(...) inside gauss_hermite_product_expectation(...), then apply the declared settlement discount outside the expectation"
-    - "Monte Carlo lane: pass observation_return_payoff(...) to MonteCarloEngine with return_paths=False; the payoff declares a PathReducer that stores only previous level and accumulated locally bounded return"
+    - "Monte Carlo lane: pass observation_return_payoff(...) to MonteCarloEngine with return_paths=False; use PiecewiseConstantGBM when interval drift or volatility differs so reset returns preserve the declared term structure; the payoff declares a PathReducer that stores only previous level and accumulated locally bounded return"
     - "The analytical expectation assumes independent normal interval drivers; the Monte Carlo reducer accepts any scalar positive-level process on an exact uniform observation grid; vector state and nonpositive levels require a different admitted substrate"
 
 rate_monte_carlo_composition:

--- a/trellis/agent/knowledge/canonical/backend_bindings.yaml
+++ b/trellis/agent/knowledge/canonical/backend_bindings.yaml
@@ -256,6 +256,28 @@ bindings:
         role: route_helper
     conditional_primitives:
       - when:
+          contract_pattern:
+            payoff:
+              kind: cliquet_payoff
+            exercise:
+              style: european
+        primitives:
+          - module: trellis.models.observation_returns
+            symbol: ObservationReturnContract
+            role: payoff_contract
+          - module: trellis.models.observation_returns
+            symbol: observation_return_payoff
+            role: payoff_primitive
+          - module: trellis.models.processes.gbm
+            symbol: GBM
+            role: state_process
+          - module: trellis.models.monte_carlo.engine
+            symbol: MonteCarloEngine
+            role: path_simulation
+          - module: trellis.core.date_utils
+            symbol: year_fraction
+            role: time_measure
+      - when:
           payoff_family: variance_swap
           exercise_style: [none]
         primitives:
@@ -909,9 +931,24 @@ bindings:
             exercise:
               style: european
         primitives:
-          - module: trellis.models.analytical.equity_exotics
-            symbol: price_equity_cliquet_option_analytical
-            role: route_helper
+          - module: trellis.models.observation_returns
+            symbol: ObservationReturnContract
+            role: payoff_contract
+          - module: trellis.models.observation_returns
+            symbol: bounded_observation_return_sum
+            role: payoff_primitive
+          - module: trellis.models.black
+            symbol: black76_call
+            role: pricing_kernel
+          - module: trellis.models.black
+            symbol: black76_put
+            role: pricing_kernel
+          - module: trellis.models.analytical.support.expectations
+            symbol: gauss_hermite_product_expectation
+            role: pricing_kernel
+          - module: trellis.core.date_utils
+            symbol: year_fraction
+            role: time_measure
       - when:
           contract_pattern:
             payoff:

--- a/trellis/agent/knowledge/canonical/backend_bindings.yaml
+++ b/trellis/agent/knowledge/canonical/backend_bindings.yaml
@@ -269,7 +269,7 @@ bindings:
             symbol: observation_return_payoff
             role: payoff_primitive
           - module: trellis.models.processes.gbm
-            symbol: GBM
+            symbol: PiecewiseConstantGBM
             role: state_process
           - module: trellis.models.monte_carlo.engine
             symbol: MonteCarloEngine

--- a/trellis/agent/knowledge/canonical/routes.yaml
+++ b/trellis/agent/knowledge/canonical/routes.yaml
@@ -467,7 +467,7 @@ routes:
             symbol: observation_return_payoff
             role: payoff_primitive
           - module: trellis.models.processes.gbm
-            symbol: GBM
+            symbol: PiecewiseConstantGBM
             role: state_process
           - module: trellis.models.monte_carlo.engine
             symbol: MonteCarloEngine
@@ -478,6 +478,7 @@ routes:
         adapters: []
         notes:
           - "Resolve the contractual observation grid and local/global bounds explicitly, then pass observation_return_payoff(...) to MonteCarloEngine with return_paths=False."
+          - "Bind one drift and Black volatility per reset interval through PiecewiseConstantGBM; do not flatten the term structure to the final maturity."
           - "The payoff and engine must use the same exact uniform grid; let ObservationReturnContract fail closed when contractual dates cannot be represented."
           - "Do not call a product pricing wrapper or hand-roll reset branching in the generated adapter."
       - when:

--- a/trellis/agent/knowledge/canonical/routes.yaml
+++ b/trellis/agent/knowledge/canonical/routes.yaml
@@ -454,6 +454,33 @@ routes:
         black_vol_surface: [market_state.vol_surface]
     conditional_primitives:
       - when:
+          contract_pattern:
+            payoff:
+              kind: cliquet_payoff
+            exercise:
+              style: european
+        primitives:
+          - module: trellis.models.observation_returns
+            symbol: ObservationReturnContract
+            role: payoff_contract
+          - module: trellis.models.observation_returns
+            symbol: observation_return_payoff
+            role: payoff_primitive
+          - module: trellis.models.processes.gbm
+            symbol: GBM
+            role: state_process
+          - module: trellis.models.monte_carlo.engine
+            symbol: MonteCarloEngine
+            role: path_simulation
+          - module: trellis.core.date_utils
+            symbol: year_fraction
+            role: time_measure
+        adapters: []
+        notes:
+          - "Resolve the contractual observation grid and local/global bounds explicitly, then pass observation_return_payoff(...) to MonteCarloEngine with return_paths=False."
+          - "The payoff and engine must use the same exact uniform grid; let ObservationReturnContract fail closed when contractual dates cannot be represented."
+          - "Do not call a product pricing wrapper or hand-roll reset branching in the generated adapter."
+      - when:
           payoff_family: variance_swap
           exercise_style: [none]
         primitives:
@@ -1484,12 +1511,29 @@ routes:
             exercise:
               style: european
         primitives:
-          - module: trellis.models.analytical.equity_exotics
-            symbol: price_equity_cliquet_option_analytical
-            role: route_helper
+          - module: trellis.models.observation_returns
+            symbol: ObservationReturnContract
+            role: payoff_contract
+          - module: trellis.models.observation_returns
+            symbol: bounded_observation_return_sum
+            role: payoff_primitive
+          - module: trellis.models.black
+            symbol: black76_call
+            role: pricing_kernel
+          - module: trellis.models.black
+            symbol: black76_put
+            role: pricing_kernel
+          - module: trellis.models.analytical.support.expectations
+            symbol: gauss_hermite_product_expectation
+            role: pricing_kernel
+          - module: trellis.core.date_utils
+            symbol: year_fraction
+            role: time_measure
         adapters: []
         notes:
-          - "Use the cliquet helper with `market_state` and `spec`; keep observation-date resets and carry handling in the shared helper."
+          - "For an unbounded reset-return sum, assemble each reset optionlet from black76_call/black76_put with explicit interval forward, discount, volatility, and carry."
+          - "When any local/global bound is present, map independent normal interval shocks to gross returns and evaluate bounded_observation_return_sum(...) inside gauss_hermite_product_expectation(...)."
+          - "Apply the declared notional, spot scale, and settlement discount explicitly; do not call a product pricing wrapper."
       - when:
           contract_pattern:
             payoff:

--- a/trellis/agent/knowledge/import_registry.py
+++ b/trellis/agent/knowledge/import_registry.py
@@ -629,7 +629,7 @@ from trellis.models.levy_option import LevyOptionMonteCarloResult, LevyOptionTra
 from trellis.models.bates_option import BatesOptionMonteCarloResult, BatesOptionTransformResult, ResolvedBatesOptionInputs, bates_log_ratio_char_fn, bates_log_spot_char_fn, price_bates_option_monte_carlo, price_bates_option_monte_carlo_result, price_bates_option_transform, price_bates_option_transform_result, resolve_bates_option_inputs
 
 ### Models — Processes
-from trellis.models.processes.gbm import GBM
+from trellis.models.processes.gbm import GBM, PiecewiseConstantGBM
 from trellis.models.processes.heston import Heston
 from trellis.models.processes.hull_white import HullWhite
 from trellis.models.processes.vasicek import Vasicek

--- a/trellis/agent/knowledge/retrieval.py
+++ b/trellis/agent/knowledge/retrieval.py
@@ -844,6 +844,7 @@ def build_shared_knowledge_payload(
         pricing_method=resolved_method,
         route_ids=resolved_route_ids,
         route_families=resolved_route_families,
+        product_ir=product_ir,
         knowledge_surface="compact",
     )
     review_artifacts = select_prompt_skill_artifacts(
@@ -854,6 +855,7 @@ def build_shared_knowledge_payload(
         pricing_method=resolved_method,
         route_ids=resolved_route_ids,
         route_families=resolved_route_families,
+        product_ir=product_ir,
         knowledge_surface="compact",
     )
     routing_artifacts = select_prompt_skill_artifacts(
@@ -864,6 +866,7 @@ def build_shared_knowledge_payload(
         pricing_method=resolved_method,
         route_ids=resolved_route_ids,
         route_families=resolved_route_families,
+        product_ir=product_ir,
         knowledge_surface="compact",
     )
 

--- a/trellis/agent/knowledge/skills.py
+++ b/trellis/agent/knowledge/skills.py
@@ -322,7 +322,7 @@ def _resolved_route_accepts_helper_hint(
     primitives = resolve_route_primitives(
         route,
         product_ir,
-        method=pricing_method,
+        method=normalize_method(pricing_method),
     )
     return any(primitive.role == "route_helper" for primitive in primitives)
 

--- a/trellis/agent/knowledge/skills.py
+++ b/trellis/agent/knowledge/skills.py
@@ -184,6 +184,7 @@ def select_prompt_skill_artifacts(
     pricing_method: str | None = None,
     route_ids: Iterable[str] = (),
     route_families: Iterable[str] = (),
+    product_ir: Any = None,
     knowledge_surface: str = "compact",
 ) -> list[dict[str, Any]]:
     """Return small prompt-ready skill guidance for one agent audience/stage.
@@ -239,6 +240,13 @@ def select_prompt_skill_artifacts(
             route_families=normalized_route_families,
         ):
             continue
+        if not _resolved_route_accepts_helper_hint(
+            record,
+            product_ir=product_ir,
+            pricing_method=pricing_method,
+            route_ids=normalized_route_ids,
+        ):
+            continue
         candidates.append(record)
 
     candidates.sort(
@@ -284,6 +292,41 @@ def select_prompt_skill_artifacts(
     )
 
 
+def _resolved_route_accepts_helper_hint(
+    record: SkillRecord,
+    *,
+    product_ir: Any,
+    pricing_method: str | None,
+    route_ids: tuple[str, ...],
+) -> bool:
+    """Reject broad helper hints when the resolved product branch has no helper."""
+    if product_ir is None or not record.skill_id.endswith(":route-helper"):
+        return True
+
+    route_id = _normalize_key(record.source_artifact)
+    if not route_id or route_id not in route_ids:
+        return True
+
+    from trellis.agent.route_registry import load_route_registry, resolve_route_primitives
+
+    route = next(
+        (
+            candidate
+            for candidate in load_route_registry().routes
+            if _normalize_key(candidate.id) == route_id
+        ),
+        None,
+    )
+    if route is None:
+        return False
+    primitives = resolve_route_primitives(
+        route,
+        product_ir,
+        method=pricing_method,
+    )
+    return any(primitive.role == "route_helper" for primitive in primitives)
+
+
 def append_prompt_skill_artifacts(
     text: str,
     artifacts: Iterable[dict[str, Any]],
@@ -319,6 +362,7 @@ def augment_prompt_with_skill_records(
     pricing_method: str | None = None,
     route_ids: Iterable[str] = (),
     route_families: Iterable[str] = (),
+    product_ir: Any = None,
     knowledge_surface: str = "compact",
     heading: str = "## Generated Skills",
 ) -> tuple[str, list[dict[str, Any]]]:
@@ -331,6 +375,7 @@ def augment_prompt_with_skill_records(
         pricing_method=pricing_method,
         route_ids=route_ids,
         route_families=route_families,
+        product_ir=product_ir,
         knowledge_surface=knowledge_surface,
     )
     return append_prompt_skill_artifacts(text, artifacts, heading=heading), artifacts

--- a/trellis/agent/lite_review.py
+++ b/trellis/agent/lite_review.py
@@ -32,7 +32,6 @@ _SUSPICIOUS_LITERAL_NAMES = {
 }
 _CHECKED_ROUTE_HELPER_SYMBOLS = frozenset({
     "price_heston_option_monte_carlo",
-    "price_equity_cliquet_option_monte_carlo",
 })
 _CHECKED_MARKET_BINDING_OWNER_SYMBOLS = frozenset({
     "price_single_state_terminal_claim_monte_carlo_result",

--- a/trellis/agent/semantic_validation.py
+++ b/trellis/agent/semantic_validation.py
@@ -51,7 +51,6 @@ _ROUTE_HELPER_SUBSUMED_PRIMITIVE_ROLES = frozenset({
 })
 _CHECKED_ROUTE_HELPER_CALLS = frozenset({
     "trellis.models.monte_carlo.stochastic_vol.price_heston_option_monte_carlo",
-    "trellis.models.monte_carlo.event_aware.price_equity_cliquet_option_monte_carlo",
 })
 
 

--- a/trellis/agent/semantic_validators/algorithm_contract.py
+++ b/trellis/agent/semantic_validators/algorithm_contract.py
@@ -50,10 +50,6 @@ _CHECKED_ROUTE_HELPER_BINDINGS = {
         "routes": frozenset({"monte_carlo_paths"}),
         "instruments": frozenset({"heston_option", "european_option", "vanilla_option"}),
     },
-    "price_equity_cliquet_option_monte_carlo": {
-        "routes": frozenset({"monte_carlo_paths"}),
-        "instruments": frozenset({"cliquet_option"}),
-    },
 }
 _CHECKED_ROUTE_HELPER_SYMBOLS = frozenset(_CHECKED_ROUTE_HELPER_BINDINGS)
 _HELPER_OWNED_ROUTE_SYMBOLS = _CHECKED_ROUTE_HELPER_SYMBOLS | frozenset({

--- a/trellis/instruments/_agent/cliquetoption.py
+++ b/trellis/instruments/_agent/cliquetoption.py
@@ -1,13 +1,22 @@
-"""Deterministic benchmark wrapper for FinancePy-style cliquet parity tasks."""
+"""Checked cliquet adapter assembled from public observation-return primitives."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import date
+from math import exp, sqrt
 
+from trellis.core.date_utils import year_fraction
 from trellis.core.market_state import MarketState
 from trellis.core.types import DayCountConvention
-from trellis.models.analytical import price_equity_cliquet_option_analytical
+from trellis.models.analytical.support.expectations import (
+    gauss_hermite_product_expectation,
+)
+from trellis.models.black import black76_call, black76_put
+from trellis.models.observation_returns import (
+    ObservationReturnContract,
+    bounded_observation_return_sum,
+)
 
 
 @dataclass(frozen=True)
@@ -19,12 +28,20 @@ class CliquetOptionSpec:
     expiry_date: date
     observation_dates: tuple[date, ...]
     option_type: str = "call"
-    day_count: DayCountConvention = DayCountConvention.THIRTY_E_360
+    local_cap: float | None = None
+    local_floor: float | None = None
+    global_cap: float | None = None
+    global_floor: float | None = None
     time_day_count: DayCountConvention = DayCountConvention.ACT_365
+    quadrature_order: int = 21
+    max_quadrature_nodes: int = 2_000_000
+    n_paths: int = 120_000
+    seed: int | None = 42
+    day_count: DayCountConvention = DayCountConvention.THIRTY_E_360
 
 
 class CliquetOptionPayoff:
-    """Reset-style cliquet payoff backed by the shared analytical helper."""
+    """Reset-style payoff with explicit primitive-level analytical assembly."""
 
     def __init__(self, spec: CliquetOptionSpec):
         self._spec = spec
@@ -38,4 +55,108 @@ class CliquetOptionPayoff:
         return {"black_vol_surface", "discount_curve"}
 
     def evaluate(self, market_state: MarketState) -> float:
-        return float(price_equity_cliquet_option_analytical(market_state, self._spec))
+        spec = self._spec
+        settlement = market_state.settlement or market_state.as_of
+        if settlement is None:
+            raise ValueError("scheduled observation returns require settlement or as_of")
+        if market_state.discount is None:
+            raise ValueError("scheduled observation returns require market_state.discount")
+        if market_state.vol_surface is None:
+            raise ValueError("scheduled observation returns require market_state.vol_surface")
+
+        observation_dates = tuple(sorted(spec.observation_dates))
+        observation_times = tuple(
+            float(year_fraction(settlement, observation_date, spec.time_day_count))
+            for observation_date in observation_dates
+        )
+        if not observation_times:
+            raise ValueError("scheduled observation returns require observation dates")
+
+        option_type = spec.option_type.strip().lower()
+        if option_type not in {"call", "put"}:
+            raise ValueError(f"unsupported observation-return direction {option_type!r}")
+        contract = ObservationReturnContract(
+            observation_times=observation_times,
+            direction="up" if option_type == "call" else "down",
+            local_floor=0.0 if spec.local_floor is None else float(spec.local_floor),
+            local_cap=float("inf") if spec.local_cap is None else float(spec.local_cap),
+            global_floor=(
+                float("-inf")
+                if spec.global_floor is None
+                else float(spec.global_floor)
+            ),
+            global_cap=(
+                float("inf") if spec.global_cap is None else float(spec.global_cap)
+            ),
+        )
+        params = dict(market_state.model_parameters or {})
+        carry_rates = dict(params.get("underlier_carry_rates") or {})
+        carry = float(next(iter(carry_rates.values()), 0.0))
+        notional = float(spec.notional)
+        spot = float(spec.spot)
+
+        has_explicit_bounds = any(
+            value is not None
+            for value in (
+                spec.local_floor,
+                spec.local_cap,
+                spec.global_floor,
+                spec.global_cap,
+            )
+        )
+        if not has_explicit_bounds:
+            total = 0.0
+            previous_time = 0.0
+            for observation_time in observation_times:
+                tau = observation_time - previous_time
+                rate = float(
+                    market_state.discount.zero_rate(max(observation_time, 1e-6))
+                )
+                sigma = float(
+                    market_state.vol_surface.black_vol(max(tau, 1e-6), spot)
+                )
+                forward_ratio = exp((rate - carry) * tau)
+                if option_type == "call":
+                    optionlet = black76_call(forward_ratio, 1.0, sigma, tau)
+                else:
+                    optionlet = black76_put(forward_ratio, 1.0, sigma, tau)
+                total += (
+                    spot
+                    * exp(-carry * previous_time)
+                    * exp(-rate * tau)
+                    * optionlet
+                )
+                previous_time = observation_time
+            return float(notional * total)
+
+        period_inputs: list[tuple[float, float, float]] = []
+        previous_time = 0.0
+        for observation_time in observation_times:
+            tau = observation_time - previous_time
+            rate = float(
+                market_state.discount.zero_rate(max(observation_time, 1e-6))
+            )
+            sigma = float(market_state.vol_surface.black_vol(max(tau, 1e-6), spot))
+            period_inputs.append((tau, rate, sigma))
+            previous_time = observation_time
+
+        def interval_payoff(normals):
+            gross_returns = [
+                exp(
+                    (rate - carry - 0.5 * sigma * sigma) * tau
+                    + sigma * sqrt(tau) * float(normal)
+                )
+                for normal, (tau, rate, sigma) in zip(normals, period_inputs)
+            ]
+            return bounded_observation_return_sum(gross_returns, contract)
+
+        expected_return = gauss_hermite_product_expectation(
+            interval_payoff,
+            dimension=len(period_inputs),
+            order=max(int(spec.quadrature_order), 3),
+            max_nodes=max(int(spec.max_quadrature_nodes), 1),
+        )
+        discount_factor = float(
+            market_state.discount.discount(observation_times[-1])
+        )
+        return float(notional * spot * discount_factor * expected_return)

--- a/trellis/instruments/_agent/cliquetoption.py
+++ b/trellis/instruments/_agent/cliquetoption.py
@@ -64,7 +64,7 @@ class CliquetOptionPayoff:
         if market_state.vol_surface is None:
             raise ValueError("scheduled observation returns require market_state.vol_surface")
 
-        observation_dates = tuple(sorted(spec.observation_dates))
+        observation_dates = tuple(sorted(spec.observation_dates or ()))
         observation_times = tuple(
             float(year_fraction(settlement, observation_date, spec.time_day_count))
             for observation_date in observation_dates

--- a/trellis/models/processes/__init__.py
+++ b/trellis/models/processes/__init__.py
@@ -4,7 +4,7 @@ Each process provides drift, diffusion, and (where available) exact sampling.
 Used by tree builders and simulation engines.
 """
 
-from trellis.models.processes.gbm import GBM
+from trellis.models.processes.gbm import GBM, PiecewiseConstantGBM
 from trellis.models.processes.correlated_gbm import CorrelatedGBM
 from trellis.models.processes.vasicek import Vasicek
 from trellis.models.processes.cir import CIR

--- a/trellis/models/processes/gbm.py
+++ b/trellis/models/processes/gbm.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from bisect import bisect_right
+from math import isfinite
+
 from trellis.core.differentiable import get_numpy
 from trellis.models.processes.base import StochasticProcess
 
@@ -25,11 +28,11 @@ class GBM(StochasticProcess):
         self.sigma = sigma
 
     def drift(self, x, t):
-        """Return the GBM drift term ``\mu S_t``."""
+        """Return the GBM drift term ``\\mu S_t``."""
         return self.mu * x
 
     def diffusion(self, x, t):
-        """Return the GBM diffusion loading ``\sigma S_t``."""
+        """Return the GBM diffusion loading ``\\sigma S_t``."""
         return self.sigma * x
 
     def exact_sample(self, x, t, dt, dw):
@@ -45,3 +48,90 @@ class GBM(StochasticProcess):
     def exact_variance(self, x, t, dt):
         """Return ``Var[S_{t+dt} | S_t = x]`` for the exact GBM transition."""
         return x ** 2 * np.exp(2 * self.mu * dt) * (np.exp(self.sigma ** 2 * dt) - 1)
+
+
+class PiecewiseConstantGBM(StochasticProcess):
+    """GBM with deterministic drift and volatility on ordered time intervals.
+
+    ``interval_ends[i]`` closes the interval governed by ``mus[i]`` and
+    ``sigmas[i]``. Exact transitions integrate drift and variance across every
+    crossed interval, so simulation steps do not need to align with regime
+    boundaries.
+    """
+
+    def __init__(self, interval_ends, mus, sigmas):
+        """Validate and store one drift/volatility pair per time interval."""
+        ends = tuple(float(value) for value in interval_ends)
+        drift_rates = tuple(float(value) for value in mus)
+        volatilities = tuple(float(value) for value in sigmas)
+        if not ends:
+            raise ValueError("PiecewiseConstantGBM requires at least one interval")
+        if len(ends) != len(drift_rates) or len(ends) != len(volatilities):
+            raise ValueError(
+                "PiecewiseConstantGBM interval_ends, mus, and sigmas must have the same length"
+            )
+        if any(not isfinite(value) or value <= 0.0 for value in ends):
+            raise ValueError("PiecewiseConstantGBM interval ends must be finite and positive")
+        if any(right <= left for left, right in zip(ends, ends[1:])):
+            raise ValueError("PiecewiseConstantGBM interval ends must be strictly increasing")
+        if any(not isfinite(value) for value in drift_rates):
+            raise ValueError("PiecewiseConstantGBM drift rates must be finite")
+        if any(not isfinite(value) or value < 0.0 for value in volatilities):
+            raise ValueError("PiecewiseConstantGBM volatilities must be finite and non-negative")
+        self.interval_ends = ends
+        self.mus = drift_rates
+        self.sigmas = volatilities
+
+    def _parameter_index(self, t: float) -> int:
+        return min(bisect_right(self.interval_ends, float(t)), len(self.interval_ends) - 1)
+
+    def _integrated_moments(self, t: float, dt: float) -> tuple[float, float]:
+        start = float(t)
+        width = float(dt)
+        if not isfinite(start) or start < 0.0:
+            raise ValueError("PiecewiseConstantGBM transition time must be finite and non-negative")
+        if not isfinite(width) or width < 0.0:
+            raise ValueError("PiecewiseConstantGBM transition width must be finite and non-negative")
+        end = start + width
+        integrated_mu = 0.0
+        integrated_variance = 0.0
+        current = start
+        while current < end:
+            index = self._parameter_index(current)
+            segment_end = min(end, self.interval_ends[index])
+            if segment_end <= current:
+                segment_end = end
+            segment_width = segment_end - current
+            integrated_mu += self.mus[index] * segment_width
+            integrated_variance += self.sigmas[index] ** 2 * segment_width
+            current = segment_end
+        return integrated_mu, integrated_variance
+
+    def drift(self, x, t):
+        """Return the active interval drift term."""
+        return self.mus[self._parameter_index(t)] * x
+
+    def diffusion(self, x, t):
+        """Return the active interval diffusion loading."""
+        return self.sigmas[self._parameter_index(t)] * x
+
+    def exact_sample(self, x, t, dt, dw):
+        """Sample the exact log-normal transition over all crossed intervals."""
+        integrated_mu, integrated_variance = self._integrated_moments(t, dt)
+        return x * np.exp(
+            integrated_mu
+            - 0.5 * integrated_variance
+            + np.sqrt(integrated_variance) * dw
+        )
+
+    def exact_mean(self, x, t, dt):
+        """Return the exact conditional mean over a piecewise interval."""
+        integrated_mu, _ = self._integrated_moments(t, dt)
+        return x * np.exp(integrated_mu)
+
+    def exact_variance(self, x, t, dt):
+        """Return the exact conditional variance over a piecewise interval."""
+        integrated_mu, integrated_variance = self._integrated_moments(t, dt)
+        return x ** 2 * np.exp(2.0 * integrated_mu) * (
+            np.exp(integrated_variance) - 1.0
+        )


### PR DESCRIPTION
## Summary
- replace cliquet wrapper authority with observation-return, Black-76, quadrature, GBM, and Monte Carlo primitives
- remove helper-owned validator exemptions and keep wrappers as reference-only APIs
- preserve compiled route identity during live knowledge refresh and suppress helper hints for primitive-only branches
- update checked adapter, route metadata, diagnostics, official docs, and regression coverage

## Validation
- strict fresh F014/P007 replay: 2/2 green, zero LLM calls/retries, no helper artifacts
- `make gate-pr`: 4,368 core + 32 tier-2 contract tests passed
- `make gate-release`: repeated PR gate, 487 crossval/verification/task tests, freshness, and T13 replay passed; T38 replay remains unsupported
- Sphinx HTML build passed with existing repository-wide warnings

No cookbook files were changed.

Linear: QUA-1177