### PR TITLE
QUA-1182: resolve bounded runtime agent context

### DIFF
--- a/doc/plan/active__semantic-task-synthesis-helper-retirement.md
+++ b/doc/plan/active__semantic-task-synthesis-helper-retirement.md
@@ -42,16 +42,19 @@ Status mirror last synced: `2026-07-14`
 | `QUA-1179` | Monte Carlo: reusable scheduled observation aggregation | Done |
 | `QUA-1180` | Analytical support: weighted lognormal-sum moments | Done |
 | `QUA-1181` | Arithmetic Asian pricing: retire helper authority | In Progress |
+| `QUA-1182` | Semantic agent navigation: bounded knowledge and documentation packets | In Progress |
 
 ## Current Sequence
 
-1. Implement QUA-1179 product-neutral scheduled observation aggregation for
-   reduced-state Monte Carlo.
-2. Implement QUA-1180 product-neutral weighted lognormal-sum moments for
-   analytical composition.
-3. Complete QUA-1181 by removing arithmetic-Asian helper authority only after
-   both reusable primitive tickets land; keep geometric and multi-asset Asian
-   contracts outside that admitted cohort.
+1. Complete QUA-1182 so hosted quant and model-validator calls receive bounded,
+   task-relevant content behind their navigation contracts rather than path-only
+   cards.
+2. Complete QUA-1181's live fresh-generation proof only after explicit external
+   model approval; its implementation, offline replay, and release gate are
+   already complete.
+3. Select the next helper-authoritative green family using the merged audit and
+   prove the improved navigation during fresh generation before retiring its
+   helper authority.
 
 ## Completion Evidence
 

--- a/docs/agent/model_validator_agent.rst
+++ b/docs/agent/model_validator_agent.rst
@@ -27,13 +27,21 @@ LLM opinion. The validator is useful when executed evidence leaves a genuine
 question about model suitability, calibration, numerical quality, or a support
 boundary.
 
+The version-2 resolver supplies the actual bounded evidence behind those
+targets. It includes the already-selected review memory, relevant model grammar
+and method requirements, read-only cookbook assumptions, current limitation
+sections, and matching calibration/quant documentation. It strips code blocks,
+imports, route-helper instructions, and full cookbook templates because the
+validator does not own construction.
+
 Review Policy
 -------------
 
 Build-time LLM model validation remains governed by the validation profile and
 risk policy. Skipped and completed lifecycle events both record the orientation
-contract identity, so an audit can establish which role contract governed a
-review without persisting the full prompt card.
+contract identity. Completed LLM reviews additionally record the selected
+resource and section ids, bounded character count, omission count, and content
+digest. Skipped reviews explicitly record that no packet was injected.
 
 Implementation
 --------------

--- a/docs/agent/model_validator_agent.rst
+++ b/docs/agent/model_validator_agent.rst
@@ -17,7 +17,7 @@ order starts with runtime evidence:
 #. the compiled validation contract
 #. the deterministic evidence packet
 #. the quant challenger packet
-#. admitted route, model-grammar, and method-requirement context
+#. retrieved lessons plus admitted route, model-grammar, and method-requirement context
 #. cookbook patterns as read-only supporting evidence
 #. ``LIMITATIONS.md`` and the validation, calibration, quant, and audit docs
 
@@ -28,9 +28,10 @@ question about model suitability, calibration, numerical quality, or a support
 boundary.
 
 The version-2 resolver supplies the actual bounded evidence behind those
-targets. It includes the already-selected review memory, relevant model grammar
-and method requirements, read-only cookbook assumptions, current limitation
-sections, and matching calibration/quant documentation. It strips code blocks,
+targets. It includes the already-selected review memory, validated/promoted
+lessons, relevant model grammar and method requirements, read-only cookbook
+assumptions, current limitation sections, and matching calibration/quant
+documentation. It strips code blocks,
 imports, route-helper instructions, and full cookbook templates because the
 validator does not own construction.
 

--- a/docs/agent/quant_agent.rst
+++ b/docs/agent/quant_agent.rst
@@ -16,7 +16,7 @@ its LLM boundary. The card is rendered from
 smallest useful navigation surface in this order:
 
 #. the runtime semantic contract, ``ProductIR``, and quant challenger packet
-#. canonical product decompositions and admitted route families
+#. canonical product decompositions, retrieved lessons, and admitted route families
 #. the model grammar and method requirements
 #. the cookbook catalog as read-only pattern evidence
 #. the quant documentation index and model-grammar design reference

--- a/docs/agent/quant_agent.rst
+++ b/docs/agent/quant_agent.rst
@@ -21,11 +21,14 @@ smallest useful navigation surface in this order:
 #. the cookbook catalog as read-only pattern evidence
 #. the quant documentation index and model-grammar design reference
 
-The card deliberately omits exact symbol and import lookup. Existing routing
-context may still include the family-level API map, but exact symbol selection
-remains the builder's responsibility through the API map and import registry.
-This keeps method selection independent from whichever convenience helper
-happens to exist.
+The version-2 resolver follows those targets and supplies only task-relevant
+source excerpts. It projects typed decomposition, model-grammar,
+method-requirement, lesson, and cookbook solution-contract evidence, then
+selects bounded sections from the quant documentation index. Cookbook code,
+route-helper hints, code blocks, and exact symbol/import lookup are removed.
+Exact symbol selection remains the builder's responsibility through the API map
+and import registry. This keeps method selection independent from whichever
+convenience helper happens to exist.
 
 Method Selection
 ----------------
@@ -35,7 +38,9 @@ table in ``quant.py``. Product features, method candidates, required market
 data, exercise style, state dependence, and model family become ``ProductIR``.
 The quant layer ranks the admitted candidates and emits a ``PricingPlan`` plus
 a ``QuantChallengerPacket``. Genuinely novel products may use bounded LLM
-decomposition, and that prompt receives the same orientation card.
+decomposition, and that prompt receives the resolved quant packet. The selected
+resource ids, section ids, omissions, and content digest are retained as trace
+metadata without retaining the excerpts themselves.
 The selected method family is mapped to deterministic default construction
 modules in runtime code; the LLM is not asked to emit module or import paths.
 

--- a/docs/developer/audit_and_observability.rst
+++ b/docs/developer/audit_and_observability.rst
@@ -220,7 +220,8 @@ The cycle report records:
   stages
 - the bounded orientation-resolution summary when present: prompt-injected
   state, selected resource/section ids, character and omission counts, and
-  content digest, without duplicating source excerpts
+  content digest, plus unavailable documentation resource ids for slim
+  installed runtimes, without duplicating source excerpts
 
 Use ``load_platform_trace_cycle_report(...)`` when code needs the typed
 ``CycleReport`` object for one trace. Use ``load_platform_traces(...)`` when a

--- a/docs/developer/audit_and_observability.rst
+++ b/docs/developer/audit_and_observability.rst
@@ -217,7 +217,10 @@ The cycle report records:
 - compact stage summaries and low-cardinality details suitable for replay,
   dashboards, and later promotion/adoption checks
 - the versioned runtime orientation identity for quant and model-validator
-  stages, without duplicating either role's full prompt card
+  stages
+- the bounded orientation-resolution summary when present: prompt-injected
+  state, selected resource/section ids, character and omission counts, and
+  content digest, without duplicating source excerpts
 
 Use ``load_platform_trace_cycle_report(...)`` when code needs the typed
 ``CycleReport`` object for one trace. Use ``load_platform_traces(...)`` when a
@@ -232,8 +235,10 @@ from ad hoc event strings.
 
 The ``orientation_contract`` field contains only ``role``, ``contract_id``,
 and ``version``. Use it to establish which navigation and ownership contract
-governed a runtime role. See :doc:`runtime_agent_orientation` for the canonical
-manifest and the distinction from repository-level ``AGENTS.md`` guidance.
+governed a runtime role. The separate ``orientation_resolution`` field proves
+whether content was injected and which bounded sources governed that call.
+See :doc:`runtime_agent_orientation` for the canonical manifest, resolution
+contract, and distinction from repository-level ``AGENTS.md`` guidance.
 
 Agent Cycle Result Surface
 --------------------------

--- a/docs/developer/runtime_agent_orientation.rst
+++ b/docs/developer/runtime_agent_orientation.rst
@@ -36,7 +36,11 @@ present and every navigation order is consecutive. Tests also verify that all
 file-backed targets exist. Runtime targets use the ``runtime:`` prefix because
 their evidence is supplied by the compiled request rather than read from disk.
 File-backed resolution is confined to the repository root. Missing indexed
-documents and paths that escape that root fail closed.
+children and paths that escape that root fail closed. A slim installed wheel
+may intentionally omit the repository's top-level documentation tree; in that
+case the resolver keeps canonical packaged knowledge, records the unavailable
+documentation resource ids as omissions, and continues within the same prompt
+budget.
 
 Role Boundaries
 ---------------
@@ -60,7 +64,8 @@ features, model family, route identity, residual risks, and review trigger. It
 then:
 
 #. projects the already-ranked ``KnowledgeStore`` result into role-safe
-   decomposition, model-grammar, method-requirement, lesson, and read-only
+   decomposition, promoted/validated lesson, model-grammar,
+   method-requirement, and read-only
    cookbook evidence
 #. consults the generated skill index but rejects route-helper records and
    construction-shaped guidance for these roles
@@ -87,7 +92,8 @@ Lifecycle events and cycle reports persist ``role``, ``contract_id``, and
 ``version`` under ``orientation_contract``. They persist a separate
 ``orientation_resolution`` summary containing whether a packet was injected,
 selected resource and section ids, character and omission counts, and a content
-digest. Full excerpts are not copied into traces.
+digest. It also identifies documentation resources unavailable in a slim
+installed runtime. Full excerpts are not copied into traces.
 
 Cookbook Authority
 ------------------

--- a/docs/developer/runtime_agent_orientation.rst
+++ b/docs/developer/runtime_agent_orientation.rst
@@ -14,13 +14,19 @@ prompt boundary. The canonical source is
 ``trellis/agent/knowledge/canonical/agent_orientations.yaml`` and the typed
 loader is ``trellis.agent.role_orientation``.
 
+The version-2 contracts are made operational by
+``trellis.agent.orientation_resolution``. The resolver does not give hosted
+roles filesystem tools. It follows the declared indexes inside the repository,
+selects relevant source sections deterministically, and injects only the
+bounded result at the LLM boundary.
+
 Contract Shape
 --------------
 
 Each role contract declares:
 
 - a stable contract id and positive version
-- a prompt-size budget
+- separate card, resolved-context, and per-resource character budgets
 - the decisions the role owns and explicitly does not own
 - an ordered list of runtime evidence, canonical knowledge, support contracts,
   and official documentation targets
@@ -29,6 +35,8 @@ The loader fails closed unless both ``quant`` and ``model_validator`` are
 present and every navigation order is consecutive. Tests also verify that all
 file-backed targets exist. Runtime targets use the ``runtime:`` prefix because
 their evidence is supplied by the compiled request rather than read from disk.
+File-backed resolution is confined to the repository root. Missing indexed
+documents and paths that escape that root fail closed.
 
 Role Boundaries
 ---------------
@@ -44,23 +52,50 @@ contracts, the read-only cookbook catalog, current limitations, calibration
 documentation, and audit contracts. This preserves deterministic-first review
 ownership.
 
+Bounded Resolution
+------------------
+
+The resolver builds a typed semantic query from the instrument, method,
+features, model family, route identity, residual risks, and review trigger. It
+then:
+
+#. projects the already-ranked ``KnowledgeStore`` result into role-safe
+   decomposition, model-grammar, method-requirement, lesson, and read-only
+   cookbook evidence
+#. consults the generated skill index but rejects route-helper records and
+   construction-shaped guidance for these roles
+#. follows declared RST ``toctree`` entries, including Markdown targets, and
+   ranks actual document sections against the same query
+#. strips code blocks and builder-only import/helper instructions
+#. truncates each resource and the final packet independently, recording any
+   omissions
+
+Documentation ranking scores only the bounded text that could enter the
+prompt. A keyword that appears later in a long unrelated section therefore
+cannot make that section outrank a directly relevant heading.
+
 Prompt And Trace Behavior
 -------------------------
 
 Only the role that makes an LLM call receives its rendered card. The quant
