### PR TITLE
QUA-1186: add Gaussian probability composition primitives

### DIFF
--- a/doc/plan/active__semantic-task-synthesis-helper-retirement.md
+++ b/doc/plan/active__semantic-task-synthesis-helper-retirement.md
@@ -46,7 +46,7 @@ Status mirror last synced: `2026-07-14`
 | `QUA-1183` | Digital option pricing: retire analytical helper authority | Done |
 | `QUA-1184` | Semantic agent navigation: render task-relevant canonical composition cards | Done |
 | `QUA-1185` | Task runtime: offline cached replays suppress post-build LLM stages | Backlog |
-| `QUA-1186` | Analytical support: Gaussian probability and scalar-root navigation | Backlog |
+| `QUA-1186` | Analytical support: Gaussian probability and scalar-root navigation | In Progress |
 | `QUA-1187` | Monte Carlo path state: extrema and squared-log-return reducers | Backlog |
 
 ## Current Sequence

--- a/docs/developer/runtime_agent_orientation.rst
+++ b/docs/developer/runtime_agent_orientation.rst
@@ -74,6 +74,16 @@ Exact symbols remain the import registry's responsibility after family
 selection. Quant and model-validator regression tests reject API-map imports
 or code templates in their resolved context.
 
+Composition cards may join public primitives from more than one subsystem
+without introducing a new product helper. For example,
+``analytical_gaussian_composition`` points a builder handling chooser,
+compound, or other critical-state analytical work to scalar Gaussian
+probability kernels and the existing typed ``SolveRequest`` root surface. The
+card does not contain a derivative formula and does not enter the quant or
+model-validator role packets. Those roles continue to reason from semantic
+contracts, quantitative documentation, and executed evidence; implementation
+symbol selection remains builder-owned.
+
 Bounded Resolution
 ------------------
 

--- a/docs/quant/pricing_stack.rst
+++ b/docs/quant/pricing_stack.rst
@@ -707,6 +707,37 @@ reference PV, and generic lattice/PDE event assembly no longer live only in
 stable while moving the reusable short-rate claim logic into a broader helper
 surface for later fixed-income families.
 
+Analytical Probability And Critical-State Composition
+-----------------------------------------------------
+
+Analytical adapters can compose Gaussian probability terms from the public,
+product-neutral kernels in ``trellis.models.analytical.support.probability``.
+``standard_normal_cdf(x)`` supplies :math:`\Phi(x)`, while
+``bivariate_standard_normal_cdf(x, y, \rho)`` supplies
+:math:`\Phi_2(x, y; \rho)`. Inputs must be finite and correlation is admitted
+only on the closed interval :math:`[-1, 1]`; the exact singular boundaries are
+handled explicitly rather than perturbed onto a nearby model.
+
+These are scalar SciPy-backed functions, not automatic-differentiation
+primitives. They provide probability integration only. A derivative adapter
+still owns the contractual formula, state transformation, discounting,
+notional, and call/put or exercise branching.
+
+When an analytical formula requires an implicit critical state, the adapter
+should define its scalar residual and lower it onto the existing typed solve
+surface:
+
+1. put the residual in a ``root_scalar`` ``ObjectiveBundle``
+2. provide finite bracketing bounds with ``SolveBounds``
+3. construct ``SolveRequest`` with ``solver_hint="brentq"``
+4. call ``execute_solve_request`` and consume the checked ``SolveResult``
+
+This keeps the numerical policy bounded and auditable. Chooser, compound, and
+other critical-state formulas should not create route-local Newton loops or
+promote a product pricing helper as construction authority. The semantic API
+map card ``analytical_gaussian_composition`` is the builder's hot start for
+these probability and root-solving pieces.
+
 Calibration Surface
 -------------------
 

--- a/docs/quant/pricing_stack.rst
+++ b/docs/quant/pricing_stack.rst
@@ -713,7 +713,7 @@ Analytical Probability And Critical-State Composition
 Analytical adapters can compose Gaussian probability terms from the public,
 product-neutral kernels in ``trellis.models.analytical.support.probability``.
 ``standard_normal_cdf(x)`` supplies :math:`\Phi(x)`, while
