### PR TITLE
QUA-1179: add scheduled observation aggregation

### DIFF
--- a/doc/plan/active__semantic-task-synthesis-helper-retirement.md
+++ b/doc/plan/active__semantic-task-synthesis-helper-retirement.md
@@ -39,7 +39,7 @@ Status mirror last synced: `2026-07-14`
 | `QUA-1176` | Observation returns: reusable bounded accumulation primitives | Done |
 | `QUA-1177` | Cliquet pricing: primitive-composed analytical and Monte Carlo lanes | Done |
 | `QUA-1178` | Semantic route audit: machine-readable helper authority inventory | Done |
-| `QUA-1179` | Monte Carlo: reusable scheduled observation aggregation | Todo |
+| `QUA-1179` | Monte Carlo: reusable scheduled observation aggregation | In Progress |
 | `QUA-1180` | Analytical support: weighted lognormal-sum moments | Todo |
 | `QUA-1181` | Arithmetic Asian pricing: retire helper authority | Todo (blocked by `QUA-1179`, `QUA-1180`) |
 

--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -585,6 +585,28 @@ payoff, schedule, strike/coupon terms, or settlement rule. Those bridge
 decisions are task-runner contracts, not general natural-language parser
 behavior.
 
+For weighted scalar observations, agents now have a compact API-map entry named
+``scheduled_observation_composition``. The required construction order is:
+
+#. declare a ``WeightedObservationContract`` with explicit times and weights
+#. choose a scalar-state process and a uniform grid that represents every
+   contractual time exactly and distinctly
+#. define derivative-specific settlement logic in the generated adapter
+#. pass ``weighted_observation_payoff(...)`` to ``MonteCarloEngine`` with
+   ``return_paths=False``
+#. apply the task's discounting and market-binding conventions explicitly
+
+The contract permits a time-zero observation and signed weights, but it never
+normalizes weights or supplies strike, direction, notional, payoff branching,
+or discounting. ``weighted_observation_sum(...)`` provides a direct path-array
+check against the reduced-state result. Off-grid/aliased times, vector state,
+non-finite path values, and malformed settlement output are deterministic
+composition failures. They must not trigger a generated product helper.
+
+This is reusable construction infrastructure only. Existing product routes and
+compatibility wrappers remain unchanged until a separate migration proves
+fresh primitive-composed source and strict replay evidence.
+
 For schedule-based consecutive returns, agents now have a compact API-map entry
 named ``observation_return_composition``. The required construction order is:
 

--- a/docs/quant/pricing_stack.rst
+++ b/docs/quant/pricing_stack.rst
@@ -174,6 +174,42 @@ schedule-driven proof routes are still separate follow-on slices, but the
 compiler no longer points at an event-aware family without a checked runtime
 problem-spec boundary underneath it.
 
+Scheduled Weighted Observations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``trellis.models.observation_aggregation`` provides one product-neutral linear
+functional of scheduled scalar process state.  A
+``WeightedObservationContract`` declares ordered non-negative observation
+times and one explicit finite weight per observation.  Trellis does not
+normalize those weights: an arithmetic mean uses ``1 / n`` for each of ``n``
+observations, while sums, spreads, and signed linear summaries keep their own
+declared coefficients.
+
+``weighted_observation_sum(...)`` evaluates the same contract from an existing
+observation matrix. ``build_weighted_observation_reducer(...)`` accumulates it
+as a ``PathReducer``, and ``weighted_observation_payoff(...)`` combines that
+reduced state with a caller-supplied ``settlement_fn``.  This keeps the
+responsibility boundary explicit:
+
+- the library maps contractual times to simulation steps and owns the weighted
+  state reduction;
+- generated pricing code owns strike, option direction, notional, final payoff
+  shape, and discounting;
+- ``MonteCarloEngine`` can run the resulting ``StateAwarePayoff`` with
+  ``return_paths=False``.
+
+Time zero is an admissible observation.  Every observation, including the
+final one, must map exactly and distinctly onto the selected uniform simulation
+grid.  Off-grid times, aliased times, vector process state, non-finite values,
+and settlement callbacks that do not return one value per path fail closed.
+Negative weights are valid because the abstraction is a linear functional, not
+an implicit average or a positive-price contract.
+
+This surface does not resolve market data and does not price a named
+derivative.  Product route authority moves only in a separate migration after
+fresh generated source demonstrates the complete process, payoff, and
+discounting composition.
+
 Scheduled Observation Returns
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/test_agent/test_api_map.py
+++ b/tests/test_agent/test_api_map.py
@@ -23,6 +23,10 @@ def test_api_map_contains_expected_core_entries():
         == "trellis.models.observation_returns"
     )
     assert (
+        api_map["scheduled_observation_composition"]["module"]
+        == "trellis.models.observation_aggregation"
+    )
+    assert (
         api_map["quanto_option_composition"]["module"]
         == "trellis.models.resolution.quanto"
     )