-card is injected into novel-product decomposition; the model-validator card is
-injected into residual conceptual review. Cards are bounded and are not a
-mechanism for loading every referenced file into a prompt.
+card and resolved context are injected into novel-product decomposition; the
+model-validator card and resolved context are injected into residual conceptual
+review. Known-product deterministic quant selection does not pretend that a
+prompt packet was used.
 
-Lifecycle events and cycle reports persist only ``role``, ``contract_id``, and
-``version`` under ``orientation_contract``. That low-cardinality identity is
-enough for replay and drift review while avoiding duplicate prompt payloads in
-traces.
+Lifecycle events and cycle reports persist ``role``, ``contract_id``, and
+``version`` under ``orientation_contract``. They persist a separate
+``orientation_resolution`` summary containing whether a packet was injected,
+selected resource and section ids, character and omission counts, and a content
+digest. Full excerpts are not copied into traces.
 
 Cookbook Authority
 ------------------
 
 Both role cards expose ``canonical/cookbooks.yaml`` as read-only validated
-pattern evidence. Runtime calls cannot update or promote entries. Candidate
-learning remains ephemeral until the governed remediation and promotion path
-has independent validation evidence.
+pattern evidence. The resolver exposes method descriptions and matching
+solution-contract assumptions, payoff meaning, and market-data obligations; it
+does not expose cookbook code templates to quant or model-validator. Runtime
+calls cannot update or promote entries. Candidate learning remains ephemeral
+until the governed remediation and promotion path has independent validation
+evidence.

--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -43,6 +43,14 @@ indexes, while the model-validator contract starts from executed validation
 evidence. Both expose cookbook entries as read-only evidence and explicitly
 exclude runtime promotion authority.
 
+Version 2 resolves those indexes into bounded task-relevant content rather than
+showing hosted roles paths they cannot open. Resolution reuses ranked knowledge
+and generated-skill records, follows actual quant-document sections, strips
+builder-only code/helper authority, and records source identities plus a digest
+without persisting excerpts. Deterministic quant selection and skipped model
+validation record ``prompt_injected=false`` rather than claiming that an LLM
+consumed the packet.
+
 Stage-aware builder retrieval also preserves the compiled generation route.
 Every live refresh scopes shared knowledge by pricing method, exact route id,
 and declared route families before replacing the trace summary. A retry may

--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -45,11 +45,17 @@ exclude runtime promotion authority.
 
 Version 2 resolves those indexes into bounded task-relevant content rather than
 showing hosted roles paths they cannot open. Resolution reuses ranked knowledge
-and generated-skill records, follows actual quant-document sections, strips
+including validated/promoted lessons and generated-skill records, follows
+actual quant-document sections, strips
 builder-only code/helper authority, and records source identities plus a digest
 without persisting excerpts. Deterministic quant selection and skipped model
 validation record ``prompt_injected=false`` rather than claiming that an LLM
 consumed the packet.
+
+Slim installed wheels may omit the repository's top-level documentation tree.
+Those calls retain packaged canonical knowledge and record unavailable document
+resources as bounded omissions; invalid indexed children and escaping paths
+still fail closed.
 
 Stage-aware builder retrieval also preserves the compiled generation route.
 Every live refresh scopes shared knowledge by pricing method, exact route id,

