### PR TITLE
QUA-1184: select bounded semantic API map cards

### DIFF
--- a/docs/agent/builder_agent.rst
+++ b/docs/agent/builder_agent.rst
@@ -9,7 +9,8 @@ Two-Step Pipeline
 
 **Step 1: Spec Design** (deterministic or LLM)
 
-For known instruments (10 static specs), the spec dataclass is deterministic:
+For known instruments with a registered static spec, the spec dataclass is
+deterministic:
 
 .. code-block:: python
 
@@ -32,48 +33,35 @@ For unknown instruments, an LLM call designs the spec via structured JSON output
 The system generates a complete skeleton (imports, spec, class, requirements)
 and asks the LLM to fill in ``evaluate()``. The prompt includes:
 
-- The skeleton code
-- The quant agent's method selection
-- The relevant **cookbook** pattern
-- Reference implementations for the chosen method
+- the compiled semantic contract, method selection, and route obligations
+- task-relevant API-map cards selected from typed product and route cues
+- exact public symbols verified against the import registry
+- bounded validated lessons and read-only cookbook evidence
+- the skeleton code and deterministic acceptance requirements
 
-Cookbooks
----------
+Navigation And Authority
+------------------------
 
-Five evaluate() body templates, one per method:
+The builder owns code and import selection. A no-query ``inspect_api_map``
+call returns a bounded complete catalog; semantic fields or explicit family
+names return the relevant full construction cards. The builder confirms exact
+symbols with ``find_symbol`` or ``list_exports`` before reading modules
+or writing code.
 
-.. list-table::
-   :header-rows: 1
-
-   * - Method
-     - Return Type
-     - Pattern
-   * - ``analytical``
-     - ``Cashflows``
-     - Forward rates → Black76 → dated payoffs
-   * - ``rate_tree``
-     - ``PresentValue``
-     - Build tree → backward induction with exercise
-   * - ``monte_carlo``
-     - ``PresentValue``
-     - Simulate paths → compute path-dependent payoff
-   * - ``copula``
-     - ``PresentValue``
-     - Simulate correlated defaults → tranche loss
-   * - ``waterfall``
-     - ``Cashflows``
-     - Amortize → prepay → run through tranches
-
-Each cookbook marks ``>>> INSTRUMENT-SPECIFIC <<<`` where the builder fills in
-instrument logic.
+Cookbooks are validated method-pattern evidence, not product implementation
+authority. Runtime tasks cannot write or promote cookbook entries, and a
+product- or method-specific pricing helper is not a substitute for assembling
+an admitted route from reusable market, process, payoff, control, numerical,
+and validation primitives. The quant and model-validator role packets remain
+code-free and do not receive the builder API-map surface.
 
 Static Specs
 ------------
 
-10 instrument types with deterministic field names:
-
-swaption, cap, floor, callable_bond, puttable_bond, barrier_option,
-asian_option, cdo, nth_to_default, bermudan_swaption.
+Registered static specs provide deterministic field names and defaults for
+known instrument families. Product meaning still comes from the semantic
+contract; a static spec cannot broaden exercise style, payoff family, model
+family, or market binding.
 
 Caching
 -------
@@ -86,3 +74,11 @@ Implementation
 --------------
 
 .. autofunction:: trellis.agent.executor.build_payoff
+
+See Also
+--------
+
+- :doc:`../developer/runtime_agent_orientation` for the separation between
+  worktree instructions, runtime role packets, and builder API navigation
+- :doc:`../quant/knowledge_maintenance` for primitive-first knowledge
+  maintenance and cookbook governance

--- a/docs/developer/runtime_agent_orientation.rst
+++ b/docs/developer/runtime_agent_orientation.rst
@@ -56,6 +56,24 @@ contracts, the read-only cookbook catalog, current limitations, calibration
 documentation, and audit contracts. This preserves deterministic-first review
 ownership.
 
+Builder API Navigation
+----------------------
+
+The builder has a separate navigation surface in
+``canonical/api_map.yaml``. It is not part of either runtime role packet.
+The typed ``ApiMapQuery`` selector uses product, payoff, method, model,
+feature, and route cues to render only the relevant full cards. A no-query
+``inspect_api_map`` call returns a bounded catalog of every canonical model
+and utility card; callers can then request exact cards or submit semantic
+fields. This keeps new canonical cards reachable without adding their names to
+a second hand-maintained global order.
+
+Builder prompt traces record selected and omitted API-map card identities.
+Rendered cards have a hard character budget and mark truncation explicitly.
+Exact symbols remain the import registry's responsibility after family
+selection. Quant and model-validator regression tests reject API-map imports
+or code templates in their resolved context.
+
 Bounded Resolution
 ------------------
 

--- a/docs/quant/knowledge_maintenance.rst
+++ b/docs/quant/knowledge_maintenance.rst
@@ -107,7 +107,9 @@ therefore narrow context in this order:
 
 1. preserve the declared semantic contract, including product refinements,
    schedules, observables, state, and exercise/control semantics;
-2. use ``canonical/api_map.yaml`` to find the relevant module families;
+2. use the typed semantic selector over ``canonical/api_map.yaml`` to find
+   relevant module families; use its bounded complete catalog when no semantic
+   query is available;
 3. retrieve exact public symbols from the import registry;
 4. assemble reusable process, market-binding, schedule, payoff, control,
    discounting, and validation capabilities;

--- a/docs/quant/pricing_stack.rst
+++ b/docs/quant/pricing_stack.rst
@@ -688,6 +688,10 @@ the resolver, basis selection, and scaling obligations, while exact symbol
 validation resolves through the import registry. Cash/asset settlement and
 call/put orientation remain contract choices; a product wrapper cannot
 substitute for that semantic selection even when one numeric case is close.
+API-map rendering selects this card from typed digital product/payoff cues
+rather than from a separate global family list. Other composition cards remain
+reachable through the complete bounded catalog without being injected into
+unrelated builder prompts.
 
 For schedule-driven cap/floor strips lowered onto ``analytical_black76``, the
 typed schedule state now carries admissibility directly. Structural

--- a/tests/test_agent/test_api_map.py
+++ b/tests/test_agent/test_api_map.py
@@ -150,6 +150,23 @@ def test_api_map_no_query_formatter_is_bounded_complete_catalog():
     assert len(text) <= 4000
 
 
+def test_api_map_compact_default_enforces_four_thousand_character_budget():
+    text = format_api_map_for_prompt(
+        compact=True,
+        query=ApiMapQuery(
+            requested_families=(
+                "monte_carlo",
+                "pde",
+                "rate_monte_carlo_composition",
+                "quanto_option_composition",
+            )
+        ),
+    )
+
+    assert len(text) <= 4000
+    assert "truncated" in text.lower()
+
+
 def test_every_canonical_api_map_family_is_explicitly_reachable():
     available = select_api_map_sections().available_families
 
@@ -158,6 +175,23 @@ def test_every_canonical_api_map_family_is_explicitly_reachable():
             ApiMapQuery(requested_families=(family_name,))
         )
         assert family_name in selection.selected_families