@@ -51,6 +55,7 @@ def test_api_map_key_imports_are_registry_valid():
         "equity_tree",
         "rate_lattice",
         "monte_carlo",
+        "scheduled_observation_composition",
         "observation_return_composition",
         "quanto_option_composition",
         "rate_monte_carlo_composition",
@@ -132,6 +137,21 @@ def test_api_map_exposes_product_neutral_observation_return_composition():
     ):
         assert symbol in text
     assert "cliquet" not in text.lower()
+
+
+def test_api_map_exposes_product_neutral_scheduled_observation_composition():
+    section = get_api_map()["scheduled_observation_composition"]
+    text = "\n".join((*section["key_imports"], *section["notes"]))
+
+    for symbol in (
+        "WeightedObservationContract",
+        "weighted_observation_sum",
+        "weighted_observation_payoff",
+        "GBM",
+        "MonteCarloEngine",
+    ):
+        assert symbol in text
+    assert "asian" not in text.lower()
 
 
 def test_api_map_prioritizes_fx_vanilla_primitive_composition():

--- a/tests/test_agent/test_import_registry.py
+++ b/tests/test_agent/test_import_registry.py
@@ -65,6 +65,27 @@ def test_observation_return_primitives_are_visible_to_import_registry():
     assert is_valid_import(process_module, process_symbol)
 
 
+def test_weighted_observation_primitives_are_visible_to_import_registry():
+    module = "trellis.models.observation_aggregation"
+    symbols = {
+        "WeightedObservationContract",
+        "build_weighted_observation_reducer",
+        "weighted_observation_payoff",
+        "weighted_observation_sum",
+    }
+
+    assert module_exists(module)
+    assert symbols <= set(list_module_exports(module))
+    for symbol in symbols:
+        assert module in find_symbol_modules(symbol)
+        assert is_valid_import(module, symbol)
+
+    registry_text = get_import_registry()
+    assert f"from {module} import" in registry_text
+    for symbol in symbols:
+        assert symbol in registry_text
+
+
 def test_quoted_observable_helpers_are_visible_to_import_registry():
     module = "trellis.models.quoted_observable"
 

