### PR TITLE
QUA-1192: ignore ambient market model capabilities

### DIFF
--- a/docs/developer/stochastic_vol_computational_ir.rst
+++ b/docs/developer/stochastic_vol_computational_ir.rst
@@ -99,6 +99,38 @@ Production-like behavior remains deterministic and fail-closed. Any
 AI-assisted repair belongs in offline task, canary, developer, or remediation
 workflows; it is not live self-modifying pricing logic.
 
+Classifier evidence boundary
+----------------------------
+
+The classifier admits only explicit semantic evidence. Task identifiers,
+titles, descriptions, comparison-target identifiers, ``construct`` and
+``new_component`` declarations, and named model/process fields can declare a
+stochastic-volatility problem. Named model fields may appear at the task level
+or inside a ``semantic_contract``, ``product_contract``, ``model_contract``,
+``benchmark_contract``, ``extension_contract``, ``model_assertions``, or
+``semantic_assertions`` block.
+
+The classifier does not inspect ``task["market"]`` or
+``task["market_assertions"]``. Those blocks describe available or selected
+market components, not the model chosen by the pricing contract. A shared
+scenario may contain a Heston-derived implied-volatility surface or a Heston
+parameter pack while an ordinary Black-Scholes, chooser, or quanto task uses
+neither. Component names such as ``spx_heston_implied_vol`` therefore cannot
+create a stochastic-volatility computational IR by themselves.
+
+This boundary is deliberately asymmetric: explicit model semantics can require
+market capabilities, but the presence of a capability cannot infer the model.
+Target-local method and calibration markers also retain their own axis: an
+inherited Bates model can make ``pde`` a Bates PDE problem or
+``market_prices`` a Bates calibration problem, but it cannot rewrite either
+target into an affine-jump transform. An explicit target-local model name has
+precedence. SLV/LSV remains a dedicated bucket because its leverage-function
+contract spans both PDE and Monte Carlo solvers.
+
+When no explicit stochastic-volatility evidence exists,
+``classify_stochastic_vol_task(...)`` returns ``None`` and the task record
+omits the ``computational_problem`` block.
+
 Computational buckets
 ---------------------
 

--- a/docs/developer/task_diagnostics.rst
+++ b/docs/developer/task_diagnostics.rst
@@ -103,6 +103,13 @@ one task compares multiple stochastic-volatility methods, the task-level value
 can be ``stochastic_vol_mixed`` even though each target still has one of the
 stable buckets above.
 
+The block is attached only when task, target, or named model-contract evidence
+explicitly selects a stochastic-volatility family. Ambient market inventories,
+scenario capability names, and ``market_assertions`` do not declare model
+semantics. If a shared scenario exposes a Heston surface or parameter pack to a
+Black-Scholes task, the result and runtime contract omit
+``computational_problem`` rather than recording a false Heston problem.
+
 For the full lifecycle, notation, and route responsibilities for this block,
 see :doc:`stochastic_vol_computational_ir`.
 

--- a/tests/test_agent/test_computational_problem_ir.py
+++ b/tests/test_agent/test_computational_problem_ir.py
@@ -12,6 +12,15 @@ def _legacy_tasks() -> dict[str, dict]:
     }
 
 
+def _financepy_tasks() -> dict[str, dict]:
+    from trellis.agent.task_manifests import load_task_manifest
+
+    return {
+        str(task["id"]): task
+        for task in load_task_manifest("TASKS_BENCHMARK_FINANCEPY.yaml")
+    }
+
+
 def _target_buckets(report) -> dict[str, str]:
     return {target.target_id: target.bucket for target in report.target_problems}
 
@@ -81,6 +90,84 @@ def test_classifies_recent_stochastic_vol_task_pack_into_stable_buckets():
         report = classify_stochastic_vol_task(tasks[task_id])
         assert report is not None, task_id
         assert _target_buckets(report) == target_expectations
