### PR TITLE
Retire digital analytical helper authority (QUA-1183)

### DIFF
--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -802,6 +802,23 @@ The compact ``quanto_option_composition`` entry in ``canonical/api_map.yaml``
 is the intended hot start for a fresh builder; exact symbols are then confirmed
 through the import registry.
 
+The F010 analytical digital lane follows the same authority boundary without
+adding a numerical abstraction. Canonical route and exact-binding records now
+select the shared single-state diffusion resolver, forward/discount/payoff
+support primitives, and four Black-76 cash/asset digital basis kernels. The
+checked adapter visibly composes payout selection and scaling from those
+product-neutral APIs and rejects unknown settlement types. The older product
+function remains available only for cash-digital compatibility comparison. The
+helper-authority audit must therefore find no analytical digital helper in the
+route, binding, or checked adapter, while route and adapter tests preserve
+cash/asset and call/put basis selection.
+
+Package-level primitive APIs remain discoverable rather than merely importable.
+The import registry's static package-export inventory records the same digital
+support symbols and is merged with live module introspection. Route validation
+therefore fails if documentation names a package-level composition primitive
+that a fresh builder cannot confirm through symbol lookup.
+
 The compiled metadata preserves this distinction. ``dsl_target_refs`` and
 ``lowering_target_refs`` list all selected primitive targets. ``dsl_helper_refs``,
 ``lowering_helper_refs``, and backend ``helper_refs`` contain only primitives

--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -813,6 +813,11 @@ helper-authority audit must therefore find no analytical digital helper in the
 route, binding, or checked adapter, while route and adapter tests preserve
 cash/asset and call/put basis selection.
 
+The deterministic digital spec schema includes ``dividend_yield``. Benchmark
+``dividend_rate`` aliases therefore survive spec-override filtering when an
+adapter is regenerated, rather than silently reverting the analytical forward
+to zero carry.
+
 Package-level primitive APIs remain discoverable rather than merely importable.
 The import registry's static package-export inventory records the same digital
 support symbols and is merged with live module introspection. Route validation

--- a/docs/quant/pricing_stack.rst
+++ b/docs/quant/pricing_stack.rst
@@ -435,6 +435,19 @@ The first migrated vanilla cases now use that boundary directly:
   owns the bounded Black-Scholes grid on ``[lower_barrier, upper_barrier]``,
   absorbing boundaries, and knock-in/out parity; the Monte Carlo helper owns
   the GBM engine binding, two barrier monitors, and deterministic discounting.
+- European analytical digital routes are primitive-composed. They bind the
+  contract day count, rate, Black volatility, dividend carry, and option type
+  through ``resolve_single_state_diffusion_inputs(...)``. They build the
+  forward through ``forward_from_dividend_yield(...)`` and then select one of
+  ``black76_cash_or_nothing_call``, ``black76_cash_or_nothing_put``,
+  ``black76_asset_or_nothing_call``, or
+  ``black76_asset_or_nothing_put`` from the payoff semantics. These kernels
+  return undiscounted basis values; the adapter applies discount and notional
+  once through ``discounted_value(...)`` and applies the cash amount only to
+  cash settlement. Shared cash/asset intrinsic primitives own strict expiry
+  semantics. The retained
+  ``price_equity_digital_option_analytical`` function is a cash-digital
+  compatibility/reference surface, not route construction authority.
 - Digital proof routes now include a bounded one-dimensional PDE helper,
   ``trellis.models.equity_option_pde.price_equity_digital_option_pde``. It
   prices cash-or-nothing and asset-or-nothing equity digitals with the shared
@@ -667,6 +680,14 @@ require agent-written route assembly rather than a product/method wrapper.
 Their lowering records primitive targets separately from true ``route_helper``
 bindings so generic resolvers and kernels are not mislabeled as helper authority
 in prompts or traces.
+
+The admitted European analytical digital lane is also primitive-only. Its
+compact hot start is ``digital_option_composition`` in
+``canonical/api_map.yaml``. Canonical decomposition and route evidence state
+the resolver, basis selection, and scaling obligations, while exact symbol
+validation resolves through the import registry. Cash/asset settlement and
+call/put orientation remain contract choices; a product wrapper cannot
+substitute for that semantic selection even when one numeric case is close.
 
 For schedule-driven cap/floor strips lowered onto ``analytical_black76``, the
 typed schedule state now carries admissibility directly. Structural

--- a/docs/user_guide/pricing.rst
+++ b/docs/user_guide/pricing.rst
@@ -131,6 +131,23 @@ seeded two-factor Sobol shocks. Checked-in adapters under
 ``trellis.instruments._agent`` remain compatibility artifacts and examples;
 the primitive contract, not a product-pricing wrapper, is authoritative.
 
