### PR TITLE
Retire compound analytical helper authority

### DIFF
--- a/FINANCEPY_BINDINGS.yaml
+++ b/FINANCEPY_BINDINGS.yaml
@@ -179,9 +179,12 @@ bindings:
     financepy_model: BlackScholes
     overlapping_outputs:
     - price
+    - delta
     comparison_modes:
     - price_parity
     - warm_runtime
+    greek_fallback:
+      kind: bump_and_reprice
   financepy.equity.cliquet.black_scholes:
     instrument_family: cliquet_option
     method_family: analytical

--- a/docs/developer/runtime_agent_orientation.rst
+++ b/docs/developer/runtime_agent_orientation.rst
@@ -76,22 +76,31 @@ or code templates in their resolved context.
 
 Composition cards may join public primitives from more than one subsystem
 without introducing a new product helper. The general
-``analytical_gaussian_composition`` card points a builder handling compound or
-other critical-state analytical work to scalar Gaussian probability kernels
-and the existing typed ``SolveRequest`` root surface. The more specific
+``analytical_gaussian_composition`` card points a builder handling general
+critical-state analytical work to scalar Gaussian probability kernels and the
+existing typed ``SolveRequest`` root surface. The more specific
 ``chooser_option_composition`` card is a complete bounded navigation packet:
 it adds the scalar-diffusion market projection, contractual time function,
 Black call/put kernels, discount/forward support, the bivariate Gaussian
 kernel, and the bounded root contracts. It states the adapter-owned balance
 equation and date/bracket obligations without importing the retained chooser
-pricing wrapper.
+pricing wrapper. ``compound_option_composition`` supplies the corresponding
+complete packet for European options on European options, adds the univariate
+Gaussian kernel, and states the four subtype, critical-state, strict date, and
+one-time scaling obligations without importing the retained compound wrapper.
+
+Structured lane cards render every selected primitive in these bounded route
+packets. They do not silently truncate the final solver or probability symbol;
+compactness is enforced when the canonical semantic query selects the card,
+not by making a selected composition incomplete.
 
 Neither card enters the quant or model-validator role packets. Those roles
 continue to reason from semantic contracts, quantitative documentation, and
 executed evidence; implementation symbol selection remains builder-owned.
 The quant and model-validator may consult the read-only cookbook catalog after
 typed decomposition, but they cannot promote cookbook entries during task
-execution or use those patterns to override the chooser semantic contract.
+execution or use those patterns to override chooser or compound semantic
+contracts.
 
 The ``path_statistic_composition`` card applies the same rule to path-dependent
 Monte Carlo construction. Semantic aliases such as ``running_extremum``,

--- a/docs/quant/pricing_stack.rst
+++ b/docs/quant/pricing_stack.rst
@@ -1061,6 +1061,96 @@ the pricing formula compatible with the product-neutral central spot-bump
 ``Delta`` measure. The F012 FinancePy binding requests the same generic
 ``bump_and_reprice`` policy; no chooser-specific Greek helper is required.
 
+European compound composition
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The admitted European compound lane uses the complete
+``compound_option_composition`` card. Like the chooser lane, it joins one
+scalar-diffusion market projection, contractual time fractions, Black-76
+call/put kernels, discount and forward support, Gaussian probabilities, and
+the typed scalar-root surface. The checked adapter owns the four
+call/put-on-call/put formulas. The retained
+``price_equity_compound_option_analytical`` wrapper is comparison evidence and
+does not appear in route, backend, or deterministic generation authority.
+
+Let :math:`t_o` be the outer expiry, :math:`T_i` the inner expiry,
+:math:`K_o` the outer strike, and :math:`K_i` the inner strike, with
+
+.. math::
+
+   0 < t_o < T_i.
+
+The admitted market projection resolves one constant :math:`r`, :math:`q`,
+and :math:`\sigma` at :math:`T_i`, using :math:`K_i` as the explicit
+volatility coordinate. At :math:`t_o`, the positive critical stock state
+:math:`S^*` solves
+
+.. math::
+
+   V_i(S^*, K_i, T_i-t_o) - K_o = 0,
+
+where :math:`V_i` is the Black-Scholes value of the inner call or put. The
+adapter constructs :math:`V_i` from
+``forward_from_dividend_yield``, ``discount_factor_from_zero_rate``,
+``discounted_value``, and the matching public Black-76 kernel. It verifies a
+sign change over the finite positive bracket
+
+.. math::
+
+   [10^{-8}M, 10^6M], \qquad
+   M = \max(S_0, K_o, K_i, 1),
+
+before submitting one ``root_scalar`` ``SolveRequest`` with the bounded
+Brent solver. A missing sign change is an honest admission failure; it is not
+permission to switch to an unbounded route-local Newton loop.
+
+For the solved state, define
+
+.. math::
+
+   \begin{aligned}
+   a_1 &= \frac{\log(S_0/S^*) + (r-q+\tfrac12\sigma^2)t_o}
+                 {\sigma\sqrt{t_o}},
+   & a_2 &= a_1-\sigma\sqrt{t_o}, \\
+   b_1 &= \frac{\log(S_0/K_i) + (r-q+\tfrac12\sigma^2)T_i}
+                 {\sigma\sqrt{T_i}},
+   & b_2 &= b_1-\sigma\sqrt{T_i}, \\
+   \rho &= \sqrt{t_o/T_i}.
+   \end{aligned}
+
+With :math:`\Phi` and :math:`\Phi_2` denoting the univariate and bivariate
+standard-normal CDFs, the four per-unit-notional values are
+
+.. math::
+
+   \begin{aligned}
+   V_{CC} ={}& S_0e^{-qT_i}\Phi_2(a_1,b_1;\rho)
+      - K_ie^{-rT_i}\Phi_2(a_2,b_2;\rho)
+      - K_oe^{-rt_o}\Phi(a_2), \\
+   V_{PC} ={}& K_ie^{-rT_i}\Phi_2(-a_2,b_2;-\rho)
+      - S_0e^{-qT_i}\Phi_2(-a_1,b_1;-\rho)
+      + K_oe^{-rt_o}\Phi(-a_2), \\
+   V_{CP} ={}& K_ie^{-rT_i}\Phi_2(-a_2,-b_2;\rho)
+      - S_0e^{-qT_i}\Phi_2(-a_1,-b_1;\rho)
+      - K_oe^{-rt_o}\Phi(-a_2), \\
+   V_{PP} ={}& S_0e^{-qT_i}\Phi_2(a_1,-b_1;-\rho)
+      - K_ie^{-rT_i}\Phi_2(a_2,-b_2;-\rho)
+      + K_oe^{-rt_o}\Phi(a_2).
+   \end{aligned}
+
+The first subscript is the outer option type and the second is the inner
+option type. Notional is applied once after selecting the contractual subtype.
+The lane fails closed for invalid option types, non-finite contract scalars,
+non-positive spot, strikes, or volatility, and any date ordering outside
+settlement :math:`< t_o < T_i`. Time-varying coefficient, local-volatility,
+stochastic-volatility, American, and Bermudan compound claims are outside this
+constant-input analytical formula.
+
+The adapter prefers ``MarketState.spot`` over the contract fallback spot, so
+the product-neutral central spot-bump ``Delta`` measure reprices the actual
+runtime state. The F013 FinancePy binding declares the same
+``bump_and_reprice`` fallback; no compound-specific Greek helper is required.
+
 Calibration Surface
 -------------------
 

