### PR TITLE
QUA-1183: sync completed digital milestone

### DIFF
--- a/doc/plan/active__semantic-task-synthesis-helper-retirement.md
+++ b/doc/plan/active__semantic-task-synthesis-helper-retirement.md
@@ -41,19 +41,25 @@ Status mirror last synced: `2026-07-14`
 | `QUA-1178` | Semantic route audit: machine-readable helper authority inventory | Done |
 | `QUA-1179` | Monte Carlo: reusable scheduled observation aggregation | Done |
 | `QUA-1180` | Analytical support: weighted lognormal-sum moments | Done |
-| `QUA-1181` | Arithmetic Asian pricing: retire helper authority | In Progress |
+| `QUA-1181` | Arithmetic Asian pricing: retire helper authority | Done |
 | `QUA-1182` | Semantic agent navigation: bounded knowledge and documentation packets | Done |
+| `QUA-1183` | Digital option pricing: retire analytical helper authority | Done |
+| `QUA-1184` | Semantic agent navigation: render task-relevant canonical composition cards | Backlog |
+| `QUA-1185` | Task runtime: offline cached replays suppress post-build LLM stages | Backlog |
 
 ## Current Sequence
 
-1. Select the next helper-authoritative green family using the merged audit and
-   prove QUA-1182's bounded navigation during fresh generation before retiring
-   that helper authority.
-2. Use the resulting trace to compare first-pass source selection, retrieved
-   lessons, documentation sections, retries, and residual validation findings.
-3. Complete QUA-1181's live fresh-generation proof only after explicit external
-   model approval; its implementation, offline replay, and release gate are
-   already complete.
+1. Complete QUA-1184 so every canonical composition card is either reachable
+   through bounded semantic selection or explicitly classified as intentionally
+   non-rendered.
+2. Re-run the helper-authority audit on merged `main` and select the next
+   green family whose reusable numerical and market primitives already exist.
+   Open a focused retirement ticket only after that capability audit.
+3. Complete QUA-1185 before treating cached offline replay as zero-model
+   evidence without explicit reflection/consolidation skip flags.
+4. Run live fresh-generation evidence only with current external-model approval;
+   use it to compare first-pass source selection, retrieved documentation,
+   retries, and residual validator findings rather than as pricing authority.
 
 ## Completion Evidence
 


### PR DESCRIPTION
## Summary
- mark QUA-1181 and QUA-1183 done in the helper-retirement plan mirror
- add QUA-1184 and QUA-1185 follow-on backlog tickets
- update the current execution sequence to match live Linear state

## Validation
- git diff --check
- documentation-only closeout; TDD does not apply

Closes QUA-1183