-``bivariate_standard_normal_cdf(x, y, \rho)`` supplies
+``bivariate_standard_normal_cdf(x, y, rho)`` supplies
 :math:`\Phi_2(x, y; \rho)`. Inputs must be finite and correlation is admitted
 only on the closed interval :math:`[-1, 1]`; the exact singular boundaries are
 handled explicitly rather than perturbed onto a nearby model.

--- a/tests/test_agent/test_api_map.py
+++ b/tests/test_agent/test_api_map.py
@@ -295,6 +295,7 @@ def test_api_map_semantic_selection_reaches_gaussian_root_composition(
     assert "bivariate_standard_normal_cdf" in text
     assert "SolveRequest" in text
     assert "execute_solve_request" in text
+    assert "from trellis.models.calibration.solve_request import" in text
 
 
 def test_api_map_selection_and_rendering_are_stable_and_budgeted():

--- a/tests/test_agent/test_api_map.py
+++ b/tests/test_agent/test_api_map.py
@@ -61,6 +61,7 @@ def test_api_map_contains_expected_core_entries():
         "equity_tree",
         "rate_lattice",
         "rate_monte_carlo_composition",
+        "analytical_gaussian_composition",
     ):
         assert module_exists(api_map[section_name]["module"])
 
@@ -264,6 +265,36 @@ def test_api_map_semantic_selection_reaches_composition_cards():
     for query, expected_family in cases:
         selection = select_api_map_sections(query)
         assert expected_family in selection.selected_families
+
+
+@pytest.mark.parametrize(
+    "payoff_family",
+    ["chooser_option", "compound_option", "lookback_option"],
+)
+def test_api_map_semantic_selection_reaches_gaussian_root_composition(
+    payoff_family,
+):
+    selection = select_api_map_sections(
+        ApiMapQuery(
+            payoff_family=payoff_family,
+            method="analytical",
+            model_family="equity_diffusion",
+        )
+    )
+    text = format_api_map_for_prompt(
+        compact=True,
+        query=ApiMapQuery(
+            payoff_family=payoff_family,
+            method="analytical",
+            model_family="equity_diffusion",
+        ),
+    )
+
+    assert "analytical_gaussian_composition" in selection.selected_families
+    assert "standard_normal_cdf" in text
+    assert "bivariate_standard_normal_cdf" in text
+    assert "SolveRequest" in text
+    assert "execute_solve_request" in text
 
 
 def test_api_map_selection_and_rendering_are_stable_and_budgeted():

--- a/tests/test_agent/test_codegen_guardrails.py
+++ b/tests/test_agent/test_codegen_guardrails.py
@@ -264,6 +264,38 @@ def test_validate_generated_imports_accepts_control_timeline_facade_exports():
     assert report.ok
 
 