+
+
+def test_ambient_market_capabilities_do_not_declare_stochastic_vol_semantics():
+    from trellis.agent.computational_problem_ir import classify_stochastic_vol_task
+
+    assert classify_stochastic_vol_task(_financepy_tasks()["F012"]) is None
+    assert classify_stochastic_vol_task(_legacy_tasks()["T105"]) is None
+    assert (
+        classify_stochastic_vol_task(
+            {
+                "id": "TAMBIENT",
+                "title": "Black-Scholes European equity option",
+                "construct": "analytical",
+                "market": {
+                    "available_capabilities": [
+                        "discount_curve",
+                        "spx_heston_implied_vol",
+                    ],
+                    "model_parameters": "heston_equity",
+                    "metadata": {"surface_builder": "heston_implied_vol"},
+                },
+                "cross_validate": {"internal": ["black_scholes"]},
+            }
+        )
+        is None
+    )
+
+
+def test_explicit_semantic_model_contract_declares_stochastic_vol_semantics():
+    from trellis.agent.computational_problem_ir import classify_stochastic_vol_task
+
+    for model_family, target_id, expected_bucket, expected_process in (
+        ("heston", "fft", "stochastic_vol_transform", "heston"),
+        ("rough_heston", "fft", "stochastic_vol_transform", "rough_heston"),
+        ("bates", "fft", "stochastic_vol_transform", "bates"),
+        ("slv_lsv", "pde", "slv_lsv", "slv_lsv"),
+    ):
+        report = classify_stochastic_vol_task(
+            {
+                "id": "TEXPLICIT",
+                "title": "European equity option comparison",
+                "semantic_contract": {
+                    "product": {"model_family": model_family},
+                },
+                "cross_validate": {"internal": [target_id]},
+            }
+        )
+
+        assert report is not None
+        target = _target_payload(report, target_id)
+        assert target["bucket"] == expected_bucket
+        assert target["process_family"] == expected_process
+
+
+def test_inherited_bates_model_preserves_route_only_target_shape():
+    from trellis.agent.computational_problem_ir import classify_stochastic_vol_task
+
+    report = classify_stochastic_vol_task(
+        {
+            "id": "TBATESROUTES",
+            "title": "European equity option comparison",
+            "model_contract": {"model_family": "bates"},
+            "cross_validate": {"internal": ["pde", "market_prices"]},
+        }
+    )
+
+    assert report is not None
+    pde = _target_payload(report, "pde")
+    assert pde["bucket"] == "stochastic_vol_pde"
+    assert pde["solver_target"] == "pde"
+    assert pde["process_family"] == "bates"
+    assert pde["validation_bundle"] == "bates:pde"
+
+    calibration = _target_payload(report, "market_prices")
+    assert calibration["bucket"] == "calibration_to_surface"
+    assert calibration["solver_target"] == "surface_calibration"
+    assert calibration["process_family"] == "bates"
+    assert calibration["calibration_problem"]["status"] == "calibration_blocked"
 
 
 def test_heston_parameter_semantics_distinguish_parameters_from_surface_bumps():