--- a/tests/test_agent/test_build_loop.py
+++ b/tests/test_agent/test_build_loop.py
@@ -1404,7 +1404,13 @@ class TestBuildLoop:
         assert quant_event["orientation_contract"] == {
             "role": "quant",
             "contract_id": "quant-runtime-navigation",
-            "version": 1,
+            "version": 2,
+        }
+        assert quant_event["orientation_resolution"] == {
+            "role": "quant",
+            "orientation_identity": "quant-runtime-navigation@2",
+            "prompt_injected": False,
+            "reason": "deterministic_method_selection",
         }
 
     @patch(

--- a/tests/test_agent/test_lite_review.py
+++ b/tests/test_agent/test_lite_review.py
@@ -1440,8 +1440,9 @@ def test_validate_build_passes_quant_selected_method_to_model_validator(monkeypa
     assert skipped["orientation_contract"] == {
         "role": "model_validator",
         "contract_id": "model-validator-runtime-navigation",
-        "version": 1,
+        "version": 2,
     }
+    assert skipped["orientation_resolution"]["prompt_injected"] is False
 
 
 def test_format_validation_failure_feedback_includes_structured_diagnostics():

--- a/tests/test_agent/test_model_validator.py
+++ b/tests/test_agent/test_model_validator.py
@@ -221,7 +221,9 @@ def test_llm_conceptual_review_includes_shared_knowledge(monkeypatch):
     )
 
     assert findings == []
-    assert "model-validator-runtime-navigation@1" in captured["prompt"]
+    assert "model-validator-runtime-navigation@2" in captured["prompt"]
+    assert "## Resolved Role Context" in captured["prompt"]
+    assert "docs/mathematical/calibration.rst#" in captured["prompt"]
     assert "deterministic_evidence_packet" in captured["prompt"]
     assert "quant-runtime-navigation" not in captured["prompt"]
     assert "Shared Review Principles" in captured["prompt"]
@@ -695,6 +697,8 @@ def test_validate_model_threads_deterministic_evidence_packet(monkeypatch):
 
     assert report.findings == []
     assert captured["deterministic_evidence_packet"] == packet
+    assert report.orientation_resolution["prompt_injected"] is True
+    assert report.orientation_resolution["selected_resource_ids"]
 
 
 def test_validate_model_for_request_threads_generation_plan(monkeypatch):

--- a/tests/test_agent/test_platform_traces.py
+++ b/tests/test_agent/test_platform_traces.py
@@ -201,7 +201,13 @@ def test_platform_trace_persists_cycle_report_from_lifecycle_events(tmp_path):
             "orientation_contract": {
                 "role": "quant",
                 "contract_id": "quant-runtime-navigation",
-                "version": 1,
+                "version": 2,
+            },
+            "orientation_resolution": {
+                "role": "quant",
+                "orientation_identity": "quant-runtime-navigation@2",
+                "prompt_injected": False,
+                "reason": "deterministic_method_selection",
             },
             "challenger_packet": {
                 "selected_method": "analytical",
@@ -271,7 +277,12 @@ def test_platform_trace_persists_cycle_report_from_lifecycle_events(tmp_path):
             "orientation_contract": {
                 "role": "model_validator",
                 "contract_id": "model-validator-runtime-navigation",
-                "version": 1,
+                "version": 2,
+            },
+            "orientation_resolution": {
+                "role": "model_validator",
+                "prompt_injected": False,
+                "reason": "standard_validation_profile",
             },
         },
         root=tmp_path,
@@ -319,6 +330,7 @@ def test_platform_trace_persists_cycle_report_from_lifecycle_events(tmp_path):
     assert quant_stage["details"]["orientation_contract"]["contract_id"] == (
         "quant-runtime-navigation"
     )
+    assert quant_stage["details"]["orientation_resolution"]["prompt_injected"] is False
     model_validator_stage = next(
         stage
         for stage in cycle_report["stages"]
@@ -327,8 +339,12 @@ def test_platform_trace_persists_cycle_report_from_lifecycle_events(tmp_path):
     assert model_validator_stage["details"]["orientation_contract"] == {
         "role": "model_validator",
         "contract_id": "model-validator-runtime-navigation",
-        "version": 1,
+        "version": 2,
     }
+    assert (
+        model_validator_stage["details"]["orientation_resolution"]["reason"]
+        == "standard_validation_profile"
+    )
     arbiter_stage = next(
         stage for stage in cycle_report["stages"] if stage["stage"] == "arbiter"
     )

--- a/tests/test_agent/test_quant.py
+++ b/tests/test_agent/test_quant.py
@@ -304,7 +304,7 @@ class TestPricingPlan:
         assert summary["orientation_contract"] == {
             "role": "quant",
             "contract_id": "quant-runtime-navigation",
-            "version": 1,
+            "version": 2,
         }
 
     def test_product_ir_sensitivity_request_prefers_rate_tree_for_callable_bond(self):

--- a/tests/test_agent/test_role_orientation.py
+++ b/tests/test_agent/test_role_orientation.py
@@ -25,6 +25,26 @@ def test_load_role_orientations_exposes_required_runtime_roles():
     assert all(orientation.navigation for orientation in orientations.values())
 
 
+def test_product_decomposition_hash_ignores_trace_metadata():
+    from trellis.agent.knowledge.schema import ProductDecomposition
+
+    first = ProductDecomposition(
+        instrument="example",
+        features=("terminal_payoff",),
+        method="analytical",
+        orientation_resolution={"content_digest": "first"},
+    )
+    second = ProductDecomposition(
+        instrument="example",
+        features=("terminal_payoff",),
+        method="analytical",
+        orientation_resolution={"content_digest": "second"},
+    )
+
+    assert first == second
+    assert hash(first) == hash(second)
+
+
 def test_role_orientation_cards_are_bounded_and_role_separated():
     from trellis.agent.role_orientation import (
         get_role_orientation,

--- a/tests/test_agent/test_role_orientation.py
+++ b/tests/test_agent/test_role_orientation.py
@@ -19,7 +19,9 @@ def test_load_role_orientations_exposes_required_runtime_roles():
     assert orientations["model_validator"].contract_id == (
         "model-validator-runtime-navigation"
     )
-    assert all(orientation.version == 1 for orientation in orientations.values())
+    assert all(orientation.version == 2 for orientation in orientations.values())
+    assert all(orientation.max_context_chars > 0 for orientation in orientations.values())
+    assert all(orientation.max_resource_chars > 0 for orientation in orientations.values())
     assert all(orientation.navigation for orientation in orientations.values())
 
 
@@ -36,7 +38,7 @@ def test_role_orientation_cards_are_bounded_and_role_separated():
 
     assert len(quant_card) <= quant.max_render_chars
     assert len(validator_card) <= validator.max_render_chars
-    assert "`quant-runtime-navigation@1`" in quant_card
+    assert "`quant-runtime-navigation@2`" in quant_card
     assert "canonical/decompositions.yaml" in quant_card
     assert "canonical/model_grammar.yaml" in quant_card
     assert "canonical/cookbooks.yaml" in quant_card
@@ -44,7 +46,7 @@ def test_role_orientation_cards_are_bounded_and_role_separated():
     assert "Do not generate code or select import paths" in quant_card
     assert "deterministic_evidence_packet" not in quant_card
 
-    assert "`model-validator-runtime-navigation@1`" in validator_card
+    assert "`model-validator-runtime-navigation@2`" in validator_card
     assert "deterministic_evidence_packet" in validator_card
     assert "docs/mathematical/calibration.rst" in validator_card
     assert "canonical/cookbooks.yaml" in validator_card
@@ -59,12 +61,12 @@ def test_role_orientation_summary_is_trace_safe():
     assert role_orientation_summary("quant") == {
         "role": "quant",
         "contract_id": "quant-runtime-navigation",
-        "version": 1,
+        "version": 2,
     }
     assert role_orientation_summary("model_validator") == {
         "role": "model_validator",
         "contract_id": "model-validator-runtime-navigation",
-        "version": 1,
+        "version": 2,
     }
 
 
@@ -84,12 +86,12 @@ def test_custom_role_orientation_manifest_is_reloaded(tmp_path):
     path.write_text(yaml.safe_dump(canonical, sort_keys=False))
     first = load_role_orientations(path)
 
-    canonical["orientations"]["quant"]["version"] = 2
+    canonical["orientations"]["quant"]["version"] = 3
     path.write_text(yaml.safe_dump(canonical, sort_keys=False))
     second = load_role_orientations(path)
 
-    assert first["quant"].version == 1
-    assert second["quant"].version == 2
+    assert first["quant"].version == 2
+    assert second["quant"].version == 3
 
 
 def test_role_orientation_file_navigation_targets_exist():
@@ -169,9 +171,14 @@ def test_quant_llm_decomposition_prompt_includes_only_quant_orientation(monkeypa
 
     assert result.method == "monte_carlo"
     assert result.method_modules == ("trellis.models.monte_carlo.engine",)
-    assert "quant-runtime-navigation@1" in captured["prompt"]
+    assert "quant-runtime-navigation@2" in captured["prompt"]
+    assert "## Resolved Role Context" in captured["prompt"]
     assert "canonical/decompositions.yaml" in captured["prompt"]
     assert "model-validator-runtime-navigation" not in captured["prompt"]
+    assert "## API Map" not in captured["prompt"]
+    assert result.orientation_resolution["role"] == "quant"
+    assert result.orientation_resolution["context_chars"] > 0
+    assert result.orientation_resolution["selected_resource_ids"]
     assert '"method_modules"' not in captured["prompt"]
 
     pricing_plan = _plan_from_decomposition(result)

--- a/tests/test_agent/test_role_orientation_resolution.py
+++ b/tests/test_agent/test_role_orientation_resolution.py
@@ -8,11 +8,15 @@ from pathlib import Path
 import pytest
 
 from trellis.agent.knowledge.schema import (
+    AppliesWhen,
     CookbookEntry,
+    Lesson,
+    LessonStatus,
     MethodRequirements,
     ModelGrammarEntry,
     Principle,
     ProductDecomposition,
+    Severity,
 )
 from trellis.agent.role_orientation import (
     OrientationResource,
@@ -209,6 +213,7 @@ def test_quant_projection_uses_canonical_evidence_without_cookbook_code(
             if resource.resource_id
             in {
                 "product_decompositions",
+                "retrieved_lessons",
                 "model_grammar",
                 "method_requirements",
                 "cookbook_catalog",
@@ -245,6 +250,23 @@ def test_quant_projection_uses_canonical_evidence_without_cookbook_code(
         ),
         "lessons": [],
     }
+    knowledge["lessons"] = [
+        Lesson(
+            id="test_lesson",
+            title="Preserve observation state",
+            severity=Severity.HIGH,
+            category="path_state",
+            applies_when=AppliesWhen(
+                method=("monte_carlo",),
+                features=("path_dependent",),
+            ),
+            symptom="Scheduled observations were lost.",
+            root_cause="The estimator used terminal state only.",
+            fix="Carry observation state through the sampled path.",
+            validation="A scheduled-observation regression passed.",
+            status=LessonStatus.PROMOTED,
+        )
+    ]
 
     monkeypatch.setattr(
         "trellis.agent.knowledge.skills.select_prompt_skill_artifacts",
@@ -280,6 +302,8 @@ def test_quant_projection_uses_canonical_evidence_without_cookbook_code(
     assert "Geometric Brownian motion" in packet.context
     assert "Simulation with explicit process" in packet.context
     assert "Generated skill principle:safe-navigation" in packet.context
+    assert "Lesson test_lesson: Preserve observation state" in packet.context
+    assert "Carry observation state" in packet.context
     assert "forbidden-helper" not in packet.context
     assert "forbidden.builder_api" not in packet.context
     assert "task_specific_helper" not in packet.context
@@ -321,3 +345,56 @@ def test_default_role_packets_are_role_separated_and_source_bounded():
     assert len(validator.context) <= get_role_orientation(
         "model_validator"
     ).max_context_chars
+
+
+def test_resolution_reports_docs_unavailable_in_slim_installed_runtime(
+    tmp_path,
+    monkeypatch,
+):
+    from trellis.agent import orientation_resolution
+
+    monkeypatch.setattr(orientation_resolution, "_REPO_ROOT", tmp_path)
+    packet = orientation_resolution.resolve_role_orientation_packet(
+        "quant",
+        orientation_resolution.RoleOrientationQuery(
+            instrument_type="novel_claim",
+            method="monte_carlo",
+        ),
+        knowledge={
+            "decomposition": ProductDecomposition(
+                instrument="novel_claim",
+                features=("path_dependent",),
+                method="monte_carlo",
+            ),
+        },
+    )
+
+    assert "quant_docs_index" in packet.unavailable_resource_ids
+    assert "model_grammar_design" in packet.unavailable_resource_ids
+    assert packet.omitted_count >= len(packet.unavailable_resource_ids)
+    assert packet.summary()["unavailable_resource_ids"] == [
+        "quant_docs_index",
+        "model_grammar_design",
+    ]
+
+
+def test_custom_orientation_card_still_enforces_render_budget(tmp_path):
+    from trellis.agent.orientation_resolution import (
+        RoleOrientationQuery,
+        resolve_role_orientation_packet,
+    )
+
+    _write_docs(tmp_path)
+    orientation = replace(
+        _docs_only_orientation("quant"),
+        max_render_chars=10,
+    )
+
+    with pytest.raises(ValueError, match="above its 10-char budget"):
+        resolve_role_orientation_packet(
+            "quant",
+            RoleOrientationQuery(method="monte_carlo"),
+            orientation=orientation,
+            repo_root=tmp_path,
+            knowledge={},
+        )

--- a/tests/test_agent/test_role_orientation_resolution.py
+++ b/tests/test_agent/test_role_orientation_resolution.py
@@ -1,0 +1,323 @@
+"""Tests for bounded runtime-agent orientation content resolution."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from trellis.agent.knowledge.schema import (
+    CookbookEntry,
+    MethodRequirements,
+    ModelGrammarEntry,
+    Principle,
+    ProductDecomposition,
+)
+from trellis.agent.role_orientation import (
+    OrientationResource,
+    get_role_orientation,
+)
+
+
+def _write_docs(root: Path) -> None:
+    docs = root / "docs" / "quant"
+    docs.mkdir(parents=True)
+    (docs / "index.rst").write_text(
+        """Quant Documentation
+===================
+
+.. toctree::
+   :maxdepth: 1
+
+   monte_carlo
+   calibration
+"""
+    )
+    (docs / "monte_carlo.rst").write_text(
+        """Monte Carlo
+===========
+
+Path Simulation
+---------------
+
+Use bounded path state and explicit observation schedules for path-dependent claims.
+
+Builder Example
+---------------
+
+.. code-block:: python
+
+   from trellis.models.product_helper import price_task_specific_claim
+"""
+    )
+    (docs / "calibration.rst").write_text(
+        """Calibration
+===========
+
+Heston Calibration Consistency
+------------------------------
+
+A volatility-surface bump and a Heston parameter bump are different experiments.
+Recalibration must be explicit and its target quotes must be recorded.
+
+Unrelated Vanilla Note
+----------------------
+
+This section discusses a plain constant-volatility European option.
+"""
+    )
+
+
+def _docs_only_orientation(role: str, *, max_context_chars: int = 900):
+    return replace(
+        get_role_orientation(role),
+        max_context_chars=max_context_chars,
+        max_resource_chars=360,
+        navigation=(
+            OrientationResource(
+                order=1,
+                resource_id="quant_docs_index",
+                kind="official_docs_index",
+                path="docs/quant/index.rst",
+                purpose="Resolve task-relevant quantitative documentation.",
+            ),
+        ),
+    )
+
+
+def test_resolution_follows_docs_index_ranks_sections_and_is_deterministic(tmp_path):
+    from trellis.agent.orientation_resolution import (
+        RoleOrientationQuery,
+        resolve_role_orientation_packet,
+    )
+
+    _write_docs(tmp_path)
+    query = RoleOrientationQuery(
+        instrument_type="european_option",
+        method="pde_solver",
+        model_family="heston",
+        residual_risks=("calibration_consistency",),
+        description="Review Heston recalibration after a volatility surface bump.",
+    )
+    orientation = _docs_only_orientation("model_validator")
+
+    first = resolve_role_orientation_packet(
+        "model_validator",
+        query,
+        orientation=orientation,
+        repo_root=tmp_path,
+        knowledge={},
+    )
+    second = resolve_role_orientation_packet(
+        "model_validator",
+        query,
+        orientation=orientation,
+        repo_root=tmp_path,
+        knowledge={},
+    )
+
+    assert first == second
+    assert "Heston Calibration Consistency" in first.context
+    assert "volatility-surface bump" in first.context
+    assert "price_task_specific_claim" not in first.context
+    assert len(first.context) <= orientation.max_context_chars
+    assert first.content_digest == second.content_digest
+    assert first.excerpts[0].source_path == "docs/quant/calibration.rst"
+    assert first.excerpts[0].section == "Heston Calibration Consistency"
+    assert len(first.excerpts[0].source_digest) == 64
+
+    summary = first.summary()
+    assert summary["role"] == "model_validator"
+    assert summary["content_digest"] == first.content_digest
+    assert summary["selected_sections"] == [
+        "docs/quant/calibration.rst#Heston Calibration Consistency"
+    ]
+    assert "volatility-surface bump" not in str(summary)
+
+
+def test_resolution_enforces_context_budget_and_reports_omissions(tmp_path):
+    from trellis.agent.orientation_resolution import (
+        RoleOrientationQuery,
+        resolve_role_orientation_packet,
+    )
+
+    _write_docs(tmp_path)
+    orientation = _docs_only_orientation("quant", max_context_chars=140)
+    packet = resolve_role_orientation_packet(
+        "quant",
+        RoleOrientationQuery(
+            method="monte_carlo",
+            features=("path_dependent", "scheduled_observation"),
+            description="Path-dependent scheduled-observation Monte Carlo claim.",
+        ),
+        orientation=orientation,
+        repo_root=tmp_path,
+        knowledge={},
+    )
+
+    assert len(packet.context) <= 140
+    assert packet.omitted_count >= 1
+    assert "[orientation context truncated" in packet.context
+
+
+def test_resolution_rejects_resource_paths_outside_repository(tmp_path):
+    from trellis.agent.orientation_resolution import (
+        RoleOrientationQuery,
+        resolve_role_orientation_packet,
+    )
+
+    outside = tmp_path.parent / "outside-agent-doc.md"
+    outside.write_text("# Outside\n\nThis must never be loaded.\n")
+    orientation = replace(
+        get_role_orientation("quant"),
+        navigation=(
+            OrientationResource(
+                order=1,
+                resource_id="escaping_doc",
+                kind="official_docs",
+                path="../outside-agent-doc.md",
+                purpose="Invalid test resource.",
+            ),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="outside repository root"):
+        resolve_role_orientation_packet(
+            "quant",
+            RoleOrientationQuery(description="outside"),
+            orientation=orientation,
+            repo_root=tmp_path,
+            knowledge={},
+        )
+
+
+def test_quant_projection_uses_canonical_evidence_without_cookbook_code(
+    tmp_path,
+    monkeypatch,
+):
+    from trellis.agent.orientation_resolution import (
+        RoleOrientationQuery,
+        resolve_role_orientation_packet,
+    )
+
+    orientation = replace(
+        get_role_orientation("quant"),
+        navigation=tuple(
+            resource
+            for resource in get_role_orientation("quant").navigation
+            if resource.resource_id
+            in {
+                "product_decompositions",
+                "model_grammar",
+                "method_requirements",
+                "cookbook_catalog",
+            }
+        ),
+    )
+    knowledge = {
+        "decomposition": ProductDecomposition(
+            instrument="bounded_path_claim",
+            features=("path_dependent", "scheduled_observation"),
+            method="monte_carlo",
+            reasoning="The payoff requires scheduled path state.",
+        ),
+        "principles": [
+            Principle(id="P-test", rule="Keep contractual observation times explicit."),
+        ],
+        "method_requirements": MethodRequirements(
+            method="monte_carlo",
+            requirements=("Use a convergence diagnostic for sampled estimators.",),
+        ),
+        "model_grammar": [
+            ModelGrammarEntry(
+                id="gbm",
+                title="Geometric Brownian motion",
+                methods=("monte_carlo",),
+                model_families=("black_scholes",),
+                state_semantics=("positive scalar spot",),
+            )
+        ],
+        "cookbook": CookbookEntry(
+            method="monte_carlo",
+            description="Simulation with explicit process, path state, and estimator controls.",
+            template="from forbidden.builder_api import task_specific_helper\n",
+        ),
+        "lessons": [],
+    }
+
+    monkeypatch.setattr(
+        "trellis.agent.knowledge.skills.select_prompt_skill_artifacts",
+        lambda *args, **kwargs: [
+            {
+                "id": "principle:safe-navigation",
+                "kind": "principle",
+                "summary": "Challenge model assumptions before selecting a method.",
+            },
+            {
+                "id": "route_hint:forbidden-helper",
+                "kind": "route_hint",
+                "summary": "Call a task-specific helper.",
+            },
+        ],
+    )
+
+    packet = resolve_role_orientation_packet(
+        "quant",
+        RoleOrientationQuery(
+            instrument_type="bounded_path_claim",
+            method="monte_carlo",
+            model_family="black_scholes",
+            features=("path_dependent", "scheduled_observation"),
+        ),
+        orientation=orientation,
+        repo_root=tmp_path,
+        knowledge=knowledge,
+    )
+
+    assert "scheduled path state" in packet.context
+    assert "convergence diagnostic" in packet.context
+    assert "Geometric Brownian motion" in packet.context
+    assert "Simulation with explicit process" in packet.context
+    assert "Generated skill principle:safe-navigation" in packet.context
+    assert "forbidden-helper" not in packet.context
+    assert "forbidden.builder_api" not in packet.context
+    assert "task_specific_helper" not in packet.context
+    assert "from trellis" not in packet.context
+
+
+def test_default_role_packets_are_role_separated_and_source_bounded():
+    from trellis.agent.orientation_resolution import (
+        RoleOrientationQuery,
+        resolve_role_orientation_packet,
+    )
+
+    query = RoleOrientationQuery(
+        instrument_type="european_option",
+        method="pde_solver",
+        model_family="heston",
+        residual_risks=("calibration_consistency", "boundary_conditions"),
+        description="Validate a Heston PDE price and calibration contract.",
+    )
+    quant = resolve_role_orientation_packet("quant", query)
+    validator = resolve_role_orientation_packet("model_validator", query)
+
+    assert quant.orientation_identity.startswith("quant-runtime-navigation@")
+    assert validator.orientation_identity.startswith(
+        "model-validator-runtime-navigation@"
+    )
+    assert "model-validator-runtime-navigation" not in quant.rendered
+    assert "quant-runtime-navigation" not in validator.rendered
+    assert "deterministic evidence" not in quant.context.lower()
+    assert "from trellis" not in quant.context.lower()
+    assert "route_helper" not in quant.context.lower()
+    assert any(
+        "heston" in excerpt.section.lower()
+        for excerpt in quant.excerpts
+        if excerpt.resource_id == "quant_docs_index"
+    )
+    assert "calibration" in validator.context.lower()
+    assert len(quant.context) <= get_role_orientation("quant").max_context_chars
+    assert len(validator.context) <= get_role_orientation(
+        "model_validator"
+    ).max_context_chars

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -963,6 +963,16 @@ def build_payoff(
     quant_challenger_packet = quant_challenger_packet_summary(pricing_plan)
     # Keep identity queryable without decoding the nested challenger packet.
     quant_orientation = role_orientation_summary("quant")
+    quant_orientation_resolution = dict(
+        getattr(pricing_plan, "orientation_resolution", {}) or {}
+    ) or {
+        "role": "quant",
+        "orientation_identity": (
+            f"{quant_orientation['contract_id']}@{quant_orientation['version']}"
+        ),
+        "prompt_injected": False,
+        "reason": "deterministic_method_selection",
+    }
     _record_platform_event(
         compiled_request,
         "quant_selected_method",
@@ -979,6 +989,7 @@ def build_payoff(
             "assumption_summary": list(pricing_plan.assumption_summary),
             "required_market_data": sorted(pricing_plan.required_market_data),
             "orientation_contract": quant_orientation,
+            "orientation_resolution": quant_orientation_resolution,
             "challenger_packet": quant_challenger_packet,
             "sensitivity_support": (
                 pricing_plan.sensitivity_support.to_dict()
@@ -1001,6 +1012,7 @@ def build_payoff(
             ),
             "required_market_data": sorted(pricing_plan.required_market_data),
             "orientation_contract": quant_orientation,
+            "orientation_resolution": quant_orientation_resolution,
             "method_modules": list(pricing_plan.method_modules),
             "reasoning": pricing_plan.reasoning,
             "selection_reason": pricing_plan.selection_reason,
@@ -2688,6 +2700,11 @@ def _validate_build(
                         "orientation_contract": role_orientation_summary(
                             "model_validator"
                         ),
+                        "orientation_resolution": {
+                            "role": "model_validator",
+                            "prompt_injected": False,
+                            "reason": review_policy.model_validator_reason,
+                        },
                     },
                 )
                 report = validate_model(
@@ -2752,6 +2769,13 @@ def _validate_build(
                     "orientation_contract": role_orientation_summary(
                         "model_validator"
                     ),
+                    "orientation_resolution": dict(
+                        getattr(report, "orientation_resolution", {}) or {}
+                    ) or {
+                        "role": "model_validator",
+                        "prompt_injected": False,
+                        "reason": review_policy.model_validator_reason,
+                    },
                     "blocker_count": len(blocker_findings),
                     "approved": report.approved,
                     "llm_review": review_policy.run_model_validator_llm,
@@ -2795,6 +2819,11 @@ def _validate_build(
                 "orientation_contract": role_orientation_summary(
                     "model_validator"
                 ),
+                "orientation_resolution": {
+                    "role": "model_validator",
+                    "prompt_injected": False,
+                    "reason": deterministic_review_block_reason,
+                },
                 "failure_count": len(failures),
                 "deterministic_evidence": model_validation_evidence_packet,
             },

--- a/trellis/agent/knowledge/canonical/agent_orientations.yaml
+++ b/trellis/agent/knowledge/canonical/agent_orientations.yaml
@@ -28,31 +28,36 @@ orientations:
         path: trellis/agent/knowledge/canonical/decompositions.yaml
         purpose: Resolve known product features, candidate methods, required data, and modeling requirements.
       - order: 3
+        resource_id: retrieved_lessons
+        kind: canonical_knowledge
+        path: trellis/agent/knowledge/lessons/index.yaml
+        purpose: Apply validated and promoted failure lessons selected for this task without granting construction authority.
+      - order: 4
         resource_id: admitted_routes
         kind: canonical_knowledge
         path: trellis/agent/knowledge/canonical/routes.yaml
         purpose: Check which method families are admitted for the typed product; do not choose implementation symbols.
-      - order: 4
+      - order: 5
         resource_id: model_grammar
         kind: canonical_knowledge
         path: trellis/agent/knowledge/canonical/model_grammar.yaml
         purpose: Compare model dynamics, state variables, calibration targets, and numerical families.
-      - order: 5
+      - order: 6
         resource_id: method_requirements
         kind: canonical_knowledge
         path: trellis/agent/knowledge/canonical/method_requirements.yaml
         purpose: Apply method-level assumptions and market-data obligations.
-      - order: 6
+      - order: 7
         resource_id: cookbook_catalog
         kind: read_only_pattern_index
         path: trellis/agent/knowledge/canonical/cookbooks.yaml
         purpose: Consult validated pattern evidence only after typed decomposition; never promote or let it override semantics.
-      - order: 7
+      - order: 8
         resource_id: quant_docs_index
         kind: official_docs_index
         path: docs/quant/index.rst
         purpose: Navigate pricing-stack, ContractIR, DSL, numerical, and knowledge-maintenance documentation.
-      - order: 8
+      - order: 9
         resource_id: model_grammar_design
         kind: official_docs
         path: docs/unified_pricing_engine_model_grammar.md
@@ -91,46 +96,51 @@ orientations:
         path: runtime:quant_challenger_packet
         purpose: Review the selected method, rejected alternatives, assumptions, and residual-risk handoff without reconstructing quant reasoning.
       - order: 4
+        resource_id: retrieved_lessons
+        kind: canonical_knowledge
+        path: trellis/agent/knowledge/lessons/index.yaml
+        purpose: Review validated and promoted failure lessons selected for this task as bounded model-risk evidence.
+      - order: 5
         resource_id: admitted_routes
         kind: canonical_knowledge
         path: trellis/agent/knowledge/canonical/routes.yaml
         purpose: Inspect declared route assumptions and validation expectations as read-only context.
-      - order: 5
+      - order: 6
         resource_id: model_grammar
         kind: canonical_knowledge
         path: trellis/agent/knowledge/canonical/model_grammar.yaml
         purpose: Evaluate dynamics, factors, calibration targets, and numerical-method compatibility.
-      - order: 6
+      - order: 7
         resource_id: method_requirements
         kind: canonical_knowledge
         path: trellis/agent/knowledge/canonical/method_requirements.yaml
         purpose: Check method-level conceptual and calibration obligations.
-      - order: 7
+      - order: 8
         resource_id: cookbook_catalog
         kind: read_only_pattern_index
         path: trellis/agent/knowledge/canonical/cookbooks.yaml
         purpose: Use validated patterns only as supporting model evidence, never as validation or promotion authority.
-      - order: 8
+      - order: 9
         resource_id: limitations
         kind: support_contract
         path: LIMITATIONS.md
         purpose: Bound findings against current supported and unsupported behavior.
-      - order: 9
+      - order: 10
         resource_id: validation_loop_design
         kind: official_docs
         path: docs/design_validation_contract_loop.md
         purpose: Preserve deterministic-first ownership and residual-review boundaries.
-      - order: 10
+      - order: 11
         resource_id: calibration_reference
         kind: official_docs
         path: docs/mathematical/calibration.rst
         purpose: Review calibration targets, solve diagnostics, provenance, and known workflow boundaries.
-      - order: 11
+      - order: 12
         resource_id: quant_docs_index
         kind: official_docs_index
         path: docs/quant/index.rst
         purpose: Navigate mathematical and computational references without loading all documents.
-      - order: 12
+      - order: 13
         resource_id: audit_contract
         kind: official_docs
         path: docs/developer/audit_and_observability.rst

--- a/trellis/agent/knowledge/canonical/agent_orientations.yaml
+++ b/trellis/agent/knowledge/canonical/agent_orientations.yaml
@@ -2,10 +2,12 @@ schema_version: 1
 orientations:
   quant:
     contract_id: quant-runtime-navigation
-    version: 1
+    version: 2
     title: Quant Runtime Orientation
     purpose: Select and challenge pricing methods from typed product semantics and canonical quantitative knowledge.
     max_render_chars: 3600
+    max_context_chars: 4800
+    max_resource_chars: 700
     owns:
       - Interpret ProductIR and semantic contract assumptions for method selection.
       - Rank candidate method families and state rejected alternatives.
@@ -58,10 +60,12 @@ orientations:
 
   model_validator:
     contract_id: model-validator-runtime-navigation
-    version: 1
+    version: 2
     title: Model Validator Runtime Orientation
     purpose: Review only residual conceptual, calibration, numerical-model, and limitation risks after deterministic evidence.
     max_render_chars: 4200
+    max_context_chars: 5600
+    max_resource_chars: 500
     owns:
       - Assess residual conceptual soundness and calibration adequacy named by the validation contract.
       - Challenge model assumptions using the quant packet, route contract, and executed evidence.

--- a/trellis/agent/knowledge/decompose.py
+++ b/trellis/agent/knowledge/decompose.py
@@ -3892,10 +3892,10 @@ def _decompose_via_llm(
 ) -> ProductDecomposition:
     """Use LLM to decompose a novel product into known features."""
     from trellis.agent.config import llm_generate_json, load_env
-    from trellis.agent.knowledge.retrieval import (
-        format_decomposition_knowledge_for_prompt,
+    from trellis.agent.orientation_resolution import (
+        RoleOrientationQuery,
+        resolve_role_orientation_packet,
     )
-    from trellis.agent.role_orientation import render_role_orientation_card
     load_env()
 
     # Build feature taxonomy context
@@ -3918,13 +3918,17 @@ def _decompose_via_llm(
             max_lessons=5,
         )
     )
-    knowledge_text = format_decomposition_knowledge_for_prompt(prior_knowledge)
-    knowledge_section = ""
-    if knowledge_text:
-        knowledge_section = f"\n\n## Shared Knowledge\n{knowledge_text}"
-    orientation_card = render_role_orientation_card("quant")
+    orientation_packet = resolve_role_orientation_packet(
+        "quant",
+        RoleOrientationQuery(
+            instrument_type=instrument_hint or key,
+            description=description,
+            features=tuple(heuristic_features),
+        ),
+        knowledge=prior_knowledge,
+    )
 
-    prompt = f"""{orientation_card}
+    prompt = f"""{orientation_packet.rendered}
 
 You are a quantitative finance expert decomposing a financial instrument
 into its constituent features for a pricing library.
@@ -3934,7 +3938,6 @@ into its constituent features for a pricing library.
 
 ## Available Pricing Methods
 {', '.join(methods)}
-{knowledge_section}
 
 ## Instrument to Decompose
 "{description}"
@@ -3964,6 +3967,7 @@ Return JSON:
             method_modules=default_method_modules("analytical"),
             reasoning="LLM decomposition failed — falling back to analytical.",
             learned=True,
+            orientation_resolution=orientation_packet.summary(),
         )
 
     method = normalize_method(data.get("method", "analytical"))
@@ -3976,4 +3980,5 @@ Return JSON:
         reasoning=data.get("reasoning", ""),
         notes=data.get("notes", ""),
         learned=True,
+        orientation_resolution=orientation_packet.summary(),
     )

--- a/trellis/agent/knowledge/schema.py
+++ b/trellis/agent/knowledge/schema.py
@@ -76,6 +76,7 @@ class ProductDecomposition:
     reasoning: str = ""
     notes: str = ""                             # known complexities
     learned: bool = False                       # True if auto-discovered
+    orientation_resolution: dict[str, object] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)

--- a/trellis/agent/knowledge/schema.py
+++ b/trellis/agent/knowledge/schema.py
@@ -76,7 +76,11 @@ class ProductDecomposition:
     reasoning: str = ""
     notes: str = ""                             # known complexities
     learned: bool = False                       # True if auto-discovered
-    orientation_resolution: dict[str, object] = field(default_factory=dict)
+    orientation_resolution: dict[str, object] = field(
+        default_factory=dict,
+        compare=False,
+        repr=False,
+    )
 
 
 @dataclass(frozen=True)

--- a/trellis/agent/model_validator.py
+++ b/trellis/agent/model_validator.py
@@ -84,6 +84,15 @@ def validate_model(
         )
         run_llm_review = policy.run_model_validator_llm
     if run_llm_review:
+        orientation_packet = _resolve_model_validator_orientation_packet(
+            instrument_type=instrument_type,
+            method=method,
+            knowledge_context=knowledge_context,
+            product_ir=product_ir,
+            residual_risks=_model_validator_residual_risks(validation_contract),
+            review_reason=review_reason,
+        )
+        report.orientation_resolution = orientation_packet.summary()
         llm_findings = _llm_conceptual_review(
             code,
             instrument_type,
@@ -97,6 +106,7 @@ def validate_model(
             deterministic_evidence_packet=deterministic_evidence_packet,
             review_reason=review_reason,
             model=model,
+            orientation_packet=orientation_packet,
         )
         report.findings.extend(llm_findings)
 
@@ -156,16 +166,21 @@ def _llm_conceptual_review(
     deterministic_evidence_packet: Mapping[str, object] | None = None,
     review_reason: str | None = None,
     model: str | None = None,
+    orientation_packet=None,
 ) -> list[ValidationFinding]:
     """LLM-based model validation — conceptual soundness review."""
     from trellis.agent.config import llm_generate_json, get_default_model
-    from trellis.agent.role_orientation import render_role_orientation_card
 
     model = model or get_default_model()
 
-    knowledge_section = ""
-    if knowledge_context.strip():
-        knowledge_section = f"\n## Shared Knowledge\n{knowledge_context}\n"
+    if orientation_packet is None:
+        orientation_packet = _resolve_model_validator_orientation_packet(
+            instrument_type=instrument_type,
+            method=method,
+            knowledge_context=knowledge_context,
+            residual_risks=residual_risks,
+            review_reason=review_reason,
+        )
     residual_risk_section = ""
     if residual_risks:
         residual_risk_lines = "\n".join(f"- `{risk}`" for risk in residual_risks)
@@ -200,8 +215,7 @@ def _llm_conceptual_review(
 
         route_contract_section = "\n" + render_review_contract_card(generation_plan) + "\n"
 
-    orientation_card = render_role_orientation_card("model_validator")
-    prompt = f"""{orientation_card}
+    prompt = f"""{orientation_packet.rendered}
 
 You are a model validation analyst at a quantitative finance firm.
 Your role is to independently assess whether a pricing model is conceptually
@@ -214,7 +228,6 @@ reference bounds, or other validations already covered by the validation contrac
 
 ## Instrument type: {instrument_type}
 ## Pricing method: {method}
-{knowledge_section}
 {route_contract_section}
 {residual_risk_section}
 {quant_packet_section}
@@ -288,6 +301,42 @@ Return ONLY the JSON array."""
                 remediation=item.get("remediation", ""),
             ))
     return findings
+
+
+def _resolve_model_validator_orientation_packet(
+    *,
+    instrument_type: str,
+    method: str,
+    knowledge_context: str,
+    product_ir=None,
+    residual_risks: tuple[str, ...] = (),
+    review_reason: str | None = None,
+):
+    """Resolve the bounded context actually supplied to model validation."""
+    from trellis.agent.orientation_resolution import (
+        RoleOrientationQuery,
+        resolve_role_orientation_packet,
+    )
+
+    return resolve_role_orientation_packet(
+        "model_validator",
+        RoleOrientationQuery(
+            instrument_type=instrument_type,
+            method=method,
+            features=tuple(getattr(product_ir, "payoff_traits", ()) or ()),
+            model_family=str(getattr(product_ir, "model_family", "") or ""),
+            route_families=tuple(
+                getattr(product_ir, "route_families", ()) or ()
+            ),
+            residual_risks=tuple(residual_risks),
+            review_reason=str(review_reason or ""),
+            description=(
+                "Conceptual soundness, calibration, numerical quality, and "
+                f"limitations for {instrument_type} using {method}."
+            ),
+        ),
+        supplemental_context=knowledge_context,
+    )
 
 
 def _model_validator_residual_risks(validation_contract) -> tuple[str, ...]:

--- a/trellis/agent/orientation_resolution.py
+++ b/trellis/agent/orientation_resolution.py
@@ -1,0 +1,872 @@
+"""Bounded, task-relevant content resolution for hosted runtime-agent roles."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from hashlib import sha256
+from pathlib import Path, PurePosixPath
+import re
+from typing import Any, Mapping
+
+import yaml
+
+from trellis.agent.role_orientation import (
+    OrientationResource,
+    RoleOrientation,
+    get_role_orientation,
+    render_role_orientation_card,
+)
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_RUNTIME_KINDS = frozenset({"runtime_contract", "runtime_evidence"})
+_DOCUMENT_KINDS = frozenset(
+    {"official_docs", "official_docs_index", "support_contract"}
+)
+_STOP_WORDS = frozenset(
+    {
+        "a",
+        "after",
+        "an",
+        "and",
+        "as",
+        "at",
+        "be",
+        "by",
+        "for",
+        "from",
+        "in",
+        "is",
+        "it",
+        "of",
+        "on",
+        "or",
+        "price",
+        "pricing",
+        "review",
+        "the",
+        "to",
+        "under",
+        "use",
+        "validate",
+        "with",
+    }
+)
+_RST_HEADING_UNDERLINE = re.compile(r"^([=\-~^\"`:+*#])\1{2,}\s*$")
+_MARKDOWN_HEADING = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
+_WORD = re.compile(r"[a-z0-9]+")
+
+
+@dataclass(frozen=True)
+class RoleOrientationQuery:
+    """Typed semantic cues used to resolve one hosted-role context packet."""
+
+    instrument_type: str = ""
+    description: str = ""
+    method: str = ""
+    features: tuple[str, ...] = ()
+    model_family: str = ""
+    route_ids: tuple[str, ...] = ()
+    route_families: tuple[str, ...] = ()
+    residual_risks: tuple[str, ...] = ()
+    review_reason: str = ""
+
+
+@dataclass(frozen=True)
+class ResolvedOrientationExcerpt:
+    """One selected, bounded excerpt and its source provenance."""
+
+    resource_id: str
+    kind: str
+    source_path: str
+    section: str
+    text: str
+    score: int
+    source_digest: str
+    navigation_order: int
+
+    @property
+    def section_id(self) -> str:
+        """Return the stable path-and-heading identity used in trace summaries."""
+        return f"{self.source_path}#{self.section}"
+
+
+@dataclass(frozen=True)
+class ResolvedRoleOrientationPacket:
+    """Rendered role card plus bounded content selected for one LLM call."""
+
+    role: str
+    orientation_identity: str
+    context: str
+    rendered: str
+    excerpts: tuple[ResolvedOrientationExcerpt, ...]
+    omitted_count: int
+    content_digest: str
+
+    def summary(self) -> dict[str, object]:
+        """Return prompt-safe provenance without persisting source excerpts."""
+        resource_ids: list[str] = []
+        for excerpt in self.excerpts:
+            if excerpt.resource_id not in resource_ids:
+                resource_ids.append(excerpt.resource_id)
+        return {
+            "role": self.role,
+            "orientation_identity": self.orientation_identity,
+            "prompt_injected": True,
+            "selected_resource_ids": resource_ids,
+            "selected_sections": [excerpt.section_id for excerpt in self.excerpts],
+            "context_chars": len(self.context),
+            "omitted_count": self.omitted_count,
+            "content_digest": self.content_digest,
+        }
+
+
+@dataclass(frozen=True)
+class _DocumentSection:
+    path: str
+    heading: str
+    text: str
+
+
+def resolve_role_orientation_packet(
+    role: str,
+    query: RoleOrientationQuery,
+    *,
+    orientation: RoleOrientation | None = None,
+    repo_root: str | Path | None = None,
+    knowledge: Mapping[str, Any] | None = None,
+    supplemental_context: str = "",
+) -> ResolvedRoleOrientationPacket:
+    """Resolve deterministic knowledge and documentation for one runtime role."""
+    resolved_orientation = orientation or get_role_orientation(role)
+    if resolved_orientation.role != role:
+        raise ValueError(
+            f"Orientation role {resolved_orientation.role!r} does not match {role!r}"
+        )
+    root = Path(repo_root or _REPO_ROOT).resolve()
+    resolved_knowledge = (
+        dict(knowledge)
+        if knowledge is not None
+        else _retrieve_knowledge_for_query(query)
+    )
+    candidates = _canonical_excerpts(
+        resolved_orientation,
+        query,
+        resolved_knowledge,
+        root=root,
+    )
+    candidates.extend(
+        _documentation_excerpts(
+            resolved_orientation,
+            query,
+            root=root,
+        )
+    )
+    supplemental = _supplemental_excerpt(
+        resolved_orientation,
+        query,
+        supplemental_context,
+    )
+    if supplemental is not None:
+        candidates.append(supplemental)
+
+    candidates.sort(
+        key=lambda item: (
+            item.navigation_order,
+            -item.score,
+            item.source_path,
+            item.section,
+        )
+    )
+    context, selected, omitted_count = _render_bounded_context(
+        candidates,
+        max_chars=resolved_orientation.max_context_chars,
+        max_resource_chars=resolved_orientation.max_resource_chars,
+    )
+    card = (
+        render_role_orientation_card(role)
+        if orientation is None
+        else _render_supplied_orientation_card(resolved_orientation)
+    )
+    rendered = f"{card}\n\n{context}" if context else card
+    return ResolvedRoleOrientationPacket(
+        role=role,
+        orientation_identity=resolved_orientation.identity,
+        context=context,
+        rendered=rendered,
+        excerpts=selected,
+        omitted_count=omitted_count,
+        content_digest=sha256(context.encode("utf-8")).hexdigest(),
+    )
+
+
+def _retrieve_knowledge_for_query(query: RoleOrientationQuery) -> dict[str, Any]:
+    from trellis.agent.knowledge import get_store
+    from trellis.agent.knowledge.schema import RetrievalSpec
+
+    return get_store().retrieve_for_task(
+        RetrievalSpec(
+            method=query.method or None,
+            features=list(query.features),
+            instrument=query.instrument_type or None,
+            model_family=query.model_family or None,
+            candidate_engine_families=tuple(query.route_families),
+            semantic_text_markers=tuple(_query_terms(query)),
+            max_lessons=4,
+        )
+    )
+
+
+def _canonical_excerpts(
+    orientation: RoleOrientation,
+    query: RoleOrientationQuery,
+    knowledge: Mapping[str, Any],
+    *,
+    root: Path,
+) -> list[ResolvedOrientationExcerpt]:
+    excerpts: list[ResolvedOrientationExcerpt] = []
+    for resource in orientation.navigation:
+        if resource.kind in _RUNTIME_KINDS or resource.kind in _DOCUMENT_KINDS:
+            continue
+        text = ""
+        section = resource.purpose
+        if resource.resource_id == "product_decompositions":
+            text = _render_decomposition(knowledge.get("decomposition"))
+            text = _append_generated_skill_evidence(
+                text,
+                query,
+                role=orientation.role,
+            )
+            text = _append_selected_principles(text, knowledge.get("principles", ()))
+            section = "Product decomposition and principles"
+        elif resource.resource_id == "admitted_routes":
+            text = _render_route_identity(query)
+            section = "Admitted route identity"
+        elif resource.resource_id == "model_grammar":
+            text = _render_model_grammar(knowledge.get("model_grammar", ()))
+            section = "Selected model grammar"
+        elif resource.resource_id == "method_requirements":
+            text = _render_method_requirements(knowledge.get("method_requirements"))
+            section = "Selected method requirements"
+        elif resource.resource_id == "cookbook_catalog":
+            text = _render_cookbook_evidence(
+                knowledge.get("cookbook"),
+                query,
+                root=root,
+                relative_path=resource.path,
+            )
+            if orientation.role == "model_validator":
+                text = _append_generated_skill_evidence(
+                    text,
+                    query,
+                    role=orientation.role,
+                )
+            section = "Read-only cookbook evidence"
+        if not text.strip():
+            continue
+        prose = _sanitize_role_context(text)
+        if not prose:
+            continue
+        excerpts.append(
+            _make_excerpt(
+                resource=resource,
+                source_path=resource.path,
+                section=section,
+                text=prose,
+                score=max(_score_text(query, section, prose), 1),
+            )
+        )
+    return excerpts
+
+
+def _render_decomposition(decomposition: Any) -> str:
+    if decomposition is None:
+        return ""
+    lines = [
+        f"Instrument: {getattr(decomposition, 'instrument', '')}",
+        "Features: "
+        + ", ".join(str(item) for item in getattr(decomposition, "features", ()) or ()),
+        f"Preferred method: {getattr(decomposition, 'method', '')}",
+    ]
+    reasoning = str(getattr(decomposition, "reasoning", "") or "").strip()
+    notes = str(getattr(decomposition, "notes", "") or "").strip()
+    if reasoning:
+        lines.append(f"Reasoning: {reasoning}")
+    if notes:
+        lines.append(f"Notes: {notes}")
+    return "\n".join(line for line in lines if not line.endswith(": "))
+
+
+def _append_selected_principles(text: str, principles: Any) -> str:
+    rows = []
+    for principle in list(principles or ())[:3]:
+        rule = str(getattr(principle, "rule", "") or "").strip()
+        if rule:
+            rows.append(f"Principle {getattr(principle, 'id', '')}: {rule}")
+    if not rows:
+        return text
+    return "\n".join(part for part in (text, *rows) if part)
+
+
+def _append_generated_skill_evidence(
+    text: str,
+    query: RoleOrientationQuery,
+    *,
+    role: str,
+) -> str:
+    """Append only role-safe records from the existing generated-skill index."""
+    from trellis.agent.knowledge.skills import select_prompt_skill_artifacts
+
+    audience = "routing" if role == "quant" else "review"
+    stage = "route_selection" if role == "quant" else "model_validator_review"
+    artifacts = select_prompt_skill_artifacts(
+        "",
+        audience=audience,
+        stage=stage,
+        instrument_type=query.instrument_type or None,
+        pricing_method=query.method or None,
+        route_ids=query.route_ids,
+        route_families=query.route_families,
+        knowledge_surface="distilled",
+    )
+    safe_kinds = {"principle", "lesson", "cookbook"}
+    rows = []
+    for artifact in artifacts:
+        if artifact.get("kind") not in safe_kinds:
+            continue
+        summary = _sanitize_role_context(str(artifact.get("summary") or ""))
+        if not summary:
+            continue
+        rows.append(
+            f"Generated skill {artifact.get('id')}: {summary}"
+        )
+        if len(rows) >= 3:
+            break
+    if not rows:
+        return text
+    return "\n".join(part for part in (text, *rows) if part)
+
+
+def _render_route_identity(query: RoleOrientationQuery) -> str:
+    lines = []
+    if query.route_ids:
+        lines.append("Resolved route ids: " + ", ".join(query.route_ids))
+    if query.route_families:
+        lines.append("Admitted route families: " + ", ".join(query.route_families))
+    return "\n".join(lines)
+
+
+def _render_model_grammar(entries: Any) -> str:
+    lines: list[str] = []
+    for entry in list(entries or ())[:2]:
+        title = str(getattr(entry, "title", "") or getattr(entry, "id", "")).strip()
+        lines.append(title)
+        model_name = str(getattr(entry, "model_name", "") or "").strip()
+        if model_name:
+            lines.append(f"Model: {model_name}")
+        state = tuple(getattr(entry, "state_semantics", ()) or ())
+        if state:
+            lines.append("State semantics: " + "; ".join(str(item) for item in state))
+        workflows = tuple(getattr(entry, "calibration_workflows", ()) or ())
+        if workflows:
+            lines.append("Calibration workflows: " + ", ".join(str(item) for item in workflows))
+        deferred = tuple(getattr(entry, "deferred_scope", ()) or ())
+        if deferred:
+            lines.append("Deferred scope: " + ", ".join(str(item) for item in deferred))
+        notes = str(getattr(entry, "notes", "") or "").strip()
+        if notes:
+            lines.append(notes)
+    return "\n".join(lines)
+
+
+def _render_method_requirements(requirements: Any) -> str:
+    if requirements is None:
+        return ""
+    method = str(getattr(requirements, "method", "") or "").strip()
+    rows = tuple(getattr(requirements, "requirements", ()) or ())
+    lines = [f"Method: {method}"] if method else []
+    lines.extend(f"- {row}" for row in rows[:6] if str(row).strip())
+    return "\n".join(lines)
+
+
+def _render_cookbook_evidence(
+    cookbook: Any,
+    query: RoleOrientationQuery,
+    *,
+    root: Path,
+    relative_path: str,
+) -> str:
+    lines: list[str] = []
+    if cookbook is not None:
+        method = str(getattr(cookbook, "method", "") or "").strip()
+        description = str(getattr(cookbook, "description", "") or "").strip()
+        applicable = tuple(getattr(cookbook, "applicable_instruments", ()) or ())
+        if method:
+            lines.append(f"Method family: {method}")
+        if description:
+            lines.append(description)
+        if applicable:
+            lines.append("Applicable instruments: " + ", ".join(applicable))
+
+    path = _confined_path(root, relative_path)
+    if not path.exists():
+        return "\n".join(lines)
+    data = yaml.safe_load(path.read_text()) or {}
+    if not isinstance(data, Mapping):
+        return "\n".join(lines)
+    method_key = query.method
+    entry = data.get(method_key) if method_key else None
+    if not isinstance(entry, Mapping):
+        return "\n".join(lines)
+    contracts = [
+        contract
+        for contract in entry.get("solution_contracts", ()) or ()
+        if isinstance(contract, Mapping)
+    ]
+    if not contracts:
+        return "\n".join(lines)
+    contracts.sort(
+        key=lambda contract: (
+            -_score_text(
+                query,
+                str(contract.get("name") or contract.get("id") or ""),
+                yaml.safe_dump(dict(contract), sort_keys=True),
+            ),
+            str(contract.get("id") or ""),
+        )
+    )
+    selected = contracts[0]
+    contract_score = _score_text(
+        query,
+        str(selected.get("name") or selected.get("id") or ""),
+        yaml.safe_dump(dict(selected), sort_keys=True),
+    )
+    if contract_score <= 0:
+        return "\n".join(lines)
+    lines.append(
+        "Solution contract: "
+        + str(selected.get("name") or selected.get("id") or "")
+    )
+    assumptions = tuple(selected.get("assumptions", ()) or ())
+    if assumptions:
+        lines.append("Assumptions: " + "; ".join(str(item) for item in assumptions))
+    payoff = str(selected.get("payoff") or "").strip()
+    if payoff:
+        lines.append(f"Payoff: {payoff}")
+    market_data = tuple(selected.get("market_data", ()) or ())
+    if market_data:
+        lines.append("Market data: " + ", ".join(str(item) for item in market_data))
+    return "\n".join(lines)
+
+
+def _documentation_excerpts(
+    orientation: RoleOrientation,
+    query: RoleOrientationQuery,
+    *,
+    root: Path,
+) -> list[ResolvedOrientationExcerpt]:
+    excerpts: list[ResolvedOrientationExcerpt] = []
+    for resource in orientation.navigation:
+        if resource.kind not in _DOCUMENT_KINDS:
+            continue
+        sections = _sections_for_resource(resource, root=root)
+        ranked: list[tuple[int, _DocumentSection]] = []
+        for section in sections:
+            prose = _sanitize_role_context(section.text)
+            if not prose:
+                continue
+            score = _score_text(
+                query,
+                section.heading,
+                prose[: orientation.max_resource_chars],
+            )
+            if score > 0:
+                ranked.append((score, replace(section, text=prose)))
+        if not ranked:
+            continue
+        ranked.sort(key=lambda item: (-item[0], item[1].path, item[1].heading))
+        score, selected = ranked[0]
+        excerpts.append(
+            _make_excerpt(
+                resource=resource,
+                source_path=selected.path,
+                section=selected.heading,
+                text=selected.text,
+                score=score,
+            )
+        )
+    return excerpts
+
+
+def _sections_for_resource(
+    resource: OrientationResource,
+    *,
+    root: Path,
+) -> list[_DocumentSection]:
+    path = _confined_path(root, resource.path)
+    if not path.exists() or not path.is_file():
+        raise ValueError(
+            f"Orientation resource {resource.resource_id!r} references missing {resource.path}"
+        )
+    source_paths = [(resource.path, path)]
+    if resource.kind == "official_docs_index":
+        source_paths.extend(_toctree_targets(path, resource.path, root=root))
+    sections: list[_DocumentSection] = []
+    seen: set[str] = set()
+    for relative, source_path in source_paths:
+        if relative in seen:
+            continue
+        seen.add(relative)
+        text = source_path.read_text()
+        sections.extend(_parse_document_sections(relative, text))
+    return sections
+
+
+def _toctree_targets(
+    index_path: Path,
+    index_relative: str,
+    *,
+    root: Path,
+) -> list[tuple[str, Path]]:
+    lines = index_path.read_text().splitlines()
+    targets: list[tuple[str, Path]] = []
+    in_toctree = False
+    for line in lines:
+        if line.strip().startswith(".. toctree::"):
+            in_toctree = True
+            continue
+        if not in_toctree:
+            continue
+        if line and not line[0].isspace():
+            in_toctree = False
+            continue
+        stripped = line.strip()
+        if not stripped or stripped.startswith(":"):
+            continue
+        if "<" in stripped and stripped.endswith(">"):
+            stripped = stripped.rsplit("<", 1)[1][:-1].strip()
+        if "://" in stripped or stripped.startswith("/"):
+            continue
+        target = PurePosixPath(index_relative).parent / stripped
+        target_candidates = (
+            (target.with_suffix(".rst"), target.with_suffix(".md"))
+            if target.suffix == ""
+            else (target,)
+        )
+        resolved_target: tuple[str, Path] | None = None
+        for candidate in target_candidates:
+            relative = candidate.as_posix()
+            target_path = _confined_path(root, relative)
+            if target_path.exists() and target_path.is_file():
+                resolved_target = (relative, target_path)
+                break
+        if resolved_target is None:
+            raise ValueError(
+                f"Documentation index {index_relative!r} references missing {stripped!r}"
+            )
+        _, resolved_path = resolved_target
+        targets.append((resolved_path.relative_to(root).as_posix(), resolved_path))
+    return targets
+
+
+def _parse_document_sections(path: str, text: str) -> list[_DocumentSection]:
+    if path.lower().endswith(".rst"):
+        return _parse_rst_sections(path, text)
+    return _parse_markdown_sections(path, text)
+
+
+def _parse_rst_sections(path: str, text: str) -> list[_DocumentSection]:
+    lines = text.splitlines()
+    headings: list[tuple[int, str]] = []
+    for index in range(len(lines) - 1):
+        title = lines[index].strip()
+        underline = lines[index + 1].strip()
+        if title and _RST_HEADING_UNDERLINE.fullmatch(underline):
+            headings.append((index, title))
+    return _materialize_sections(path, lines, headings, heading_span=2)
+
+
+def _parse_markdown_sections(path: str, text: str) -> list[_DocumentSection]:
+    lines = text.splitlines()
+    headings = [
+        (index, match.group(2).strip())
+        for index, line in enumerate(lines)
+        if (match := _MARKDOWN_HEADING.match(line)) is not None
+    ]
+    return _materialize_sections(path, lines, headings, heading_span=1)
+
+
+def _materialize_sections(
+    path: str,
+    lines: list[str],
+    headings: list[tuple[int, str]],
+    *,
+    heading_span: int,
+) -> list[_DocumentSection]:
+    if not headings:
+        prose = "\n".join(lines).strip()
+        return [_DocumentSection(path=path, heading=Path(path).stem, text=prose)] if prose else []
+    sections: list[_DocumentSection] = []
+    for position, (line_index, heading) in enumerate(headings):
+        end = headings[position + 1][0] if position + 1 < len(headings) else len(lines)
+        body = "\n".join(lines[line_index + heading_span : end]).strip()
+        if body:
+            sections.append(_DocumentSection(path=path, heading=heading, text=body))
+    return sections
+
+
+def _supplemental_excerpt(
+    orientation: RoleOrientation,
+    query: RoleOrientationQuery,
+    text: str,
+) -> ResolvedOrientationExcerpt | None:
+    prose = _sanitize_role_context(text)
+    if not prose:
+        return None
+    return ResolvedOrientationExcerpt(
+        resource_id="shared_task_knowledge",
+        kind="runtime_knowledge",
+        source_path="runtime:shared_task_knowledge",
+        section="Previously selected task knowledge",
+        text=prose,
+        score=max(_score_text(query, "Previously selected task knowledge", prose), 1),
+        source_digest=sha256(prose.encode("utf-8")).hexdigest(),
+        navigation_order=max(
+            (
+                item.order
+                for item in orientation.navigation
+                if item.kind in _RUNTIME_KINDS
+            ),
+            default=0,
+        )
+        + 1,
+    )
+
+
+def _make_excerpt(
+    *,
+    resource: OrientationResource,
+    source_path: str,
+    section: str,
+    text: str,
+    score: int,
+) -> ResolvedOrientationExcerpt:
+    return ResolvedOrientationExcerpt(
+        resource_id=resource.resource_id,
+        kind=resource.kind,
+        source_path=source_path,
+        section=section,
+        text=text,
+        score=score,
+        source_digest=sha256(text.encode("utf-8")).hexdigest(),
+        navigation_order=resource.order,
+    )
+
+
+def _render_bounded_context(
+    candidates: list[ResolvedOrientationExcerpt],
+    *,
+    max_chars: int,
+    max_resource_chars: int,
+) -> tuple[str, tuple[ResolvedOrientationExcerpt, ...], int]:
+    if not candidates or max_chars <= 0:
+        return "", (), len(candidates)
+    heading = "## Resolved Role Context\n"
+    selected: list[ResolvedOrientationExcerpt] = []
+    blocks: list[str] = []
+    for candidate in candidates:
+        excerpt_text, _ = _truncate(candidate.text, max_resource_chars)
+        bounded = replace(candidate, text=excerpt_text)
+        block = _render_excerpt(bounded)
+        current = heading + "\n\n".join(blocks + [block])
+        if len(current) <= max_chars:
+            selected.append(bounded)
+            blocks.append(block)
+    omitted = len(candidates) - len(selected)
+    context = heading + "\n\n".join(blocks)
+    if omitted:
+        while selected:
+            omitted = len(candidates) - len(selected)
+            marker = (
+                f"[orientation context truncated; {omitted} excerpt(s) omitted]"
+            )
+            context = heading + "\n\n".join(
+                _render_excerpt(excerpt) for excerpt in selected
+            )
+            overflow = len(context) + 2 + len(marker) - max_chars
+            if overflow <= 0:
+                context = f"{context}\n\n{marker}"
+                break
+            last = selected[-1]
+            desired_text_chars = len(last.text) - overflow
+            if desired_text_chars > 0:
+                shortened, _ = _truncate(last.text, desired_text_chars)
+                selected[-1] = replace(last, text=shortened)
+                continue
+            selected.pop()
+        if not selected:
+            omitted = len(candidates)
+            marker = (
+                f"[orientation context truncated; {omitted} excerpt(s) omitted]"
+            )
+            context, _ = _truncate(marker, max_chars)
+    return context, tuple(selected), omitted
+
+
+def _render_excerpt(excerpt: ResolvedOrientationExcerpt) -> str:
+    return (
+        f"### {excerpt.section}\n"
+        f"Source: `{excerpt.section_id}` ({excerpt.resource_id})\n"
+        f"{excerpt.text}"
+    )
+
+
+def _truncate(text: str, max_chars: int) -> tuple[str, bool]:
+    if len(text) <= max_chars:
+        return text, False
+    if max_chars <= 3:
+        return text[:max_chars], True
+    return text[: max_chars - 3].rstrip() + "...", True
+
+
+def _score_text(query: RoleOrientationQuery, heading: str, body: str) -> int:
+    terms = _query_terms(query)
+    if not terms:
+        return 1
+    heading_tokens = set(_tokens(heading))
+    body_tokens = set(_tokens(body))
+    score = 0
+    for term in terms:
+        term_tokens = tuple(_tokens(term))
+        if not term_tokens:
+            continue
+        if all(token in heading_tokens for token in term_tokens):
+            score += 8 + len(term_tokens)
+        elif all(token in body_tokens for token in term_tokens):
+            score += 3 + len(term_tokens)
+        else:
+            score += 2 * len(heading_tokens.intersection(term_tokens))
+            score += len(body_tokens.intersection(term_tokens))
+    return score
+
+
+def _query_terms(query: RoleOrientationQuery) -> tuple[str, ...]:
+    raw = (
+        query.instrument_type,
+        query.method,
+        query.model_family,
+        *query.features,
+        *query.route_ids,
+        *query.route_families,
+        *query.residual_risks,
+        query.review_reason,
+        query.description,
+    )
+    terms: list[str] = []
+    for value in raw:
+        normalized = " ".join(_tokens(str(value)))
+        if normalized and normalized not in terms:
+            terms.append(normalized)
+    return tuple(terms)
+
+
+def _tokens(text: str) -> tuple[str, ...]:
+    return tuple(
+        token
+        for token in _WORD.findall(text.lower().replace("_", " ").replace("-", " "))
+        if token not in _STOP_WORDS and len(token) > 1
+    )
+
+
+def _strip_nonprose(text: str) -> str:
+    lines = text.splitlines()
+    output: list[str] = []
+    in_fence = False
+    rst_code_indent: int | None = None
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        if stripped.startswith(".. code-block::") or stripped.startswith(".. code::"):
+            rst_code_indent = len(line) - len(line.lstrip())
+            continue
+        if rst_code_indent is not None:
+            if not stripped:
+                continue
+            indent = len(line) - len(line.lstrip())
+            if indent > rst_code_indent:
+                continue
+            rst_code_indent = None
+        if re.match(r"^(from|import)\s+trellis(?:\.|\s)", stripped):
+            continue
+        output.append(line.rstrip())
+    while output and not output[0].strip():
+        output.pop(0)
+    while output and not output[-1].strip():
+        output.pop()
+    compact: list[str] = []
+    blank = False
+    for line in output:
+        if not line.strip():
+            if not blank:
+                compact.append("")
+            blank = True
+        else:
+            compact.append(line)
+            blank = False
+    return "\n".join(compact).strip()
+
+
+def _sanitize_role_context(text: str) -> str:
+    """Remove code and builder-only construction authority from role packets."""
+    prose = _strip_nonprose(text)
+    safe_lines: list[str] = []
+    for line in prose.splitlines():
+        lowered = line.lower()
+        if (
+            "from trellis." in lowered
+            or "import trellis" in lowered
+            or " import " in lowered
+            or "route_helper" in lowered
+            or "route helper" in lowered
+            or "helper-backed" in lowered
+            or "checked helper" in lowered
+            or "task-specific helper" in lowered
+        ):
+            continue
+        safe_lines.append(line)
+    return _strip_nonprose("\n".join(safe_lines))
+
+
+def _confined_path(root: Path, relative_path: str) -> Path:
+    if not relative_path or relative_path.startswith("runtime:"):
+        raise ValueError(f"File-backed orientation resource requires a path: {relative_path!r}")
+    candidate = (root / relative_path).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError as exc:
+        raise ValueError(
+            f"Orientation resource path {relative_path!r} is outside repository root"
+        ) from exc
+    return candidate
+
+
+def _render_supplied_orientation_card(orientation: RoleOrientation) -> str:
+    lines = [
+        f"## {orientation.title}",
+        f"- Contract: `{orientation.identity}`",
+        f"- Purpose: {orientation.purpose}",
+        "### Owns",
+        *(f"- {item}" for item in orientation.owns),
+        "### Does Not Own",
+        *(f"- {item}" for item in orientation.excludes),
+        "### Navigation Order",
+        *(
+            f"{item.order}. [{item.kind}] `{item.path}`: {item.purpose}"
+            for item in orientation.navigation
+        ),
+    ]
+    return "\n".join(lines)

--- a/trellis/agent/orientation_resolution.py
+++ b/trellis/agent/orientation_resolution.py
@@ -101,6 +101,7 @@ class ResolvedRoleOrientationPacket:
     rendered: str
     excerpts: tuple[ResolvedOrientationExcerpt, ...]
     omitted_count: int
+    unavailable_resource_ids: tuple[str, ...]
     content_digest: str
 
     def summary(self) -> dict[str, object]:
@@ -117,6 +118,7 @@ class ResolvedRoleOrientationPacket:
             "selected_sections": [excerpt.section_id for excerpt in self.excerpts],
             "context_chars": len(self.context),
             "omitted_count": self.omitted_count,
+            "unavailable_resource_ids": list(self.unavailable_resource_ids),
             "content_digest": self.content_digest,
         }
 
@@ -155,13 +157,15 @@ def resolve_role_orientation_packet(
         resolved_knowledge,
         root=root,
     )
-    candidates.extend(
-        _documentation_excerpts(
-            resolved_orientation,
-            query,
-            root=root,
-        )
+    documentation, unavailable_resource_ids = _documentation_excerpts(
+        resolved_orientation,
+        query,
+        root=root,
+        allow_missing_resources=(
+            repo_root is None and not (root / "docs").is_dir()
+        ),
     )
+    candidates.extend(documentation)
     supplemental = _supplemental_excerpt(
         resolved_orientation,
         query,
@@ -182,6 +186,7 @@ def resolve_role_orientation_packet(
         candidates,
         max_chars=resolved_orientation.max_context_chars,
         max_resource_chars=resolved_orientation.max_resource_chars,
+        base_omitted_count=len(unavailable_resource_ids),
     )
     card = (
         render_role_orientation_card(role)
@@ -196,6 +201,7 @@ def resolve_role_orientation_packet(
         rendered=rendered,
         excerpts=selected,
         omitted_count=omitted_count,
+        unavailable_resource_ids=unavailable_resource_ids,
         content_digest=sha256(context.encode("utf-8")).hexdigest(),
     )
 
@@ -239,6 +245,12 @@ def _canonical_excerpts(
             )
             text = _append_selected_principles(text, knowledge.get("principles", ()))
             section = "Product decomposition and principles"
+        elif resource.resource_id == "retrieved_lessons":
+            text = _render_lessons(
+                knowledge.get("lessons", ()),
+                knowledge.get("borrowed_lessons", ()),
+            )
+            section = "Selected validated lessons"
         elif resource.resource_id == "admitted_routes":
             text = _render_route_identity(query)
             section = "Admitted route identity"
@@ -306,6 +318,31 @@ def _append_selected_principles(text: str, principles: Any) -> str:
     if not rows:
         return text
     return "\n".join(part for part in (text, *rows) if part)
+
+
+def _render_lessons(primary: Any, borrowed: Any) -> str:
+    """Render bounded retrieved lessons without builder or import authority."""
+    rows: list[str] = []
+    seen: set[str] = set()
+    for lesson in (*tuple(primary or ()), *tuple(borrowed or ())):
+        lesson_id = str(getattr(lesson, "id", "") or "").strip()
+        if not lesson_id or lesson_id in seen:
+            continue
+        seen.add(lesson_id)
+        title = str(getattr(lesson, "title", "") or "").strip()
+        root_cause = str(getattr(lesson, "root_cause", "") or "").strip()
+        fix = str(getattr(lesson, "fix", "") or "").strip()
+        validation = str(getattr(lesson, "validation", "") or "").strip()
+        rows.append(f"Lesson {lesson_id}: {title}")
+        if root_cause:
+            rows.append(f"Root cause: {root_cause}")
+        if fix:
+            rows.append(f"Validated correction: {fix}")
+        if validation:
+            rows.append(f"Validation evidence: {validation}")
+        if len(seen) >= 3:
+            break
+    return "\n".join(rows)
 
 
 def _append_generated_skill_evidence(
@@ -464,11 +501,22 @@ def _documentation_excerpts(
     query: RoleOrientationQuery,
     *,
     root: Path,
-) -> list[ResolvedOrientationExcerpt]:
+    allow_missing_resources: bool,
+) -> tuple[list[ResolvedOrientationExcerpt], tuple[str, ...]]:
     excerpts: list[ResolvedOrientationExcerpt] = []
+    unavailable_resource_ids: list[str] = []
     for resource in orientation.navigation:
         if resource.kind not in _DOCUMENT_KINDS:
             continue
+        resource_path = _confined_path(root, resource.path)
+        if not resource_path.exists():
+            if allow_missing_resources:
+                unavailable_resource_ids.append(resource.resource_id)
+                continue
+            raise ValueError(
+                f"Orientation resource {resource.resource_id!r} references "
+                f"missing {resource.path}"
+            )
         sections = _sections_for_resource(resource, root=root)
         ranked: list[tuple[int, _DocumentSection]] = []
         for section in sections:
@@ -495,7 +543,7 @@ def _documentation_excerpts(
                 score=score,
             )
         )
-    return excerpts
+    return excerpts, tuple(unavailable_resource_ids)
 
 
 def _sections_for_resource(
@@ -668,9 +716,17 @@ def _render_bounded_context(
     *,
     max_chars: int,
     max_resource_chars: int,
+    base_omitted_count: int = 0,
 ) -> tuple[str, tuple[ResolvedOrientationExcerpt, ...], int]:
     if not candidates or max_chars <= 0:
-        return "", (), len(candidates)
+        omitted = len(candidates) + base_omitted_count
+        if omitted and max_chars > 0:
+            marker, _ = _truncate(
+                f"[orientation context truncated; {omitted} excerpt(s) omitted]",
+                max_chars,
+            )
+            return marker, (), omitted
+        return "", (), omitted
     heading = "## Resolved Role Context\n"
     selected: list[ResolvedOrientationExcerpt] = []
     blocks: list[str] = []
@@ -682,11 +738,13 @@ def _render_bounded_context(
         if len(current) <= max_chars:
             selected.append(bounded)
             blocks.append(block)
-    omitted = len(candidates) - len(selected)
+    omitted = len(candidates) - len(selected) + base_omitted_count
     context = heading + "\n\n".join(blocks)
     if omitted:
         while selected:
-            omitted = len(candidates) - len(selected)
+            omitted = (
+                len(candidates) - len(selected) + base_omitted_count
+            )
             marker = (
                 f"[orientation context truncated; {omitted} excerpt(s) omitted]"
             )
@@ -705,7 +763,7 @@ def _render_bounded_context(
                 continue
             selected.pop()
         if not selected:
-            omitted = len(candidates)
+            omitted = len(candidates) + base_omitted_count
             marker = (
                 f"[orientation context truncated; {omitted} excerpt(s) omitted]"
             )
@@ -869,4 +927,10 @@ def _render_supplied_orientation_card(orientation: RoleOrientation) -> str:
             for item in orientation.navigation
         ),
     ]
-    return "\n".join(lines)
+    card = "\n".join(lines)
+    if len(card) > orientation.max_render_chars:
+        raise ValueError(
+            f"Role orientation {orientation.identity} renders to {len(card)} chars, "
+            f"above its {orientation.max_render_chars}-char budget"
+        )
+    return card

--- a/trellis/agent/platform_traces.py
+++ b/trellis/agent/platform_traces.py
@@ -1077,6 +1077,7 @@ def _cycle_stage_details(stage: str, details: dict[str, Any]) -> dict[str, Any]:
             "assumption_summary",
             "required_market_data",
             "orientation_contract",
+            "orientation_resolution",
             "challenger_packet",
         ),
         "validation_bundle": (
@@ -1100,6 +1101,7 @@ def _cycle_stage_details(stage: str, details: dict[str, Any]) -> dict[str, Any]:
             "llm_review",
             "risk_level",
             "orientation_contract",
+            "orientation_resolution",
             "residual_risks",
             "finding_classification",
             "reason",

--- a/trellis/agent/quant.py
+++ b/trellis/agent/quant.py
@@ -81,6 +81,7 @@ class PricingPlan:
     selection_reason: str = ""
     assumption_summary: tuple[str, ...] = ()
     challenger_packet: QuantChallengerPacket | Mapping[str, object] | None = None
+    orientation_resolution: Mapping[str, object] | None = None
 
 
 # Legacy _FAMILY_BLUEPRINT_ROUTE_MODULES removed.
@@ -558,6 +559,9 @@ def _plan_from_decomposition(decomposition) -> PricingPlan:
         sensitivity_support=support_for_method(method),
         selection_reason=selection_reason,
         assumption_summary=assumption_summary,
+        orientation_resolution=dict(
+            getattr(decomposition, "orientation_resolution", {}) or {}
+        ),
     )
     return _attach_challenger_packet(plan, candidate_methods=(method,))
 

--- a/trellis/agent/role_orientation.py
+++ b/trellis/agent/role_orientation.py
@@ -41,6 +41,8 @@ class RoleOrientation:
     title: str
     purpose: str
     max_render_chars: int
+    max_context_chars: int
+    max_resource_chars: int
     owns: tuple[str, ...]
     excludes: tuple[str, ...]
     navigation: tuple[OrientationResource, ...]
@@ -101,8 +103,22 @@ def _parse_orientation(role: str, payload: object) -> RoleOrientation:
 
     version = int(payload.get("version") or 0)
     max_render_chars = int(payload.get("max_render_chars") or 0)
-    if version <= 0 or max_render_chars <= 0:
-        raise ValueError(f"{context} requires positive version and max_render_chars")
+    max_context_chars = int(payload.get("max_context_chars") or 0)
+    max_resource_chars = int(payload.get("max_resource_chars") or 0)
+    if (
+        version <= 0
+        or max_render_chars <= 0
+        or max_context_chars <= 0
+        or max_resource_chars <= 0
+    ):
+        raise ValueError(
+            f"{context} requires positive version, max_render_chars, "
+            "max_context_chars, and max_resource_chars"
+        )
+    if max_resource_chars > max_context_chars:
+        raise ValueError(
+            f"{context} max_resource_chars cannot exceed max_context_chars"
+        )
     orientation = RoleOrientation(
         role=role,
         contract_id=_required_text(payload, "contract_id", context=context),
@@ -110,6 +126,8 @@ def _parse_orientation(role: str, payload: object) -> RoleOrientation:
         title=_required_text(payload, "title", context=context),
         purpose=_required_text(payload, "purpose", context=context),
         max_render_chars=max_render_chars,
+        max_context_chars=max_context_chars,
+        max_resource_chars=max_resource_chars,
         owns=_string_tuple(payload.get("owns"), context=f"{context} owns"),
         excludes=_string_tuple(
             payload.get("excludes"),

--- a/trellis/agent/validation_report.py
+++ b/trellis/agent/validation_report.py
@@ -33,6 +33,7 @@ class ValidationReport:
     findings: list[ValidationFinding] = field(default_factory=list)
     timestamp: str = field(default_factory=lambda: datetime.now().isoformat())
     approved: bool = False
+    orientation_resolution: dict[str, object] = field(default_factory=dict)
 
     @property
     def critical_findings(self) -> list[ValidationFinding]:


### PR DESCRIPTION
## Summary
- resolve task-relevant quant and model-validator context from existing knowledge and documentation indexes
- enforce role separation, repository confinement, per-source and total prompt budgets
- record trace-safe source provenance without storing prompt excerpts
- update runtime, agent, observability, and task-loop documentation

## Validation
- focused orientation/quant/model-validator/trace suite: 87 passed
- make gate-pr: 4,431 core tests passed; 32 tier-2 contract tests passed
- Sphinx dummy build succeeded with only pre-existing repository warnings
- scoped mypy for the new resolver and orientation contracts passed

## Boundaries
- no pricing, route, product, or method helper added
- no cookbook entry or template modified
- no public pricing API or production recovery policy changed

Linear: QUA-1182