+European Digital Options
+------------------------
+
+For a European cash-or-nothing or asset-or-nothing equity digital, the
+analytical task route selects a Black-76 basis kernel from the declared payout
+and call/put orientation. The adapter first uses the shared single-state
+diffusion resolver for time, rate, volatility, carry, and option type, then
+uses shared forward, discount, and terminal-payoff primitives around the
+selected kernel. It applies notional once and applies ``cash_payoff`` only for
+cash settlement.
+
+This makes the supported boundary visible: European exercise, lognormal equity
+dynamics, deterministic rates, and strict terminal indicators. Unknown payout
+or option types fail instead of being treated as puts or cash digitals. The
+product-level analytical function remains a compatibility reference for cash
+digitals; task construction uses the basis kernels directly.
+
 Scheduled Observation Returns
 -----------------------------
 

--- a/tests/test_agent/test_api_map.py
+++ b/tests/test_agent/test_api_map.py
@@ -35,6 +35,10 @@ def test_api_map_contains_expected_core_entries():
         == "trellis.models.resolution.quanto"
     )
     assert (
+        api_map["digital_option_composition"]["module"]
+        == "trellis.models.resolution.single_state_diffusion"
+    )
+    assert (
         api_map["rate_monte_carlo_composition"]["module"]
         == "trellis.models.monte_carlo.simulation_substrate"
     )
@@ -62,6 +66,7 @@ def test_api_map_key_imports_are_registry_valid():
         "scheduled_observation_composition",
         "weighted_lognormal_sum_composition",
         "observation_return_composition",
+        "digital_option_composition",
         "quanto_option_composition",
         "rate_monte_carlo_composition",
         "qmc",
@@ -240,6 +245,25 @@ def test_api_map_prioritizes_quanto_primitive_composition():
         assert symbol in text
     assert "price_quanto_option_analytical" not in text
     assert "price_quanto_option_monte_carlo" not in text
+
+
+def test_api_map_prioritizes_digital_basis_composition():
+    section = get_api_map()["digital_option_composition"]
+    text = "\n".join((*section["key_imports"], *section["notes"]))
+
+    for symbol in (
+        "resolve_single_state_diffusion_inputs",
+        "forward_from_dividend_yield",
+        "discounted_value",
+        "cash_or_nothing_intrinsic",
+        "asset_or_nothing_intrinsic",
+        "black76_cash_or_nothing_call",
+        "black76_cash_or_nothing_put",
+        "black76_asset_or_nothing_call",
+        "black76_asset_or_nothing_put",
+    ):
+        assert symbol in text
+    assert "price_equity_digital_option_analytical" not in text
 
 
 def test_equity_tree_api_map_prioritizes_lattice_algebra_primitives():

--- a/tests/test_agent/test_api_map.py
+++ b/tests/test_agent/test_api_map.py
@@ -103,6 +103,9 @@ def test_api_map_formatter_includes_navigation_guidance():
     assert "equity_tree" in text
     assert "rate_lattice" in text
     assert "trellis.models.monte_carlo" in text
+    assert "digital_option_composition" in text
+    assert "resolve_single_state_diffusion_inputs" in text
+    assert "black76_cash_or_nothing_call" in text
     assert "inspect_api_map" not in text
 
 

--- a/tests/test_agent/test_backend_bindings.py
+++ b/tests/test_agent/test_backend_bindings.py
@@ -702,10 +702,13 @@ def test_resolve_backend_binding_spec_uses_quanto_primitive_composition(
                 model_family="equity_diffusion",
             ),
             "analytical",
-            (
-                "trellis.models.analytical.equity_exotics.price_equity_digital_option_analytical",
-            ),
             (),
+            (
+                "trellis.models.black.black76_cash_or_nothing_call",
+                "trellis.models.black.black76_cash_or_nothing_put",
+                "trellis.models.black.black76_asset_or_nothing_call",
+                "trellis.models.black.black76_asset_or_nothing_put",
+            ),
             id="digital",
         ),
         pytest.param(

--- a/tests/test_agent/test_helper_authority_audit.py
+++ b/tests/test_agent/test_helper_authority_audit.py
@@ -274,3 +274,23 @@ def test_current_repository_retires_arithmetic_asian_helper_authority():
         if item.path == "trellis/instruments/_agent/asianoption.py"
         and item.symbol in asian_symbols
     ]
+
+
+def test_current_repository_retires_analytical_digital_helper_authority():
+    from trellis.agent.helper_authority_audit import build_helper_authority_report
+
+    root = Path(__file__).resolve().parents[2]
+    report = build_helper_authority_report(root)
+    helper_symbol = "price_equity_digital_option_analytical"
+
+    assert not [
+        item
+        for item in (*report.route_authority, *report.binding_authority)
+        if item.symbol == helper_symbol
+    ]
+    assert not [
+        item
+        for item in report.adapter_calls
+        if item.path == "trellis/instruments/_agent/digitaloption.py"
+        and item.symbol == helper_symbol
+    ]

--- a/tests/test_agent/test_import_registry.py
+++ b/tests/test_agent/test_import_registry.py
@@ -502,6 +502,22 @@ def test_quanto_composition_primitives_are_in_static_import_registry():
     ]
 
 
