### PR TITLE
QUA-1191 Retire chooser analytical helper authority

### DIFF
--- a/FINANCEPY_BINDINGS.yaml
+++ b/FINANCEPY_BINDINGS.yaml
@@ -166,9 +166,12 @@ bindings:
     financepy_model: BlackScholes
     overlapping_outputs:
     - price
+    - delta
     comparison_modes:
     - price_parity
     - warm_runtime
+    greek_fallback:
+      kind: bump_and_reprice
   financepy.equity.compound.black_scholes:
     instrument_family: compound_option
     method_family: analytical

--- a/docs/developer/runtime_agent_orientation.rst
+++ b/docs/developer/runtime_agent_orientation.rst
@@ -75,14 +75,23 @@ selection. Quant and model-validator regression tests reject API-map imports
 or code templates in their resolved context.
 
 Composition cards may join public primitives from more than one subsystem
-without introducing a new product helper. For example,
-``analytical_gaussian_composition`` points a builder handling chooser,
-compound, or other critical-state analytical work to scalar Gaussian
-probability kernels and the existing typed ``SolveRequest`` root surface. The
-card does not contain a derivative formula and does not enter the quant or
-model-validator role packets. Those roles continue to reason from semantic
-contracts, quantitative documentation, and executed evidence; implementation
-symbol selection remains builder-owned.
+without introducing a new product helper. The general
+``analytical_gaussian_composition`` card points a builder handling compound or
+other critical-state analytical work to scalar Gaussian probability kernels
+and the existing typed ``SolveRequest`` root surface. The more specific
+``chooser_option_composition`` card is a complete bounded navigation packet:
+it adds the scalar-diffusion market projection, contractual time function,
+Black call/put kernels, discount/forward support, the bivariate Gaussian
+kernel, and the bounded root contracts. It states the adapter-owned balance
+equation and date/bracket obligations without importing the retained chooser
+pricing wrapper.
+
+Neither card enters the quant or model-validator role packets. Those roles
+continue to reason from semantic contracts, quantitative documentation, and
+executed evidence; implementation symbol selection remains builder-owned.
+The quant and model-validator may consult the read-only cookbook catalog after
+typed decomposition, but they cannot promote cookbook entries during task
+execution or use those patterns to override the chooser semantic contract.
 
 The ``path_statistic_composition`` card applies the same rule to path-dependent
 Monte Carlo construction. Semantic aliases such as ``running_extremum``,

--- a/docs/quant/pricing_stack.rst
+++ b/docs/quant/pricing_stack.rst
@@ -978,11 +978,88 @@ surface:
 3. construct ``SolveRequest`` with ``solver_hint="brentq"``
 4. call ``execute_solve_request`` and consume the checked ``SolveResult``
 
-This keeps the numerical policy bounded and auditable. Chooser, compound, and
-other critical-state formulas should not create route-local Newton loops or
-promote a product pricing helper as construction authority. The semantic API
-map card ``analytical_gaussian_composition`` is the builder's hot start for
+This keeps the numerical policy bounded and auditable. Compound and other
+critical-state formulas should not create route-local Newton loops or promote
+a product pricing helper as construction authority. The semantic API map card
+``analytical_gaussian_composition`` is the builder's general hot start for
 these probability and root-solving pieces.
+
+Simple chooser composition
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The admitted European simple-chooser lane uses the more complete
+``chooser_option_composition`` card. It joins the scalar-diffusion market
+resolver, contractual time fractions, Black-76 call/put kernels, discount and
+forward support, bivariate Gaussian probabilities, and the typed scalar-root
+surface. The checked adapter owns the derivative formula; the retained
+``price_equity_chooser_option_analytical`` wrapper is comparison evidence and
+does not appear in promoted route or backend construction authority.
+
+Let :math:`t_c` be the choice time, :math:`T_C` and :math:`T_P` the call and
+put expiries, and :math:`K_C` and :math:`K_P` their strikes. The admitted
+market projection resolves one constant :math:`r`, :math:`q`, and
+:math:`\sigma` at the longest expiry, using :math:`K_C` as the explicit
+volatility coordinate. At the choice date, the critical stock state
+:math:`S^*` solves
+
+.. math::
+
+   C_{BS}(S^*, K_C, T_C-t_c)
+   - P_{BS}(S^*, K_P, T_P-t_c) = 0.
+
+The adapter builds each Black-Scholes value from an equity forward, a discount
+factor, and the public Black-76 kernel. It submits the residual through one
+``root_scalar`` ``SolveRequest``. The checked F012 adapter uses the finite
+positive bracket
+
+.. math::
+
+   [10^{-8}M, 10^6M], \qquad
+   M = \max(S_0, K_C, K_P, 1),
+
+and verifies a sign change before solving. This is a deterministic admission
+policy, not a claim that every chooser contract has a root on that bracket.
+
+For the solved state, define
+
+.. math::
+
+   \begin{aligned}
+   d_1 &= \frac{\log(S_0/S^*) + (r-q+\tfrac12\sigma^2)t_c}
+                 {\sigma\sqrt{t_c}},
+   & d_2 &= d_1-\sigma\sqrt{t_c}, \\
+   y_C &= \frac{\log(S_0/K_C) + (r-q+\tfrac12\sigma^2)T_C}
+                 {\sigma\sqrt{T_C}},
+   & y_P &= \frac{\log(S_0/K_P) + (r-q+\tfrac12\sigma^2)T_P}
+                 {\sigma\sqrt{T_P}}, \\
+   \rho_C &= \sqrt{t_c/T_C},
+   & \rho_P &= \sqrt{t_c/T_P}.
+   \end{aligned}
+
+With :math:`\Phi_2` denoting the bivariate standard-normal CDF, the price per
+unit notional is
+
+.. math::
+
+   \begin{aligned}
+   V ={}& S_0 e^{-qT_C}\Phi_2(d_1,y_C;\rho_C)
+      - K_C e^{-rT_C}\Phi_2(d_2,y_C-\sigma\sqrt{T_C};\rho_C) \\
+      &- S_0 e^{-qT_P}\Phi_2(-d_1,-y_P;\rho_P)
+      + K_P e^{-rT_P}\Phi_2(-d_2,-y_P+\sigma\sqrt{T_P};\rho_P).
+   \end{aligned}
+
+The admitted lane fails closed unless settlement is strictly before the choice
+date and the choice date is strictly before both expiries. Spot, strikes, and
+volatility must be positive and finite. Immediate-choice, choice-at-expiry,
+zero-volatility, time-varying coefficient, local-volatility, and
+stochastic-volatility chooser claims are outside this formula rather than
+silently narrowed onto it.
+
+For risk, the adapter first uses the selected runtime ``MarketState.spot`` and
+falls back to the contract spot only when no runtime spot is bound. That keeps
+the pricing formula compatible with the product-neutral central spot-bump
+``Delta`` measure. The F012 FinancePy binding requests the same generic
+``bump_and_reprice`` policy; no chooser-specific Greek helper is required.
 
 Calibration Surface
 -------------------