--- a/tests/test_agent/test_task_runtime.py
+++ b/tests/test_agent/test_task_runtime.py
@@ -1857,6 +1857,48 @@ def test_run_task_carries_stochastic_vol_problem_metadata_for_comparison_task(mo
     assert qe_target["validation_bundle"] == "heston:monte_carlo"
 
 
+def test_run_task_does_not_attach_ambient_stochastic_vol_problem_to_f012(monkeypatch, tmp_path):
+    from trellis.agent.task_manifests import load_task_manifest
+    from trellis.agent.task_runtime import run_task
+
+    task = next(
+        task
+        for task in load_task_manifest("TASKS_BENCHMARK_FINANCEPY.yaml")
+        if task["id"] == "F012"
+    )
+
+    class FakeResult:
+        success = True
+        attempts = 1
+        gap_confidence = 0.9
+        knowledge_gaps = []
+        payoff_cls = type("ChooserOptionPayoff", (), {"price": 13.84})
+        failures = []
+        reflection = {}
+
+    monkeypatch.setattr(
+        "trellis.agent.task_run_store.persist_task_run_record",
+        lambda *_args, **_kwargs: {
+            "history_path": str(tmp_path / "history.json"),
+            "latest_path": str(tmp_path / "latest.json"),
+            "latest_index_path": str(tmp_path / "latest-index.json"),
+        },
+    )
+
+    result = run_task(
+        task,
+        market_state=object(),
+        build_fn=lambda **_kwargs: FakeResult(),
+        payoff_factory=lambda payoff_cls, _spec_schema, _settle: payoff_cls(),
+        price_fn=lambda payoff, _market_state: payoff.price,
+        task_run_storage_root=tmp_path,
+        task_run_storage_layout="standalone",
+    )
+
+    assert "computational_problem" not in result
+    assert "computational_problem" not in result["runtime_contract"]
+
+
 def test_task_runtime_bridges_sparse_proof_mc_rows_to_vanilla_option_contract():
     from trellis.agent.semantic_contracts import semantic_contract_summary
     from trellis.agent.task_manifests import load_task_manifest

--- a/trellis/agent/computational_problem_ir.py
+++ b/trellis/agent/computational_problem_ir.py
@@ -16,6 +16,50 @@ SLV_LSV = "slv_lsv"
 UNSUPPORTED_PATH_DEPENDENT_CONTROL = "unsupported_path_dependent_control"
 STOCHASTIC_VOL_MIXED = "stochastic_vol_mixed"
 
+_MODEL_EVIDENCE_KEYS = frozenset(
+    {
+        "calibration_model",
+        "calibration_model_family",
+        "model",
+        "model_family",
+        "model_id",
+        "model_name",
+        "model_parameter_source",
+        "model_parameters",
+        "process",
+        "process_family",
+        "process_id",
+        "process_name",
+        "selected_model",
+        "selected_process",
+    }
+)
+_MODEL_EVIDENCE_CONTAINERS = (
+    "semantic_contract",
+    "product_contract",
+    "model_contract",
+    "benchmark_contract",
+    "extension_contract",
+    "model_assertions",
+    "semantic_assertions",
+)
+_STOCHASTIC_VOL_EVIDENCE_TERMS = (
+    "heston",
+    "bates",
+    "stochastic vol",
+    "stochastic local vol",
+    "local-stochastic vol",
+    "slv",
+    "lsv",
+    "rough heston",
+)
+_LEVERAGE_MODEL_EVIDENCE_TERMS = (
+    "stochastic local vol",
+    "local-stochastic vol",
+    "slv",
+    "lsv",
+)
+
 
 @dataclass(frozen=True)
 class RepairPacket:
@@ -522,9 +566,9 @@ def _solver_target(text: str, bucket: str) -> str:
 
 
 def _process_family(text: str, bucket: str) -> str:
-    if bucket == SLV_LSV:
+    if bucket == SLV_LSV or _has_any(text, _LEVERAGE_MODEL_EVIDENCE_TERMS):
         return "slv_lsv"
-    if bucket == AFFINE_JUMP_STOCHASTIC_VOL:
+    if bucket == AFFINE_JUMP_STOCHASTIC_VOL or "bates" in text:
         return "bates"
     if "rough" in text:
         return "rough_heston"
@@ -1009,19 +1053,7 @@ def _looks_stochastic_vol_task(
     target_ids: Sequence[str],
 ) -> bool:
     text = _text_blob(task, *target_ids)
-    return _has_any(
-        text,
-        (
-            "heston",
-            "bates",
-            "stochastic vol",
-            "stochastic local vol",
-            "local-stochastic vol",
-            "slv",
-            "lsv",
-            "rough heston",
-        ),
-    )
+    return _has_any(text, _STOCHASTIC_VOL_EVIDENCE_TERMS)
 
 
 def _text_blob(task: Mapping[str, Any], *target_ids: str) -> str:
@@ -1033,13 +1065,36 @@ def _text_blob(task: Mapping[str, Any], *target_ids: str) -> str:
     pieces.extend(target_ids)
     pieces.extend(str(item) for item in _as_list(task.get("construct")))
     pieces.extend(str(item) for item in _as_list(task.get("new_component")))
-    market = task.get("market")
-    if isinstance(market, Mapping):
-        pieces.extend(str(value) for value in market.values())
-    assertions = task.get("market_assertions")
-    if isinstance(assertions, Mapping):
-        pieces.extend(_flatten_strings(assertions))
+    pieces.extend(_explicit_model_evidence(task))
     return " ".join(pieces).replace("_", " ").lower()
+
+
+def _explicit_model_evidence(task: Mapping[str, Any]) -> list[str]:
+    """Return declared model semantics without inspecting ambient market data."""
+    evidence: list[str] = []
+    for key, value in task.items():
+        normalized_key = str(key).strip().lower().replace("-", "_")
+        if normalized_key in _MODEL_EVIDENCE_KEYS:
+            evidence.extend(_flatten_strings(value))
+    for container in _MODEL_EVIDENCE_CONTAINERS:
+        evidence.extend(_named_model_evidence(task.get(container)))
+    return evidence
+
+
+def _named_model_evidence(value: Any) -> list[str]:
+    if not isinstance(value, Mapping):
+        return []
+    evidence: list[str] = []
+    for key, inner in value.items():
+        normalized_key = str(key).strip().lower().replace("-", "_")
+        if normalized_key in _MODEL_EVIDENCE_KEYS:
+            evidence.extend(_flatten_strings(inner))
+        elif isinstance(inner, Mapping):
+            evidence.extend(_named_model_evidence(inner))
+        elif isinstance(inner, (list, tuple)):
+            for item in inner:
+                evidence.extend(_named_model_evidence(item))
+    return evidence
 
 
 def _target_text(target_id: str) -> str:
@@ -1048,12 +1103,17 @@ def _target_text(target_id: str) -> str:
 
 def _target_route_text(task: Mapping[str, Any], target_id: str) -> str:
     text = _target_text(target_id)
-    if target_id != "task":
+    if target_id == "task":
+        pieces = [text, str(task.get("title") or "")]
+        pieces.extend(str(item) for item in _as_list(task.get("construct")))
+        pieces.extend(str(item) for item in _as_list(task.get("new_component")))
+        text = " ".join(pieces).replace("_", " ").lower()
+    if _has_any(text, _STOCHASTIC_VOL_EVIDENCE_TERMS):
         return text
-    pieces = [text, str(task.get("title") or "")]
-    pieces.extend(str(item) for item in _as_list(task.get("construct")))
-    pieces.extend(str(item) for item in _as_list(task.get("new_component")))
-    return " ".join(pieces).replace("_", " ").lower()
+    model_text = " ".join(_explicit_model_evidence(task)).replace("_", " ").lower()
+    if _has_any(model_text, _LEVERAGE_MODEL_EVIDENCE_TERMS):
+        return " ".join(part for part in (text, model_text) if part)
+    return text
 
 
 def _short_text_evidence(text: str) -> str:


### PR DESCRIPTION
## Summary
- stop stochastic-vol computational IR from inferring model semantics from ambient market inventories and market assertions
- admit only explicit task/model/process evidence while preserving method/calibration shape on its own axis
- prevent F012 and T105 from persisting false Heston computational-problem packets

## Tests
- `/Users/steveyang/miniforge3/bin/python3 -m pytest tests/test_agent/test_computational_problem_ir.py tests/test_agent/test_task_runtime.py -q --disable-warnings` (143 passed)
- `make gate-pr` (4,556 primary tests passed; 32 tier-2 contract tests passed)

## Review
- fixed and resolved the P2 inherited-Bates route-shape finding with explicit `pde` and `market_prices` regressions
- refreshed CI is green on `0d7f9253`

## Docs
- document classifier evidence boundaries, target/model-axis precedence, and absent computational-problem packets
- no `LIMITATIONS.md` change because pricing support is unchanged

Linear: QUA-1192