### PR TITLE
QUA-1178: add machine-readable helper authority audit

### DIFF
--- a/doc/plan/active__semantic-task-synthesis-helper-retirement.md
+++ b/doc/plan/active__semantic-task-synthesis-helper-retirement.md
@@ -38,12 +38,14 @@ Status mirror last synced: `2026-07-14`
 | `QUA-1175` | Agent orientation: runtime quant and model-validator navigation contracts | Done |
 | `QUA-1176` | Observation returns: reusable bounded accumulation primitives | Done |
 | `QUA-1177` | Cliquet pricing: primitive-composed analytical and Monte Carlo lanes | Done |
+| `QUA-1178` | Semantic route audit: machine-readable helper authority inventory | In Progress |
 
 ## Current Sequence
 
-1. Re-run the helper-authority audit on merged main.
-2. Choose the next coherent product family by remaining authority count and
-   semantic risk.
+1. Land the repeatable QUA-1178 helper-authority audit and record the merged
+   baseline.
+2. Use its route, binding, and adapter evidence to choose the next coherent
+   product family by remaining authority count and semantic risk.
 
 ## Completion Evidence
 

--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -777,6 +777,38 @@ comparators. That keeps canaries such as ``T65`` on the stable
 ``price_swaption_tree(...)`` surface instead of regenerating inline lattice
 exercise code for the comparison target.
 
+Helper-authority inventory
+--------------------------
+
+Helper retirement uses a deterministic repository audit rather than text
+searches or hand-maintained totals:
+
+.. code-block:: console
+
+   python scripts/audit_helper_authority.py
+   python scripts/audit_helper_authority.py --json
+
+The report keeps four evidence surfaces separate:
+
+- required ``route_helper`` declarations on promoted canonical routes;
+- required ``route_helper`` declarations on exact backend bindings;
+- route-only and binding-only declarations, compared as a multiset without
+  normalizing away condition differences;
+- imported ``price_*`` calls executed by checked-in ``_agent`` adapters, with
+  calls to currently authoritative symbols marked separately.
+
+The adapter scan uses Python AST import resolution, including local aliases and
+module aliases. A locally defined function or an unused import is not counted
+as delegation. Re-exported symbols still match helper authority by canonical
+symbol identity, so changing an import path cannot hide continued delegation.
+
+Use ``--fail-on-drift`` when route and backend-binding parity is an explicit
+gate. The ordinary command remains read-only and returns the complete report
+even when drift exists. Counts are repository-state observations, not desired
+constants: migrations should reduce real product/method authority while
+preserving legitimate reusable kernels and making any route/binding movement
+explicit.
+
 Semantic composition gaps versus helper gaps
 ---------------------------------------------
 