--- a/tests/test_agent/test_api_map.py
+++ b/tests/test_agent/test_api_map.py
@@ -292,7 +292,7 @@ def test_api_map_semantic_selection_reaches_composition_cards():
 
 @pytest.mark.parametrize(
     "payoff_family",
-    ["chooser_option", "compound_option", "lookback_option"],
+    ["compound_option", "lookback_option"],
 )
 def test_api_map_semantic_selection_reaches_gaussian_root_composition(
     payoff_family,
@@ -319,6 +319,42 @@ def test_api_map_semantic_selection_reaches_gaussian_root_composition(
     assert "SolveRequest" in text
     assert "execute_solve_request" in text
     assert "from trellis.models.calibration.solve_request import" in text
+
+
+def test_api_map_exposes_complete_chooser_raw_composition():
+    selection = select_api_map_sections(
+        ApiMapQuery(
+            payoff_family="chooser_option",
+            method="analytical",
+            model_family="equity_diffusion",
+        )
+    )
+    text = format_api_map_for_prompt(
+        compact=True,
+        query=ApiMapQuery(
+            payoff_family="chooser_option",
+            method="analytical",
+            model_family="equity_diffusion",
+        ),
+    )
+
+    assert "chooser_option_composition" in selection.selected_families
+    for symbol in (
+        "resolve_scalar_diffusion_market_inputs",
+        "year_fraction",
+        "forward_from_dividend_yield",
+        "discount_factor_from_zero_rate",
+        "discounted_value",
+        "black76_call",
+        "black76_put",
+        "bivariate_standard_normal_cdf",
+        "ObjectiveBundle",
+        "SolveBounds",
+        "SolveRequest",
+        "execute_solve_request",
+    ):
+        assert symbol in text
+    assert "price_equity_chooser_option_analytical" not in text
 
 
 def test_api_map_selection_and_rendering_are_stable_and_budgeted():

--- a/tests/test_agent/test_backend_bindings.py
+++ b/tests/test_agent/test_backend_bindings.py
@@ -745,10 +745,11 @@ def test_resolve_backend_binding_spec_uses_quanto_primitive_composition(
                 model_family="equity_diffusion",
             ),
             "analytical",
-            (
-                "trellis.models.analytical.equity_exotics.price_equity_chooser_option_analytical",
-            ),
             (),
+            (
+                "trellis.models.black.black76_call",
+                "trellis.models.black.black76_put",
+            ),
             id="chooser",
         ),
         pytest.param(
@@ -812,6 +813,41 @@ def test_resolve_backend_binding_spec_uses_exact_helpers_for_absorbed_black76_eq
     assert resolved.route_family == expected_route_family
     assert resolved.helper_refs == expected_helper_refs
     assert resolved.pricing_kernel_refs == expected_kernel_refs
+
+
+def test_resolve_backend_binding_spec_exposes_complete_chooser_composition():
+    catalog = load_backend_binding_catalog()
+    analytical = find_backend_binding_by_route_id("analytical_black76", catalog)
+
+    assert analytical is not None
+
+    resolved = resolve_backend_binding_spec(
+        analytical,
+        product_ir=ProductIR(
+            instrument="chooser_option",
+            payoff_family="chooser_option",
+            payoff_traits=("discounting", "terminal_markov", "vol_surface_dependence"),
+            exercise_style="european",
+            state_dependence="terminal_markov",
+            model_family="equity_diffusion",
+        ),
+    )
+
+    assert resolved.helper_refs == ()
+    assert {
+        "trellis.models.resolution.single_state_diffusion.resolve_scalar_diffusion_market_inputs",
+        "trellis.core.date_utils.year_fraction",
+        "trellis.models.analytical.support.forward_from_dividend_yield",
+        "trellis.models.analytical.support.discount_factor_from_zero_rate",
+        "trellis.models.analytical.support.discounted_value",
+        "trellis.models.black.black76_call",
+        "trellis.models.black.black76_put",
+        "trellis.models.analytical.support.probability.bivariate_standard_normal_cdf",
+        "trellis.models.calibration.solve_request.ObjectiveBundle",
+        "trellis.models.calibration.solve_request.SolveBounds",
+        "trellis.models.calibration.solve_request.SolveRequest",
+        "trellis.models.calibration.solve_request.execute_solve_request",
+    } <= set(resolved.primitive_refs)
 
 
 def test_resolve_backend_binding_spec_uses_cliquet_primitive_composition():

--- a/tests/test_agent/test_codegen_guardrails.py
+++ b/tests/test_agent/test_codegen_guardrails.py
@@ -1293,10 +1293,6 @@ def test_cds_analytical_route_card_surfaces_helper_signature_keywords():
     "instrument_type,expected_helper_ref",
     [
         (
-            "chooser_option",
-            "trellis.models.analytical.equity_exotics.price_equity_chooser_option_analytical",
-        ),
-        (
             "compound_option",
             "trellis.models.analytical.equity_exotics.price_equity_compound_option_analytical",
         ),
@@ -1336,6 +1332,48 @@ def test_absorbed_black76_structural_exotic_route_uses_exact_helper_binding(
     }
     assert expected_helper_ref in primitive_refs
     assert expected_helper_ref.rsplit(".", 1)[-1] in card
+
+
+def test_chooser_route_card_uses_raw_composition_not_product_helper():
+    pricing_plan = PricingPlan(
+        method="analytical",
+        method_modules=[
+            "trellis.models.resolution.single_state_diffusion",
+            "trellis.models.analytical.support",
+            "trellis.models.analytical.support.probability",
+            "trellis.models.black",
+            "trellis.models.calibration.solve_request",
+        ],
+        required_market_data={"discount_curve", "black_vol_surface"},
+        model_to_build="chooser_option",
+        reasoning="test",
+    )
+    plan = build_generation_plan(
+        pricing_plan=pricing_plan,
+        instrument_type="chooser_option",
+        inspected_modules=tuple(pricing_plan.method_modules),
+        product_ir=ProductIR(
+            instrument="chooser_option",
+            payoff_family="chooser_option",
+            payoff_traits=("discounting", "terminal_markov", "vol_surface_dependence"),
+            exercise_style="european",
+            state_dependence="terminal_markov",
+            model_family="equity_diffusion",
+        ),
+    )
+
+    card = render_generation_route_card(plan)
+
+    assert "price_equity_chooser_option_analytical" not in card
+    for symbol in (
+        "resolve_scalar_diffusion_market_inputs",
+        "black76_call",
+        "black76_put",
+        "bivariate_standard_normal_cdf",
+        "SolveRequest",
+        "execute_solve_request",
+    ):
+        assert symbol in card
 
 
 def test_nth_to_default_monte_carlo_route_uses_copula_assembly():

--- a/tests/test_agent/test_financepy_benchmark.py
+++ b/tests/test_agent/test_financepy_benchmark.py
@@ -68,7 +68,7 @@ def test_financepy_benchmark_manifest_includes_tranche_two_families():
         ("F009", ("price",)),
         ("F010", ("price",)),
         ("F011", ("price",)),
-        ("F012", ("price",)),
+        ("F012", ("price", "delta")),
         ("F013", ("price",)),
         ("F014", ("price",)),
         ("F015", ("price",)),
@@ -82,6 +82,17 @@ def test_price_financepy_reference_supports_tranche_two_families(task_id, expect
     assert result["elapsed_seconds"] >= 0.0
     for output_name in expected_outputs:
         assert output_name in result["outputs"]
+
+
+def test_f012_binding_declares_generic_delta_fallback():
+    from trellis.agent.task_manifests import load_financepy_bindings
+
+    binding = load_financepy_bindings(root=ROOT)[
+        "financepy.equity.chooser.black_scholes"
+    ]
+
+    assert binding["overlapping_outputs"] == ["price", "delta"]
+    assert binding["greek_fallback"] == {"kind": "bump_and_reprice"}
 
 
 def test_build_financepy_benchmark_report_accumulates_totals():

--- a/tests/test_agent/test_helper_authority_audit.py
+++ b/tests/test_agent/test_helper_authority_audit.py
@@ -294,3 +294,23 @@ def test_current_repository_retires_analytical_digital_helper_authority():
         if item.path == "trellis/instruments/_agent/digitaloption.py"
         and item.symbol == helper_symbol
     ]
+
+
+def test_current_repository_retires_analytical_chooser_helper_authority():
+    from trellis.agent.helper_authority_audit import build_helper_authority_report
+
+    root = Path(__file__).resolve().parents[2]
+    report = build_helper_authority_report(root)
+    helper_symbol = "price_equity_chooser_option_analytical"
+
+    assert not [
+        item
+        for item in (*report.route_authority, *report.binding_authority)
+        if item.symbol == helper_symbol
+    ]
+    assert not [
+        item
+        for item in report.adapter_calls
+        if item.path == "trellis/instruments/_agent/chooseroption.py"
+        and item.symbol == helper_symbol
+    ]

--- a/tests/test_agent/test_import_registry.py
+++ b/tests/test_agent/test_import_registry.py
@@ -33,6 +33,20 @@ def test_find_symbol_modules_returns_garman_kohlhagen_kernel_module():
     assert "trellis.models.black" in modules
 
 
+def test_analytical_discount_factor_is_visible_to_import_registry():
+    module = "trellis.models.analytical.support"
+    symbol = "discount_factor_from_zero_rate"
+
+    assert symbol in list_module_exports(module)
+    assert module in find_symbol_modules(symbol)
+    assert is_valid_import(module, symbol)
+
+    static_registry = import_registry._parse_static_registry(
+        import_registry._STATIC_REGISTRY
+    )
+    assert symbol in static_registry[module]
+
+
 def test_observation_return_primitives_are_visible_to_import_registry():
     module = "trellis.models.observation_returns"
     symbols = {

--- a/tests/test_agent/test_knowledge_store.py
+++ b/tests/test_agent/test_knowledge_store.py
@@ -688,9 +688,31 @@ class TestKnowledgeStore:
             assert kernel in digital_requirements
         assert "price_equity_digital_option_analytical" not in digital_requirements
 
+        chooser = store._decompositions.get("chooser_option")
+        assert chooser is not None
+        assert chooser.method == "analytical"
+        assert set(chooser.method_modules) >= {
+            "trellis.models.resolution.single_state_diffusion",
+            "trellis.models.analytical.support",
+            "trellis.models.analytical.support.probability",
+            "trellis.models.black",
+            "trellis.models.calibration.solve_request",
+        }
+        chooser_requirements = " ".join(chooser.modeling_requirements)
+        for symbol in (
+            "resolve_scalar_diffusion_market_inputs",
+            "year_fraction",
+            "black76_call",
+            "black76_put",
+            "bivariate_standard_normal_cdf",
+            "SolveRequest",
+            "execute_solve_request",
+        ):
+            assert symbol in chooser_requirements
+        assert "price_equity_chooser_option_analytical" not in chooser_requirements
+
         for instrument, helper_symbol in (
             ("lookback_option", "price_equity_fixed_lookback_option_analytical"),
-            ("chooser_option", "price_equity_chooser_option_analytical"),
             ("compound_option", "price_equity_compound_option_analytical"),
         ):
             decomp = store._decompositions.get(instrument)

--- a/tests/test_agent/test_platform_requests.py
+++ b/tests/test_agent/test_platform_requests.py
@@ -885,7 +885,7 @@ def test_semantic_blueprint_summary_preserves_range_accrual_callability_blockers
         (
             "F012",
             "analytical",
-            "trellis.models.analytical.equity_exotics.price_equity_chooser_option_analytical",
+            "trellis.models.black.black76_call",
         ),
         (
             "F013",
@@ -925,6 +925,11 @@ def test_compile_build_request_preserves_exact_absorbed_black76_binding_for_fina
     if task_id == "F010":
         assert (
             "trellis.models.analytical.equity_exotics.price_equity_digital_option_analytical"
+            not in compiled.generation_plan.backend_exact_target_refs
+        )
+    if task_id == "F012":
+        assert (
+            "trellis.models.analytical.equity_exotics.price_equity_chooser_option_analytical"
             not in compiled.generation_plan.backend_exact_target_refs
         )
 

--- a/tests/test_agent/test_route_registry.py
+++ b/tests/test_agent/test_route_registry.py
@@ -1816,15 +1816,58 @@ class TestAnalyticalRoutes:
             ),
         }
 
-    def test_chooser_primitives_use_exact_helper(self, registry):
+    def test_chooser_primitives_use_raw_analytical_composition(self, registry):
         spec = [r for r in registry.routes if r.id == "analytical_black76"][0]
         new_prims = resolve_route_primitives(spec, self.CHOOSER_IR)
         assert resolve_route_family(spec, self.CHOOSER_IR) == "analytical"
         assert _prim_set(new_prims) == {
             (
-                "trellis.models.analytical.equity_exotics",
-                "price_equity_chooser_option_analytical",
-                "route_helper",
+                "trellis.models.resolution.single_state_diffusion",
+                "resolve_scalar_diffusion_market_inputs",
+                "market_binding",
+            ),
+            ("trellis.core.date_utils", "year_fraction", "time_measure"),
+            (
+                "trellis.models.analytical.support",
+                "forward_from_dividend_yield",
+                "forward_builder",
+            ),
+            (
+                "trellis.models.analytical.support",
+                "discount_factor_from_zero_rate",
+                "discounting",
+            ),
+            (
+                "trellis.models.analytical.support",
+                "discounted_value",
+                "discounting",
+            ),
+            ("trellis.models.black", "black76_call", "pricing_kernel"),
+            ("trellis.models.black", "black76_put", "pricing_kernel"),
+            (
+                "trellis.models.analytical.support.probability",
+                "bivariate_standard_normal_cdf",
+                "probability_kernel",
+            ),
+            (
+                "trellis.models.calibration.solve_request",
+                "ObjectiveBundle",
+                "objective_contract",
+            ),
+            (
+                "trellis.models.calibration.solve_request",
+                "SolveBounds",
+                "solver_bounds",
+            ),
+            (
+                "trellis.models.calibration.solve_request",
+                "SolveRequest",
+                "solver_request",
+            ),
+            (
+                "trellis.models.calibration.solve_request",
+                "execute_solve_request",
+                "solver",
             ),
         }
 

--- a/tests/test_instruments/test_agent_chooser_option.py
+++ b/tests/test_instruments/test_agent_chooser_option.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+import trellis.instruments._agent.chooseroption as chooser_module
+from trellis.core.market_state import MarketState
+from trellis.curves.yield_curve import YieldCurve
+from trellis.instruments._agent.chooseroption import (
+    ChooserOptionPayoff,
+    ChooserOptionSpec,
+)
+from trellis.models.analytical.equity_exotics import (
+    price_equity_chooser_option_analytical,
+)
+from trellis.models.vol_surface import FlatVol
+from trellis.analytics.measures import Delta
+from trellis.models.calibration.solve_request import SolveResult
+
+
+SETTLEMENT = date(2024, 11, 15)
+
+
+def _market_state(*, spot: float | None = None) -> MarketState:
+    return MarketState(
+        as_of=SETTLEMENT,
+        settlement=SETTLEMENT,
+        discount=YieldCurve.flat(0.05),
+        vol_surface=FlatVol(0.2),
+        spot=spot,
+    )
+
+
+def test_checked_chooser_adapter_matches_retained_reference_for_unequal_terms():
+    spec = ChooserOptionSpec(
+        notional=2.0,
+        spot=100.0,
+        choose_date=date(2025, 5, 15),
+        call_expiry_date=date(2025, 11, 15),
+        put_expiry_date=date(2026, 5, 15),
+        call_strike=105.0,
+        put_strike=95.0,
+        dividend_yield=0.01,
+    )
+
+    actual = ChooserOptionPayoff(spec).evaluate(_market_state())
+    expected = price_equity_chooser_option_analytical(_market_state(), spec)
+
+    assert actual == pytest.approx(expected, rel=2e-8, abs=2e-8)
+
+
+def test_checked_chooser_adapter_honors_runtime_spot_for_generic_delta():
+    spec = ChooserOptionSpec(
+        notional=1.0,
+        spot=100.0,
+        choose_date=date(2025, 5, 15),
+        call_expiry_date=date(2025, 11, 15),
+        put_expiry_date=date(2025, 11, 15),
+        call_strike=100.0,
+        put_strike=100.0,
+    )
+    payoff = ChooserOptionPayoff(spec)
+    market_state = _market_state(spot=100.0)
+
+    delta = float(Delta(bump_pct=0.1).compute(payoff, market_state))
+
+    assert delta > 0.0
+    assert payoff.evaluate(_market_state(spot=101.0)) != pytest.approx(
+        payoff.evaluate(_market_state(spot=99.0))
+    )
+
+
+def test_checked_chooser_adapter_rejects_invalid_solved_state(monkeypatch):
+    spec = ChooserOptionSpec(
+        notional=1.0,
+        spot=100.0,
+        choose_date=date(2025, 5, 15),
+        call_expiry_date=date(2025, 11, 15),
+        put_expiry_date=date(2025, 11, 15),
+        call_strike=100.0,
+        put_strike=100.0,
+    )
+    monkeypatch.setattr(
+        chooser_module,
+        "execute_solve_request",
+        lambda request: SolveResult(
+            solution=(float("nan"),),
+            objective_value=0.0,
+            success=True,
+        ),
+    )
+
+    with pytest.raises(ValueError, match="positive finite critical stock state"):
+        ChooserOptionPayoff(spec).evaluate(_market_state())
+
+
+@pytest.mark.parametrize(
+    ("choose_date", "call_expiry", "put_expiry"),
+    [
+        (SETTLEMENT, date(2025, 11, 15), date(2025, 11, 15)),
+        (date(2025, 11, 15), date(2025, 11, 15), date(2026, 5, 15)),
+        (date(2025, 5, 15), date(2025, 4, 15), date(2025, 11, 15)),
+    ],
+)
+def test_checked_chooser_adapter_rejects_degenerate_date_ordering(
+    choose_date,
+    call_expiry,
+    put_expiry,
+):
+    spec = ChooserOptionSpec(
+        notional=1.0,
+        spot=100.0,
+        choose_date=choose_date,
+        call_expiry_date=call_expiry,
+        put_expiry_date=put_expiry,
+        call_strike=100.0,
+        put_strike=100.0,
+    )
+
+    with pytest.raises(ValueError, match="strictly between settlement and both expiries"):
+        ChooserOptionPayoff(spec).evaluate(_market_state())
+
+
+def test_checked_chooser_adapter_source_composes_reusable_primitives():
+    source_path = (
+        Path(__file__).resolve().parents[2]
+        / "trellis/instruments/_agent/chooseroption.py"
+    )
+    source = source_path.read_text(encoding="utf-8")
+
+    assert "price_equity_chooser_option_analytical" not in source
+    for symbol in (
+        "resolve_scalar_diffusion_market_inputs",
+        "year_fraction",
+        "forward_from_dividend_yield",
+        "discount_factor_from_zero_rate",
+        "discounted_value",
+        "black76_call",
+        "black76_put",
+        "bivariate_standard_normal_cdf",
+        "ObjectiveBundle",
+        "SolveBounds",
+        "SolveRequest",
+        "execute_solve_request",
+    ):
+        assert symbol in source

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -5920,9 +5920,6 @@ def _deterministic_exact_binding_evaluate_body(
         "trellis.models.equity_option_pde.price_equity_digital_option_pde": (
             "return price_equity_digital_option_pde(market_state, spec)"
         ),
-        "trellis.models.analytical.equity_exotics.price_equity_chooser_option_analytical": (
-            "return price_equity_chooser_option_analytical(market_state, spec)"
-        ),
         "trellis.models.analytical.equity_exotics.price_equity_compound_option_analytical": (
             "return price_equity_compound_option_analytical(market_state, spec)"
         ),

--- a/trellis/agent/financepy_reference.py
+++ b/trellis/agent/financepy_reference.py
@@ -409,9 +409,16 @@ def _chooser_reference(*, contract: Mapping[str, Any], scenario_inputs: Mapping[
     discount_curve = _flat_curve(float(contract["domestic_rate"]), value_dt)
     dividend_curve = _flat_curve(float(contract["dividend_rate"]), value_dt)
     model = BlackScholes(float(contract["volatility"]))
-    return {
-        "price": float(option.value(value_dt, float(contract["spot"]), discount_curve, dividend_curve, model))
-    }
+    args = (
+        value_dt,
+        float(contract["spot"]),
+        discount_curve,
+        dividend_curve,
+        model,
+    )
+    outputs = {"price": float(option.value(*args))}
+    outputs.update(_maybe_method_outputs(option, ["delta"], *args))
+    return outputs
 
 
 def _compound_reference(*, contract: Mapping[str, Any], scenario_inputs: Mapping[str, Any]) -> dict[str, float]:

--- a/trellis/agent/knowledge/canonical/api_map.yaml
+++ b/trellis/agent/knowledge/canonical/api_map.yaml
@@ -60,7 +60,7 @@ analytical_gaussian_composition:
   module: trellis.models.analytical.support.probability
   methods: [analytical]
   navigation:
-    aliases: [gaussian_probability, bivariate_gaussian, critical_state, scalar_root, chooser_option, compound_option, lookback_option]
+    aliases: [gaussian_probability, bivariate_gaussian, critical_state, scalar_root, compound_option, lookback_option]
   modules:
     probability: trellis.models.analytical.support.probability
     scalar_root: trellis.models.calibration.solve_request
@@ -72,6 +72,36 @@ analytical_gaussian_composition:
     - "For an implicit critical state, define the derivative-specific scalar objective in adapter code and solve it through a bounded root_scalar SolveRequest; do not introduce route-local Newton loops or product helpers"
     - "The generated adapter owns the contractual formula, critical-state equation, discounting, and notional application; this card supplies navigation and reusable numerical pieces only"
     - "The bivariate kernel admits finite thresholds and correlations in the closed interval [-1, 1], handles exact singular boundaries explicitly, and fails closed outside that domain"
+
+# ---------------------------------------------------------------------------
+# Simple chooser option raw composition
+# ---------------------------------------------------------------------------
+chooser_option_composition:
+  module: trellis.models.resolution.single_state_diffusion
+  methods: [analytical]
+  navigation:
+    aliases: [chooser_option, chooser_payoff, simple_chooser, critical_state_option]
+  modules:
+    market_binding: trellis.models.resolution.single_state_diffusion
+    time_measure: trellis.core.date_utils
+    analytical_support: trellis.models.analytical.support
+    probability: trellis.models.analytical.support.probability
+    black_kernel: trellis.models.black
+    scalar_root: trellis.models.calibration.solve_request
+  key_imports:
+    - "from trellis.models.resolution.single_state_diffusion import resolve_scalar_diffusion_market_inputs"
+    - "from trellis.core.date_utils import year_fraction"
+    - "from trellis.models.analytical.support import discount_factor_from_zero_rate, discounted_value, forward_from_dividend_yield"
+    - "from trellis.models.black import black76_call, black76_put"
+    - "from trellis.models.analytical.support.probability import bivariate_standard_normal_cdf"
+    - "from trellis.models.calibration.solve_request import ObjectiveBundle, SolveBounds, SolveRequest, execute_solve_request"
+  notes:
+    - "Admitted scope is a simple European chooser under one constant rate, dividend yield, and Black volatility projected at the longest expiry and the call-strike volatility coordinate"
+    - "Represent the longest-expiry market coordinate with a local frozen value satisfying ScalarDiffusionMarketSpecLike; do not add a chooser resolver or pass the multi-date chooser spec as if it had one expiry_date"
+    - "Require settlement < choose_date < call_expiry_date and put_expiry_date, with positive spot, strikes, and volatility"
+    - "At the choice date, build call and put present values with forward_from_dividend_yield, discount_factor_from_zero_rate, discounted_value, black76_call, and black76_put; their difference is the scalar root objective"
+    - "Use finite positive SolveBounds with a verified sign change, then execute one root_scalar SolveRequest; do not use an unbounded Newton loop"
+    - "The adapter owns the critical-state equation, bivariate-Gaussian chooser formula, contractual date coordinates, and one-time notional scaling; the retained chooser wrapper is reference evidence only"
 
 # ---------------------------------------------------------------------------
 # European digital option composition

--- a/trellis/agent/knowledge/canonical/backend_bindings.yaml
+++ b/trellis/agent/knowledge/canonical/backend_bindings.yaml
@@ -1005,9 +1005,42 @@ bindings:
             exercise:
               style: european
         primitives:
-          - module: trellis.models.analytical.equity_exotics
-            symbol: price_equity_chooser_option_analytical
-            role: route_helper
+          - module: trellis.models.resolution.single_state_diffusion
+            symbol: resolve_scalar_diffusion_market_inputs
+            role: market_binding
+          - module: trellis.core.date_utils
+            symbol: year_fraction
+            role: time_measure
+          - module: trellis.models.analytical.support
+            symbol: forward_from_dividend_yield
+            role: forward_builder
+          - module: trellis.models.analytical.support
+            symbol: discount_factor_from_zero_rate
+            role: discounting
+          - module: trellis.models.analytical.support
+            symbol: discounted_value
+            role: discounting
+          - module: trellis.models.black
+            symbol: black76_call
+            role: pricing_kernel
+          - module: trellis.models.black
+            symbol: black76_put
+            role: pricing_kernel
+          - module: trellis.models.analytical.support.probability
+            symbol: bivariate_standard_normal_cdf
+            role: probability_kernel
+          - module: trellis.models.calibration.solve_request
+            symbol: ObjectiveBundle
+            role: objective_contract
+          - module: trellis.models.calibration.solve_request
+            symbol: SolveBounds
+            role: solver_bounds
+          - module: trellis.models.calibration.solve_request
+            symbol: SolveRequest
+            role: solver_request
+          - module: trellis.models.calibration.solve_request
+            symbol: execute_solve_request
+            role: solver
       - when:
           contract_pattern:
             payoff:

--- a/trellis/agent/knowledge/canonical/decompositions.yaml
+++ b/trellis/agent/knowledge/canonical/decompositions.yaml
@@ -443,11 +443,19 @@
   features: [terminal_markov, discounting, vol_surface_dependence]
   method: analytical
   method_modules:
-    - trellis.models.analytical.equity_exotics
+    - trellis.models.resolution.single_state_diffusion
+    - trellis.models.analytical.support
+    - trellis.models.analytical.support.probability
+    - trellis.models.black
+    - trellis.models.calibration.solve_request
   required_market_data: [discount_curve, black_vol_surface]
   modeling_requirements:
-    - "USE THE EXACT HELPER: Call `price_equity_chooser_option_analytical(market_state, spec)` directly; keep the critical-spot solve inside the shared analytical module."
-  reasoning: "Simple chooser options decompose into a call plus a put on a common underlier at the choice date — closed form via the shared helper."
+    - "Resolve one explicit longest-expiry market coordinate with `resolve_scalar_diffusion_market_inputs(..., volatility_coordinate=call_strike)`; the admitted formula assumes one constant rate, dividend yield, and Black volatility across both expiry legs."
+    - "Require the choice date to lie strictly after settlement and strictly before both expiries; use `year_fraction` for every contractual time."
+    - "At the choice date, form call and put values from `forward_from_dividend_yield`, `discount_factor_from_zero_rate`, `discounted_value`, `black76_call`, and `black76_put`; define their difference as the critical-state objective."
+    - "Solve the positive critical stock state through finite `SolveBounds`, `ObjectiveBundle`, `SolveRequest`, and `execute_solve_request`; do not add a product helper or an adapter-local Newton loop."
+    - "Assemble the simple-chooser value from `bivariate_standard_normal_cdf`, explicit carry/discount factors, strikes, and the solved critical state, then apply notional exactly once."
+  reasoning: "A simple chooser is a bounded analytical composition: solve where the future call and put values balance, then integrate the two choice regions with bivariate Gaussian probabilities."
   learned: false
 
 - instrument: compound_option

--- a/trellis/agent/knowledge/canonical/routes.yaml
+++ b/trellis/agent/knowledge/canonical/routes.yaml
@@ -1626,12 +1626,52 @@ routes:
             exercise:
               style: european
         primitives:
-          - module: trellis.models.analytical.equity_exotics
-            symbol: price_equity_chooser_option_analytical
-            role: route_helper
+          - module: trellis.models.resolution.single_state_diffusion
+            symbol: resolve_scalar_diffusion_market_inputs
+            role: market_binding
+          - module: trellis.core.date_utils
+            symbol: year_fraction
+            role: time_measure
+          - module: trellis.models.analytical.support
+            symbol: forward_from_dividend_yield
+            role: forward_builder
+          - module: trellis.models.analytical.support
+            symbol: discount_factor_from_zero_rate
+            role: discounting
+          - module: trellis.models.analytical.support
+            symbol: discounted_value
+            role: discounting
+          - module: trellis.models.black
+            symbol: black76_call
+            role: pricing_kernel
+          - module: trellis.models.black
+            symbol: black76_put
+            role: pricing_kernel
+          - module: trellis.models.analytical.support.probability
+            symbol: bivariate_standard_normal_cdf
+            role: probability_kernel
+          - module: trellis.models.calibration.solve_request
+            symbol: ObjectiveBundle
+            role: objective_contract
+          - module: trellis.models.calibration.solve_request
+            symbol: SolveBounds
+            role: solver_bounds
+          - module: trellis.models.calibration.solve_request
+            symbol: SolveRequest
+            role: solver_request
+          - module: trellis.models.calibration.solve_request
+            symbol: execute_solve_request
+            role: solver
         adapters: []
         notes:
-          - "Use the chooser helper with `market_state` and `spec`; keep the critical-spot solve inside the shared helper."
+          - >-
+            Admit only a simple European chooser under one constant scalar-diffusion
+            market projection. The adapter owns the balance equation, bounded
+            critical-state request, bivariate formula, and one-time notional scaling.
+          - >-
+            Fail closed unless settlement < choice date < both expiries, spot and
+            strikes are positive, volatility is positive, and the finite positive
+            root bracket changes sign. Do not call a chooser product helper.
       - when:
           contract_pattern:
             payoff:

--- a/trellis/agent/knowledge/import_registry.py
+++ b/trellis/agent/knowledge/import_registry.py
@@ -561,7 +561,7 @@ from trellis.curves.credit_curve import CreditCurve
 ### Models — Analytical
 from trellis.models.black import black76_call, black76_put, black76_asset_or_nothing_call, black76_asset_or_nothing_put, black76_cash_or_nothing_call, black76_cash_or_nothing_put
 from trellis.models.analytical import terminal_intrinsic, terminal_vanilla_from_basis
-from trellis.models.analytical.support import asset_or_nothing_intrinsic, cash_or_nothing_intrinsic, discounted_value, forward_from_dividend_yield, gauss_hermite_product_expectation, implied_zero_rate, normalized_option_type, quanto_adjusted_forward, terminal_intrinsic
+from trellis.models.analytical.support import asset_or_nothing_intrinsic, cash_or_nothing_intrinsic, discount_factor_from_zero_rate, discounted_value, forward_from_dividend_yield, gauss_hermite_product_expectation, implied_zero_rate, normalized_option_type, quanto_adjusted_forward, terminal_intrinsic
 from trellis.models.analytical.support.expectations import gauss_hermite_product_expectation
 from trellis.models.analytical.fx import ResolvedGarmanKohlhagenInputs, garman_kohlhagen_call_raw, garman_kohlhagen_price_raw, garman_kohlhagen_put_raw
 from trellis.models.analytical.jamshidian import zcb_option_hw

--- a/trellis/instruments/_agent/chooseroption.py
+++ b/trellis/instruments/_agent/chooseroption.py
@@ -24,36 +24,34 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import date
+from math import isfinite, log, sqrt
 
+from trellis.core.date_utils import year_fraction
 from trellis.core.market_state import MarketState
 from trellis.core.types import DayCountConvention
-from trellis.models.analytical import price_equity_chooser_option_analytical
-
+from trellis.models.analytical.support import (
+    discount_factor_from_zero_rate,
+    discounted_value,
+    forward_from_dividend_yield,
+)
+from trellis.models.analytical.support.probability import (
+    bivariate_standard_normal_cdf,
+)
+from trellis.models.black import black76_call, black76_put
+from trellis.models.calibration.solve_request import (
+    ObjectiveBundle,
+    SolveBounds,
+    SolveRequest,
+    execute_solve_request,
+)
+from trellis.models.resolution.single_state_diffusion import (
+    resolve_scalar_diffusion_market_inputs,
+)
 
 
 @dataclass(frozen=True)
 class ChooserOptionSpec:
-    """Specification for Build a pricer for: FinancePy parity: equity chooser option
-
-chooser_option
-
-Spot: 100.0.
-Choose date: 2025-05-16.
-Call expiry date: 2025-11-15.
-Put expiry date: 2025-11-15.
-Call strike: 100.0.
-Put strike: 100.0.
-
-Preferred method family: analytical
-FinancePy binding: financepy.equity.chooser.black_scholes
-Benchmark product: chooser_option
-
-Construct methods: analytical
-Comparison targets: analytical (analytical)
-Cross-validation harness:
-  external targets: financepy
-
-Implementation target: analytical."""
+    """Simple European chooser contract under constant diffusion inputs."""
     notional: float
     spot: float
     choose_date: date
@@ -61,7 +59,18 @@ Implementation target: analytical."""
     put_expiry_date: date
     call_strike: float
     put_strike: float
+    dividend_yield: float | None = None
     day_count: DayCountConvention = DayCountConvention.ACT_365
+
+
+@dataclass(frozen=True)
+class _ScalarMarketCoordinate:
+    """Product-neutral coordinate used for one explicit market projection."""
+
+    spot: float
+    expiry_date: date
+    day_count: DayCountConvention
+    dividend_yield: float | None = None
 
 
 class ChooserOptionPayoff:
@@ -100,9 +109,164 @@ Implementation target: analytical."""
 
     def evaluate(self, market_state: MarketState) -> float:
         spec = self._spec
-        if market_state.vol_surface is None:
-            raise ValueError("ChooserOptionPayoff requires a black vol surface in market_state")
-        if market_state.discount is None:
-            raise ValueError("ChooserOptionPayoff requires a discount curve in market_state")
+        settlement = market_state.settlement or market_state.as_of
+        if settlement is None:
+            raise ValueError("chooser option pricing requires settlement or as_of")
 
-        return float(price_equity_chooser_option_analytical(market_state, spec))
+        choose_time = float(year_fraction(settlement, spec.choose_date, spec.day_count))
+        call_time = float(year_fraction(settlement, spec.call_expiry_date, spec.day_count))
+        put_time = float(year_fraction(settlement, spec.put_expiry_date, spec.day_count))
+        if not (0.0 < choose_time < call_time and choose_time < put_time):
+            raise ValueError(
+                "choice date must lie strictly between settlement and both expiries"
+            )
+
+        runtime_spot = market_state.spot
+        spot = float(spec.spot if runtime_spot is None else runtime_spot)
+        call_strike = float(spec.call_strike)
+        put_strike = float(spec.put_strike)
+        notional = float(spec.notional)
+        if not all(isfinite(value) for value in (spot, call_strike, put_strike, notional)):
+            raise ValueError("chooser option scalar contract values must be finite")
+        if spot <= 0.0 or call_strike <= 0.0 or put_strike <= 0.0:
+            raise ValueError("chooser option spot and strikes must be positive")
+
+        coordinate = _ScalarMarketCoordinate(
+            spot=spot,
+            expiry_date=max(spec.call_expiry_date, spec.put_expiry_date),
+            day_count=spec.day_count,
+            dividend_yield=spec.dividend_yield,
+        )
+        resolved = resolve_scalar_diffusion_market_inputs(
+            market_state,
+            coordinate,
+            volatility_coordinate=call_strike,
+        )
+        rate = resolved.rate
+        dividend_yield = resolved.dividend_yield
+        sigma = resolved.sigma
+        if sigma <= 0.0:
+            raise ValueError("simple chooser analytical pricing requires positive volatility")
+
+        def option_value_at_choice(
+            stock_level: float,
+            *,
+            strike: float,
+            remaining_time: float,
+            option_type: str,
+        ) -> float:
+            forward = forward_from_dividend_yield(
+                spot=stock_level,
+                domestic_rate=rate,
+                dividend_yield=dividend_yield,
+                T=remaining_time,
+            )
+            kernel = black76_call if option_type == "call" else black76_put
+            return float(
+                discounted_value(
+                    kernel(forward, strike, sigma, remaining_time),
+                    discount_factor_from_zero_rate(rate, remaining_time),
+                )
+            )
+
+        def chooser_balance(stock_level: object) -> float:
+            state = float(stock_level)
+            call_value = option_value_at_choice(
+                state,
+                strike=call_strike,
+                remaining_time=call_time - choose_time,
+                option_type="call",
+            )
+            put_value = option_value_at_choice(
+                state,
+                strike=put_strike,
+                remaining_time=put_time - choose_time,
+                option_type="put",
+            )
+            return call_value - put_value
+
+        state_scale = max(spot, call_strike, put_strike, 1.0)
+        lower_state = state_scale * 1e-8
+        upper_state = state_scale * 1e6
+        lower_balance = chooser_balance(lower_state)
+        upper_balance = chooser_balance(upper_state)
+        if not isfinite(lower_balance) or not isfinite(upper_balance):
+            raise ValueError("chooser critical-state bracket values must be finite")
+        if lower_balance > 0.0 or upper_balance < 0.0:
+            raise ValueError(
+                "chooser critical-state objective has no sign change on the admitted bracket"
+            )
+
+        solve_result = execute_solve_request(
+            SolveRequest(
+                request_id="chooser-critical-state",
+                problem_kind="root_scalar",
+                parameter_names=("critical_stock",),
+                initial_guess=(spot,),
+                objective=ObjectiveBundle(
+                    objective_kind="root_scalar",
+                    labels=("call_value_minus_put_value",),
+                    target_values=(0.0,),
+                    scalar_objective_fn=chooser_balance,
+                ),
+                bounds=SolveBounds(
+                    lower=(lower_state,),
+                    upper=(upper_state,),
+                ),
+                solver_hint="brentq",
+                metadata={"contract": "simple_chooser"},
+                options={"tol": 1e-10},
+            )
+        )
+        critical_spot = solve_result.solution[0]
+        if not isfinite(critical_spot) or critical_spot <= 0.0:
+            raise ValueError("chooser solve must return a positive finite critical stock state")
+
+        sigma_choose = sigma * sqrt(choose_time)
+        d1 = (
+            log(spot / critical_spot)
+            + (rate - dividend_yield + 0.5 * sigma * sigma) * choose_time
+        ) / sigma_choose
+        d2 = d1 - sigma_choose
+        call_sigma_time = sigma * sqrt(call_time)
+        put_sigma_time = sigma * sqrt(put_time)
+        y1 = (
+            log(spot / call_strike)
+            + (rate - dividend_yield + 0.5 * sigma * sigma) * call_time
+        ) / call_sigma_time
+        y2 = (
+            log(spot / put_strike)
+            + (rate - dividend_yield + 0.5 * sigma * sigma) * put_time
+        ) / put_sigma_time
+        call_correlation = sqrt(choose_time / call_time)
+        put_correlation = sqrt(choose_time / put_time)
+
+        call_asset = (
+            spot
+            * discount_factor_from_zero_rate(dividend_yield, call_time)
+            * bivariate_standard_normal_cdf(d1, y1, call_correlation)
+        )
+        call_cash = (
+            call_strike
+            * discount_factor_from_zero_rate(rate, call_time)
+            * bivariate_standard_normal_cdf(
+                d2,
+                y1 - call_sigma_time,
+                call_correlation,
+            )
+        )
+        put_asset = (
+            spot
+            * discount_factor_from_zero_rate(dividend_yield, put_time)
+            * bivariate_standard_normal_cdf(-d1, -y2, put_correlation)
+        )
+        put_cash = (
+            put_strike
+            * discount_factor_from_zero_rate(rate, put_time)
+            * bivariate_standard_normal_cdf(
+                -d2,
+                -y2 + put_sigma_time,
+                put_correlation,
+            )
+        )
+        return float(notional * (call_asset - call_cash - put_asset + put_cash))


### PR DESCRIPTION
## Summary
- replace chooser product-helper authority with reusable market, time, Black, Gaussian, discount, and bounded-root primitives
- assemble the checked F012 chooser formula in the task adapter while retaining the product wrapper only as reference evidence
- preserve FinancePy price and delta parity without cookbook mutation or live LLM execution

## Validation
- strict offline F012 replay: passed, zero LLM calls/tokens
- FinancePy price deviation: 0.10451%; delta deviation: 0.158183%
- bounded remediation analysis: 0 failures
- make gate-pr: 4,567 core passed; 32 tier-two contracts passed
- changed chooser docs parsed cleanly; repository-wide Sphinx -W remains blocked by unrelated pre-existing warnings/errors

Linear: QUA-1191