--- a/tests/test_models/test_observation_aggregation.py
+++ b/tests/test_models/test_observation_aggregation.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import numpy as raw_np
+import pytest
+
+
+def test_weighted_observation_contract_validates_schedule_weights_and_grid():
+    from trellis.models.observation_aggregation import WeightedObservationContract
+
+    contract = WeightedObservationContract(
+        observation_times=(0.0, 0.5, 1.0),
+        weights=(0.2, 0.3, 0.5),
+    )
+
+    assert contract.observation_times == (0.0, 0.5, 1.0)
+    assert contract.weights == (0.2, 0.3, 0.5)
+    assert contract.observation_steps(maturity=1.0, n_steps=4) == (0, 2, 4)
+
+    with pytest.raises(ValueError, match="at least one"):
+        WeightedObservationContract(observation_times=(), weights=())
+    with pytest.raises(ValueError, match="strictly increasing"):
+        WeightedObservationContract(
+            observation_times=(0.5, 0.5),
+            weights=(0.5, 0.5),
+        )
+    with pytest.raises(ValueError, match="non-negative"):
+        WeightedObservationContract(
+            observation_times=(-0.1, 1.0),
+            weights=(0.5, 0.5),
+        )
+    with pytest.raises(ValueError, match="finite"):
+        WeightedObservationContract(
+            observation_times=(0.5, float("nan")),
+            weights=(0.5, 0.5),
+        )
+    with pytest.raises(ValueError, match="same length"):
+        WeightedObservationContract(
+            observation_times=(0.5, 1.0),
+            weights=(1.0,),
+        )
+    with pytest.raises(ValueError, match="finite"):
+        WeightedObservationContract(
+            observation_times=(0.5, 1.0),
+            weights=(0.5, float("inf")),
+        )
+    with pytest.raises(ValueError, match="cannot exceed maturity"):
+        contract.observation_steps(maturity=0.75, n_steps=4)
+    with pytest.raises(ValueError, match="represented exactly"):
+        WeightedObservationContract(
+            observation_times=(0.3, 1.0),
+            weights=(0.5, 0.5),
+        ).observation_steps(maturity=1.0, n_steps=4)
+    with pytest.raises(ValueError, match="distinct simulation steps"):
+        WeightedObservationContract(
+            observation_times=(0.2, 0.24),
+            weights=(0.5, 0.5),
+        ).observation_steps(maturity=1.0, n_steps=2)
+
+
+def test_weighted_observation_sum_uses_explicit_weights_and_preserves_autograd():
+    from trellis.core.differentiable import get_numpy, gradient
+    from trellis.models.observation_aggregation import (
+        WeightedObservationContract,
+        weighted_observation_sum,
+    )
+
+    contract = WeightedObservationContract(
+        observation_times=(0.0, 0.5, 1.0),
+        weights=(0.2, 0.3, 0.5),
+    )
+    observations = raw_np.array(
+        [
+            [100.0, 110.0, 120.0],
+            [80.0, 90.0, 70.0],
+        ]
+    )
+
+    raw_np.testing.assert_allclose(
+        weighted_observation_sum(observations, contract),
+        raw_np.array([113.0, 78.0]),
+    )
+
+    np = get_numpy()
+    sensitivity = gradient(
+        lambda final_level: weighted_observation_sum(
+            np.array([100.0, 110.0, final_level]),
+            contract,
+        )
+    )(120.0)
+    assert sensitivity == pytest.approx(0.5)
+
+    spread_contract = WeightedObservationContract(
+        observation_times=(0.5, 1.0),
+        weights=(1.0, -1.0),
+    )
+    raw_np.testing.assert_allclose(
+        weighted_observation_sum(
+            raw_np.array([[110.0, 100.0], [90.0, 95.0]]),
+            spread_contract,
+        ),
+        raw_np.array([10.0, -5.0]),
+    )
+
+    with pytest.raises(ValueError, match="trailing value per observation time"):
+        weighted_observation_sum(raw_np.ones((2, 2)), contract)
+
+
+def test_weighted_observation_payoff_matches_full_paths_and_reduced_state():
+    from trellis.core.differentiable import get_numpy
+    from trellis.models.monte_carlo.engine import MonteCarloEngine
+    from trellis.models.observation_aggregation import (
+        WeightedObservationContract,
+        weighted_observation_payoff,
+    )
+    from trellis.models.processes.gbm import GBM
+
+    np = get_numpy()
+    contract = WeightedObservationContract(
+        observation_times=(0.0, 0.5, 1.0),
+        weights=(1.0 / 3.0,) * 3,
+    )
+    payoff = weighted_observation_payoff(
+        contract,
+        maturity=1.0,
+        n_steps=4,
+        settlement_fn=lambda average: np.maximum(average - 105.0, 0.0),
+        reducer_name="weighted_levels",
+    )
+    paths = raw_np.array(
+        [
+            [100.0, 103.0, 110.0, 115.0, 120.0],
+            [100.0, 98.0, 95.0, 92.0, 90.0],
+        ]
+    )
+
+    raw_np.testing.assert_allclose(
+        payoff(paths),
+        raw_np.array([5.0, 0.0]),
+    )
+
+    from trellis.models.monte_carlo.path_state import MonteCarloPathState
+
+    reduced_state = MonteCarloPathState(
+        initial_value=100.0,
+        n_steps=4,
+        terminal_values=paths[:, -1],
+        reducer_values={"weighted_levels": raw_np.array([110.0, 95.0])},
+    )
+    raw_np.testing.assert_allclose(payoff.evaluate_state(reduced_state), payoff(paths))
+
+    engine = MonteCarloEngine(
+        GBM(mu=0.10, sigma=0.0),
+        n_paths=16,
+        n_steps=4,
+        seed=7,
+        method="exact",
+    )
+    result = engine.price(
+        100.0,
+        1.0,
+        payoff,
+        return_paths=False,
+    )
+
+    expected_average = 100.0 * (
+        1.0 + raw_np.exp(0.05) + raw_np.exp(0.10)
+    ) / 3.0
+    assert result["price"] == pytest.approx(max(expected_average - 105.0, 0.0))
+    assert result["paths"] is None
+    assert result["path_state"] is not None
+    assert result["path_state"].full_paths is None
+    assert tuple(result["path_state"].reducer_values) == ("weighted_levels",)
+
+
+def test_weighted_observation_payoff_rejects_vector_state_and_grid_mismatch():
+    from trellis.models.monte_carlo.path_state import MonteCarloPathState
+    from trellis.models.observation_aggregation import (
+        WeightedObservationContract,
+        build_weighted_observation_reducer,
+        weighted_observation_payoff,
+    )
+
+    contract = WeightedObservationContract(
+        observation_times=(0.5, 1.0),
+        weights=(0.5, 0.5),
+    )
+    payoff = weighted_observation_payoff(
+        contract,
+        maturity=1.0,
+        n_steps=4,
+        settlement_fn=lambda aggregate: aggregate,
+    )
+    with pytest.raises(ValueError, match="scalar state per path"):
+        payoff(raw_np.ones((2, 5, 2)))
+    with pytest.raises(ValueError, match="execution grid has 8 steps; expected 4"):
+        payoff(raw_np.ones((2, 9)))
+
+    scalar_settlement = weighted_observation_payoff(
+        contract,
+        maturity=1.0,
+        n_steps=4,
+        settlement_fn=lambda aggregate: 1.0,
+    )
+    with pytest.raises(ValueError, match="one value per path"):
+        scalar_settlement(raw_np.ones((2, 5)))
+
+    reducer = build_weighted_observation_reducer(
+        contract,
+        maturity=1.0,
+        n_steps=4,
+    )
+    with pytest.raises(ValueError, match="scalar state per path"):
+        reducer.init(raw_np.ones((2, 2)), 4)
+    with pytest.raises(ValueError, match="execution grid has 8 steps; expected 4"):
+        reducer.init(raw_np.ones(2), 8)
+
+    state = MonteCarloPathState(
+        initial_value=100.0,
+        n_steps=8,
+        terminal_values=raw_np.array([100.0]),
+        reducer_values={"weighted_observations": raw_np.array([100.0])},
+    )
+    with pytest.raises(ValueError, match="execution grid has 8 steps; expected 4"):
+        payoff.evaluate_state(state)