+
+
+def test_every_canonical_api_map_utility_is_explicitly_reachable():
+    available = select_api_map_sections().available_utilities
+
+    for utility_name in available:
+        selection = select_api_map_sections(
+            ApiMapQuery(requested_families=(utility_name,))
+        )
+        assert utility_name in selection.selected_utilities
+
+
+def test_empty_api_map_treats_empty_query_as_catalog_only(monkeypatch):
+    monkeypatch.setattr(api_map_module, "get_api_map", lambda: {})
+
+    assert select_api_map_sections().catalog_only is True
+    assert select_api_map_sections(ApiMapQuery()).catalog_only is True
 
 
 def test_api_map_semantic_selection_reaches_composition_cards():
@@ -261,7 +295,7 @@ def test_api_map_reachability_does_not_depend_on_manual_family_tuple():
 
 
 def test_api_map_rejects_unknown_explicit_cards_and_invalid_budgets():
-    with pytest.raises(ValueError, match="Unknown API map families"):
+    with pytest.raises(ValueError, match="Unknown API map cards"):
         select_api_map_sections(
             ApiMapQuery(requested_families=("not_a_canonical_card",))
         )

--- a/tests/test_agent/test_api_map.py
+++ b/tests/test_agent/test_api_map.py
@@ -2,11 +2,20 @@
 
 from __future__ import annotations
 
-import re
 import importlib
+import inspect
+import re
+
+import pytest
 
 from trellis.agent.knowledge.import_registry import module_exists
-from trellis.agent.knowledge.api_map import format_api_map_for_prompt, get_api_map
+from trellis.agent.knowledge import api_map as api_map_module
+from trellis.agent.knowledge.api_map import (
+    ApiMapQuery,
+    format_api_map_for_prompt,
+    get_api_map,
+    select_api_map_sections,
+)
 
 
 _IMPORT_RE = re.compile(r"^from\s+([A-Za-z0-9_.]+)\s+import\s+(.+?)\s*$")
@@ -96,25 +105,169 @@ def test_api_map_key_imports_are_registry_valid():
 
 
 def test_api_map_formatter_includes_navigation_guidance():
-    text = format_api_map_for_prompt(compact=True)
+    text = format_api_map_for_prompt(
+        compact=True,
+        query=ApiMapQuery(
+            instrument_type="digital_option",
+            payoff_family="digital_option",
+            method="analytical",
+            model_family="equity_diffusion",
+        ),
+    )
 
     assert "API Map" in text
     assert "MarketState" in text
-    assert "equity_tree" in text
-    assert "rate_lattice" in text
-    assert "trellis.models.monte_carlo" in text
     assert "digital_option_composition" in text
     assert "resolve_single_state_diffusion_inputs" in text
     assert "black76_cash_or_nothing_call" in text
+    assert "#### quanto_option_composition" not in text
+    assert "Selected cards:" in text
+    assert "Omitted cards:" in text
     assert "inspect_api_map" not in text
 
 
-def test_api_map_formatter_includes_all_canonical_utilities():
+def test_api_map_no_query_formatter_is_bounded_complete_catalog():
     text = format_api_map_for_prompt(compact=True)
+    selection = select_api_map_sections()
+    api_map = get_api_map()
+    expected_families = tuple(
+        name
+        for name, section in api_map.items()
+        if name not in {"market_state", "payoff", "utilities"}
+        and isinstance(section, dict)
+        and section.get("module")
+    )
 
+    assert selection.catalog_only is True
+    assert selection.available_families == expected_families
+    assert not selection.selected_families
+    for family_name in selection.available_families:
+        assert family_name in text
     assert "rate_style_swaption" in text
     assert "jamshidian_zcb_option" in text
     assert "credit_curve" in text
+    assert "from trellis" not in text
+    assert len(text) <= 4000
+
+
+def test_every_canonical_api_map_family_is_explicitly_reachable():
+    available = select_api_map_sections().available_families
+
+    for family_name in available:
+        selection = select_api_map_sections(
+            ApiMapQuery(requested_families=(family_name,))
+        )
+        assert family_name in selection.selected_families
+
+
+def test_api_map_semantic_selection_reaches_composition_cards():
+    cases = (
+        (
+            ApiMapQuery(
+                payoff_family="digital_option",
+                method="analytical",
+            ),
+            "digital_option_composition",
+        ),
+        (
+            ApiMapQuery(
+                instrument_type="quanto_option",
+                payoff_family="quanto_option",
+                method="monte_carlo",
+                model_family="hybrid",
+            ),
+            "quanto_option_composition",
+        ),
+        (
+            ApiMapQuery(
+                instrument_type="arithmetic_asian_option",
+                payoff_family="asian_option",
+                method="analytical",
+                features=("scheduled_observation", "arithmetic_average"),
+            ),
+            "arithmetic_asian_composition",
+        ),
+        (
+            ApiMapQuery(
+                features=("scheduled_observation",),
+                method="monte_carlo",
+            ),
+            "scheduled_observation_composition",
+        ),
+        (
+            ApiMapQuery(
+                features=("weighted_lognormal_sum",),
+                method="analytical",
+            ),
+            "weighted_lognormal_sum_composition",
+        ),
+        (
+            ApiMapQuery(
+                instrument_type="cliquet",
+                payoff_family="cliquet",
+                method="monte_carlo",
+                features=("observation_return",),
+            ),
+            "observation_return_composition",
+        ),
+        (
+            ApiMapQuery(
+                description="Price a cliquet with capped interval returns.",
+            ),
+            "observation_return_composition",
+        ),
+        (
+            ApiMapQuery(
+                instrument_type="bermudan_swaption",
+                payoff_family="swaption",
+                method="monte_carlo",
+                model_family="interest_rate",
+            ),
+            "rate_monte_carlo_composition",
+        ),
+    )
+
+    for query, expected_family in cases:
+        selection = select_api_map_sections(query)
+        assert expected_family in selection.selected_families
+
+
+def test_api_map_selection_and_rendering_are_stable_and_budgeted():
+    query = ApiMapQuery(
+        instrument_type="arithmetic_asian_option",
+        payoff_family="asian_option",
+        method="monte_carlo",
+        features=("scheduled_observation", "arithmetic_average"),
+    )
+
+    first = select_api_map_sections(query)
+    second = select_api_map_sections(query)
+    text = format_api_map_for_prompt(
+        compact=True,
+        query=query,
+        max_chars=1200,
+    )
+
+    assert first == second
+    assert len(text) <= 1200
+    assert "truncated" in text.lower()
+    assert "arithmetic_asian_composition" in text
+
+
+def test_api_map_reachability_does_not_depend_on_manual_family_tuple():
+    source = inspect.getsource(api_map_module)
+
+    assert "_FAMILY_ORDER" not in source
+
+
+def test_api_map_rejects_unknown_explicit_cards_and_invalid_budgets():
+    with pytest.raises(ValueError, match="Unknown API map families"):
+        select_api_map_sections(
+            ApiMapQuery(requested_families=("not_a_canonical_card",))
+        )
+
+    with pytest.raises(ValueError, match="at least 240"):
+        format_api_map_for_prompt(max_chars=0)
 
 
 def test_monte_carlo_api_map_prioritizes_american_lsm_primitives():

--- a/tests/test_agent/test_knowledge_store.py
+++ b/tests/test_agent/test_knowledge_store.py
@@ -830,9 +830,15 @@ class TestFormatting:
 
         assert "## Product Semantics" in payload["builder_text"]
         assert "API Map" in payload["builder_text_distilled"]
