### PR TITLE
docs: sync QUA-1190 helper retirement plan

### DIFF
--- a/doc/plan/active__semantic-task-synthesis-helper-retirement.md
+++ b/doc/plan/active__semantic-task-synthesis-helper-retirement.md
@@ -50,21 +50,19 @@ Status mirror last synced: `2026-07-14`
 | `QUA-1187` | Monte Carlo path state: extrema and squared-log-return reducers | Done |
 | `QUA-1188` | Monte Carlo transition state: conditional bridge extrema primitive | Backlog |
 | `QUA-1189` | Fixed lookback Monte Carlo: retire helper authority (blocked by QUA-1188) | Backlog |
-| `QUA-1190` | Variance swap Monte Carlo: retire helper authority | Backlog |
+| `QUA-1190` | Variance swap Monte Carlo: retire helper authority | Done |
 
 ## Current Sequence
 
-1. Complete QUA-1190 so the variance-swap Monte Carlo lane composes the
-   QUA-1187 squared-log-return state instead of delegating to a product helper.
-2. Complete QUA-1188, then unblock QUA-1189 so fixed-lookback Monte Carlo
+1. Complete QUA-1188, then unblock QUA-1189 so fixed-lookback Monte Carlo
    preserves conditional continuous extrema rather than silently substituting
    the QUA-1187 discrete-observation reducer.
-3. Complete QUA-1185 before treating cached offline replay as zero-model
+2. Complete QUA-1185 before treating cached offline replay as zero-model
    evidence without explicit reflection/consolidation skip flags.
-4. After each substrate lands, open focused helper-retirement tickets only for
+3. After each substrate lands, open focused helper-retirement tickets only for
    product families whose remaining market, numerical, payoff, and validation
    components are confirmed reusable.
-5. Run live fresh-generation evidence only with current external-model approval;
+4. Run live fresh-generation evidence only with current external-model approval;
    use it to compare first-pass source selection, retrieved documentation,
    retries, and residual validator findings rather than as pricing authority.
 


### PR DESCRIPTION
## Summary
- mark QUA-1190 Done in the Linear plan mirror
- advance the current sequence to QUA-1188 and QUA-1189

## Validation
- documentation-only diff
- git diff --check passed

Follows merged PR #787.