--- a/trellis/agent/knowledge/canonical/api_map.yaml
+++ b/trellis/agent/knowledge/canonical/api_map.yaml
@@ -141,6 +141,18 @@ monte_carlo:
     - "If the control primitive uses continuation regression, choose the estimator or basis explicitly; LaguerreBasis is optional, not mandatory"
     - "Do not invent method='lsm' on MonteCarloEngine"
 
+scheduled_observation_composition:
+  module: trellis.models.observation_aggregation
+  key_imports:
+    - "from trellis.models.observation_aggregation import WeightedObservationContract, build_weighted_observation_reducer, weighted_observation_payoff, weighted_observation_sum"
+    - "from trellis.models.monte_carlo.engine import MonteCarloEngine"
+    - "from trellis.models.processes.gbm import GBM, PiecewiseConstantGBM"
+  notes:
+    - "Declare every observation time and weight explicitly with WeightedObservationContract; weights are not normalized implicitly, so an average uses one weight of 1 / n per observation."
+    - "The observation grid may include time zero, but every time must map exactly and distinctly onto the MonteCarloEngine grid or the contract fails closed."
+    - "Use weighted_observation_sum(...) for direct path-array checks and weighted_observation_payoff(...) with return_paths=False for reduced-state execution."
+    - "Pass derivative-specific settlement logic through settlement_fn; strike, direction, notional, and payoff branching belong in generated adapter code rather than this product-neutral aggregate."
+
 observation_return_composition:
   module: trellis.models.observation_returns
   key_imports:

