### PR TITLE
docs(plan): close QUA-1188 transition substrate

### DIFF
--- a/doc/plan/active__semantic-task-synthesis-helper-retirement.md
+++ b/doc/plan/active__semantic-task-synthesis-helper-retirement.md
@@ -48,15 +48,15 @@ Status mirror last synced: `2026-07-14`
 | `QUA-1185` | Task runtime: offline cached replays suppress post-build LLM stages | Backlog |
 | `QUA-1186` | Analytical support: Gaussian probability and scalar-root navigation | Done |
 | `QUA-1187` | Monte Carlo path state: extrema and squared-log-return reducers | Done |
-| `QUA-1188` | Monte Carlo transition state: conditional bridge extrema primitive | Backlog |
-| `QUA-1189` | Fixed lookback Monte Carlo: retire helper authority (blocked by QUA-1188) | Backlog |
+| `QUA-1188` | Monte Carlo transition state: conditional bridge extrema primitive | Done |
+| `QUA-1189` | Fixed lookback Monte Carlo: retire helper authority | Backlog |
 | `QUA-1190` | Variance swap Monte Carlo: retire helper authority | Done |
 
 ## Current Sequence
 
-1. Complete QUA-1188, then unblock QUA-1189 so fixed-lookback Monte Carlo
-   preserves conditional continuous extrema rather than silently substituting
-   the QUA-1187 discrete-observation reducer.
+1. Complete QUA-1189 on the QUA-1188 transition-state substrate so
+   fixed-lookback Monte Carlo preserves conditional continuous extrema rather
+   than silently substituting the QUA-1187 discrete-observation reducer.
 2. Complete QUA-1185 before treating cached offline replay as zero-model
    evidence without explicit reflection/consolidation skip flags.
 3. After each substrate lands, open focused helper-retirement tickets only for


### PR DESCRIPTION
Marks QUA-1188 Done in the execution mirror, removes the stale QUA-1189 blocker label, and advances the current sequence. Documentation-only closeout; no runtime behavior changed.