--- a/scripts/audit_helper_authority.py
+++ b/scripts/audit_helper_authority.py
@@ -1,0 +1,16 @@
+"""Report canonical helper authority and checked-in adapter delegation."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from trellis.agent.helper_authority_audit import main
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_agent/test_helper_authority_audit.py
+++ b/tests/test_agent/test_helper_authority_audit.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+
+def _write_yaml(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+
+def _fixture_root(tmp_path: Path) -> Path:
+    routes = {
+        "routes": [
+            {
+                "id": "promoted_route",
+                "status": "promoted",
+                "primitives": [
+                    {
+                        "module": "trellis.models.example",
+                        "symbol": "price_example",
+                        "role": "route_helper",
+                    },
+                    {
+                        "module": "trellis.models.example",
+                        "symbol": "barrier_option_price",
+                        "role": "route_helper",
+                    },
+                    {
+                        "module": "trellis.models.example",
+                        "symbol": "price_optional",
+                        "role": "route_helper",
+                        "required": False,
+                    },
+                ],
+                "conditional_primitives": [
+                    {
+                        "when": {
+                            "payoff_family": "example",
+                            "methods": ["monte_carlo"],
+                        },
+                        "primitives": [
+                            {
+                                "module": "trellis.models.example",
+                                "symbol": "price_example_monte_carlo",
+                                "role": "route_helper",
+                            }
+                        ],
+                    }
+                ],
+            },
+            {
+                "id": "candidate_route",
+                "status": "candidate",
+                "primitives": [
+                    {
+                        "module": "trellis.models.candidate",
+                        "symbol": "price_candidate",
+                        "role": "route_helper",
+                    }
+                ],
+            },
+        ]
+    }
+    bindings = {
+        "bindings": [
+            {
+                "route_id": "promoted_route",
+                "primitives": [
+                    {
+                        "module": "trellis.models.example",
+                        "symbol": "price_example",
+                        "role": "route_helper",
+                    },
+                    {
+                        "module": "trellis.models.example",
+                        "symbol": "barrier_option_price",
+                        "role": "route_helper",
+                    }
+                ],
+                "conditional_primitives": [
+                    {
+                        "when": "default",
+                        "primitives": [
+                            {
+                                "module": "trellis.models.binding_only",
+                                "symbol": "price_binding_only",
+                                "role": "route_helper",
+                            }
+                        ],
+                    }
+                ],
+            },
+            {
+                "route_id": "candidate_route",
+                "primitives": [
+                    {
+                        "module": "trellis.models.candidate",
+                        "symbol": "price_candidate",
+                        "role": "route_helper",
+                    }
+                ],
+            },
+        ]
+    }
+    _write_yaml(
+        tmp_path / "trellis/agent/knowledge/canonical/routes.yaml",
+        routes,
+    )
+    _write_yaml(
+        tmp_path / "trellis/agent/knowledge/canonical/backend_bindings.yaml",
+        bindings,
+    )
+    adapter = tmp_path / "trellis/instruments/_agent/example.py"
+    adapter.parent.mkdir(parents=True, exist_ok=True)
+    adapter.write_text(
+        """
+from trellis.models.example import price_example as delegated_price
+from trellis.models.example import barrier_option_price as delegated_barrier
+from trellis.models.unused import price_unused
+import trellis.models.binding_only as binding
+import trellis.models.direct
+
+
+def price_local():
+    return 0.0
+
+
+def evaluate():
+    return delegated_price(None, None) + delegated_barrier(None, None) + binding.price_binding_only(None, None) + trellis.models.direct.price_direct(None, None) + price_local()
+""".lstrip(),
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def test_audit_preserves_required_route_and_binding_authority_drift(tmp_path):
+    from trellis.agent.helper_authority_audit import build_helper_authority_report
+
+    report = build_helper_authority_report(_fixture_root(tmp_path))
+
+    assert report.promoted_route_count == 1
+    assert [(item.route_id, item.condition, item.symbol) for item in report.route_authority] == [
+        ("promoted_route", "base", "barrier_option_price"),
+        ("promoted_route", "base", "price_example"),
+        (
+            "promoted_route",
+            '{"methods":["monte_carlo"],"payoff_family":"example"}',
+            "price_example_monte_carlo",
+        ),
+    ]
+    assert [(item.route_id, item.condition, item.symbol) for item in report.binding_authority] == [
+        ("promoted_route", "base", "barrier_option_price"),
+        ("promoted_route", "base", "price_example"),
+        ("promoted_route", '"default"', "price_binding_only"),
+    ]
+    assert [item.symbol for item in report.route_only_authority] == [
+        "price_example_monte_carlo"
+    ]
+    assert [item.symbol for item in report.binding_only_authority] == [
+        "price_binding_only"
+    ]
+
+
+def test_audit_resolves_import_aliases_and_ignores_unused_or_local_price_calls(tmp_path):
+    from trellis.agent.helper_authority_audit import build_helper_authority_report
+
+    report = build_helper_authority_report(_fixture_root(tmp_path))
+
+    assert [item.symbol for item in report.adapter_calls] == [
+        "price_binding_only",
+        "barrier_option_price",
+        "price_example",
+        "price_direct",
+    ]
+    assert all(
+        item.matches_required_authority
+        for item in report.adapter_calls
+        if item.symbol != "price_direct"
+    )
+    direct = next(item for item in report.adapter_calls if item.symbol == "price_direct")
+    assert direct.module == "trellis.models.direct"
+    assert direct.matches_required_authority is False
+    assert [item.symbol for item in report.adapter_calls if item.is_price_call] == [
+        "price_binding_only",
+        "price_example",
+        "price_direct",
+    ]
+    example = next(item for item in report.adapter_calls if item.symbol == "price_example")
+    assert example.local_name == "delegated_price"
+    assert example.path == "trellis/instruments/_agent/example.py"
+    assert example.line == 13
+
+
+def test_helper_authority_report_has_stable_machine_readable_shape(tmp_path):
+    from trellis.agent.helper_authority_audit import build_helper_authority_report
+
+    payload = build_helper_authority_report(_fixture_root(tmp_path)).to_dict()
+
+    assert payload["schema_version"] == 1
+    assert payload["summary"] == {
+        "promoted_route_count": 1,
+        "route_authority_route_count": 1,
+        "route_authority_reference_count": 3,
+        "binding_authority_route_count": 1,
+        "binding_authority_reference_count": 3,
+        "route_only_reference_count": 1,
+        "binding_only_reference_count": 1,
+        "adapter_price_call_file_count": 1,
+        "adapter_price_call_count": 3,
+        "adapter_authority_call_file_count": 1,
+        "adapter_authority_call_count": 3,
+    }
+    assert json.loads(json.dumps(payload)) == payload
+
+
+def test_helper_authority_human_report_surfaces_drift_and_adapter_authority(tmp_path):
+    from trellis.agent.helper_authority_audit import (
+        build_helper_authority_report,
+        render_helper_authority_report,
+    )
+
+    rendered = render_helper_authority_report(
+        build_helper_authority_report(_fixture_root(tmp_path))
+    )
+
+    assert "Helper authority audit" in rendered
+    assert "route_authority_references=3" in rendered
+    assert "binding_authority_references=3" in rendered
+    assert "route_only_references=1" in rendered
+    assert "binding_only_references=1" in rendered
+    assert "price_example_monte_carlo" in rendered
+    assert "price_binding_only" in rendered
+    assert "barrier_option_price" in rendered
+    assert "trellis/instruments/_agent/example.py:13" in rendered
+
+
+def test_current_repository_helper_authority_report_is_internally_consistent():
+    from trellis.agent.helper_authority_audit import build_helper_authority_report
+
+    root = Path(__file__).resolve().parents[2]
+    report = build_helper_authority_report(root)
+
+    assert report.promoted_route_count > 0
+    assert all(item.required for item in report.route_authority)
+    assert all(item.required for item in report.binding_authority)
+    assert all((root / item.path).is_file() for item in report.adapter_calls)
+    assert report.to_dict()["summary"]["route_authority_reference_count"] == len(
+        report.route_authority
+    )

--- a/tests/test_cli/test_audit_helper_authority.py
+++ b/tests/test_cli/test_audit_helper_authority.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+
+def test_helper_authority_cli_emits_json_for_explicit_root(capsys, tmp_path):
+    from tests.test_agent.test_helper_authority_audit import _fixture_root
+    from trellis.agent import helper_authority_audit
+
+    root = _fixture_root(tmp_path)
+    exit_code = helper_authority_audit.main(["--root", str(root), "--json"])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert payload["summary"]["route_only_reference_count"] == 1
+    assert payload["summary"]["binding_only_reference_count"] == 1
+
+
+def test_helper_authority_cli_can_fail_on_route_binding_drift(capsys, tmp_path):
+    from tests.test_agent.test_helper_authority_audit import _fixture_root
+    from trellis.agent import helper_authority_audit
+
+    root = _fixture_root(tmp_path)
+    exit_code = helper_authority_audit.main(
+        ["--root", str(root), "--fail-on-drift"]
+    )
+
+    assert exit_code == 1
+    assert "route_only_references=1" in capsys.readouterr().out
+
+
+def test_helper_authority_script_runs_against_the_worktree(tmp_path):
+    from tests.test_agent.test_helper_authority_audit import _fixture_root
+
+    root = Path(__file__).resolve().parents[2]
+    fixture = _fixture_root(tmp_path)
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(root / "scripts/audit_helper_authority.py"),
+            "--root",
+            str(fixture),
+            "--json",
+        ],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload["summary"]["adapter_authority_call_count"] == 3

--- a/trellis/agent/helper_authority_audit.py
+++ b/trellis/agent/helper_authority_audit.py
@@ -1,0 +1,528 @@
+"""Deterministic inventory of route-helper authority and adapter delegation."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+from collections import Counter, defaultdict
+from dataclasses import asdict, dataclass
+import json
+from pathlib import Path
+from typing import Iterable, Mapping
+
+import yaml
+
+
+_ROUTES_PATH = Path("trellis/agent/knowledge/canonical/routes.yaml")
+_BINDINGS_PATH = Path(
+    "trellis/agent/knowledge/canonical/backend_bindings.yaml"
+)
+_ADAPTER_ROOT = Path("trellis/instruments/_agent")
+
+
+@dataclass(frozen=True, order=True)
+class HelperAuthorityReference:
+    """One required route-helper declaration under an explicit condition."""
+
+    route_id: str
+    condition: str
+    module: str
+    symbol: str
+    required: bool = True
+
+    @property
+    def identity(self) -> tuple[str, str, str, str, bool]:
+        """Return the source-independent identity used for drift comparison."""
+        return (
+            self.route_id,
+            self.condition,
+            self.module,
+            self.symbol,
+            self.required,
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-safe representation."""
+        return asdict(self)
+
+
+@dataclass(frozen=True, order=True)
+class AdapterDelegationCall:
+    """One imported pricing or authoritative call in a checked-in adapter."""
+
+    path: str
+    line: int
+    local_name: str
+    module: str
+    symbol: str
+    is_price_call: bool
+    matches_required_authority: bool
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-safe representation."""
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class HelperAuthorityReport:
+    """Machine-readable helper-authority inventory for one repository state."""
+
+    schema_version: int
+    promoted_route_count: int
+    route_authority: tuple[HelperAuthorityReference, ...]
+    binding_authority: tuple[HelperAuthorityReference, ...]
+    route_only_authority: tuple[HelperAuthorityReference, ...]
+    binding_only_authority: tuple[HelperAuthorityReference, ...]
+    adapter_calls: tuple[AdapterDelegationCall, ...]
+
+    @property
+    def has_route_binding_drift(self) -> bool:
+        """Return whether canonical routes and exact bindings disagree."""
+        return bool(self.route_only_authority or self.binding_only_authority)
+
+    @property
+    def summary(self) -> dict[str, int]:
+        """Return stable low-cardinality counts for comparisons over time."""
+        route_ids = {item.route_id for item in self.route_authority}
+        binding_ids = {item.route_id for item in self.binding_authority}
+        price_calls = tuple(item for item in self.adapter_calls if item.is_price_call)
+        price_call_paths = {item.path for item in price_calls}
+        authority_calls = tuple(
+            item for item in self.adapter_calls if item.matches_required_authority
+        )
+        authority_call_paths = {item.path for item in authority_calls}
+        return {
+            "promoted_route_count": self.promoted_route_count,
+            "route_authority_route_count": len(route_ids),
+            "route_authority_reference_count": len(self.route_authority),
+            "binding_authority_route_count": len(binding_ids),
+            "binding_authority_reference_count": len(self.binding_authority),
+            "route_only_reference_count": len(self.route_only_authority),
+            "binding_only_reference_count": len(self.binding_only_authority),
+            "adapter_price_call_file_count": len(price_call_paths),
+            "adapter_price_call_count": len(price_calls),
+            "adapter_authority_call_file_count": len(authority_call_paths),
+            "adapter_authority_call_count": len(authority_calls),
+        }
+
+    def to_dict(self) -> dict[str, object]:
+        """Return the versioned JSON payload emitted by the audit CLI."""
+        return {
+            "schema_version": self.schema_version,
+            "summary": self.summary,
+            "route_authority": [item.to_dict() for item in self.route_authority],
+            "binding_authority": [
+                item.to_dict() for item in self.binding_authority
+            ],
+            "drift": {
+                "route_only": [
+                    item.to_dict() for item in self.route_only_authority
+                ],
+                "binding_only": [
+                    item.to_dict() for item in self.binding_only_authority
+                ],
+            },
+            "adapter_calls": [
+                item.to_dict() for item in self.adapter_calls
+            ],
+        }
+
+
+def build_helper_authority_report(root: str | Path) -> HelperAuthorityReport:
+    """Build a deterministic helper-authority report from repository files."""
+    repo_root = Path(root).resolve()
+    routes = _load_manifest(repo_root / _ROUTES_PATH, key="routes")
+    bindings = _load_manifest(repo_root / _BINDINGS_PATH, key="bindings")
+
+    promoted_routes = tuple(
+        entry for entry in routes if str(entry.get("status") or "") == "promoted"
+    )
+    promoted_route_ids = {
+        str(entry.get("id") or "").strip() for entry in promoted_routes
+    }
+    promoted_bindings = tuple(
+        entry
+        for entry in bindings
+        if str(entry.get("route_id") or "").strip() in promoted_route_ids
+    )
+    route_authority = _collect_authority(
+        promoted_routes,
+        route_id_key="id",
+    )
+    binding_authority = _collect_authority(
+        promoted_bindings,
+        route_id_key="route_id",
+    )
+    route_only, binding_only = _authority_drift(
+        route_authority,
+        binding_authority,
+    )
+    authority_symbols = {
+        item.symbol for item in route_authority + binding_authority
+    }
+    adapter_calls = _scan_adapter_calls(
+        repo_root,
+        authority_symbols=authority_symbols,
+    )
+    return HelperAuthorityReport(
+        schema_version=1,
+        promoted_route_count=len(promoted_routes),
+        route_authority=route_authority,
+        binding_authority=binding_authority,
+        route_only_authority=route_only,
+        binding_only_authority=binding_only,
+        adapter_calls=adapter_calls,
+    )
+
+
+def render_helper_authority_report(report: HelperAuthorityReport) -> str:
+    """Render the inventory as deterministic human-readable text."""
+    summary = report.summary
+    lines = [
+        "Helper authority audit",
+        f"schema_version={report.schema_version}",
+        f"promoted_routes={summary['promoted_route_count']}",
+        f"route_authority_routes={summary['route_authority_route_count']}",
+        f"route_authority_references={summary['route_authority_reference_count']}",
+        f"binding_authority_routes={summary['binding_authority_route_count']}",
+        f"binding_authority_references={summary['binding_authority_reference_count']}",
+        f"route_only_references={summary['route_only_reference_count']}",
+        f"binding_only_references={summary['binding_only_reference_count']}",
+        f"adapter_price_call_files={summary['adapter_price_call_file_count']}",
+        f"adapter_price_calls={summary['adapter_price_call_count']}",
+        f"adapter_authority_call_files={summary['adapter_authority_call_file_count']}",
+        f"adapter_authority_calls={summary['adapter_authority_call_count']}",
+    ]
+    _append_authority_section(lines, "Route authority", report.route_authority)
+    _append_authority_section(lines, "Binding authority", report.binding_authority)
+    _append_authority_section(
+        lines,
+        "Route-only authority drift",
+        report.route_only_authority,
+    )
+    _append_authority_section(
+        lines,
+        "Binding-only authority drift",
+        report.binding_only_authority,
+    )
+    lines.append("")
+    lines.append("Adapter imported pricing and authority calls")
+    if not report.adapter_calls:
+        lines.append("- none")
+    else:
+        for item in report.adapter_calls:
+            marker = "authority" if item.matches_required_authority else "price-call"
+            lines.append(
+                f"- [{marker}] {item.path}:{item.line} "
+                f"{item.module}.{item.symbol} as {item.local_name}"
+            )
+    return "\n".join(lines) + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI parser for ``scripts/audit_helper_authority.py``."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        default=str(Path(__file__).resolve().parents[2]),
+        help="Repository root containing canonical knowledge and adapters.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the versioned machine-readable report.",
+    )
+    parser.add_argument(
+        "--fail-on-drift",
+        action="store_true",
+        help="Return exit code 1 when route and binding authority differ.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the helper-authority audit CLI."""
+    args = build_parser().parse_args(argv)
+    report = build_helper_authority_report(args.root)
+    if args.json:
+        print(json.dumps(report.to_dict(), indent=2, sort_keys=True))
+    else:
+        print(render_helper_authority_report(report), end="")
+    if args.fail_on_drift and report.has_route_binding_drift:
+        return 1
+    return 0
+
+
+def _load_manifest(path: Path, *, key: str) -> tuple[Mapping[str, object], ...]:
+    if not path.is_file():
+        raise FileNotFoundError(f"Helper-authority audit requires {path}")
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, Mapping):
+        raise ValueError(f"Helper-authority manifest {path} must be a mapping")
+    entries = payload.get(key)
+    if not isinstance(entries, list):
+        raise ValueError(f"Helper-authority manifest {path} requires list {key!r}")
+    if any(not isinstance(entry, Mapping) for entry in entries):
+        raise ValueError(f"Helper-authority manifest {path} has non-mapping entries")
+    return tuple(entries)
+
+
+def _collect_authority(
+    entries: Iterable[Mapping[str, object]],
+    *,
+    route_id_key: str,
+) -> tuple[HelperAuthorityReference, ...]:
+    authority: list[HelperAuthorityReference] = []
+    for entry in entries:
+        route_id = str(entry.get(route_id_key) or "").strip()
+        if not route_id:
+            raise ValueError(f"Helper-authority entry requires {route_id_key!r}")
+        authority.extend(
+            _authority_from_primitives(
+                route_id,
+                "base",
+                entry.get("primitives"),
+            )
+        )
+        conditional = entry.get("conditional_primitives") or ()
+        if not isinstance(conditional, (list, tuple)):
+            raise ValueError(
+                f"Helper-authority route {route_id!r} conditional_primitives must be a list"
+            )
+        for block in conditional:
+            if not isinstance(block, Mapping):
+                raise ValueError(
+                    f"Helper-authority route {route_id!r} has invalid conditional block"
+                )
+            condition = json.dumps(
+                block.get("when"),
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            authority.extend(
+                _authority_from_primitives(
+                    route_id,
+                    condition,
+                    block.get("primitives"),
+                )
+            )
+    return tuple(sorted(authority, key=_authority_sort_key))
+
+
+def _authority_from_primitives(
+    route_id: str,
+    condition: str,
+    raw_primitives: object,
+) -> list[HelperAuthorityReference]:
+    primitives = raw_primitives or ()
+    if not isinstance(primitives, (list, tuple)):
+        raise ValueError(
+            f"Helper-authority route {route_id!r} primitives must be a list"
+        )
+    authority: list[HelperAuthorityReference] = []
+    for primitive in primitives:
+        if not isinstance(primitive, Mapping):
+            raise ValueError(
+                f"Helper-authority route {route_id!r} has invalid primitive"
+            )
+        if str(primitive.get("role") or "") != "route_helper":
+            continue
+        required = bool(primitive.get("required", True))
+        if not required:
+            continue
+        module = str(primitive.get("module") or "").strip()
+        symbol = str(primitive.get("symbol") or "").strip()
+        if not module or not symbol:
+            raise ValueError(
+                f"Required route helper for {route_id!r} requires module and symbol"
+            )
+        authority.append(
+            HelperAuthorityReference(
+                route_id=route_id,
+                condition=condition,
+                module=module,
+                symbol=symbol,
+                required=required,
+            )
+        )
+    return authority
+
+
+def _authority_drift(
+    routes: tuple[HelperAuthorityReference, ...],
+    bindings: tuple[HelperAuthorityReference, ...],
+) -> tuple[
+    tuple[HelperAuthorityReference, ...],
+    tuple[HelperAuthorityReference, ...],
+]:
+    route_counts = Counter(item.identity for item in routes)
+    binding_counts = Counter(item.identity for item in bindings)
+    route_examples = {item.identity: item for item in routes}
+    binding_examples = {item.identity: item for item in bindings}
+    route_only = tuple(
+        sorted(
+            [
+                route_examples[identity]
+                for identity, count in (route_counts - binding_counts).items()
+                for _ in range(count)
+            ],
+            key=_authority_sort_key,
+        )
+    )
+    binding_only = tuple(
+        sorted(
+            [
+                binding_examples[identity]
+                for identity, count in (binding_counts - route_counts).items()
+                for _ in range(count)
+            ],
+            key=_authority_sort_key,
+        )
+    )
+    return route_only, binding_only
+
+
+def _authority_sort_key(
+    item: HelperAuthorityReference,
+) -> tuple[str, int, str, str, str, bool]:
+    return (
+        item.route_id,
+        0 if item.condition == "base" else 1,
+        item.condition,
+        item.module,
+        item.symbol,
+        item.required,
+    )
+
+
+def _scan_adapter_calls(
+    repo_root: Path,
+    *,
+    authority_symbols: set[str],
+) -> tuple[AdapterDelegationCall, ...]:
+    adapter_root = repo_root / _ADAPTER_ROOT
+    if not adapter_root.is_dir():
+        return ()
+    calls: list[AdapterDelegationCall] = []
+    for path in sorted(adapter_root.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        imported_names, imported_modules = _import_index(tree)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            resolved = _resolve_imported_call(
+                node.func,
+                imported_names=imported_names,
+                imported_modules=imported_modules,
+            )
+            if resolved is None:
+                continue
+            local_name, module, symbol = resolved
+            is_price_call = symbol.startswith("price_")
+            matches_required_authority = symbol in authority_symbols
+            if not is_price_call and not matches_required_authority:
+                continue
+            calls.append(
+                AdapterDelegationCall(
+                    path=path.relative_to(repo_root).as_posix(),
+                    line=int(node.lineno),
+                    local_name=local_name,
+                    module=module,
+                    symbol=symbol,
+                    is_price_call=is_price_call,
+                    matches_required_authority=matches_required_authority,
+                )
+            )
+    return tuple(sorted(calls))
+
+
+def _import_index(
+    tree: ast.AST,
+) -> tuple[dict[str, tuple[str, str]], dict[str, str]]:
+    imported_names: dict[str, tuple[str, str]] = {}
+    imported_modules: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            for alias in node.names:
+                imported_names[alias.asname or alias.name] = (
+                    node.module,
+                    alias.name,
+                )
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                local_name = alias.asname or alias.name
+                imported_modules[local_name] = alias.name
+    return imported_names, imported_modules
+
+
+def _resolve_imported_call(
+    function: ast.expr,
+    *,
+    imported_names: Mapping[str, tuple[str, str]],
+    imported_modules: Mapping[str, str],
+) -> tuple[str, str, str] | None:
+    if isinstance(function, ast.Name):
+        imported = imported_names.get(function.id)
+        if imported is None:
+            return None
+        module, symbol = imported
+        return function.id, module, symbol
+
+    dotted = _dotted_name(function)
+    if dotted is None or "." not in dotted:
+        return None
+    matching_imports = [
+        local_name
+        for local_name in imported_modules
+        if dotted.startswith(f"{local_name}.")
+    ]
+    if not matching_imports:
+        return None
+    local_root = max(matching_imports, key=len)
+    remainder = dotted[len(local_root) + 1 :]
+    imported_module = imported_modules[local_root]
+    parts = remainder.rsplit(".", 1)
+    if len(parts) == 1:
+        module = imported_module
+        symbol = parts[0]
+    else:
+        module = f"{imported_module}.{parts[0]}"
+        symbol = parts[1]
+    return dotted, module, symbol
+
+
+def _dotted_name(node: ast.AST) -> str | None:
+    parts: list[str] = []
+    current = node
+    while isinstance(current, ast.Attribute):
+        parts.append(current.attr)
+        current = current.value
+    if not isinstance(current, ast.Name):
+        return None
+    parts.append(current.id)
+    return ".".join(reversed(parts))
+
+
+def _append_authority_section(
+    lines: list[str],
+    title: str,
+    authority: tuple[HelperAuthorityReference, ...],
+) -> None:
+    lines.append("")
+    lines.append(title)
+    if not authority:
+        lines.append("- none")
+        return
+    grouped: dict[str, list[HelperAuthorityReference]] = defaultdict(list)
+    for item in authority:
+        grouped[item.route_id].append(item)
+    for route_id in sorted(grouped):
+        lines.append(f"- {route_id}")
+        for item in grouped[route_id]:
+            lines.append(
+                f"  [{item.condition}] {item.module}.{item.symbol}"
+            )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary\n- add a deterministic, typed helper-authority inventory for canonical routes, exact bindings, and checked-in adapters\n- expose text/JSON output plus optional route-binding drift failure\n- document the audit lifecycle and update the QUA-1166 plan mirror\n\n## Current baseline\n- 28 promoted routes\n- 18 routes / 64 canonical required helper references\n- 18 routes / 68 exact-binding required helper references\n- 4 route-only and 8 binding-only references\n- 20 adapters / 22 imported price calls\n- 16 adapters / 18 calls matching required authority\n\n## Validation\n- 8 focused audit/CLI tests passed\n- make gate-pr: 4,380 core passed; 32 tier-two contracts passed\n- Sphinx HTML build succeeded with 38 existing warnings\n- no cookbook or pricing behavior changes\n\nLinear: QUA-1178