--- a/trellis/agent/knowledge/import_registry.py
+++ b/trellis/agent/knowledge/import_registry.py
@@ -466,7 +466,10 @@ def _format_registry(registry: dict[str, tuple[str, ...]]) -> str:
             groups["Core"].append(line)
         elif "trellis.curves." in mod:
             groups["Curves"].append(line)
-        elif mod == "trellis.models.observation_returns":
+        elif mod in {
+            "trellis.models.observation_aggregation",
+            "trellis.models.observation_returns",
+        }:
             groups["Models — Payoff Composition"].append(line)
         elif "trellis.models.black" in mod:
             groups["Models — Analytical"].append(line)
@@ -571,6 +574,7 @@ from trellis.models.fx_vanilla import FXVanillaSpecLike, ResolvedFXVanillaInputs
 from trellis.models.fx_barrier_option import FXBarrierMonteCarloResult, FXBarrierOptionSpec, ResolvedFXBarrierInputs, price_fx_barrier_option_analytical, price_fx_barrier_option_monte_carlo, price_fx_barrier_option_monte_carlo_result, resolve_fx_barrier_inputs
 from trellis.models.credit_index_option import CreditIndexOptionSpec, price_credit_index_option_black_on_spread, price_credit_index_option_monte_carlo
 from trellis.models.local_vol_option import LocalVolPDEResult, LocalVolVanillaOptionSpec, price_local_vol_option_monte_carlo, price_local_vol_option_pde, price_local_vol_option_pde_result
+from trellis.models.observation_aggregation import WeightedObservationContract, build_weighted_observation_reducer, weighted_observation_payoff, weighted_observation_sum
 from trellis.models.observation_returns import ObservationReturnContract, bounded_observation_return_sum, build_observation_return_reducer, observation_return_payoff, simple_observation_returns
 from trellis.models.quoted_observable import CurveQuoteSpreadSpecLike, QuotedObservableSpreadResult, SurfaceQuoteSpreadSpecLike, price_curve_quote_spread_analytical, price_curve_quote_spread_analytical_result, price_surface_quote_spread_analytical, price_surface_quote_spread_analytical_result
 from trellis.models.resolution.quanto import ResolvedQuantoInputs, resolve_quanto_correlation, resolve_quanto_foreign_curve, resolve_quanto_inputs, resolve_quanto_underlier_spot