+def test_digital_composition_support_reexports_are_discoverable():
+    module = "trellis.models.analytical.support"
+    symbols = {
+        "asset_or_nothing_intrinsic",
+        "cash_or_nothing_intrinsic",
+        "discounted_value",
+        "forward_from_dividend_yield",
+    }
+
+    assert symbols <= set(list_module_exports(module))
+    static_registry = import_registry._parse_static_registry(
+        import_registry._STATIC_REGISTRY
+    )
+    assert symbols <= set(static_registry[module])
+
+
 def test_resolve_import_candidates_handles_known_and_unknown_symbols():
     candidates = resolve_import_candidates(["theta_method_1d", "definitely_not_real"])
     assert "trellis.models.pde.theta_method" in candidates["theta_method_1d"]

--- a/tests/test_agent/test_knowledge_store.py
+++ b/tests/test_agent/test_knowledge_store.py
@@ -651,7 +651,7 @@ class TestKnowledgeStore:
         assert "callable" in d.features
         assert d.method == "rate_tree"
 
-    def test_analytical_exotic_decompositions_anchor_on_equity_exotics_module(self):
+    def test_analytical_exotic_decompositions_anchor_on_checked_implementations(self):
         """QUA-852: digital/lookback/chooser/compound intent requests resolve to analytical.
 
         Without these entries the planner's decomposition router falls through to
@@ -664,8 +664,31 @@ class TestKnowledgeStore:
         from trellis.agent.knowledge import get_store
         store = get_store()
 
+        digital = store._decompositions.get("digital_option")
+        assert digital is not None
+        assert digital.method == "analytical"
+        assert "trellis.models.resolution.single_state_diffusion" in digital.method_modules
+        assert "trellis.models.analytical.support" in digital.method_modules
+        assert "trellis.models.black" in digital.method_modules
+        assert "trellis.models.analytical.equity_exotics" not in digital.method_modules
+        assert "discount_curve" in digital.required_market_data
+        assert "black_vol_surface" in digital.required_market_data
+        digital_requirements = " ".join(digital.modeling_requirements)
+        for kernel in (
+            "resolve_single_state_diffusion_inputs",
+            "forward_from_dividend_yield",
+            "discounted_value",
+            "cash_or_nothing_intrinsic",
+            "asset_or_nothing_intrinsic",
+            "black76_cash_or_nothing_call",
+            "black76_cash_or_nothing_put",
+            "black76_asset_or_nothing_call",
+            "black76_asset_or_nothing_put",
+        ):
+            assert kernel in digital_requirements
+        assert "price_equity_digital_option_analytical" not in digital_requirements
+
         for instrument, helper_symbol in (
-            ("digital_option", "price_equity_digital_option_analytical"),
             ("lookback_option", "price_equity_fixed_lookback_option_analytical"),
             ("chooser_option", "price_equity_chooser_option_analytical"),
             ("compound_option", "price_equity_compound_option_analytical"),

--- a/tests/test_agent/test_planner.py
+++ b/tests/test_agent/test_planner.py
@@ -44,6 +44,14 @@ class TestSpecSchema:
         assert "strike" in field_names
         assert "expiry_date" in field_names
 
+    def test_digital_static_spec_preserves_dividend_yield_override(self):
+        fields = {
+            field.name: field for field in STATIC_SPECS["digital_option"].fields
+        }
+
+        assert fields["dividend_yield"].type == "float"
+        assert fields["dividend_yield"].default == "0.0"
+
     def test_schedule_dependent_static_specs_use_typed_date_tuples(self):
         callable_spec = STATIC_SPECS["callable_bond"]
         puttable_spec = STATIC_SPECS["puttable_bond"]

--- a/tests/test_agent/test_platform_requests.py
+++ b/tests/test_agent/test_platform_requests.py
@@ -875,7 +875,7 @@ def test_semantic_blueprint_summary_preserves_range_accrual_callability_blockers
         (
             "F010",
             "analytical",
-            "trellis.models.analytical.equity_exotics.price_equity_digital_option_analytical",
+            "trellis.models.black.black76_cash_or_nothing_call",
         ),
         (
             "F011",
@@ -922,6 +922,11 @@ def test_compile_build_request_preserves_exact_absorbed_black76_binding_for_fina
     assert compiled.generation_plan.primitive_plan.route_family == expected_route_family
     assert "primitive_plan_not_available" not in compiled.generation_plan.uncertainty_flags
     assert expected_backend_ref in compiled.generation_plan.backend_exact_target_refs
+    if task_id == "F010":
+        assert (
+            "trellis.models.analytical.equity_exotics.price_equity_digital_option_analytical"
+            not in compiled.generation_plan.backend_exact_target_refs
+        )
 
     if task_id == "F009":
         assert set(compiled.product_ir.candidate_engine_families) >= {"analytical", "pde"}

--- a/tests/test_agent/test_route_registry.py
+++ b/tests/test_agent/test_route_registry.py
@@ -1717,15 +1717,55 @@ class TestAnalyticalRoutes:
             ("trellis.models.analytical.barrier", "barrier_option_price", "route_helper"),
         }
 
-    def test_digital_primitives_use_exact_helper(self, registry):
+    def test_digital_primitives_use_black76_basis_kernels(self, registry):
         spec = [r for r in registry.routes if r.id == "analytical_black76"][0]
         new_prims = resolve_route_primitives(spec, self.DIGITAL_IR)
         assert resolve_route_family(spec, self.DIGITAL_IR) == "analytical"
         assert _prim_set(new_prims) == {
             (
-                "trellis.models.analytical.equity_exotics",
-                "price_equity_digital_option_analytical",
-                "route_helper",
+                "trellis.models.black",
+                "black76_asset_or_nothing_call",
+                "pricing_kernel",
+            ),
+            (
+                "trellis.models.black",
+                "black76_asset_or_nothing_put",
+                "pricing_kernel",
+            ),
+            (
+                "trellis.models.black",
+                "black76_cash_or_nothing_call",
+                "pricing_kernel",
+            ),
+            (
+                "trellis.models.black",
+                "black76_cash_or_nothing_put",
+                "pricing_kernel",
+            ),
+            (
+                "trellis.models.resolution.single_state_diffusion",
+                "resolve_single_state_diffusion_inputs",
+                "market_binding",
+            ),
+            (
+                "trellis.models.analytical.support",
+                "forward_from_dividend_yield",
+                "forward_builder",
+            ),
+            (
+                "trellis.models.analytical.support",
+                "discounted_value",
+                "discounting",
+            ),
+            (
+                "trellis.models.analytical.support",
+                "cash_or_nothing_intrinsic",
+                "payoff_primitive",
+            ),
+            (
+                "trellis.models.analytical.support",
+                "asset_or_nothing_intrinsic",
+                "payoff_primitive",
             ),
         }
 

--- a/tests/test_instruments/test_agent_digital_option.py
+++ b/tests/test_instruments/test_agent_digital_option.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from trellis.core.market_state import MarketState
+from trellis.curves.yield_curve import YieldCurve
+from trellis.instruments._agent.digitaloption import DigitalOptionPayoff, DigitalOptionSpec
+from trellis.models.analytical.equity_exotics import (
+    price_equity_digital_option_analytical,
+)
+from trellis.models.black import (
+    black76_asset_or_nothing_call,
+    black76_asset_or_nothing_put,
+    black76_cash_or_nothing_call,
+    black76_cash_or_nothing_put,
+)
+from trellis.models.analytical.support import forward_from_dividend_yield
+from trellis.models.vol_surface import FlatVol
+
+
+SETTLEMENT = date(2024, 11, 15)
+EXPIRY = date(2025, 11, 15)
+
+
+def _market_state() -> MarketState:
+    return MarketState(
+        as_of=SETTLEMENT,
+        settlement=SETTLEMENT,
+        discount=YieldCurve.flat(0.05),
+        vol_surface=FlatVol(0.22),
+    )
+
+
+@pytest.mark.parametrize("option_type", ["call", "put"])
+def test_checked_cash_digital_adapter_matches_reference_wrapper(option_type):
+    spec = DigitalOptionSpec(
+        notional=2.0,
+        spot=100.0,
+        strike=105.0,
+        expiry_date=EXPIRY,
+        option_type=option_type,
+        payout_type="cash_or_nothing",
+        cash_payoff=10.0,
+    )
+
+    actual = DigitalOptionPayoff(spec).evaluate(_market_state())
+    expected = price_equity_digital_option_analytical(_market_state(), spec)
+
+    assert actual == pytest.approx(expected, rel=1e-12, abs=1e-12)
+
+
+@pytest.mark.parametrize(
+    ("option_type", "payout_type", "kernel"),
+    [
+        ("call", "cash_or_nothing", black76_cash_or_nothing_call),
+        ("put", "cash_or_nothing", black76_cash_or_nothing_put),
+        ("call", "asset_or_nothing", black76_asset_or_nothing_call),
+        ("put", "asset_or_nothing", black76_asset_or_nothing_put),
+    ],
+)
+def test_checked_digital_adapter_selects_declared_basis_kernel(
+    option_type, payout_type, kernel
+):
+    market_state = _market_state()
+    spec = DigitalOptionSpec(
+        notional=2.0,
+        spot=100.0,
+        strike=105.0,
+        expiry_date=EXPIRY,
+        option_type=option_type,
+        payout_type=payout_type,
+        cash_payoff=10.0,
+        dividend_yield=0.01,
+    )
+    maturity = 1.0
+    discount = market_state.discount.discount(maturity)
+    forward = forward_from_dividend_yield(
+        spot=spec.spot,
+        domestic_rate=market_state.discount.zero_rate(maturity),
+        dividend_yield=spec.dividend_yield,
+        T=maturity,
+    )
+    payout_scale = spec.cash_payoff if payout_type == "cash_or_nothing" else 1.0
+    expected = (
+        spec.notional
+        * discount
+        * payout_scale
+        * kernel(forward, spec.strike, 0.22, maturity)
+    )
+
+    actual = DigitalOptionPayoff(spec).evaluate(market_state)
+
+    assert actual == pytest.approx(expected, rel=1e-12, abs=1e-12)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("option_type", "straddle"), ("payout_type", "deferred_cash")],
+)
+def test_checked_digital_adapter_rejects_unsupported_contract_values(field, value):
+    kwargs = {
+        "notional": 1.0,
+        "spot": 100.0,
+        "strike": 100.0,
+        "expiry_date": EXPIRY,
+        field: value,
+    }
+
+    with pytest.raises(ValueError, match=f"Unsupported {field}"):
+        DigitalOptionPayoff(DigitalOptionSpec(**kwargs)).evaluate(_market_state())
+
+
+def test_checked_digital_adapter_source_has_no_product_pricing_helper():
+    source_path = (
+        Path(__file__).resolve().parents[2]
+        / "trellis/instruments/_agent/digitaloption.py"
+    )
+    source = source_path.read_text(encoding="utf-8")
+
+    assert "price_equity_digital_option_analytical" not in source
+    assert "resolve_single_state_diffusion_inputs" in source
+    assert "discounted_value" in source
+    assert "black76_cash_or_nothing_call" in source
+    assert "black76_asset_or_nothing_put" in source

--- a/tests/test_instruments/test_agent_digital_option.py
+++ b/tests/test_instruments/test_agent_digital_option.py
@@ -125,3 +125,4 @@ def test_checked_digital_adapter_source_has_no_product_pricing_helper():
     assert "discounted_value" in source
     assert "black76_cash_or_nothing_call" in source
     assert "black76_asset_or_nothing_put" in source
+    assert "cash-or-nothing and asset-or-nothing" in DigitalOptionSpec.__doc__

--- a/trellis/agent/knowledge/api_map.py
+++ b/trellis/agent/knowledge/api_map.py
@@ -20,6 +20,7 @@ _KNOWLEDGE_DIR = Path(__file__).parent
 _API_MAP_CACHE: dict[str, dict[str, Any]] = {}
 
 _FAMILY_ORDER = (
+    "digital_option_composition",
     "equity_tree",
     "rate_lattice",
     "monte_carlo",

--- a/trellis/agent/knowledge/canonical/api_map.yaml
+++ b/trellis/agent/knowledge/canonical/api_map.yaml
@@ -54,6 +54,26 @@ payoff:
     - "DeterministicCashflowPayoff wraps any Instrument into Payoff"
 
 # ---------------------------------------------------------------------------
+# European digital option composition
+# ---------------------------------------------------------------------------
+digital_option_composition:
+  module: trellis.models.resolution.single_state_diffusion
+  modules:
+    market_binding: trellis.models.resolution.single_state_diffusion
+    analytical_support: trellis.models.analytical.support
+    black_kernel: trellis.models.black
+  key_imports:
+    - "from trellis.models.resolution.single_state_diffusion import resolve_single_state_diffusion_inputs"
+    - "from trellis.models.analytical.support import asset_or_nothing_intrinsic, cash_or_nothing_intrinsic, discounted_value, forward_from_dividend_yield"
+    - "from trellis.models.black import black76_asset_or_nothing_call, black76_asset_or_nothing_put, black76_cash_or_nothing_call, black76_cash_or_nothing_put"
+  notes:
+    - "Admitted scope is European cash-or-nothing or asset-or-nothing call/put claims under lognormal equity dynamics and deterministic rates"
+    - "Start with resolve_single_state_diffusion_inputs, then form the forward with forward_from_dividend_yield before selecting the kernel"
+    - "Black-76 digital kernels return undiscounted basis values; use discounted_value to apply discount and notional once, and apply cash_payoff only to cash-or-nothing settlement"
+    - "At expiry use cash_or_nothing_intrinsic or asset_or_nothing_intrinsic so strict indicator semantics stay on the shared payoff basis"
+    - "The product-level analytical digital wrapper remains a compatibility/reference API and is not generated-route construction authority"
+
+# ---------------------------------------------------------------------------
 # Quanto option composition
 # ---------------------------------------------------------------------------
 quanto_option_composition:
@@ -289,6 +309,7 @@ analytical:
   notes:
     - "For FX vanilla analytics, resolve spot, domestic/foreign discount factors, volatility, and contract terms, then call `garman_kohlhagen_price_raw(...)` on the resolved basis and apply notional"
     - "For FX single-barrier analytics, resolve FX spot, domestic/foreign rates, volatility, monitoring, and payoff terms, then call `barrier_option_price(...)` with foreign rate as `q` and apply notional"
+    - "For European digitals, use the Black-76 cash-or-nothing or asset-or-nothing call/put basis kernel selected by contract semantics; bind the carry-adjusted forward and apply discount, notional, and cash amount explicitly"
 
 # ---------------------------------------------------------------------------
 # Model imports — calibration
@@ -309,6 +330,8 @@ utilities:
     module: trellis.models.black
     imports:
       - "from trellis.models.black import black76_call, black76_put, black76_asset_or_nothing_call, black76_asset_or_nothing_put, black76_cash_or_nothing_call, black76_cash_or_nothing_put"
+    notes:
+      - "All Black-76 kernels return undiscounted values on the forward basis; callers own market binding, discounting, notional, and payout scaling"
   garman_kohlhagen:
     module: trellis.models.analytical.fx
     imports:

--- a/trellis/agent/knowledge/canonical/backend_bindings.yaml
+++ b/trellis/agent/knowledge/canonical/backend_bindings.yaml
@@ -1003,9 +1003,33 @@ bindings:
             exercise:
               style: european
         primitives:
-          - module: trellis.models.analytical.equity_exotics
-            symbol: price_equity_digital_option_analytical
-            role: route_helper
+          - module: trellis.models.resolution.single_state_diffusion
+            symbol: resolve_single_state_diffusion_inputs
+            role: market_binding
+          - module: trellis.models.analytical.support
+            symbol: forward_from_dividend_yield
+            role: forward_builder
+          - module: trellis.models.analytical.support
+            symbol: discounted_value
+            role: discounting
+          - module: trellis.models.analytical.support
+            symbol: cash_or_nothing_intrinsic
+            role: payoff_primitive
+          - module: trellis.models.analytical.support
+            symbol: asset_or_nothing_intrinsic
+            role: payoff_primitive
+          - module: trellis.models.black
+            symbol: black76_cash_or_nothing_call
+            role: pricing_kernel
+          - module: trellis.models.black
+            symbol: black76_cash_or_nothing_put
+            role: pricing_kernel
+          - module: trellis.models.black
+            symbol: black76_asset_or_nothing_call
+            role: pricing_kernel
+          - module: trellis.models.black
+            symbol: black76_asset_or_nothing_put
+            role: pricing_kernel
       - when: default
         primitives:
           - module: trellis.models.black

--- a/trellis/agent/knowledge/canonical/decompositions.yaml
+++ b/trellis/agent/knowledge/canonical/decompositions.yaml
@@ -408,19 +408,22 @@
   learned: false
 
 # QUA-852: anchor intent-based requests for analytical exotic pricers on the
-# promoted equity-exotic analytical routes.  For benchmark tasks these are
-# reached via ``financepy_binding_id`` + the deterministic exact-binding body
-# path, so these entries are defensive hygiene for the non-benchmark planner
-# path (intent-based requests without an explicit binding).
+# promoted analytical route. QUA-1183 moves the admitted European digital
+# cohort to basis-kernel composition; the remaining exotics still use their
+# checked compatibility implementations.
 - instrument: digital_option
   features: [terminal_markov, discounting, vol_surface_dependence]
   method: analytical
   method_modules:
-    - trellis.models.analytical.equity_exotics
+    - trellis.models.resolution.single_state_diffusion
+    - trellis.models.analytical.support
+    - trellis.models.black
   required_market_data: [discount_curve, black_vol_surface]
   modeling_requirements:
-    - "USE THE EXACT HELPER: Call `price_equity_digital_option_analytical(market_state, spec)` directly; do not restate the Black digital payoff assembly inline."
-  reasoning: "Digital cash-or-nothing and asset-or-nothing payoffs have closed-form BS expressions via the shared analytical helper."
+    - "Start with `resolve_single_state_diffusion_inputs(market_state, spec)`, then build the Black forward with `forward_from_dividend_yield`; do not duplicate date, rate, volatility, or option-type binding."
+    - "Select `black76_cash_or_nothing_call` / `black76_cash_or_nothing_put` for cash settlement and multiply by cash payoff, or `black76_asset_or_nothing_call` / `black76_asset_or_nothing_put` for asset settlement without cash scaling."
+    - "Apply discount and notional exactly once with `discounted_value`, reject unknown payout types, and use `cash_or_nothing_intrinsic` / `asset_or_nothing_intrinsic` for strict expiry semantics."
+  reasoning: "European digital claims are a small basis-selection problem over reusable Black-76 cash/asset call/put kernels; no product wrapper is required."
   learned: false
 
 - instrument: lookback_option

--- a/trellis/agent/knowledge/canonical/routes.yaml
+++ b/trellis/agent/knowledge/canonical/routes.yaml
@@ -1606,12 +1606,38 @@ routes:
             exercise:
               style: european
         primitives:
-          - module: trellis.models.analytical.equity_exotics
-            symbol: price_equity_digital_option_analytical
-            role: route_helper
+          - module: trellis.models.resolution.single_state_diffusion
+            symbol: resolve_single_state_diffusion_inputs
+            role: market_binding
+          - module: trellis.models.analytical.support
+            symbol: forward_from_dividend_yield
+            role: forward_builder
+          - module: trellis.models.analytical.support
+            symbol: discounted_value
+            role: discounting
+          - module: trellis.models.analytical.support
+            symbol: cash_or_nothing_intrinsic
+            role: payoff_primitive
+          - module: trellis.models.analytical.support
+            symbol: asset_or_nothing_intrinsic
+            role: payoff_primitive
+          - module: trellis.models.black
+            symbol: black76_cash_or_nothing_call
+            role: pricing_kernel
+          - module: trellis.models.black
+            symbol: black76_cash_or_nothing_put
+            role: pricing_kernel
+          - module: trellis.models.black
+            symbol: black76_asset_or_nothing_call
+            role: pricing_kernel
+          - module: trellis.models.black
+            symbol: black76_asset_or_nothing_put
+            role: pricing_kernel
         adapters: []
         notes:
-          - "Use the exact digital helper with `market_state` and `spec`; do not rebuild the Black digital payoff inline."
+          - "Start with `resolve_single_state_diffusion_inputs(...)`; use `forward_from_dividend_yield(...)` for the Black forward and the resolved curve for the discount factor."
+          - "Select the cash-or-nothing or asset-or-nothing call/put kernel from the declared payout and option types. Black-76 digital kernels return undiscounted values, so use `discounted_value(...)` to apply discount, notional, and the cash amount only for cash settlement."
+          - "Reject unsupported payout types and use `cash_or_nothing_intrinsic(...)` or `asset_or_nothing_intrinsic(...)` at expiry so the strict indicator is shared; do not call a product pricing wrapper."
       # The ``default`` sentinel intentionally stays in legacy form: it is
       # dispatched by ``resolve_route_primitives`` as the explicit fall-through
       # catch-all, not as a structural ContractPattern match. QUA-920 does not

--- a/trellis/agent/knowledge/import_registry.py
+++ b/trellis/agent/knowledge/import_registry.py
@@ -561,7 +561,7 @@ from trellis.curves.credit_curve import CreditCurve
 ### Models — Analytical
 from trellis.models.black import black76_call, black76_put, black76_asset_or_nothing_call, black76_asset_or_nothing_put, black76_cash_or_nothing_call, black76_cash_or_nothing_put
 from trellis.models.analytical import terminal_intrinsic, terminal_vanilla_from_basis
-from trellis.models.analytical.support import discounted_value, gauss_hermite_product_expectation, implied_zero_rate, normalized_option_type, quanto_adjusted_forward, terminal_intrinsic
+from trellis.models.analytical.support import asset_or_nothing_intrinsic, cash_or_nothing_intrinsic, discounted_value, forward_from_dividend_yield, gauss_hermite_product_expectation, implied_zero_rate, normalized_option_type, quanto_adjusted_forward, terminal_intrinsic
 from trellis.models.analytical.support.expectations import gauss_hermite_product_expectation
 from trellis.models.analytical.fx import ResolvedGarmanKohlhagenInputs, garman_kohlhagen_call_raw, garman_kohlhagen_price_raw, garman_kohlhagen_put_raw
 from trellis.models.analytical.jamshidian import zcb_option_hw

--- a/trellis/agent/planner.py
+++ b/trellis/agent/planner.py
@@ -231,6 +231,7 @@ STATIC_SPECS: dict[str, SpecSchema] = {
             FieldDef("option_type", "str", "Option type: 'call' or 'put'", "'call'"),
             FieldDef("payout_type", "str", "Digital payout type", "'cash_or_nothing'"),
             FieldDef("cash_payoff", "float", "Cash amount paid when the option finishes in the money", "1.0"),
+            FieldDef("dividend_yield", "float", "Continuous underlier dividend yield", "0.0"),
             FieldDef("day_count", "DayCountConvention", "Day count convention", "DayCountConvention.ACT_365"),
         ],
     ),

--- a/trellis/instruments/_agent/digitaloption.py
+++ b/trellis/instruments/_agent/digitaloption.py
@@ -46,27 +46,11 @@ from trellis.models.resolution.single_state_diffusion import (
 
 @dataclass(frozen=True)
 class DigitalOptionSpec:
-    """Specification for Build a pricer for: FinancePy parity: equity digital cash-or-nothing
+    """European equity digital contract.
 
-digital_option
-
-Spot: 100.0.
-Strike: 100.0.
-Option type: call.
-Payout type: cash_or_nothing.
-Cash payoff: 10.0.
-Expiry date: 2025-11-15.
-
-Preferred method family: analytical
-FinancePy binding: financepy.equity.digital.black_scholes
-Benchmark product: digital_option
-
-Construct methods: analytical
-Comparison targets: analytical (analytical)
-Cross-validation harness:
-  external targets: financepy
-
-Implementation target: analytical."""
+    Supports cash-or-nothing and asset-or-nothing call/put settlement with an
+    explicit continuous dividend yield.
+    """
     notional: float
     spot: float
     strike: float
@@ -135,9 +119,10 @@ Implementation target: analytical."""
                 )
             return float(resolved.notional * settlement_amount)
 