+def test_analytical_generation_plan_approves_gaussian_probability_and_scalar_root():
+    probability_module = "trellis.models.analytical.support.probability"
+    scalar_root_module = "trellis.models.calibration.solve_request"
+    plan = build_generation_plan(
+        pricing_plan=PricingPlan(
+            method="analytical",
+            method_modules=[probability_module],
+            required_market_data={"discount_curve", "black_vol_surface"},
+            model_to_build="critical_state_option",
+            reasoning="test",
+        ),
+        instrument_type="chooser_option",
+        inspected_modules=(probability_module,),
+        product_ir=ProductIR(
+            instrument="chooser_option",
+            payoff_family="chooser_option",
+            exercise_style="european",
+            model_family="equity_diffusion",
+        ),
+    )
+
+    assert scalar_root_module in plan.approved_modules
+    report = validate_generated_imports(
+        "from trellis.models.analytical.support.probability import "
+        "standard_normal_cdf, bivariate_standard_normal_cdf\n"
+        "from trellis.models.calibration.solve_request import "
+        "ObjectiveBundle, SolveBounds, SolveRequest, execute_solve_request\n",
+        plan,
+    )
+    assert report.ok
+
+
 def test_barrier_family_support_approves_shared_barrier_primitives():
     plan = build_generation_plan(
         pricing_plan=PricingPlan(

--- a/tests/test_agent/test_import_registry.py
+++ b/tests/test_agent/test_import_registry.py
@@ -127,6 +127,17 @@ def test_gaussian_probability_primitives_are_visible_to_import_registry():
     for symbol in symbols:
         assert symbol in registry_text
 
+    scalar_root_module = "trellis.models.calibration.solve_request"
+    scalar_root_symbols = {
+        "ObjectiveBundle",
+        "SolveBounds",
+        "SolveRequest",
+        "execute_solve_request",
+    }
+    assert scalar_root_symbols <= set(list_module_exports(scalar_root_module))
+    for symbol in scalar_root_symbols:
+        assert is_valid_import(scalar_root_module, symbol)
+
 
 def test_quoted_observable_helpers_are_visible_to_import_registry():
     module = "trellis.models.quoted_observable"

--- a/tests/test_agent/test_import_registry.py
+++ b/tests/test_agent/test_import_registry.py
@@ -109,6 +109,25 @@ def test_weighted_lognormal_moment_primitives_are_visible_to_import_registry():
         assert symbol in registry_text
 
 
+def test_gaussian_probability_primitives_are_visible_to_import_registry():
+    module = "trellis.models.analytical.support.probability"
+    symbols = {
+        "bivariate_standard_normal_cdf",
+        "standard_normal_cdf",
+    }
+
+    assert module_exists(module)
+    assert symbols <= set(list_module_exports(module))
+    for symbol in symbols:
+        assert module in find_symbol_modules(symbol)
+        assert is_valid_import(module, symbol)
+
+    registry_text = get_import_registry()
+    assert f"from {module} import" in registry_text
+    for symbol in symbols:
+        assert symbol in registry_text
+
+
 def test_quoted_observable_helpers_are_visible_to_import_registry():
     module = "trellis.models.quoted_observable"
 

--- a/tests/test_models/test_analytical_probability.py
+++ b/tests/test_models/test_analytical_probability.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from math import asin, pi
+from math import asin, nextafter, pi
 
 import pytest
 
@@ -54,6 +54,16 @@ def test_bivariate_standard_normal_cdf_is_symmetric_and_handles_singular_boundar
     assert bivariate_standard_normal_cdf(x, y, -1.0) == pytest.approx(
         max(standard_normal_cdf(x) - standard_normal_cdf(-y), 0.0)
     )
+    assert bivariate_standard_normal_cdf(
+        x,
+        y,
+        nextafter(1.0, 0.0),
+    ) == pytest.approx(bivariate_standard_normal_cdf(x, y, 1.0), abs=1e-10)
+    assert bivariate_standard_normal_cdf(
+        x,
+        y,
+        nextafter(-1.0, 0.0),
+    ) == pytest.approx(bivariate_standard_normal_cdf(x, y, -1.0), abs=1e-10)
 
 
 def test_standard_normal_cdf_composes_with_typed_bounded_scalar_root():

--- a/tests/test_models/test_analytical_probability.py
+++ b/tests/test_models/test_analytical_probability.py
@@ -1,0 +1,99 @@
+"""Tests for product-neutral analytical probability primitives."""
+
+from __future__ import annotations
+
+from math import asin, pi
+
+import pytest
+
+from trellis.models.analytical.support.probability import (
+    bivariate_standard_normal_cdf,
+    standard_normal_cdf,
+)
+from trellis.models.calibration import (
+    ObjectiveBundle,
+    SolveBounds,
+    SolveRequest,
+    execute_solve_request,
+)
+
+
+def test_standard_normal_cdf_matches_reference_values():
+    assert standard_normal_cdf(0.0) == pytest.approx(0.5)
+    assert standard_normal_cdf(1.0) == pytest.approx(0.8413447460685429)
+    assert standard_normal_cdf(-1.0) == pytest.approx(1.0 - standard_normal_cdf(1.0))
+
+
+def test_bivariate_standard_normal_cdf_matches_independent_and_zero_threshold_cases():
+    x = 0.35
+    y = -0.2
+
+    assert bivariate_standard_normal_cdf(x, y, 0.0) == pytest.approx(
+        standard_normal_cdf(x) * standard_normal_cdf(y)
+    )
+    for correlation in (-0.75, -0.25, 0.25, 0.75):
+        expected = 0.25 + asin(correlation) / (2.0 * pi)
+        assert bivariate_standard_normal_cdf(0.0, 0.0, correlation) == pytest.approx(
+            expected,
+            abs=1e-10,
+        )
+
+
+def test_bivariate_standard_normal_cdf_is_symmetric_and_handles_singular_boundaries():
+    x = -0.4
+    y = 0.7
+
+    observed = bivariate_standard_normal_cdf(x, y, 0.35)
+    assert observed == pytest.approx(
+        bivariate_standard_normal_cdf(y, x, 0.35),
+        abs=1e-12,
+    )
+    assert bivariate_standard_normal_cdf(x, y, 1.0) == pytest.approx(
+        standard_normal_cdf(min(x, y))
+    )
+    assert bivariate_standard_normal_cdf(x, y, -1.0) == pytest.approx(
+        max(standard_normal_cdf(x) - standard_normal_cdf(-y), 0.0)
+    )
+
+
+def test_standard_normal_cdf_composes_with_typed_bounded_scalar_root():
+    target_probability = 0.75
+    request = SolveRequest(
+        request_id="standard_normal_quantile",
+        problem_kind="root_scalar",
+        parameter_names=("critical_state",),
+        initial_guess=(0.0,),
+        bounds=SolveBounds(lower=(-5.0,), upper=(5.0,)),
+        objective=ObjectiveBundle(
+            objective_kind="root_scalar",
+            labels=("probability_residual",),
+            target_values=(target_probability,),
+            scalar_objective_fn=lambda value: standard_normal_cdf(float(value))
+            - target_probability,
+        ),
+        solver_hint="brentq",
+    )
+
+    result = execute_solve_request(request)
+
+    assert result.success is True
+    assert result.solution == pytest.approx((0.6744897501960817,), abs=1e-10)
+    assert result.objective_value <= 1e-12
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_gaussian_probability_primitives_reject_non_finite_inputs(value):
+    with pytest.raises(ValueError, match="finite"):
+        standard_normal_cdf(value)
+    with pytest.raises(ValueError, match="finite"):
+        bivariate_standard_normal_cdf(value, 0.0, 0.0)
+    with pytest.raises(ValueError, match="finite"):
+        bivariate_standard_normal_cdf(0.0, value, 0.0)
+    with pytest.raises(ValueError, match="finite"):
+        bivariate_standard_normal_cdf(0.0, 0.0, value)
+
+
+@pytest.mark.parametrize("correlation", [-1.000001, 1.000001])
+def test_bivariate_standard_normal_cdf_rejects_invalid_correlation(correlation):
+    with pytest.raises(ValueError, match=r"\[-1, 1\]"):
+        bivariate_standard_normal_cdf(0.0, 0.0, correlation)

--- a/trellis/agent/codegen_guardrails.py
+++ b/trellis/agent/codegen_guardrails.py
@@ -56,6 +56,7 @@ METHOD_FAMILY_PREFIXES = {
     "analytical": (
         "trellis.models.black",
         "trellis.models.analytical",
+        "trellis.models.calibration.solve_request",
     ),
     "rate_tree": (
         "trellis.models.trees",

--- a/trellis/agent/knowledge/canonical/api_map.yaml
+++ b/trellis/agent/knowledge/canonical/api_map.yaml
@@ -54,6 +54,25 @@ payoff:
     - "DeterministicCashflowPayoff wraps any Instrument into Payoff"
 
 # ---------------------------------------------------------------------------
+# Analytical Gaussian and scalar-root composition
+# ---------------------------------------------------------------------------
+analytical_gaussian_composition:
+  module: trellis.models.analytical.support.probability
+  navigation:
+    aliases: [gaussian_probability, bivariate_gaussian, critical_state, scalar_root, chooser_option, compound_option, lookback_option]
+  modules:
+    probability: trellis.models.analytical.support.probability
+    scalar_root: trellis.models.calibration.solve_request
+  key_imports:
+    - "from trellis.models.analytical.support.probability import standard_normal_cdf, bivariate_standard_normal_cdf"
+    - "from trellis.models.calibration import ObjectiveBundle, SolveBounds, SolveRequest, execute_solve_request"
+  notes:
+    - "Use standard_normal_cdf(...) and bivariate_standard_normal_cdf(...) as product-neutral scalar probability kernels; they are SciPy-backed and are not automatic-differentiation primitives"
+    - "For an implicit critical state, define the derivative-specific scalar objective in adapter code and solve it through a bounded root_scalar SolveRequest; do not introduce route-local Newton loops or product helpers"
+    - "The generated adapter owns the contractual formula, critical-state equation, discounting, and notional application; this card supplies navigation and reusable numerical pieces only"
+    - "The bivariate kernel admits finite thresholds and correlations in the closed interval [-1, 1], handles exact singular boundaries explicitly, and fails closed outside that domain"
+
+# ---------------------------------------------------------------------------
 # European digital option composition
 # ---------------------------------------------------------------------------
 digital_option_composition:

--- a/trellis/agent/knowledge/canonical/api_map.yaml
+++ b/trellis/agent/knowledge/canonical/api_map.yaml
@@ -65,7 +65,7 @@ analytical_gaussian_composition:
     scalar_root: trellis.models.calibration.solve_request
   key_imports:
     - "from trellis.models.analytical.support.probability import standard_normal_cdf, bivariate_standard_normal_cdf"
-    - "from trellis.models.calibration import ObjectiveBundle, SolveBounds, SolveRequest, execute_solve_request"
+    - "from trellis.models.calibration.solve_request import ObjectiveBundle, SolveBounds, SolveRequest, execute_solve_request"
   notes:
     - "Use standard_normal_cdf(...) and bivariate_standard_normal_cdf(...) as product-neutral scalar probability kernels; they are SciPy-backed and are not automatic-differentiation primitives"
     - "For an implicit critical state, define the derivative-specific scalar objective in adapter code and solve it through a bounded root_scalar SolveRequest; do not introduce route-local Newton loops or product helpers"

--- a/trellis/models/analytical/support/__init__.py
+++ b/trellis/models/analytical/support/__init__.py
@@ -31,9 +31,14 @@ from trellis.models.analytical.support.payoffs import (
     terminal_vanilla_from_basis,
     terminal_intrinsic,
 )
+from trellis.models.analytical.support.probability import (
+    bivariate_standard_normal_cdf,
+    standard_normal_cdf,
+)
 
 __all__ = [
     "asset_or_nothing_intrinsic",
+    "bivariate_standard_normal_cdf",
     "call_put_parity_gap",
     "cash_or_nothing_intrinsic",
     "continuous_rate_from_simple_rate",
@@ -52,6 +57,7 @@ __all__ = [
     "quanto_adjusted_forward",
     "safe_time_fraction",
     "simple_rate_from_discount_factor",
+    "standard_normal_cdf",
     "terminal_vanilla_from_basis",
     "terminal_intrinsic",
 ]

--- a/trellis/models/analytical/support/probability.py
+++ b/trellis/models/analytical/support/probability.py
@@ -1,0 +1,78 @@
+"""Scalar Gaussian probability primitives for analytical composition."""
+
+from __future__ import annotations
+
+from math import isfinite
+
+from scipy.special import ndtr
+from scipy.stats import multivariate_normal
+
+
+def _finite_float(value: float, *, name: str) -> float:
+    """Return ``value`` as a finite float or fail closed."""
+    normalized = float(value)
+    if not isfinite(normalized):
+        raise ValueError(f"{name} must be finite")
+    return normalized
+
+
+def standard_normal_cdf(value: float) -> float:
+    """Return the scalar standard-normal cumulative probability at ``value``.
+
+    This SciPy-backed scalar kernel is intended for analytical composition. It
+    is not an automatic-differentiation primitive.
+    """
+    normalized = _finite_float(value, name="value")
+    return float(ndtr(normalized))
+
+
+def bivariate_standard_normal_cdf(
+    x: float,
+    y: float,
+    correlation: float,
+) -> float:
+    """Return ``P[X <= x, Y <= y]`` for correlated standard normals.
+
+    The correlation must lie in the closed interval ``[-1, 1]``. The exact
+    singular boundaries are evaluated analytically; interior correlations use
+    SciPy's bivariate normal integration.
+    """
+    normalized_x = _finite_float(x, name="x")
+    normalized_y = _finite_float(y, name="y")
+    normalized_correlation = _finite_float(correlation, name="correlation")
+    if not -1.0 <= normalized_correlation <= 1.0:
+        raise ValueError("correlation must lie in [-1, 1]")
+
+    if normalized_correlation == 1.0:
+        return standard_normal_cdf(min(normalized_x, normalized_y))
+    if normalized_correlation == -1.0:
+        return max(
+            standard_normal_cdf(normalized_x)
+            - standard_normal_cdf(-normalized_y),
+            0.0,
+        )
+    if normalized_correlation == 0.0:
+        return standard_normal_cdf(normalized_x) * standard_normal_cdf(normalized_y)
+
+    probability = float(
+        multivariate_normal.cdf(
+            [normalized_x, normalized_y],
+            mean=[0.0, 0.0],
+            cov=[
+                [1.0, normalized_correlation],
+                [normalized_correlation, 1.0],
+            ],
+            maxpts=2_000_000,
+            abseps=1e-12,
+            releps=1e-12,
+        )
+    )
+    if not isfinite(probability) or not 0.0 <= probability <= 1.0:
+        raise RuntimeError("bivariate normal integration returned an invalid probability")
+    return probability
+
+
+__all__ = [
+    "bivariate_standard_normal_cdf",
+    "standard_normal_cdf",
+]

--- a/trellis/models/analytical/support/probability.py
+++ b/trellis/models/analytical/support/probability.py
@@ -68,6 +68,7 @@ def bivariate_standard_normal_cdf(
                 [1.0, normalized_correlation],
                 [normalized_correlation, 1.0],
             ],
+            allow_singular=True,
             maxpts=_BIVARIATE_MAX_INTEGRATION_POINTS,
             abseps=_BIVARIATE_ABSOLUTE_TOLERANCE,
             releps=_BIVARIATE_RELATIVE_TOLERANCE,

--- a/trellis/models/analytical/support/probability.py
+++ b/trellis/models/analytical/support/probability.py
@@ -7,6 +7,10 @@ from math import isfinite
 from scipy.special import ndtr
 from scipy.stats import multivariate_normal
 
+_BIVARIATE_MAX_INTEGRATION_POINTS = 200_000
+_BIVARIATE_ABSOLUTE_TOLERANCE = 1e-10
+_BIVARIATE_RELATIVE_TOLERANCE = 1e-10
+
 
 def _finite_float(value: float, *, name: str) -> float:
     """Return ``value`` as a finite float or fail closed."""
@@ -35,7 +39,9 @@ def bivariate_standard_normal_cdf(
 
     The correlation must lie in the closed interval ``[-1, 1]``. The exact
     singular boundaries are evaluated analytically; interior correlations use
-    SciPy's bivariate normal integration.
+    SciPy's bivariate normal integration. Fixed ``1e-10`` tolerances and a
+    bounded integration budget balance analytical-pricing accuracy with calls
+    made repeatedly inside critical-state root solves.
     """
     normalized_x = _finite_float(x, name="x")
     normalized_y = _finite_float(y, name="y")
@@ -62,9 +68,9 @@ def bivariate_standard_normal_cdf(
                 [1.0, normalized_correlation],
                 [normalized_correlation, 1.0],
             ],
-            maxpts=2_000_000,
-            abseps=1e-12,
-            releps=1e-12,
+            maxpts=_BIVARIATE_MAX_INTEGRATION_POINTS,
+            abseps=_BIVARIATE_ABSOLUTE_TOLERANCE,
+            releps=_BIVARIATE_RELATIVE_TOLERANCE,
         )
     )
     if not isfinite(probability) or not 0.0 <= probability <= 1.0:


### PR DESCRIPTION
## Summary
- add public product-neutral univariate and bivariate Gaussian CDF kernels
- connect analytical semantic retrieval to the existing typed bounded scalar-root substrate
- document the builder/quant/model-validator authority boundary without adding product helpers or cookbook entries

## Validation
- focused analytical, calibration, API-map, import-registry, knowledge-store, and tool tests
- Ruff and scoped mypy
- make gate-pr: 4,472 main tests passed; tier-2 contracts 32 passed
- Sphinx dummy build completed with pre-existing repository warnings/errors only

## Boundaries
- no product-, method-, or task-specific pricing helper
- no new solver facade
- no cookbook mutation
- no live LLM execution