--- a/tests/test_agent/test_api_map.py
+++ b/tests/test_agent/test_api_map.py
@@ -292,7 +292,7 @@ def test_api_map_semantic_selection_reaches_composition_cards():
 
 @pytest.mark.parametrize(
     "payoff_family",
-    ["compound_option", "lookback_option"],
+    ["lookback_option"],
 )
 def test_api_map_semantic_selection_reaches_gaussian_root_composition(
     payoff_family,
@@ -355,6 +355,35 @@ def test_api_map_exposes_complete_chooser_raw_composition():
     ):
         assert symbol in text
     assert "price_equity_chooser_option_analytical" not in text
+
+
+def test_api_map_exposes_complete_compound_raw_composition():
+    query = ApiMapQuery(
+        payoff_family="compound_option",
+        method="analytical",
+        model_family="equity_diffusion",
+    )
+    selection = select_api_map_sections(query)
+    text = format_api_map_for_prompt(compact=True, query=query)
+
+    assert "compound_option_composition" in selection.selected_families
+    for symbol in (
+        "resolve_scalar_diffusion_market_inputs",
+        "year_fraction",
+        "forward_from_dividend_yield",
+        "discount_factor_from_zero_rate",
+        "discounted_value",
+        "black76_call",
+        "black76_put",
+        "standard_normal_cdf",
+        "bivariate_standard_normal_cdf",
+        "ObjectiveBundle",
+        "SolveBounds",
+        "SolveRequest",
+        "execute_solve_request",
+    ):
+        assert symbol in text
+    assert "price_equity_compound_option_analytical" not in text
 
 
 def test_api_map_selection_and_rendering_are_stable_and_budgeted():

--- a/tests/test_agent/test_backend_bindings.py
+++ b/tests/test_agent/test_backend_bindings.py
@@ -766,10 +766,11 @@ def test_resolve_backend_binding_spec_uses_quanto_primitive_composition(
                 model_family="equity_diffusion",
             ),
             "analytical",
-            (
-                "trellis.models.analytical.equity_exotics.price_equity_compound_option_analytical",
-            ),
             (),
