### PR TITLE
Docs: synchronize QUA-1192 plan status

### DIFF
--- a/doc/plan/active__semantic-task-synthesis-helper-retirement.md
+++ b/doc/plan/active__semantic-task-synthesis-helper-retirement.md
@@ -51,7 +51,7 @@ Status mirror last synced: `2026-07-15`
 | `QUA-1188` | Monte Carlo transition state: conditional bridge extrema primitive | Done |
 | `QUA-1189` | Fixed lookback Monte Carlo: retire helper authority | Done |
 | `QUA-1190` | Variance swap Monte Carlo: retire helper authority | Done |
-| `QUA-1192` | Semantic computational IR: ignore ambient market capabilities | Backlog |
+| `QUA-1192` | Semantic computational IR: ignore ambient market capabilities | Done |
 | `QUA-1191` | Chooser option pricing: retire analytical helper authority | Backlog |
 
 ## Current Sequence
@@ -59,8 +59,9 @@ Status mirror last synced: `2026-07-15`
 1. Use QUA-1185 strict cached replays as zero-model evidence without explicit
    reflection/consolidation skip flags; persisted policy reasons must explain
    every skipped post-build stage.
-2. Complete QUA-1192 so ambient market capabilities cannot misclassify an
-   ordinary Black-Scholes task as a Heston computational problem.
+2. Apply the QUA-1192 classifier boundary: only explicit task, target, or
+   model-contract evidence may declare stochastic-volatility semantics;
+   ambient market capabilities remain non-authoritative.
 3. Complete QUA-1191 by replacing the chooser-option wrapper authority with
    the reusable Gaussian, scalar-root, market, and Black composition surface
    while preserving F012 FinancePy parity.


### PR DESCRIPTION
## Summary
- mark QUA-1192 Done in the helper-retirement plan mirror
- preserve its explicit-semantic-evidence rule in the current execution sequence
- leave QUA-1191 as the next backlog slice

## Validation
- `git diff --check`
- documentation-only status synchronization