-        if market_state.discount is None:
-            raise ValueError("single-state diffusion resolver did not bind discounting")
-        discount_factor = float(market_state.discount.discount(resolved.maturity))
+        discount_curve = market_state.discount
+        if discount_curve is None:
+            raise ValueError("digital option pricing requires market_state.discount")
+        discount_factor = float(discount_curve.discount(resolved.maturity))
         forward = forward_from_dividend_yield(
             spot=resolved.spot,
             domestic_rate=resolved.rate,

--- a/trellis/instruments/_agent/digitaloption.py
+++ b/trellis/instruments/_agent/digitaloption.py
@@ -27,8 +27,21 @@ from datetime import date
 
 from trellis.core.market_state import MarketState
 from trellis.core.types import DayCountConvention
-from trellis.models.analytical import price_equity_digital_option_analytical
-
+from trellis.models.analytical.support import (
+    asset_or_nothing_intrinsic,
+    cash_or_nothing_intrinsic,
+    discounted_value,
+    forward_from_dividend_yield,
+)
+from trellis.models.black import (
+    black76_asset_or_nothing_call,
+    black76_asset_or_nothing_put,
+    black76_cash_or_nothing_call,
+    black76_cash_or_nothing_put,
+)
+from trellis.models.resolution.single_state_diffusion import (
+    resolve_single_state_diffusion_inputs,
+)
 
 
 @dataclass(frozen=True)
@@ -61,6 +74,7 @@ Implementation target: analytical."""
     option_type: str = 'call'
     payout_type: str = 'cash_or_nothing'
     cash_payoff: float = 1.0
+    dividend_yield: float = 0.0
     day_count: DayCountConvention = DayCountConvention.ACT_365
 
 
@@ -100,6 +114,62 @@ Implementation target: analytical."""
 
     def evaluate(self, market_state: MarketState) -> float:
         spec = self._spec
-        from trellis.models.analytical import price_equity_digital_option_analytical
+        resolved = resolve_single_state_diffusion_inputs(market_state, spec)
+        payout_type = str(spec.payout_type or "cash_or_nothing").strip().lower()
+        if payout_type not in {"cash_or_nothing", "asset_or_nothing"}:
+            raise ValueError(f"Unsupported payout_type {spec.payout_type!r}")
 
-        return float(price_equity_digital_option_analytical(market_state, spec))
+        if resolved.maturity <= 0.0:
+            if payout_type == "cash_or_nothing":
+                settlement_amount = cash_or_nothing_intrinsic(
+                    resolved.option_type,
+                    spot=resolved.spot,
+                    strike=resolved.strike,
+                    cash=spec.cash_payoff,
+                )
+            else:
+                settlement_amount = asset_or_nothing_intrinsic(
+                    resolved.option_type,
+                    spot=resolved.spot,
+                    strike=resolved.strike,
+                )
+            return float(resolved.notional * settlement_amount)
+
+        if market_state.discount is None:
+            raise ValueError("single-state diffusion resolver did not bind discounting")
+        discount_factor = float(market_state.discount.discount(resolved.maturity))
+        forward = forward_from_dividend_yield(
+            spot=resolved.spot,
+            domestic_rate=resolved.rate,
+            dividend_yield=resolved.dividend_yield,
+            T=resolved.maturity,
+        )
+
+        if payout_type == "cash_or_nothing":
+            kernel = (
+                black76_cash_or_nothing_call
+                if resolved.option_type == "call"
+                else black76_cash_or_nothing_put
+            )
+            payout_scale = float(spec.cash_payoff)
+        else:
+            kernel = (
+                black76_asset_or_nothing_call
+                if resolved.option_type == "call"
+                else black76_asset_or_nothing_put
+            )
+            payout_scale = 1.0
+
+        undiscounted = kernel(
+            forward,
+            resolved.strike,
+            resolved.sigma,
+            resolved.maturity,
+        )
+        return float(
+            discounted_value(
+                undiscounted,
+                discount_factor,
+                scale=resolved.notional * payout_scale,
+            )
+        )


### PR DESCRIPTION
## Summary\n- retire the analytical digital product helper as route, binding, and checked-adapter construction authority\n- compose European cash/asset digitals from shared market resolution, analytical support, and Black-76 basis kernels\n- expose the package-level support symbols through the import registry and update agent-facing docs\n\n## Validation\n- focused acceptance: 36 passed, 637 deselected\n- strict cached F010: zero LLM calls; 0.004028% FinancePy deviation within 1%\n- helper-authority audit: route 62 -> 61, binding 66 -> 65, adapter authority calls 18 -> 17\n- make gate-pr: 4,446 core passed; tier 2 32 passed, 15 expected skips\n\n## Boundaries\n- no replacement product helper\n- no hand-authored cookbook promotion\n- no live external-model generation\n- LIMITATIONS.md unchanged because admitted support did not expand\n\nLinear: QUA-1183