+        assert "quanto_option_composition" in payload["builder_text_distilled"]
+        assert (
+            "#### digital_option_composition"
+            not in payload["builder_text_distilled"]
+        )
         assert "## Shared Failure Memory" in payload["review_text"]
         assert payload["routing_text"]
-        assert "API Map" in payload["routing_text_distilled"]
+        assert "API Map" not in payload["routing_text_distilled"]
+        assert "from trellis" not in payload["routing_text_distilled"]
         assert (
             "## Prior Lessons From Similar Products" in payload["routing_text"]
             or "## Shared Routing Principles" in payload["routing_text"]
@@ -845,6 +851,10 @@ class TestFormatting:
         assert payload["routing_text_distilled"]
         assert payload["summary"]["instrument"] == product_ir.instrument
         assert payload["summary"]["lesson_count"] >= 1
+        assert "quanto_option_composition" in (
+            payload["summary"]["api_map_selection"]["selected_families"]
+        )
+        assert payload["summary"]["api_map_selection"]["omitted_families"]
         assert payload["summary"]["selected_artifact_ids"]
         assert "## Generated Skills" in payload["builder_text_distilled"]
         assert "builder" in payload["summary"]["selected_artifacts_by_audience"]

--- a/tests/test_agent/test_role_orientation_resolution.py
+++ b/tests/test_agent/test_role_orientation_resolution.py
@@ -334,7 +334,10 @@ def test_default_role_packets_are_role_separated_and_source_bounded():
     assert "quant-runtime-navigation" not in validator.rendered
     assert "deterministic evidence" not in quant.context.lower()
     assert "from trellis" not in quant.context.lower()
+    assert "## api map" not in quant.context.lower()
     assert "route_helper" not in quant.context.lower()
+    assert "from trellis" not in validator.context.lower()
+    assert "## api map" not in validator.context.lower()
     assert any(
         "heston" in excerpt.section.lower()
         for excerpt in quant.excerpts

--- a/tests/test_agent/test_tools.py
+++ b/tests/test_agent/test_tools.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 
 from trellis.agent.executor import _handle_tool_call
+from trellis.agent.tools import TOOLS
 
 
 def test_find_symbol_tool_returns_matches():
@@ -12,11 +13,48 @@ def test_find_symbol_tool_returns_matches():
     assert any(match["module"] == "trellis.models.pde.theta_method" for match in payload)
 
 
-def test_inspect_api_map_tool_returns_navigation_card():
+def test_inspect_api_map_tool_returns_bounded_navigation_catalog():
     payload = _handle_tool_call("inspect_api_map", {})
     assert "API Map" in payload
     assert "MarketState" in payload
-    assert "trellis.models.monte_carlo" in payload
+    assert "digital_option_composition" in payload
+    assert "quanto_option_composition" in payload
+    assert "from trellis" not in payload
+    assert len(payload) <= 4000
+
+
+def test_inspect_api_map_tool_accepts_semantic_query():
+    payload = _handle_tool_call(
+        "inspect_api_map",
+        {
+            "instrument_type": "digital_option",
+            "payoff_family": "digital_option",
+            "method": "analytical",
+            "model_family": "equity_diffusion",
+        },
+    )
+
+    assert "digital_option_composition" in payload
+    assert "resolve_single_state_diffusion_inputs" in payload
+    assert "black76_cash_or_nothing_call" in payload
+    assert "#### quanto_option_composition" not in payload
+
+
+def test_inspect_api_map_tool_schema_exposes_bounded_semantic_fields():
+    tool = next(item for item in TOOLS if item["name"] == "inspect_api_map")
+    properties = tool["input_schema"]["properties"]
+
+    assert {
+        "instrument_type",
+        "payoff_family",
+        "method",
+        "model_family",
+        "features",
+        "route_ids",
+        "route_families",
+        "description",
+        "families",
+    } <= set(properties)
 
 
 def test_list_exports_tool_returns_public_exports():

--- a/tests/test_agent/test_tools.py
+++ b/tests/test_agent/test_tools.py
@@ -40,6 +40,26 @@ def test_inspect_api_map_tool_accepts_semantic_query():
     assert "#### quanto_option_composition" not in payload
 
 
+def test_inspect_api_map_tool_accepts_exact_utility_card():
+    payload = _handle_tool_call(
+        "inspect_api_map",
+        {"families": ["black76"]},
+    )
+
+    assert "#### black76" in payload
+    assert "from trellis.models.black import" in payload
+
+
+def test_inspect_api_map_tool_returns_readable_error_for_unknown_card():
+    payload = _handle_tool_call(
+        "inspect_api_map",
+        {"families": ["not_a_canonical_card"]},
+    )
+
+    assert payload.startswith("Error inspecting API map:")
+    assert "not_a_canonical_card" in payload
+
+
 def test_inspect_api_map_tool_schema_exposes_bounded_semantic_fields():
     tool = next(item for item in TOOLS if item["name"] == "inspect_api_map")
     properties = tool["input_schema"]["properties"]

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -36,7 +36,7 @@ from trellis.agent.analytical_traces import emit_analytical_trace_from_generatio
 from trellis.agent.semantic_validation import validate_semantics
 from trellis.agent.builder import write_module, run_tests
 from trellis.agent.knowledge.import_registry import resolve_import_candidates
-from trellis.agent.knowledge.api_map import format_api_map_for_prompt
+from trellis.agent.knowledge.api_map import ApiMapQuery, format_api_map_for_prompt
 from trellis.agent.role_orientation import role_orientation_summary
 
 
@@ -265,7 +265,35 @@ def _hydrate_spec_schema_defaults_from_semantics(
 def _handle_tool_call(name: str, input_data: dict) -> str:
     """Dispatch a tool call from the LLM agent."""
     if name == "inspect_api_map":
-        return format_api_map_for_prompt(compact=True)
+        query_keys = (
+            "instrument_type",
+            "payoff_family",
+            "method",
+            "model_family",
+            "features",
+            "route_ids",
+            "route_families",
+            "description",
+            "families",
+        )
+        query = None
+        if any(input_data.get(key) for key in query_keys):
+            query = ApiMapQuery(
+                instrument_type=str(input_data.get("instrument_type") or ""),
+                payoff_family=str(input_data.get("payoff_family") or ""),
+                method=str(input_data.get("method") or ""),
+                model_family=str(input_data.get("model_family") or ""),
+                features=tuple(input_data.get("features") or ()),
+                route_ids=tuple(input_data.get("route_ids") or ()),
+                route_families=tuple(input_data.get("route_families") or ()),
+                description=str(input_data.get("description") or ""),
+                requested_families=tuple(input_data.get("families") or ()),
+            )
+        return format_api_map_for_prompt(
+            compact=True,
+            query=query,
+            max_chars=6000,
+        )
 
     if name == "inspect_library":
         tree = get_package_tree()

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -265,35 +265,38 @@ def _hydrate_spec_schema_defaults_from_semantics(
 def _handle_tool_call(name: str, input_data: dict) -> str:
     """Dispatch a tool call from the LLM agent."""
     if name == "inspect_api_map":
-        query_keys = (
-            "instrument_type",
-            "payoff_family",
-            "method",
-            "model_family",
-            "features",
-            "route_ids",
-            "route_families",
-            "description",
-            "families",
-        )
-        query = None
-        if any(input_data.get(key) for key in query_keys):
-            query = ApiMapQuery(
-                instrument_type=str(input_data.get("instrument_type") or ""),
-                payoff_family=str(input_data.get("payoff_family") or ""),
-                method=str(input_data.get("method") or ""),
-                model_family=str(input_data.get("model_family") or ""),
-                features=tuple(input_data.get("features") or ()),
-                route_ids=tuple(input_data.get("route_ids") or ()),
-                route_families=tuple(input_data.get("route_families") or ()),
-                description=str(input_data.get("description") or ""),
-                requested_families=tuple(input_data.get("families") or ()),
+        try:
+            query_keys = (
+                "instrument_type",
+                "payoff_family",
+                "method",
+                "model_family",
+                "features",
+                "route_ids",
+                "route_families",
+                "description",
+                "families",
             )
-        return format_api_map_for_prompt(
-            compact=True,
-            query=query,
-            max_chars=6000,
-        )
+            query = None
+            if any(input_data.get(key) for key in query_keys):
+                query = ApiMapQuery(
+                    instrument_type=str(input_data.get("instrument_type") or ""),
+                    payoff_family=str(input_data.get("payoff_family") or ""),
+                    method=str(input_data.get("method") or ""),
+                    model_family=str(input_data.get("model_family") or ""),
+                    features=tuple(input_data.get("features") or ()),
+                    route_ids=tuple(input_data.get("route_ids") or ()),
+                    route_families=tuple(input_data.get("route_families") or ()),
+                    description=str(input_data.get("description") or ""),
+                    requested_families=tuple(input_data.get("families") or ()),
+                )
+            return format_api_map_for_prompt(
+                compact=True,
+                query=query,
+                max_chars=4000,
+            )
+        except Exception as e:
+            return f"Error inspecting API map: {e}"
 
     if name == "inspect_library":
         tree = get_package_tree()

--- a/trellis/agent/knowledge/__init__.py
+++ b/trellis/agent/knowledge/__init__.py
@@ -44,8 +44,11 @@ from trellis.agent.knowledge.import_registry import (
     suggest_tests_for_symbol,
 )
 from trellis.agent.knowledge.api_map import (
+    ApiMapQuery,
+    ApiMapSelection,
     format_api_map_for_prompt,
     get_api_map,
+    select_api_map_sections,
 )
 from trellis.agent.knowledge.skills import (
     augment_prompt_with_skill_records,
@@ -187,8 +190,11 @@ __all__ = [
     "get_test_map",
     "get_repo_facts",
     "suggest_tests_for_symbol",
+    "ApiMapQuery",
+    "ApiMapSelection",
     "get_api_map",
     "format_api_map_for_prompt",
+    "select_api_map_sections",
     "load_skill_index",
     "load_skill_lineage_index",
     "get_skill_record",

--- a/trellis/agent/knowledge/api_map.py
+++ b/trellis/agent/knowledge/api_map.py
@@ -22,7 +22,7 @@ _KNOWLEDGE_DIR = Path(__file__).parent
 _API_MAP_CACHE: dict[str, dict[str, Any]] = {}
 _SPECIAL_TOP_LEVEL_KEYS = frozenset({"market_state", "payoff", "utilities"})
 _WORD = re.compile(r"[a-z0-9]+")
-_DEFAULT_COMPACT_CHARS = 6000
+_DEFAULT_COMPACT_CHARS = 4000
 _DEFAULT_EXPANDED_CHARS = 9000
 _DEFAULT_SELECTION_LIMIT = 4
 
@@ -114,7 +114,15 @@ def select_api_map_sections(
     """Select task-relevant cards directly from the canonical API map."""
     api_map = get_api_map()
     if not api_map:
-        return ApiMapSelection((), (), (), (), (), (), query is None)
+        return ApiMapSelection(
+            available_families=(),
+            selected_families=(),
+            omitted_families=(),
+            available_utilities=(),
+            selected_utilities=(),
+            omitted_utilities=(),
+            catalog_only=query is None or query.is_empty,
+        )
 
     family_names = _family_names(api_map)
     utility_names = _utility_names(api_map)
@@ -138,9 +146,10 @@ def select_api_map_sections(
             if str(item).strip()
         )
     )
-    unknown = tuple(name for name in requested if name not in family_names)
+    available_cards = frozenset((*family_names, *utility_names))
+    unknown = tuple(name for name in requested if name not in available_cards)
     if unknown:
-        raise ValueError("Unknown API map families: " + ", ".join(unknown))
+        raise ValueError("Unknown API map cards: " + ", ".join(unknown))
 
     if requested:
         selected_families = tuple(
@@ -166,7 +175,8 @@ def select_api_map_sections(
     selected_utilities = tuple(
         name
         for name in utility_names
-        if _utility_is_relevant(
+        if name in requested
+        or _utility_is_relevant(
             name,
             api_map["utilities"][name],
             query,

--- a/trellis/agent/knowledge/api_map.py
+++ b/trellis/agent/knowledge/api_map.py
@@ -8,7 +8,9 @@ use before they expand into the full registry or a full package walk.
 from __future__ import annotations
 
 from collections.abc import Mapping
+from dataclasses import dataclass
 from pathlib import Path
+import re
 from typing import Any
 
 import yaml
@@ -18,31 +20,72 @@ from trellis.agent.knowledge.import_registry import get_repo_revision
 
 _KNOWLEDGE_DIR = Path(__file__).parent
 _API_MAP_CACHE: dict[str, dict[str, Any]] = {}
+_SPECIAL_TOP_LEVEL_KEYS = frozenset({"market_state", "payoff", "utilities"})
+_WORD = re.compile(r"[a-z0-9]+")
+_DEFAULT_COMPACT_CHARS = 6000
+_DEFAULT_EXPANDED_CHARS = 9000
+_DEFAULT_SELECTION_LIMIT = 4
 
-_FAMILY_ORDER = (
-    "digital_option_composition",
-    "equity_tree",
-    "rate_lattice",
-    "monte_carlo",
-    "observation_return_composition",
-    "qmc",
-    "pde",
-    "fft",
-    "copulas",
-    "analytical",
-    "calibration",
-)
-_UTILITY_ORDER = (
-    "black76",
-    "garman_kohlhagen",
-    "rate_style_swaption",
-    "jamshidian_zcb_option",
-    "schedule",
-    "day_count",
-    "vol_surface",
-    "cashflow_engine",
-    "credit_curve",
-)
+
+@dataclass(frozen=True)
+class ApiMapQuery:
+    """Typed semantic cues for bounded API-map family selection."""
+
+    instrument_type: str = ""
+    payoff_family: str = ""
+    method: str = ""
+    model_family: str = ""
+    features: tuple[str, ...] = ()
+    route_ids: tuple[str, ...] = ()
+    route_families: tuple[str, ...] = ()
+    description: str = ""
+    requested_families: tuple[str, ...] = ()
+
+    @property
+    def is_empty(self) -> bool:
+        """Return whether the query carries no selection cue."""
+        return not any(
+            (
+                self.instrument_type.strip(),
+                self.payoff_family.strip(),
+                self.method.strip(),
+                self.model_family.strip(),
+                tuple(item for item in self.features if str(item).strip()),
+                tuple(item for item in self.route_ids if str(item).strip()),
+                tuple(item for item in self.route_families if str(item).strip()),
+                self.description.strip(),
+                tuple(
+                    item
+                    for item in self.requested_families
+                    if str(item).strip()
+                ),
+            )
+        )
+
+
+@dataclass(frozen=True)
+class ApiMapSelection:
+    """Deterministic API-map selection and omission evidence."""
+
+    available_families: tuple[str, ...]
+    selected_families: tuple[str, ...]
+    omitted_families: tuple[str, ...]
+    available_utilities: tuple[str, ...]
+    selected_utilities: tuple[str, ...]
+    omitted_utilities: tuple[str, ...]
+    catalog_only: bool
+
+    def summary(self) -> dict[str, object]:
+        """Return machine-readable prompt-selection evidence."""
+        return {
+            "available_families": list(self.available_families),
+            "selected_families": list(self.selected_families),
+            "omitted_families": list(self.omitted_families),
+            "available_utilities": list(self.available_utilities),
+            "selected_utilities": list(self.selected_utilities),
+            "omitted_utilities": list(self.omitted_utilities),
+            "catalog_only": self.catalog_only,
+        }
 
 
 def get_api_map() -> dict[str, Any]:
@@ -65,11 +108,105 @@ def get_api_map() -> dict[str, Any]:
     return data
 
 
-def format_api_map_for_prompt(*, compact: bool = False) -> str:
-    """Render the compact API map as markdown for prompt or tool output."""
+def select_api_map_sections(
+    query: ApiMapQuery | None = None,
+) -> ApiMapSelection:
+    """Select task-relevant cards directly from the canonical API map."""
+    api_map = get_api_map()
+    if not api_map:
+        return ApiMapSelection((), (), (), (), (), (), query is None)
+
+    family_names = _family_names(api_map)
+    utility_names = _utility_names(api_map)
+    catalog_only = query is None or query.is_empty
+    if catalog_only:
+        return ApiMapSelection(
+            available_families=family_names,
+            selected_families=(),
+            omitted_families=family_names,
+            available_utilities=utility_names,
+            selected_utilities=(),
+            omitted_utilities=utility_names,
+            catalog_only=True,
+        )
+
+    assert query is not None
+    requested = tuple(
+        dict.fromkeys(
+            str(item).strip()
+            for item in query.requested_families
+            if str(item).strip()
+        )
+    )
+    unknown = tuple(name for name in requested if name not in family_names)
+    if unknown:
+        raise ValueError("Unknown API map families: " + ", ".join(unknown))
+
+    if requested:
+        selected_families = tuple(
+            name for name in family_names if name in requested
+        )
+    else:
+        scored = [
+            (_score_card(name, api_map[name], query), index, name)
+            for index, name in enumerate(family_names)
+        ]
+        selected_families = tuple(
+            name
+            for score, _, name in sorted(
+                (item for item in scored if item[0] >= 80),
+                key=lambda item: (-item[0], item[1]),
+            )[:_DEFAULT_SELECTION_LIMIT]
+        )
+
+    selected_card_text = "\n".join(
+        _section_search_text(name, api_map[name])
+        for name in selected_families
+    )
+    selected_utilities = tuple(
+        name
+        for name in utility_names
+        if _utility_is_relevant(
+            name,
+            api_map["utilities"][name],
+            query,
+            selected_card_text,
+        )
+    )
+    omitted_families = tuple(
+        name for name in family_names if name not in selected_families
+    )
+    omitted_utilities = tuple(
+        name for name in utility_names if name not in selected_utilities
+    )
+    return ApiMapSelection(
+        available_families=family_names,
+        selected_families=selected_families,
+        omitted_families=omitted_families,
+        available_utilities=utility_names,
+        selected_utilities=selected_utilities,
+        omitted_utilities=omitted_utilities,
+        catalog_only=False,
+    )
+
+
+def format_api_map_for_prompt(
+    *,
+    compact: bool = False,
+    query: ApiMapQuery | None = None,
+    max_chars: int | None = None,
+) -> str:
+    """Render a bounded catalog or task-relevant API navigation card."""
     api_map = get_api_map()
     if not api_map:
         return ""
+    selection = select_api_map_sections(query)
+    if max_chars is None:
+        limit = _DEFAULT_COMPACT_CHARS if compact else _DEFAULT_EXPANDED_CHARS
+    else:
+        limit = max_chars
+    if limit < 240:
+        raise ValueError("API map max_chars must be at least 240")
 
     lines = [
         "## API Map — start here before guessing module paths",
@@ -77,30 +214,227 @@ def format_api_map_for_prompt(*, compact: bool = False) -> str:
         "Use this navigation card to choose the right module family first. "
         "Confirm exact symbols with `find_symbol` or `list_exports` before "
         "calling `read_module`.",
-        "",
-        "### Core Types",
     ]
 
+    if selection.catalog_only:
+        _append_catalog(lines, api_map, selection)
+        return _bounded_render(
+            "\n".join(lines),
+            max_chars=limit,
+            selected_families=(),
+        )
+
+    lines.extend(
+        [
+            "",
+            "- Selected cards: "
+            + (", ".join(selection.selected_families) or "none"),
+            "- Omitted cards: "
+            + (", ".join(selection.omitted_families) or "none"),
+            "",
+            "### Core Types",
+        ]
+    )
     _append_market_state_block(lines, api_map.get("market_state"), compact=compact)
     _append_payoff_block(lines, api_map.get("payoff"))
 
-    lines.append("")
-    lines.append("### Model Families")
-    for family in _FAMILY_ORDER:
+    if selection.selected_families:
+        lines.append("")
+        lines.append("### Selected Model Families")
+    for family in selection.selected_families:
         section = api_map.get(family)
         if isinstance(section, Mapping):
             _append_family_block(lines, family, section, compact=compact)
 
     utilities = api_map.get("utilities")
-    if isinstance(utilities, Mapping) and utilities:
+    if (
+        isinstance(utilities, Mapping)
+        and utilities
+        and selection.selected_utilities
+    ):
         lines.append("")
-        lines.append("### Utilities")
-        for utility_name in _UTILITY_ORDER:
+        lines.append("### Selected Utilities")
+        for utility_name in selection.selected_utilities:
             entry = utilities.get(utility_name)
             if isinstance(entry, Mapping):
                 _append_utility_block(lines, utility_name, entry, compact=compact)
 
-    return "\n".join(lines)
+    return _bounded_render(
+        "\n".join(lines),
+        max_chars=limit,
+        selected_families=selection.selected_families,
+    )
+
+
+def _family_names(api_map: Mapping[str, Any]) -> tuple[str, ...]:
+    """Return canonical family cards in declaration order."""
+    return tuple(
+        name
+        for name, section in api_map.items()
+        if name not in _SPECIAL_TOP_LEVEL_KEYS
+        and isinstance(section, Mapping)
+        and bool(section.get("module"))
+    )
+
+
+def _utility_names(api_map: Mapping[str, Any]) -> tuple[str, ...]:
+    utilities = api_map.get("utilities")
+    if not isinstance(utilities, Mapping):
+        return ()
+    return tuple(
+        name
+        for name, section in utilities.items()
+        if isinstance(section, Mapping) and bool(section.get("module"))
+    )
+
+
+def _append_catalog(
+    lines: list[str],
+    api_map: Mapping[str, Any],
+    selection: ApiMapSelection,
+) -> None:
+    """Render a complete low-cost index without import statements."""
+    market = api_map.get("market_state")
+    payoff = api_map.get("payoff")
+    lines.extend(["", "### Core Types"])
+    if isinstance(market, Mapping):
+        lines.append(
+            f"- MarketState: {market.get('module', '')}"
+        )
+    if isinstance(payoff, Mapping):
+        lines.append(f"- Payoff: {payoff.get('module', '')}")
+
+    lines.extend(["", "### Available Model Cards"])
+    for family in selection.available_families:
+        section = api_map[family]
+        lines.append(f"- {family}: {section.get('module', '')}")
+
+    utilities = api_map.get("utilities")
+    if isinstance(utilities, Mapping) and selection.available_utilities:
+        lines.extend(["", "### Available Utility Cards"])
+        for utility_name in selection.available_utilities:
+            section = utilities[utility_name]
+            lines.append(
+                f"- {utility_name}: {section.get('module', '')}"
+            )
+    lines.extend(
+        [
+            "",
+            "Pass semantic fields or explicit families to inspect selected "
+            "imports and construction notes.",
+        ]
+    )
+
+
+def _score_card(
+    name: str,
+    section: Mapping[str, Any],
+    query: ApiMapQuery,
+) -> int:
+    aliases = _section_aliases(name, section)
+    score = 0
+    for cue, weight in _query_cues(query):
+        normalized_cue = _normalize(cue)
+        if not normalized_cue:
+            continue
+        cue_tokens = set(_WORD.findall(normalized_cue))
+        for alias in aliases:
+            if normalized_cue == alias:
+                score = max(score, weight * 4)
+                continue
+            if alias in normalized_cue or normalized_cue in alias:
+                score = max(score, weight * 3)
+                continue
+            alias_tokens = set(_WORD.findall(alias))
+            overlap = len(cue_tokens & alias_tokens)
+            if overlap:
+                score = max(
+                    score,
+                    int(weight * overlap / max(len(alias_tokens), 1)),
+                )
+    return score
+
+
+def _section_aliases(
+    name: str,
+    section: Mapping[str, Any],
+) -> tuple[str, ...]:
+    values: list[str] = [
+        name,
+        name.removesuffix("_composition"),
+    ]
+    navigation = section.get("navigation")
+    if isinstance(navigation, Mapping):
+        for item in navigation.values():
+            if isinstance(item, str):
+                values.append(item)
+            elif isinstance(item, (list, tuple)):
+                values.extend(str(value) for value in item)
+    return tuple(
+        dict.fromkeys(
+            normalized
+            for value in values
+            if (normalized := _normalize(value))
+        )
+    )
+
+
+def _query_cues(query: ApiMapQuery) -> tuple[tuple[str, int], ...]:
+    cues: list[tuple[str, int]] = [
+        (query.instrument_type, 120),
+        (query.payoff_family, 120),
+        (query.method, 20),
+        (query.model_family, 40),
+        (query.description, 30),
+    ]
+    cues.extend((str(item), 100) for item in query.features)
+    cues.extend((str(item), 80) for item in query.route_ids)
+    cues.extend((str(item), 80) for item in query.route_families)
+    return tuple((value, weight) for value, weight in cues if value.strip())
+
+
+def _section_search_text(name: str, section: Mapping[str, Any]) -> str:
+    return " ".join(
+        (
+            name,
+            str(section.get("module", "")),
+            " ".join(str(item) for item in section.get("key_imports", ()) or ()),
+            " ".join(str(item) for item in section.get("notes", ()) or ()),
+        )
+    )
+
+
+def _utility_is_relevant(
+    name: str,
+    section: Mapping[str, Any],
+    query: ApiMapQuery,
+    selected_card_text: str,
+) -> bool:
+    if _score_card(name, {**section, "key_imports": []}, query) >= 80:
+        return True
+    module = str(section.get("module", "")).strip()
+    return bool(module and module in selected_card_text)
+
+
+def _normalize(value: str) -> str:
+    return "_".join(_WORD.findall(str(value).lower()))
+
+
+def _bounded_render(
+    text: str,
+    *,
+    max_chars: int,
+    selected_families: tuple[str, ...],
+) -> str:
+    if len(text) <= max_chars:
+        return text
+    selected = ", ".join(selected_families) or "catalog"
+    marker = (
+        "\n\n[API map truncated to the configured character budget; "
+        f"selected cards: {selected}]"
+    )
+    keep = max(max_chars - len(marker), 0)
+    return text[:keep].rstrip() + marker
 
 
 def _append_market_state_block(
@@ -188,7 +522,7 @@ def _append_family_block(
     module = str(section.get("module", ""))
     key_imports = list(section.get("key_imports", []) or [])
     notes = list(section.get("notes", []) or [])
-    import_limit = len(key_imports)
+    import_limit = min(len(key_imports), 8) if compact else len(key_imports)
     note_limit = 2 if compact else len(notes)
 
     lines.extend(
@@ -201,6 +535,10 @@ def _append_family_block(
         lines.append("- Key imports:")
         for stmt in key_imports[:import_limit]:
             lines.append(f"  - `{stmt}`")
+        if import_limit < len(key_imports):
+            lines.append(
+                f"  - [omitted {len(key_imports) - import_limit} additional imports]"
+            )
     if notes:
         lines.append("- Notes:")
         for note in notes[:note_limit]:
@@ -217,7 +555,7 @@ def _append_utility_block(
     """Render a utility subsection from the canonical API map."""
     module = str(section.get("module", ""))
     imports = list(section.get("imports", []) or [])
-    import_limit = len(imports)
+    import_limit = min(len(imports), 3) if compact else len(imports)
     notes = list(section.get("notes", []) or [])
     note_limit = 1 if compact else len(notes)
 

--- a/trellis/agent/knowledge/canonical/api_map.yaml
+++ b/trellis/agent/knowledge/canonical/api_map.yaml
@@ -58,6 +58,8 @@ payoff:
 # ---------------------------------------------------------------------------
 digital_option_composition:
   module: trellis.models.resolution.single_state_diffusion
+  navigation:
+    aliases: [digital_option, cash_or_nothing, asset_or_nothing]
   modules:
     market_binding: trellis.models.resolution.single_state_diffusion
     analytical_support: trellis.models.analytical.support
@@ -78,6 +80,8 @@ digital_option_composition:
 # ---------------------------------------------------------------------------
 quanto_option_composition:
   module: trellis.models.resolution.quanto
+  navigation:
+    aliases: [quanto_option, quanto, hybrid_equity_fx]
   modules:
     market_binding: trellis.models.resolution.quanto
     analytical_support: trellis.models.analytical.support
@@ -104,6 +108,8 @@ quanto_option_composition:
 # ---------------------------------------------------------------------------
 equity_tree:
   module: trellis.models.trees.algebra
+  navigation:
+    aliases: [equity_tree, american_option, bermudan_option]
   key_imports:
     - "from trellis.models.resolution.single_state_diffusion import resolve_single_state_diffusion_inputs, terminal_intrinsic_from_resolved"
     - "from trellis.models.trees.algebra import equity_tree, with_control, compile_lattice_recipe, build_lattice, price_on_lattice"
@@ -115,6 +121,8 @@ equity_tree:
 
 rate_lattice:
   module: trellis.models.trees.lattice
+  navigation:
+    aliases: [rate_tree, callable_bond, puttable_bond, bermudan_swaption]
   key_imports:
     - "from trellis.models.trees.lattice import build_rate_lattice, lattice_backward_induction"
     - "from trellis.models.zcb_option_tree import price_zcb_option_tree"
@@ -162,6 +170,8 @@ monte_carlo:
 
 scheduled_observation_composition:
   module: trellis.models.observation_aggregation
+  navigation:
+    aliases: [scheduled_observation, weighted_observation, arithmetic_asian_option]
   key_imports:
     - "from trellis.models.observation_aggregation import WeightedObservationContract, build_weighted_observation_reducer, weighted_observation_payoff, weighted_observation_sum"
     - "from trellis.models.monte_carlo.engine import MonteCarloEngine"
@@ -175,6 +185,8 @@ scheduled_observation_composition:
 
 weighted_lognormal_sum_composition:
   module: trellis.models.analytical.support.lognormal_moments
+  navigation:
+    aliases: [weighted_lognormal_sum, arithmetic_asian_option, lognormal_moment_matching]
   key_imports:
     - "from trellis.models.analytical.support.lognormal_moments import WeightedLognormalSumContract, match_lognormal_moments, single_factor_lognormal_sum_contract, weighted_lognormal_sum_moments"
     - "from trellis.models.black import black76_call, black76_put"
@@ -186,6 +198,8 @@ weighted_lognormal_sum_composition:
 
 arithmetic_asian_composition:
   module: trellis.models.observation_aggregation
+  navigation:
+    aliases: [arithmetic_asian, arithmetic_asian_option, asian_option]
   key_imports:
     - "from trellis.models.resolution.single_state_diffusion import resolve_single_state_diffusion_inputs"
     - "from trellis.models.observation_aggregation import WeightedObservationContract, weighted_observation_payoff"
@@ -202,6 +216,8 @@ arithmetic_asian_composition:
 
 observation_return_composition:
   module: trellis.models.observation_returns
+  navigation:
+    aliases: [observation_return, cliquet, ratchet_option]
   key_imports:
     - "from trellis.models.observation_returns import ObservationReturnContract, bounded_observation_return_sum, build_observation_return_reducer, observation_return_payoff, simple_observation_returns"
     - "from trellis.models.analytical.support.expectations import gauss_hermite_product_expectation"
@@ -215,6 +231,8 @@ observation_return_composition:
 
 rate_monte_carlo_composition:
   module: trellis.models.monte_carlo.simulation_substrate
+  navigation:
+    aliases: [rate_monte_carlo, bermudan_swaption, callable_rate_product]
   key_imports:
     - "from trellis.models.monte_carlo.event_aware import build_event_aware_monte_carlo_process, resolve_hull_white_monte_carlo_process_inputs"
     - "from trellis.models.monte_carlo.simulation_substrate import FactorStateSimulationResult, HullWhiteRateProjection, HullWhiteSwapFutureValueModel, SwapFloatResetProgram"
@@ -240,6 +258,8 @@ qmc:
 # ---------------------------------------------------------------------------
 pde:
   module: trellis.models.pde
+  navigation:
+    aliases: [pde_solver, finite_difference, theta_method]
   key_imports:
     - "from trellis.models.equity_option_pde import price_cev_option_pde"
     - "from trellis.models.equity_option_pde import price_equity_digital_option_pde"
@@ -271,6 +291,8 @@ pde:
 # ---------------------------------------------------------------------------
 fft:
   module: trellis.models.transforms.fft_pricer
+  navigation:
+    aliases: [fft_pricing, transform_fft, cos_method]
   key_imports:
     - "from trellis.models.transforms.fft_pricer import fft_price"
     - "from trellis.models.transforms.cos_method import cos_price"
@@ -286,6 +308,8 @@ fft:
 # ---------------------------------------------------------------------------
 copulas:
   module: trellis.models.copulas.factor
+  navigation:
+    aliases: [copula, copula_loss_distribution, credit_copula]
   key_imports:
     - "from trellis.models.copulas.factor import FactorCopula"
     - "from trellis.models.copulas.gaussian import GaussianCopula"

--- a/trellis/agent/knowledge/retrieval.py
+++ b/trellis/agent/knowledge/retrieval.py
@@ -28,7 +28,11 @@ from trellis.agent.knowledge.promotion import (
     summarize_adapter_lifecycle_records,
 )
 from trellis.agent.knowledge.store import identify_superseded_basket_lesson_ids
-from trellis.agent.knowledge.api_map import format_api_map_for_prompt
+from trellis.agent.knowledge.api_map import (
+    ApiMapQuery,
+    format_api_map_for_prompt,
+    select_api_map_sections,
+)
 
 _COMPACT_LIMITS = {
     "builder": {
@@ -73,6 +77,74 @@ _DISTILLED_LIMITS = {
         "lessons": 2,
     },
 }
+
+
+def _api_map_query_for_knowledge(
+    knowledge: dict[str, Any],
+    *,
+    pricing_method: str | None = None,
+    route_ids: tuple[str, ...] | list[str] = (),
+    route_families: tuple[str, ...] | list[str] | None = None,
+) -> ApiMapQuery:
+    """Project retrieved semantic knowledge into builder-only API navigation."""
+    product_ir: ProductIR | None = knowledge.get("product_ir")
+    decomposition: ProductDecomposition | None = knowledge.get("decomposition")
+    cookbook: CookbookEntry | None = knowledge.get("cookbook")
+
+    instrument = str(
+        getattr(product_ir, "instrument", "")
+        or getattr(decomposition, "instrument", "")
+        or ""
+    )
+    payoff_family = str(getattr(product_ir, "payoff_family", "") or "")
+    method = str(
+        pricing_method
+        or getattr(decomposition, "method", "")
+        or getattr(cookbook, "method", "")
+        or ""
+    )
+    model_family = str(getattr(product_ir, "model_family", "") or "")
+    features = tuple(
+        dict.fromkeys(
+            str(item)
+            for item in (
+                *tuple(getattr(product_ir, "payoff_traits", ()) or ()),
+                *tuple(getattr(decomposition, "features", ()) or ()),
+            )
+            if str(item).strip()
+        )
+    )
+    resolved_route_families = tuple(
+        str(item)
+        for item in (
+            route_families
+            if route_families is not None
+            else tuple(getattr(product_ir, "route_families", ()) or ())
+        )
+        if str(item).strip()
+    )
+    description = " ".join(
+        part
+        for part in (
+            instrument,
+            payoff_family,
+            str(getattr(product_ir, "derivative_family", "") or ""),
+            str(getattr(product_ir, "underlying_asset_class", "") or ""),
+        )
+        if part
+    )
+    return ApiMapQuery(
+        instrument_type=instrument,
+        payoff_family=payoff_family,
+        method=method,
+        model_family=model_family,
+        features=features,
+        route_ids=tuple(
+            str(item) for item in route_ids if str(item).strip()
+        ),
+        route_families=resolved_route_families,
+        description=description,
+    )
 
 
 def _adapter_lifecycle_warnings(*, compact: bool) -> str:
@@ -140,7 +212,12 @@ def _adapter_lifecycle_summary() -> dict[str, Any]:
     }
 
 
-def format_knowledge_for_prompt(knowledge: dict[str, Any], *, compact: bool = False) -> str:
+def format_knowledge_for_prompt(
+    knowledge: dict[str, Any],
+    *,
+    compact: bool = False,
+    api_map_query: ApiMapQuery | None = None,
+) -> str:
     """Format a ``retrieve_for_task()`` result dict as a single markdown string.
 
     The output is structured as numbered sections in this order:
@@ -156,7 +233,10 @@ def format_knowledge_for_prompt(knowledge: dict[str, Any], *, compact: bool = Fa
 
     # 0. API map (small family-level orientation before the full registry)
     try:
-        api_map = format_api_map_for_prompt(compact=compact)
+        api_map = format_api_map_for_prompt(
+            compact=compact,
+            query=api_map_query or _api_map_query_for_knowledge(knowledge),
+        )
         if api_map:
             sections.append(api_map)
     except Exception:
@@ -575,17 +655,10 @@ def format_review_knowledge_for_prompt(
 def format_decomposition_knowledge_for_prompt(knowledge: dict[str, Any], *, compact: bool = False) -> str:
     """Format shared knowledge for decomposition / routing prompts.
 
-    The API map is surfaced first so route selection starts from the compact
-    family-level navigation layer before the broader routing context.
+    Routing roles receive semantic and method evidence only. Builder-only API
+    imports remain in the builder knowledge surfaces.
     """
     sections: list[str] = []
-
-    try:
-        api_map = format_api_map_for_prompt(compact=compact)
-        if api_map:
-            sections.append(api_map)
-    except Exception:
-        pass
 
     principles: list[Principle] = knowledge.get("principles", [])
     model_grammar: list[ModelGrammarEntry] = knowledge.get("model_grammar", [])
@@ -658,6 +731,7 @@ def format_distilled_knowledge_for_prompt(
     knowledge: dict[str, Any],
     *,
     audience: str = "builder",
+    api_map_query: ApiMapQuery | None = None,
 ) -> str:
     """Format the smallest useful reusable memory card for repeated tasks."""
     sections: list[str] = []
@@ -673,7 +747,10 @@ def format_distilled_knowledge_for_prompt(
     if audience == "builder":
         limits = _DISTILLED_LIMITS["builder"]
         lines = []
-        api_map = format_api_map_for_prompt(compact=True)
+        api_map = format_api_map_for_prompt(
+            compact=True,
+            query=api_map_query or _api_map_query_for_knowledge(knowledge),
+        )
         instrument_label = (
             str(getattr(product_ir, "instrument", "") or "").strip().lower()
             if product_ir is not None
@@ -759,9 +836,6 @@ def format_distilled_knowledge_for_prompt(
     elif audience == "routing":
         limits = _DISTILLED_LIMITS["routing"]
         lines = []
-        api_map = format_api_map_for_prompt(compact=True)
-        if api_map:
-            lines.append(api_map)
         lines.append("## Distilled Routing Memory\n")
         if product_ir is not None:
             display_route_families = _prompt_display_route_families(product_ir)
@@ -825,10 +899,28 @@ def build_shared_knowledge_payload(
     )
     resolved_route_ids = tuple(str(item) for item in route_ids if str(item).strip())
     resolved_method = pricing_method or None
+    api_map_query = _api_map_query_for_knowledge(
+        knowledge,
+        pricing_method=resolved_method,
+        route_ids=resolved_route_ids,
+        route_families=resolved_route_families,
+    )
 
-    builder_text_distilled_base = format_distilled_knowledge_for_prompt(knowledge, audience="builder")
-    builder_text_base = format_knowledge_for_prompt(knowledge, compact=True)
-    builder_text_expanded_base = format_knowledge_for_prompt(knowledge, compact=False)
+    builder_text_distilled_base = format_distilled_knowledge_for_prompt(
+        knowledge,
+        audience="builder",
+        api_map_query=api_map_query,
+    )
+    builder_text_base = format_knowledge_for_prompt(
+        knowledge,
+        compact=True,
+        api_map_query=api_map_query,
+    )
+    builder_text_expanded_base = format_knowledge_for_prompt(
+        knowledge,
+        compact=False,
+        api_map_query=api_map_query,
+    )
     review_text_distilled_base = format_distilled_knowledge_for_prompt(knowledge, audience="review")
     review_text_base = format_review_knowledge_for_prompt(knowledge, compact=True)
     review_text_expanded_base = format_review_knowledge_for_prompt(knowledge, compact=False)
@@ -917,6 +1009,7 @@ def build_shared_knowledge_payload(
     )
 
     summary = summarize_knowledge_for_trace(knowledge)
+    summary["api_map_selection"] = select_api_map_sections(api_map_query).summary()
     selected_by_audience = {
         "builder": builder_artifacts,
         "review": review_artifacts,

--- a/trellis/agent/prompts.py
+++ b/trellis/agent/prompts.py
@@ -24,7 +24,7 @@ run tests, fetch market data, and price instruments on demand.
 {requirements}
 
 ## Capabilities
-- inspect_api_map: Inspect the compact API navigation map before broad tree exploration.
+- inspect_api_map: Inspect the bounded API catalog or select task-relevant cards from semantic fields before broad tree exploration.
 - inspect_library: See all modules, classes, and functions in the trellis package.
 - read_module: Read source code of any module.
 - find_symbol: Locate a public Trellis symbol before importing it.

--- a/trellis/agent/tools.py
+++ b/trellis/agent/tools.py
@@ -5,10 +5,36 @@ from __future__ import annotations
 TOOLS = [
     {
         "name": "inspect_api_map",
-        "description": "Inspect the compact API navigation map before broad tree exploration.",
+        "description": (
+            "Inspect the bounded API navigation catalog, optionally selecting "
+            "task-relevant cards from semantic product and route fields."
+        ),
         "input_schema": {
             "type": "object",
-            "properties": {},
+            "properties": {
+                "instrument_type": {"type": "string"},
+                "payoff_family": {"type": "string"},
+                "method": {"type": "string"},
+                "model_family": {"type": "string"},
+                "features": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                },
+                "route_ids": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                },
+                "route_families": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                },
+                "description": {"type": "string"},
+                "families": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Explicit canonical card names to inspect.",
+                },
+            },
             "required": [],
         },
     },


### PR DESCRIPTION
## Summary
- replace the hand-maintained API-map family order with frozen semantic query/selection contracts
- make no-query inspection a complete bounded catalog and semantic queries render only relevant full cards
- persist selected/omitted builder navigation evidence while keeping quant/model-validator contexts code-free
- document the AGENTS.md, runtime-role orientation, and builder API-map boundaries

## Validation
- 34 focused API-map/tool/knowledge/orientation tests
- 295 broader agent and platform regression tests
- scoped Ruff and mypy
- make gate-pr: 4,454 core passed; 32 tier-2 passed
- Sphinx dummy build completed with existing repository warnings

## Boundaries
- no pricing helper
- no cookbook mutation
- no live external-model execution
- no LIMITATIONS.md change

Closes QUA-1184