--- a/trellis/models/observation_aggregation.py
+++ b/trellis/models/observation_aggregation.py
@@ -1,0 +1,238 @@
+"""Product-neutral weighted aggregation on scheduled Monte Carlo observations."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from math import isfinite
+
+import numpy as raw_np
+
+from trellis.core.differentiable import get_numpy
+from trellis.models.monte_carlo.event_state import event_step_indices
+from trellis.models.monte_carlo.path_state import (
+    MonteCarloPathRequirement,
+    MonteCarloPathState,
+    PathReducer,
+    StateAwarePayoff,
+)
+
+np = get_numpy()
+
+
+def _to_backend_array(values):
+    if isinstance(values, raw_np.ndarray) or hasattr(values, "_value"):
+        return values
+    return np.asarray(values)
+
+
+def _validation_view(values) -> raw_np.ndarray:
+    return raw_np.asarray(getattr(values, "_value", values))
+
+
+def _validate_execution_grid(actual_steps: int, expected_steps: int) -> None:
+    actual = int(actual_steps)
+    expected = int(expected_steps)
+    if actual != expected:
+        raise ValueError(f"execution grid has {actual} steps; expected {expected}")
+
+
+def _single_state_cross_section(values):
+    array = _to_backend_array(values)
+    view = _validation_view(array)
+    if view.ndim == 1:
+        return array
+    if view.ndim == 2 and view.shape[1] == 1:
+        return array[:, 0]
+    raise ValueError("weighted observation aggregation requires scalar state per path")
+
+
+def _scalar_path_matrix(paths):
+    values = _to_backend_array(paths)
+    view = _validation_view(values)
+    if view.ndim == 3 and view.shape[2] == 1:
+        values = values[:, :, 0]
+        view = _validation_view(values)
+    if view.ndim != 2:
+        raise ValueError("weighted observation aggregation requires scalar state per path")
+    return values
+
+
+def _validate_finite_values(values, *, name: str) -> None:
+    if raw_np.any(~raw_np.isfinite(_validation_view(values))):
+        raise ValueError(f"{name} must contain finite values")
+
+
+@dataclass(frozen=True)
+class WeightedObservationContract:
+    """Explicit times and weights for a scalar scheduled path aggregate."""
+
+    observation_times: tuple[float, ...]
+    weights: tuple[float, ...]
+
+    def __post_init__(self) -> None:
+        times = tuple(float(time) for time in self.observation_times)
+        weights = tuple(float(weight) for weight in self.weights)
+        if not times:
+            raise ValueError("observation_times must contain at least one value")
+        if len(weights) != len(times):
+            raise ValueError("weights and observation_times must have the same length")
+        if any(not isfinite(time) for time in times):
+            raise ValueError("observation_times must contain finite values")
+        if any(time < 0.0 for time in times):
+            raise ValueError("observation_times must be non-negative")
+        if any(later <= earlier for earlier, later in zip(times, times[1:])):
+            raise ValueError("observation_times must be strictly increasing")
+        if any(not isfinite(weight) for weight in weights):
+            raise ValueError("weights must contain finite values")
+        object.__setattr__(self, "observation_times", times)
+        object.__setattr__(self, "weights", weights)
+
+    def observation_steps(self, *, maturity: float, n_steps: int) -> tuple[int, ...]:
+        """Map every observation to one distinct, exact simulation step."""
+        horizon = float(maturity)
+        step_count = int(n_steps)
+        if not isfinite(horizon) or horizon <= 0.0:
+            raise ValueError("maturity must be finite and positive")
+        if step_count <= 0:
+            raise ValueError("n_steps must be positive")
+        if self.observation_times[-1] > horizon + 1e-12:
+            raise ValueError("observation_times cannot exceed maturity")
+
+        steps = event_step_indices(self.observation_times, horizon, step_count)
+        if len(steps) != len(self.observation_times):
+            raise ValueError("observation_times must map to distinct simulation steps")
+        grid_times = tuple(horizon * step / step_count for step in steps)
+        if any(
+            abs(grid_time - observation_time) > 1e-12
+            for grid_time, observation_time in zip(
+                grid_times,
+                self.observation_times,
+                strict=True,
+            )
+        ):
+            raise ValueError(
+                "observation_times must be represented exactly on the simulation grid"
+            )
+        return steps
+
+
+def weighted_observation_sum(observations, contract: WeightedObservationContract):
+    """Return the explicitly weighted sum along the observation axis."""
+    values = _to_backend_array(observations)
+    view = _validation_view(values)
+    if view.ndim == 0 or view.shape[-1] != len(contract.observation_times):
+        raise ValueError(
+            "observations must have one trailing value per observation time"
+        )
+    _validate_finite_values(values, name="observations")
+    weights = np.asarray(contract.weights)
+    aggregate = np.sum(values * weights, axis=-1)
+    _validate_finite_values(aggregate, name="weighted observation aggregate")
+    return aggregate
+
+
+def build_weighted_observation_reducer(
+    contract: WeightedObservationContract,
+    *,
+    maturity: float,
+    n_steps: int,
+    name: str = "weighted_observations",
+) -> PathReducer:
+    """Build reduced state for an explicitly weighted scalar observation sum."""
+    reducer_name = str(name).strip()
+    if not reducer_name:
+        raise ValueError("weighted observation reducer name must be non-empty")
+    steps = contract.observation_steps(maturity=maturity, n_steps=n_steps)
+    weights_by_step = dict(zip(steps, contract.weights, strict=True))
+
+    def _init(initial_values, total_steps):
+        _validate_execution_grid(total_steps, n_steps)
+        initial = _single_state_cross_section(initial_values)
+        _validate_finite_values(initial, name="observed levels")
+        if 0 in weights_by_step:
+            return float(weights_by_step[0]) * initial
+        return np.zeros_like(initial)
+
+    def _update(accumulator, values, step):
+        current_accumulator = _to_backend_array(accumulator)
+        weight = weights_by_step.get(int(step))
+        if weight is None:
+            return current_accumulator
+        current = _single_state_cross_section(values)
+        _validate_finite_values(current, name="observed levels")
+        return current_accumulator + float(weight) * current
+
+    return PathReducer(
+        name=reducer_name,
+        init_fn=_init,
+        update_fn=_update,
+    )
+
+
+def _settled_path_values(settlement_fn: Callable, aggregate, *, n_paths: int):
+    settled = _to_backend_array(settlement_fn(aggregate))
+    view = _validation_view(settled)
+    if view.shape != (int(n_paths),):
+        raise ValueError("settlement_fn must return one value per path")
+    _validate_finite_values(settled, name="settled path values")
+    return settled
+
+
+def weighted_observation_payoff(
+    contract: WeightedObservationContract,
+    *,
+    maturity: float,
+    n_steps: int,
+    settlement_fn: Callable,
+    reducer_name: str = "weighted_observations",
+    name: str = "weighted_observation_payoff",
+    derivative_metadata: Mapping[str, object] | None = None,
+) -> StateAwarePayoff:
+    """Compose weighted path state with caller-supplied settlement semantics."""
+    if not callable(settlement_fn):
+        raise TypeError("settlement_fn must be callable")
+    steps = contract.observation_steps(maturity=maturity, n_steps=n_steps)
+    reducer = build_weighted_observation_reducer(
+        contract,
+        maturity=maturity,
+        n_steps=n_steps,
+        name=reducer_name,
+    )
+
+    def _evaluate_paths(paths):
+        values = _scalar_path_matrix(paths)
+        view = _validation_view(values)
+        _validate_execution_grid(view.shape[1] - 1, n_steps)
+        aggregate = weighted_observation_sum(values[:, steps], contract)
+        return _settled_path_values(
+            settlement_fn,
+            aggregate,
+            n_paths=view.shape[0],
+        )
+
+    def _evaluate_state(state: MonteCarloPathState):
+        _validate_execution_grid(state.n_steps, n_steps)
+        aggregate = _to_backend_array(state.reduced_value(reducer_name))
+        _validate_finite_values(aggregate, name="weighted observation aggregate")
+        return _settled_path_values(
+            settlement_fn,
+            aggregate,
+            n_paths=state.n_paths,
+        )
+
+    return StateAwarePayoff(
+        path_requirement=MonteCarloPathRequirement(reducers=(reducer,)),
+        evaluate_paths_fn=_evaluate_paths,
+        evaluate_state_fn=_evaluate_state,
+        name=str(name or "weighted_observation_payoff"),
+        derivative_metadata=dict(derivative_metadata or {}),
+    )
+
+
+__all__ = [
+    "WeightedObservationContract",
+    "build_weighted_observation_reducer",
+    "weighted_observation_payoff",
+    "weighted_observation_sum",
+]


### PR DESCRIPTION
## Summary
- add a product-neutral weighted scheduled-observation contract and direct aggregate
- add reduced-state Monte Carlo composition with caller-owned settlement semantics
- expose the primitive through the API map, import registry, and quant/developer docs
- leave route authority, adapters, and cookbooks unchanged

## Validation
- focused subsystem suite: 179 passed
- make gate-pr: 4,386 core passed; tier 2: 32 passed, 15 skipped
- Sphinx HTML build succeeded

Linear: QUA-1179