+            (
+                "trellis.models.black.black76_call",
+                "trellis.models.black.black76_put",
+            ),
             id="compound",
         ),
         pytest.param(
@@ -842,6 +843,42 @@ def test_resolve_backend_binding_spec_exposes_complete_chooser_composition():
         "trellis.models.analytical.support.discounted_value",
         "trellis.models.black.black76_call",
         "trellis.models.black.black76_put",
+        "trellis.models.analytical.support.probability.bivariate_standard_normal_cdf",
+        "trellis.models.calibration.solve_request.ObjectiveBundle",
+        "trellis.models.calibration.solve_request.SolveBounds",
+        "trellis.models.calibration.solve_request.SolveRequest",
+        "trellis.models.calibration.solve_request.execute_solve_request",
+    } <= set(resolved.primitive_refs)
+
+
+def test_resolve_backend_binding_spec_exposes_complete_compound_composition():
+    catalog = load_backend_binding_catalog()
+    analytical = find_backend_binding_by_route_id("analytical_black76", catalog)
+
+    assert analytical is not None
+
+    resolved = resolve_backend_binding_spec(
+        analytical,
+        product_ir=ProductIR(
+            instrument="compound_option",
+            payoff_family="compound_option",
+            payoff_traits=("discounting", "terminal_markov", "vol_surface_dependence"),
+            exercise_style="european",
+            state_dependence="terminal_markov",
+            model_family="equity_diffusion",
+        ),
+    )
+
+    assert resolved.helper_refs == ()
+    assert {
+        "trellis.models.resolution.single_state_diffusion.resolve_scalar_diffusion_market_inputs",
+        "trellis.core.date_utils.year_fraction",
+        "trellis.models.analytical.support.forward_from_dividend_yield",
+        "trellis.models.analytical.support.discount_factor_from_zero_rate",
+        "trellis.models.analytical.support.discounted_value",
+        "trellis.models.black.black76_call",
+        "trellis.models.black.black76_put",
+        "trellis.models.analytical.support.probability.standard_normal_cdf",
         "trellis.models.analytical.support.probability.bivariate_standard_normal_cdf",
         "trellis.models.calibration.solve_request.ObjectiveBundle",
         "trellis.models.calibration.solve_request.SolveBounds",

--- a/tests/test_agent/test_codegen_guardrails.py
+++ b/tests/test_agent/test_codegen_guardrails.py
@@ -1289,33 +1289,27 @@ def test_cds_analytical_route_card_surfaces_helper_signature_keywords():
     assert "Do not reinterpret a single-name CDS" not in card
 
 
-@pytest.mark.parametrize(
-    "instrument_type,expected_helper_ref",
-    [
-        (
-            "compound_option",
-            "trellis.models.analytical.equity_exotics.price_equity_compound_option_analytical",
-        ),
-    ],
-)
-def test_absorbed_black76_structural_exotic_route_uses_exact_helper_binding(
-    instrument_type,
-    expected_helper_ref,
-):
+def test_compound_route_card_uses_raw_composition_not_product_helper():
     pricing_plan = PricingPlan(
         method="analytical",
-        method_modules=["trellis.models.analytical.equity_exotics"],
+        method_modules=[
+            "trellis.models.resolution.single_state_diffusion",
+            "trellis.models.analytical.support",
+            "trellis.models.analytical.support.probability",
+            "trellis.models.black",
+            "trellis.models.calibration.solve_request",
+        ],
         required_market_data={"discount_curve", "black_vol_surface"},
-        model_to_build=instrument_type,
+        model_to_build="compound_option",
         reasoning="test",
     )
     plan = build_generation_plan(
         pricing_plan=pricing_plan,
-        instrument_type=instrument_type,
-        inspected_modules=("trellis.models.analytical.equity_exotics",),
+        instrument_type="compound_option",
+        inspected_modules=tuple(pricing_plan.method_modules),
         product_ir=ProductIR(
-            instrument=instrument_type,
-            payoff_family=instrument_type,
+            instrument="compound_option",
+            payoff_family="compound_option",
             payoff_traits=("discounting", "terminal_markov", "vol_surface_dependence"),
             exercise_style="european",
             state_dependence="terminal_markov",
@@ -1325,13 +1319,17 @@ def test_absorbed_black76_structural_exotic_route_uses_exact_helper_binding(
 
     card = render_generation_route_card(plan)
 
-    assert plan.primitive_plan is not None
-    assert plan.primitive_plan.route == "analytical_black76"
-    primitive_refs = {
-        f"{primitive.module}.{primitive.symbol}" for primitive in plan.primitive_plan.primitives
-    }
-    assert expected_helper_ref in primitive_refs
-    assert expected_helper_ref.rsplit(".", 1)[-1] in card
+    assert "price_equity_compound_option_analytical" not in card
+    for symbol in (
+        "resolve_scalar_diffusion_market_inputs",
+        "black76_call",
+        "black76_put",
+        "standard_normal_cdf",
+        "bivariate_standard_normal_cdf",
+        "SolveRequest",
+        "execute_solve_request",
+    ):
+        assert symbol in card
 
 
 def test_chooser_route_card_uses_raw_composition_not_product_helper():

--- a/tests/test_agent/test_financepy_benchmark.py
+++ b/tests/test_agent/test_financepy_benchmark.py
@@ -69,7 +69,7 @@ def test_financepy_benchmark_manifest_includes_tranche_two_families():
         ("F010", ("price",)),
         ("F011", ("price",)),
         ("F012", ("price", "delta")),
-        ("F013", ("price",)),
+        ("F013", ("price", "delta")),
         ("F014", ("price",)),
         ("F015", ("price",)),
     ],
@@ -89,6 +89,17 @@ def test_f012_binding_declares_generic_delta_fallback():
 
     binding = load_financepy_bindings(root=ROOT)[
         "financepy.equity.chooser.black_scholes"
+    ]
+
+    assert binding["overlapping_outputs"] == ["price", "delta"]
+    assert binding["greek_fallback"] == {"kind": "bump_and_reprice"}
+
+
+def test_f013_binding_declares_generic_delta_fallback():
+    from trellis.agent.task_manifests import load_financepy_bindings
+
+    binding = load_financepy_bindings(root=ROOT)[
+        "financepy.equity.compound.black_scholes"
     ]
 
     assert binding["overlapping_outputs"] == ["price", "delta"]

--- a/tests/test_agent/test_helper_authority_audit.py
+++ b/tests/test_agent/test_helper_authority_audit.py
@@ -314,3 +314,23 @@ def test_current_repository_retires_analytical_chooser_helper_authority():
         if item.path == "trellis/instruments/_agent/chooseroption.py"
         and item.symbol == helper_symbol
     ]
+
+
+def test_current_repository_retires_analytical_compound_helper_authority():
+    from trellis.agent.helper_authority_audit import build_helper_authority_report
+
+    root = Path(__file__).resolve().parents[2]
+    report = build_helper_authority_report(root)
+    helper_symbol = "price_equity_compound_option_analytical"
+
+    assert not [
+        item
+        for item in (*report.route_authority, *report.binding_authority)
+        if item.symbol == helper_symbol
+    ]
+    assert not [
+        item
+        for item in report.adapter_calls
+        if item.path == "trellis/instruments/_agent/compoundoption.py"
+        and item.symbol == helper_symbol
+    ]

--- a/tests/test_agent/test_import_registry.py
+++ b/tests/test_agent/test_import_registry.py
@@ -213,6 +213,11 @@ def test_gaussian_probability_primitives_are_visible_to_import_registry():
     for symbol in symbols:
         assert symbol in registry_text
 
+    static_registry = import_registry._parse_static_registry(
+        import_registry._STATIC_REGISTRY
+    )
+    assert symbols <= set(static_registry[module])
+
     scalar_root_module = "trellis.models.calibration.solve_request"
     scalar_root_symbols = {
         "ObjectiveBundle",
@@ -223,6 +228,7 @@ def test_gaussian_probability_primitives_are_visible_to_import_registry():
     assert scalar_root_symbols <= set(list_module_exports(scalar_root_module))
     for symbol in scalar_root_symbols:
         assert is_valid_import(scalar_root_module, symbol)
+    assert scalar_root_symbols <= set(static_registry[scalar_root_module])
 
 
 def test_quoted_observable_helpers_are_visible_to_import_registry():

--- a/tests/test_agent/test_knowledge_store.py
+++ b/tests/test_agent/test_knowledge_store.py
@@ -711,9 +711,32 @@ class TestKnowledgeStore:
             assert symbol in chooser_requirements
         assert "price_equity_chooser_option_analytical" not in chooser_requirements
 
+        compound = store._decompositions.get("compound_option")
+        assert compound is not None
+        assert compound.method == "analytical"
+        assert set(compound.method_modules) >= {
+            "trellis.models.resolution.single_state_diffusion",
+            "trellis.models.analytical.support",
+            "trellis.models.analytical.support.probability",
+            "trellis.models.black",
+            "trellis.models.calibration.solve_request",
+        }
+        compound_requirements = " ".join(compound.modeling_requirements)
+        for symbol in (
+            "resolve_scalar_diffusion_market_inputs",
+            "year_fraction",
+            "black76_call",
+            "black76_put",
+            "standard_normal_cdf",
+            "bivariate_standard_normal_cdf",
+            "SolveRequest",
+            "execute_solve_request",
+        ):
+            assert symbol in compound_requirements
+        assert "price_equity_compound_option_analytical" not in compound_requirements
+
         for instrument, helper_symbol in (
             ("lookback_option", "price_equity_fixed_lookback_option_analytical"),
-            ("compound_option", "price_equity_compound_option_analytical"),
         ):
             decomp = store._decompositions.get(instrument)
             assert decomp is not None, f"missing analytical decomposition for {instrument}"

--- a/tests/test_agent/test_platform_requests.py
+++ b/tests/test_agent/test_platform_requests.py
@@ -890,7 +890,7 @@ def test_semantic_blueprint_summary_preserves_range_accrual_callability_blockers
         (
             "F013",
             "analytical",
-            "trellis.models.analytical.equity_exotics.price_equity_compound_option_analytical",
+            "trellis.models.black.black76_call",
         ),
         (
             "F015",
@@ -930,6 +930,11 @@ def test_compile_build_request_preserves_exact_absorbed_black76_binding_for_fina
     if task_id == "F012":
         assert (
             "trellis.models.analytical.equity_exotics.price_equity_chooser_option_analytical"
+            not in compiled.generation_plan.backend_exact_target_refs
+        )
+    if task_id == "F013":
+        assert (
+            "trellis.models.analytical.equity_exotics.price_equity_compound_option_analytical"
             not in compiled.generation_plan.backend_exact_target_refs
         )
 

--- a/tests/test_agent/test_route_registry.py
+++ b/tests/test_agent/test_route_registry.py
@@ -1871,15 +1871,63 @@ class TestAnalyticalRoutes:
             ),
         }
 
-    def test_compound_primitives_use_exact_helper(self, registry):
+    def test_compound_primitives_use_raw_analytical_composition(self, registry):
         spec = [r for r in registry.routes if r.id == "analytical_black76"][0]
         new_prims = resolve_route_primitives(spec, self.COMPOUND_IR)
         assert resolve_route_family(spec, self.COMPOUND_IR) == "analytical"
         assert _prim_set(new_prims) == {
             (
-                "trellis.models.analytical.equity_exotics",
-                "price_equity_compound_option_analytical",
-                "route_helper",
+                "trellis.models.resolution.single_state_diffusion",
+                "resolve_scalar_diffusion_market_inputs",
+                "market_binding",
+            ),
+            ("trellis.core.date_utils", "year_fraction", "time_measure"),
+            (
+                "trellis.models.analytical.support",
+                "forward_from_dividend_yield",
+                "forward_builder",
+            ),
+            (
+                "trellis.models.analytical.support",
+                "discount_factor_from_zero_rate",
+                "discounting",
+            ),
+            (
+                "trellis.models.analytical.support",
+                "discounted_value",
+                "discounting",
+            ),
+            ("trellis.models.black", "black76_call", "pricing_kernel"),
+            ("trellis.models.black", "black76_put", "pricing_kernel"),
+            (
+                "trellis.models.analytical.support.probability",
+                "standard_normal_cdf",
+                "probability_kernel",
+            ),
+            (
+                "trellis.models.analytical.support.probability",
+                "bivariate_standard_normal_cdf",
+                "probability_kernel",
+            ),
+            (
+                "trellis.models.calibration.solve_request",
+                "ObjectiveBundle",
+                "objective_contract",
+            ),
+            (
+                "trellis.models.calibration.solve_request",
+                "SolveBounds",
+                "solver_bounds",
+            ),
+            (
+                "trellis.models.calibration.solve_request",
+                "SolveRequest",
+                "solver_request",
+            ),
+            (
+                "trellis.models.calibration.solve_request",
+                "execute_solve_request",
+                "solver",
             ),
         }
 

--- a/tests/test_instruments/test_agent_compound_option.py
+++ b/tests/test_instruments/test_agent_compound_option.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+import trellis.instruments._agent.compoundoption as compound_module
+from trellis.analytics.measures import Delta
+from trellis.core.market_state import MarketState
+from trellis.curves.yield_curve import YieldCurve
+from trellis.instruments._agent.compoundoption import (
+    CompoundOptionPayoff,
+    CompoundOptionSpec,
+)
+from trellis.models.analytical.equity_exotics import (
+    price_equity_compound_option_analytical,
+)
+from trellis.models.calibration.solve_request import SolveResult
+from trellis.models.vol_surface import FlatVol
+
+
+SETTLEMENT = date(2024, 11, 15)
+
+
+def _market_state(*, spot: float | None = None) -> MarketState:
+    return MarketState(
+        as_of=SETTLEMENT,
+        settlement=SETTLEMENT,
+        discount=YieldCurve.flat(0.05),
+        vol_surface=FlatVol(0.2),
+        spot=spot,
+    )
+
+
+def _spec(*, outer_option_type: str = "call", inner_option_type: str = "call"):
+    return CompoundOptionSpec(
+        notional=2.0,
+        spot=100.0,
+        outer_expiry_date=date(2025, 5, 15),
+        inner_expiry_date=date(2025, 11, 15),
+        outer_strike=10.0,
+        inner_strike=100.0,
+        outer_option_type=outer_option_type,
+        inner_option_type=inner_option_type,
+        dividend_yield=0.01,
+    )
+
+
+@pytest.mark.parametrize(
+    ("outer_option_type", "inner_option_type"),
+    [("call", "call"), ("put", "call"), ("call", "put"), ("put", "put")],
+)
+def test_checked_compound_adapter_matches_reference_for_all_subtypes(
+    outer_option_type,
+    inner_option_type,
+):
+    spec = _spec(
+        outer_option_type=outer_option_type,
+        inner_option_type=inner_option_type,
+    )
+
+    actual = CompoundOptionPayoff(spec).evaluate(_market_state())
+    expected = price_equity_compound_option_analytical(_market_state(), spec)
+
+    assert actual == pytest.approx(expected, rel=2e-8, abs=2e-8)
+
+
+def test_checked_compound_adapter_honors_runtime_spot_for_generic_delta():
+    payoff = CompoundOptionPayoff(_spec())
+    market_state = _market_state(spot=100.0)
+
+    delta = float(Delta(bump_pct=0.1).compute(payoff, market_state))
+
+    assert delta > 0.0
+    assert payoff.evaluate(_market_state(spot=101.0)) != pytest.approx(
+        payoff.evaluate(_market_state(spot=99.0))
+    )
+
+
+@pytest.mark.parametrize(
+    ("outer_expiry", "inner_expiry"),
+    [
+        (SETTLEMENT, date(2025, 11, 15)),
+        (date(2025, 11, 15), date(2025, 11, 15)),
+        (date(2026, 5, 15), date(2025, 11, 15)),
+    ],
+)
+def test_checked_compound_adapter_rejects_degenerate_date_ordering(
+    outer_expiry,
+    inner_expiry,
+):
+    spec = CompoundOptionSpec(
+        notional=1.0,
+        spot=100.0,
+        outer_expiry_date=outer_expiry,
+        inner_expiry_date=inner_expiry,
+        outer_strike=10.0,
+        inner_strike=100.0,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="outer expiry must lie strictly between settlement and inner expiry",
+    ):
+        CompoundOptionPayoff(spec).evaluate(_market_state())
+
+
+def test_checked_compound_adapter_rejects_invalid_solved_state(monkeypatch):
+    monkeypatch.setattr(
+        compound_module,
+        "execute_solve_request",
+        lambda request: SolveResult(
+            solution=(float("nan"),),
+            objective_value=0.0,
+            success=True,
+        ),
+    )
+
+    with pytest.raises(ValueError, match="positive finite critical stock state"):
+        CompoundOptionPayoff(_spec()).evaluate(_market_state())
+
+
+def test_checked_compound_adapter_rejects_unsuccessful_solve(monkeypatch):
+    monkeypatch.setattr(
+        compound_module,
+        "execute_solve_request",
+        lambda request: SolveResult(
+            solution=(100.0,),
+            objective_value=1.0,
+            success=False,
+        ),
+    )
+
+    with pytest.raises(ValueError, match="successful critical-stock solve"):
+        CompoundOptionPayoff(_spec()).evaluate(_market_state())
+
+
+def test_checked_compound_adapter_source_composes_reusable_primitives():
+    source_path = (
+        Path(__file__).resolve().parents[2]
+        / "trellis/instruments/_agent/compoundoption.py"
+    )
+    source = source_path.read_text(encoding="utf-8")
+
+    assert "price_equity_compound_option_analytical" not in source
+    for symbol in (
+        "resolve_scalar_diffusion_market_inputs",
+        "year_fraction",
+        "forward_from_dividend_yield",
+        "discount_factor_from_zero_rate",
+        "discounted_value",
+        "black76_call",
+        "black76_put",
+        "standard_normal_cdf",
+        "bivariate_standard_normal_cdf",
+        "ObjectiveBundle",
+        "SolveBounds",
+        "SolveRequest",
+        "execute_solve_request",
+    ):
+        assert symbol in source

--- a/trellis/agent/codegen_guardrails.py
+++ b/trellis/agent/codegen_guardrails.py
@@ -664,7 +664,7 @@ def _render_backend_binding_lines(plan: GenerationPlan, *, compact: bool) -> lis
         lines.append("  - Selected primitives:")
         lines.extend(
             f"    - `{primitive.module}.{primitive.symbol}` ({primitive.role})"
-            for primitive in plan.primitive_plan.primitives[:12]
+            for primitive in plan.primitive_plan.primitives
         )
     resolved_instructions = _resolve_generation_instructions(plan)
     if resolved_instructions.effective_instructions:

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -5920,9 +5920,6 @@ def _deterministic_exact_binding_evaluate_body(
         "trellis.models.equity_option_pde.price_equity_digital_option_pde": (
             "return price_equity_digital_option_pde(market_state, spec)"
         ),
-        "trellis.models.analytical.equity_exotics.price_equity_compound_option_analytical": (
-            "return price_equity_compound_option_analytical(market_state, spec)"
-        ),
         "trellis.models.analytical.equity_exotics.price_equity_variance_swap_analytical": (
             "return price_equity_variance_swap_analytical(market_state, spec)"
         ),

--- a/trellis/agent/financepy_reference.py
+++ b/trellis/agent/financepy_reference.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from time import perf_counter
 from typing import Any
 
@@ -133,6 +133,23 @@ def _maybe_method_outputs(option, methods: list[str], *args) -> dict[str, float]
             continue
         outputs[method_name] = float(value)
     return outputs
+
+
+def _central_spot_delta(
+    price_at_spot: Callable[[float], float],
+    spot: float,
+    *,
+    bump_pct: float = 1.0,
+) -> float:
+    """Return a product-neutral central spot-bump Delta."""
+
+    bump_size = abs(float(spot)) * float(bump_pct) / 100.0
+    if bump_size <= 0.0:
+        raise ValueError("central spot-bump Delta requires positive spot and bump_pct")
+    return float(
+        (price_at_spot(spot + bump_size) - price_at_spot(spot - bump_size))
+        / (2.0 * bump_size)
+    )
 
 
 def _equity_vanilla_reference(*, contract: Mapping[str, Any], scenario_inputs: Mapping[str, Any]) -> dict[str, float]:
@@ -440,9 +457,33 @@ def _compound_reference(*, contract: Mapping[str, Any], scenario_inputs: Mapping
     discount_curve = _flat_curve(float(contract["domestic_rate"]), value_dt)
     dividend_curve = _flat_curve(float(contract["dividend_rate"]), value_dt)
     model = BlackScholes(float(contract["volatility"]))
-    return {
-        "price": float(option.value(value_dt, float(contract["spot"]), discount_curve, dividend_curve, model))
-    }
+    spot = float(contract["spot"])
+
+    def price_at_spot(stock_level: float) -> float:
+        return float(
+            option.value(
+                value_dt,
+                stock_level,
+                discount_curve,
+                dividend_curve,
+                model,
+            )
+        )
+
+    outputs = {"price": price_at_spot(spot)}
+    outputs.update(
+        _maybe_method_outputs(
+            option,
+            ["delta"],
+            value_dt,
+            spot,
+            discount_curve,
+            dividend_curve,
+            model,
+        )
+    )
+    outputs.setdefault("delta", _central_spot_delta(price_at_spot, spot))
+    return outputs
 
 
 def _cliquet_reference(*, contract: Mapping[str, Any], scenario_inputs: Mapping[str, Any]) -> dict[str, float]:

--- a/trellis/agent/knowledge/canonical/api_map.yaml
+++ b/trellis/agent/knowledge/canonical/api_map.yaml
@@ -60,7 +60,7 @@ analytical_gaussian_composition:
   module: trellis.models.analytical.support.probability
   methods: [analytical]
   navigation:
-    aliases: [gaussian_probability, bivariate_gaussian, critical_state, scalar_root, compound_option, lookback_option]
+    aliases: [gaussian_probability, bivariate_gaussian, critical_state, scalar_root, lookback_option]
   modules:
     probability: trellis.models.analytical.support.probability
     scalar_root: trellis.models.calibration.solve_request
@@ -102,6 +102,35 @@ chooser_option_composition:
     - "At the choice date, build call and put present values with forward_from_dividend_yield, discount_factor_from_zero_rate, discounted_value, black76_call, and black76_put; their difference is the scalar root objective"
     - "Use finite positive SolveBounds with a verified sign change, then execute one root_scalar SolveRequest; do not use an unbounded Newton loop"
     - "The adapter owns the critical-state equation, bivariate-Gaussian chooser formula, contractual date coordinates, and one-time notional scaling; the retained chooser wrapper is reference evidence only"
+
+# ---------------------------------------------------------------------------
+# European compound option raw composition
+# ---------------------------------------------------------------------------
+compound_option_composition:
+  module: trellis.models.resolution.single_state_diffusion
+  methods: [analytical]
+  navigation:
+    aliases: [compound_option, compound_payoff, option_on_option, geske]
+  modules:
+    market_binding: trellis.models.resolution.single_state_diffusion
+    time_measure: trellis.core.date_utils
+    analytical_support: trellis.models.analytical.support
+    probability: trellis.models.analytical.support.probability
+    black_kernel: trellis.models.black
+    scalar_root: trellis.models.calibration.solve_request
+  key_imports:
+    - "from trellis.models.resolution.single_state_diffusion import resolve_scalar_diffusion_market_inputs"
+    - "from trellis.core.date_utils import year_fraction"
+    - "from trellis.models.analytical.support import discount_factor_from_zero_rate, discounted_value, forward_from_dividend_yield"
+    - "from trellis.models.black import black76_call, black76_put"
+    - "from trellis.models.analytical.support.probability import standard_normal_cdf, bivariate_standard_normal_cdf"
+    - "from trellis.models.calibration.solve_request import ObjectiveBundle, SolveBounds, SolveRequest, execute_solve_request"
+  notes:
+    - "Admitted scope is a European call or put on a European call or put under one constant rate, dividend yield, and Black volatility projected at the inner expiry and inner-strike volatility coordinate"
+    - "Represent the inner-expiry market coordinate with a local frozen value satisfying ScalarDiffusionMarketSpecLike; require settlement < outer expiry < inner expiry and positive spot, strikes, and volatility"
+    - "At the outer expiry, build the inner option value with forward_from_dividend_yield, discount_factor_from_zero_rate, discounted_value, and the matching Black-76 kernel; subtract the outer strike for the critical-state objective"
+    - "Verify a sign change over finite positive SolveBounds, then execute one root_scalar SolveRequest; do not use an unbounded Newton loop"
+    - "The adapter owns the four bivariate-Gaussian subtype formulas, contractual dates, critical-state equation, and one-time notional scaling; the retained compound wrapper is reference evidence only"
 
 # ---------------------------------------------------------------------------
 # European digital option composition

--- a/trellis/agent/knowledge/canonical/backend_bindings.yaml
+++ b/trellis/agent/knowledge/canonical/backend_bindings.yaml
@@ -1048,9 +1048,45 @@ bindings:
             exercise:
               style: european
         primitives:
-          - module: trellis.models.analytical.equity_exotics
-            symbol: price_equity_compound_option_analytical
-            role: route_helper
+          - module: trellis.models.resolution.single_state_diffusion
+            symbol: resolve_scalar_diffusion_market_inputs
+            role: market_binding
+          - module: trellis.core.date_utils
+            symbol: year_fraction
+            role: time_measure
+          - module: trellis.models.analytical.support
+            symbol: forward_from_dividend_yield
+            role: forward_builder
+          - module: trellis.models.analytical.support
+            symbol: discount_factor_from_zero_rate
+            role: discounting
+          - module: trellis.models.analytical.support
+            symbol: discounted_value
+            role: discounting
+          - module: trellis.models.black
+            symbol: black76_call
+            role: pricing_kernel
+          - module: trellis.models.black
+            symbol: black76_put
+            role: pricing_kernel
+          - module: trellis.models.analytical.support.probability
+            symbol: standard_normal_cdf
+            role: probability_kernel
+          - module: trellis.models.analytical.support.probability
+            symbol: bivariate_standard_normal_cdf
+            role: probability_kernel
+          - module: trellis.models.calibration.solve_request
+            symbol: ObjectiveBundle
+            role: objective_contract
+          - module: trellis.models.calibration.solve_request
+            symbol: SolveBounds
+            role: solver_bounds
+          - module: trellis.models.calibration.solve_request
+            symbol: SolveRequest
+            role: solver_request
+          - module: trellis.models.calibration.solve_request
+            symbol: execute_solve_request
+            role: solver
       - when:
           contract_pattern:
             payoff:

--- a/trellis/agent/knowledge/canonical/decompositions.yaml
+++ b/trellis/agent/knowledge/canonical/decompositions.yaml
@@ -462,9 +462,17 @@
   features: [terminal_markov, discounting, vol_surface_dependence]
   method: analytical
   method_modules:
-    - trellis.models.analytical.equity_exotics
+    - trellis.models.resolution.single_state_diffusion
+    - trellis.models.analytical.support
+    - trellis.models.analytical.support.probability
+    - trellis.models.black
+    - trellis.models.calibration.solve_request
   required_market_data: [discount_curve, black_vol_surface]
   modeling_requirements:
-    - "USE THE EXACT HELPER: Call `price_equity_compound_option_analytical(market_state, spec)` directly; keep the critical-spot solve inside the shared analytical module."
-  reasoning: "Call-on-call, call-on-put, put-on-call, put-on-put compound options have a bivariate-normal closed form (Geske) via the shared helper."
+    - "Resolve one explicit inner-expiry market coordinate with `resolve_scalar_diffusion_market_inputs(..., volatility_coordinate=inner_strike)`; the admitted formula assumes one constant rate, dividend yield, and Black volatility across both expiry legs."
+    - "Require settlement < outer expiry < inner expiry; use `year_fraction` for both contractual times and reject degenerate ordering."
+    - "At the outer expiry, form the inner option value from `forward_from_dividend_yield`, `discount_factor_from_zero_rate`, `discounted_value`, and the matching `black76_call` or `black76_put`; subtract the outer strike to define the critical-state objective."
+    - "Solve the positive critical stock state through finite `SolveBounds`, `ObjectiveBundle`, `SolveRequest`, and `execute_solve_request`; verify a sign change before solving and do not add a product helper or adapter-local Newton loop."
+    - "Assemble the selected call-on-call, put-on-call, call-on-put, or put-on-put formula from `standard_normal_cdf`, `bivariate_standard_normal_cdf`, explicit discount factors, strikes, and the solved state, then apply notional exactly once."
+  reasoning: "A European compound option is a bounded analytical composition: solve where the inner option equals the outer strike, then integrate the exercise region with univariate and bivariate Gaussian probabilities."
   learned: false

--- a/trellis/agent/knowledge/canonical/routes.yaml
+++ b/trellis/agent/knowledge/canonical/routes.yaml
@@ -1679,12 +1679,56 @@ routes:
             exercise:
               style: european
         primitives:
-          - module: trellis.models.analytical.equity_exotics
-            symbol: price_equity_compound_option_analytical
-            role: route_helper
+          - module: trellis.models.resolution.single_state_diffusion
+            symbol: resolve_scalar_diffusion_market_inputs
+            role: market_binding
+          - module: trellis.core.date_utils
+            symbol: year_fraction
+            role: time_measure
+          - module: trellis.models.analytical.support
+            symbol: forward_from_dividend_yield
+            role: forward_builder
+          - module: trellis.models.analytical.support
+            symbol: discount_factor_from_zero_rate
+            role: discounting
+          - module: trellis.models.analytical.support
+            symbol: discounted_value
+            role: discounting
+          - module: trellis.models.black
+            symbol: black76_call
+            role: pricing_kernel
+          - module: trellis.models.black
+            symbol: black76_put
+            role: pricing_kernel
+          - module: trellis.models.analytical.support.probability
+            symbol: standard_normal_cdf
+            role: probability_kernel
+          - module: trellis.models.analytical.support.probability
+            symbol: bivariate_standard_normal_cdf
+            role: probability_kernel
+          - module: trellis.models.calibration.solve_request
+            symbol: ObjectiveBundle
+            role: objective_contract
+          - module: trellis.models.calibration.solve_request
+            symbol: SolveBounds
+            role: solver_bounds
+          - module: trellis.models.calibration.solve_request
+            symbol: SolveRequest
+            role: solver_request
+          - module: trellis.models.calibration.solve_request
+            symbol: execute_solve_request
+            role: solver
         adapters: []
         notes:
-          - "Use the compound-option helper with `market_state` and `spec`; keep the critical-spot solve inside the shared helper."
+          - >-
+            Admit only a European compound option under one constant
+            scalar-diffusion market projection at the inner expiry. The adapter
+            owns the inner-value objective, bounded critical-state request,
+            selected bivariate formula, and one-time notional scaling.
+          - >-
+            Fail closed unless settlement < outer expiry < inner expiry, spot and
+            strikes are positive, volatility is positive, and the finite positive
+            root bracket changes sign. Do not call a compound product helper.
       - when:
           contract_pattern:
             payoff:

--- a/trellis/agent/knowledge/import_registry.py
+++ b/trellis/agent/knowledge/import_registry.py
@@ -563,6 +563,8 @@ from trellis.models.black import black76_call, black76_put, black76_asset_or_not
 from trellis.models.analytical import terminal_intrinsic, terminal_vanilla_from_basis
 from trellis.models.analytical.support import asset_or_nothing_intrinsic, cash_or_nothing_intrinsic, discount_factor_from_zero_rate, discounted_value, forward_from_dividend_yield, gauss_hermite_product_expectation, implied_zero_rate, normalized_option_type, quanto_adjusted_forward, terminal_intrinsic
 from trellis.models.analytical.support.expectations import gauss_hermite_product_expectation
+from trellis.models.analytical.support.probability import bivariate_standard_normal_cdf, standard_normal_cdf
+from trellis.models.calibration.solve_request import ObjectiveBundle, SolveBounds, SolveRequest, execute_solve_request
 from trellis.models.analytical.fx import ResolvedGarmanKohlhagenInputs, garman_kohlhagen_call_raw, garman_kohlhagen_price_raw, garman_kohlhagen_put_raw
 from trellis.models.analytical.jamshidian import zcb_option_hw
 from trellis.models.analytical.barrier import barrier_option_price, down_and_out_call, down_and_in_call

--- a/trellis/instruments/_agent/compoundoption.py
+++ b/trellis/instruments/_agent/compoundoption.py
@@ -25,37 +25,35 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import date
+from math import isfinite, log, sqrt
 
+from trellis.core.date_utils import year_fraction
 from trellis.core.market_state import MarketState
 from trellis.core.types import DayCountConvention
-from trellis.models.analytical import price_equity_compound_option_analytical
-
-
+from trellis.models.analytical.support import (
+    discount_factor_from_zero_rate,
+    discounted_value,
+    forward_from_dividend_yield,
+)
+from trellis.models.analytical.support.probability import (
+    bivariate_standard_normal_cdf,
+    standard_normal_cdf,
+)
+from trellis.models.black import black76_call, black76_put
+from trellis.models.calibration.solve_request import (
+    ObjectiveBundle,
+    SolveBounds,
+    SolveRequest,
+    execute_solve_request,
+)
+from trellis.models.resolution.single_state_diffusion import (
+    resolve_scalar_diffusion_market_inputs,
+)
 
 @dataclass(frozen=True)
 class CompoundOptionSpec:
-    """Specification for Build a pricer for: FinancePy parity: equity compound option
+    """European option on a European option under constant diffusion inputs."""
 
-compound_option
-
-Spot: 100.0.
-Outer option type: call.
-Inner option type: call.
-Outer strike: 12.0.
-Inner strike: 100.0.
-Outer expiry date: 2025-05-16.
-Inner expiry date: 2025-11-15.
-
-Preferred method family: analytical
-FinancePy binding: financepy.equity.compound.black_scholes
-Benchmark product: compound_option
-
-Construct methods: analytical
-Comparison targets: analytical (analytical)
-Cross-validation harness:
-  external targets: financepy
-
-Implementation target: analytical."""
     notional: float
     spot: float
     outer_expiry_date: date
@@ -64,7 +62,18 @@ Implementation target: analytical."""
     inner_strike: float
     outer_option_type: str = 'call'
     inner_option_type: str = 'call'
+    dividend_yield: float | None = None
     day_count: DayCountConvention = DayCountConvention.ACT_365
+
+
+@dataclass(frozen=True)
+class _ScalarMarketCoordinate:
+    """Product-neutral coordinate for the admitted constant-input projection."""
+
+    spot: float
+    expiry_date: date
+    day_count: DayCountConvention
+    dividend_yield: float | None = None
 
 
 class CompoundOptionPayoff:
@@ -104,4 +113,180 @@ Implementation target: analytical."""
 
     def evaluate(self, market_state: MarketState) -> float:
         spec = self._spec
-        return float(price_equity_compound_option_analytical(market_state, spec))
+        settlement = market_state.settlement or market_state.as_of
+        if settlement is None:
+            raise ValueError("compound option pricing requires settlement or as_of")
+
+        outer_time = float(
+            year_fraction(settlement, spec.outer_expiry_date, spec.day_count)
+        )
+        inner_time = float(
+            year_fraction(settlement, spec.inner_expiry_date, spec.day_count)
+        )
+        if not (0.0 < outer_time < inner_time):
+            raise ValueError(
+                "outer expiry must lie strictly between settlement and inner expiry"
+            )
+
+        runtime_spot = market_state.spot
+        spot = float(spec.spot if runtime_spot is None else runtime_spot)
+        outer_strike = float(spec.outer_strike)
+        inner_strike = float(spec.inner_strike)
+        notional = float(spec.notional)
+        if not all(
+            isfinite(value)
+            for value in (spot, outer_strike, inner_strike, notional)
+        ):
+            raise ValueError("compound option scalar contract values must be finite")
+        if spot <= 0.0 or outer_strike <= 0.0 or inner_strike <= 0.0:
+            raise ValueError("compound option spot and strikes must be positive")
+
+        outer_option_type = str(spec.outer_option_type or "call").strip().lower()
+        inner_option_type = str(spec.inner_option_type or "call").strip().lower()
+        if outer_option_type not in {"call", "put"} or inner_option_type not in {
+            "call",
+            "put",
+        }:
+            raise ValueError(
+                "unsupported compound option types "
+                f"outer={outer_option_type!r}, inner={inner_option_type!r}"
+            )
+
+        coordinate = _ScalarMarketCoordinate(
+            spot=spot,
+            expiry_date=spec.inner_expiry_date,
+            day_count=spec.day_count,
+            dividend_yield=spec.dividend_yield,
+        )
+        resolved = resolve_scalar_diffusion_market_inputs(
+            market_state,
+            coordinate,
+            volatility_coordinate=inner_strike,
+        )
+        rate = resolved.rate
+        dividend_yield = resolved.dividend_yield
+        sigma = resolved.sigma
+        if sigma <= 0.0:
+            raise ValueError("compound analytical pricing requires positive volatility")
+
+        remaining_time = inner_time - outer_time
+
+        def inner_value_at_outer(stock_level: float) -> float:
+            forward = forward_from_dividend_yield(
+                spot=stock_level,
+                domestic_rate=rate,
+                dividend_yield=dividend_yield,
+                T=remaining_time,
+            )
+            kernel = black76_call if inner_option_type == "call" else black76_put
+            return float(
+                discounted_value(
+                    kernel(forward, inner_strike, sigma, remaining_time),
+                    discount_factor_from_zero_rate(rate, remaining_time),
+                )
+            )
+
+        def critical_state_balance(stock_level: object) -> float:
+            return inner_value_at_outer(float(stock_level)) - outer_strike
+
+        state_scale = max(spot, outer_strike, inner_strike, 1.0)
+        lower_state = state_scale * 1e-8
+        upper_state = state_scale * 1e6
+        lower_balance = critical_state_balance(lower_state)
+        upper_balance = critical_state_balance(upper_state)
+        if not isfinite(lower_balance) or not isfinite(upper_balance):
+            raise ValueError("compound critical-state bracket values must be finite")
+        if not (
+            lower_balance <= 0.0 <= upper_balance
+            or upper_balance <= 0.0 <= lower_balance
+        ):
+            raise ValueError(
+                "compound critical-state objective has no sign change on the admitted bracket"
+            )
+
+        solve_result = execute_solve_request(
+            SolveRequest(
+                request_id="compound-critical-state",
+                problem_kind="root_scalar",
+                parameter_names=("critical_stock",),
+                initial_guess=(spot,),
+                objective=ObjectiveBundle(
+                    objective_kind="root_scalar",
+                    labels=("inner_value_minus_outer_strike",),
+                    target_values=(0.0,),
+                    scalar_objective_fn=critical_state_balance,
+                ),
+                bounds=SolveBounds(lower=(lower_state,), upper=(upper_state,)),
+                solver_hint="brentq",
+                metadata={"contract": "european_compound"},
+                options={"tol": 1e-10},
+            )
+        )
+        if not solve_result.success or len(solve_result.solution) != 1:
+            raise ValueError("compound pricing requires a successful critical-stock solve")
+        critical_spot = solve_result.solution[0]
+        if not isfinite(critical_spot) or critical_spot <= 0.0:
+            raise ValueError(
+                "compound solve must return a positive finite critical stock state"
+            )
+
+        outer_sigma_time = sigma * sqrt(outer_time)
+        inner_sigma_time = sigma * sqrt(inner_time)
+        a1 = (
+            log(spot / critical_spot)
+            + (rate - dividend_yield + 0.5 * sigma * sigma) * outer_time
+        ) / outer_sigma_time
+        a2 = a1 - outer_sigma_time
+        b1 = (
+            log(spot / inner_strike)
+            + (rate - dividend_yield + 0.5 * sigma * sigma) * inner_time
+        ) / inner_sigma_time
+        b2 = b1 - inner_sigma_time
+        correlation = sqrt(outer_time / inner_time)
+        outer_discount = discount_factor_from_zero_rate(rate, outer_time)
+        inner_rate_discount = discount_factor_from_zero_rate(rate, inner_time)
+        inner_dividend_discount = discount_factor_from_zero_rate(
+            dividend_yield, inner_time
+        )
+
+        if outer_option_type == "call" and inner_option_type == "call":
+            value = (
+                spot
+                * inner_dividend_discount
+                * bivariate_standard_normal_cdf(a1, b1, correlation)
+                - inner_strike
+                * inner_rate_discount
+                * bivariate_standard_normal_cdf(a2, b2, correlation)
+                - outer_strike * outer_discount * standard_normal_cdf(a2)
+            )
+        elif outer_option_type == "put" and inner_option_type == "call":
+            value = (
+                inner_strike
+                * inner_rate_discount
+                * bivariate_standard_normal_cdf(-a2, b2, -correlation)
+                - spot
+                * inner_dividend_discount
+                * bivariate_standard_normal_cdf(-a1, b1, -correlation)
+                + outer_strike * outer_discount * standard_normal_cdf(-a2)
+            )
+        elif outer_option_type == "call" and inner_option_type == "put":
+            value = (
+                inner_strike
+                * inner_rate_discount
+                * bivariate_standard_normal_cdf(-a2, -b2, correlation)
+                - spot
+                * inner_dividend_discount
+                * bivariate_standard_normal_cdf(-a1, -b1, correlation)
+                - outer_strike * outer_discount * standard_normal_cdf(-a2)
+            )
+        else:
+            value = (
+                spot
+                * inner_dividend_discount
+                * bivariate_standard_normal_cdf(a1, -b1, -correlation)
+                - inner_strike
+                * inner_rate_discount
+                * bivariate_standard_normal_cdf(a2, -b2, -correlation)
+                + outer_strike * outer_discount * standard_normal_cdf(a2)
+            )
+        return float(notional * value)


### PR DESCRIPTION
## Summary\n- retire compound-option product helper authority from F013 route, backend, executor, and checked adapter construction\n- assemble all four European compound subtypes from reusable market, Black, Gaussian, discounting, and bounded-solve primitives\n- add complete builder navigation plus FinancePy price/Delta evidence and quant/developer documentation\n\n## Validation\n- focused compound/authority suite: 24 passed\n- helper-authority audit: 9 passed\n- strict offline F013: passed, zero LLM calls/tokens, zero cookbook/lesson mutations\n- FinancePy F013: price deviation 0.388159%, Delta deviation 0.131581%, tolerance 2%\n- make gate-pr: 4,580 core passed; 32 tier-2 contracts passed\n- Sphinx HTML build succeeded; changed docs emitted no warnings\n\n## Scope\n- retained compound analytical wrapper remains reference-only\n- no new product helper or cookbook mutation\n- user guide and LIMITATIONS.md unchanged because public support scope did not move\n\nLinear: QUA-1193