### PR TITLE
QUA-1194 Retire analytical lookback helper authority

### DIFF
--- a/FINANCEPY_BINDINGS.yaml
+++ b/FINANCEPY_BINDINGS.yaml
@@ -156,9 +156,12 @@ bindings:
     financepy_model: BlackScholes
     overlapping_outputs:
     - price
+    - delta
     comparison_modes:
     - price_parity
     - warm_runtime
+    greek_fallback:
+      kind: bump_and_reprice
   financepy.equity.chooser.black_scholes:
     instrument_family: chooser_option
     method_family: analytical

--- a/docs/developer/runtime_agent_orientation.rst
+++ b/docs/developer/runtime_agent_orientation.rst
@@ -102,6 +102,18 @@ typed decomposition, but they cannot promote cookbook entries during task
 execution or use those patterns to override chooser or compound semantic
 contracts.
 
+The ``fixed_lookback_analytical_composition`` card is the corresponding
+builder-only analytical hot start. It selects scalar market resolution, exact
+time, option normalization, discounting, and the univariate Gaussian CDF. It
+does not inherit the bivariate probability or scalar-root imports from
+``analytical_gaussian_composition``. The card states that generated code owns
+the Conze-Viswanathan call/put formula, historical and runtime extreme
+invariants, the analytic zero-carry limit, expiry settlement, and one-time
+notional scaling. The retained analytical lookback wrapper remains comparison
+evidence. Quant and model-validator continue to receive the semantic contract,
+quantitative documentation, and executed price/Delta evidence rather than
+implementation imports, and no cookbook entry is promoted by this route.
+
 The ``path_statistic_composition`` card applies the same rule to path-dependent
 Monte Carlo construction. Semantic aliases such as ``running_extremum``,
 ``squared_log_return``, and ``variance_swap`` lead the builder to exact

--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -1023,14 +1023,20 @@ Rebate-bearing barriers should remain on the analytical Rubinstein route until
 the PDE/MC rebate contract is implemented.
 
 Digital proof targets retain exact helper wrappers where the checked numerical
-contract still lives at that boundary. Fixed-lookback and arithmetic-Asian
-Monte Carlo targets no longer do. The fixed-lookback target assembles the
-scalar-diffusion resolver, normalized call/put semantics, one conditional
-bridge-extremum contract, exact constant-parameter GBM, and the generic Monte
-Carlo engine. Generated adapter code supplies the prior running extremum and
-owns expiry settlement, strike, notional, discounting, and estimator checks.
-It admits only European fixed-strike continuous monitoring and fails closed
-instead of substituting the discrete running-extremum reducer.
+contract still lives at that boundary. Fixed-lookback analytical and Monte
+Carlo targets, and arithmetic-Asian Monte Carlo targets, no longer do. The
+fixed-lookback analytical target assembles the scalar-diffusion resolver,
+contractual time, normalized call/put semantics, discounting, and the public
+univariate Gaussian CDF. Generated code owns the closed-form branches,
+historical/runtime extreme invariants, analytic zero-carry limit, expiry
+settlement, and notional. Its FinancePy binding requests product-neutral
+``bump_and_reprice`` Delta evidence. The Monte Carlo target assembles the same
+market and option semantics with one conditional bridge-extremum contract,
+exact constant-parameter GBM, and the generic Monte Carlo engine. Generated
+adapter code supplies the prior running extremum and owns expiry settlement,
+strike, notional, discounting, and estimator checks. Both lanes admit only
+European fixed-strike continuous monitoring and fail closed instead of
+substituting a different lookback contract.
 The support-contract pass records missing strike/monitoring semantics and
 known unsupported variants as structured primitive blockers. Those blockers
 stop the build before code generation even when the generic Monte Carlo route

--- a/docs/quant/pricing_stack.rst
+++ b/docs/quant/pricing_stack.rst
@@ -984,6 +984,103 @@ a product pricing helper as construction authority. The semantic API map card
 ``analytical_gaussian_composition`` is the builder's general hot start for
 these probability and root-solving pieces.
 
+Fixed lookback analytical composition
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The admitted European fixed-strike continuous-lookback lane uses the dedicated
+``fixed_lookback_analytical_composition`` card. It exposes
+``resolve_scalar_diffusion_market_inputs``, ``year_fraction``,
+``normalized_option_type``, ``discount_factor_from_zero_rate``, and
+``standard_normal_cdf``. A scalar root and bivariate Gaussian probability are
+not part of this formula, so the lookback alias does not select the general
+critical-state card.
+
+Let :math:`S_0` be runtime spot, :math:`K` the fixed strike, :math:`T` time to
+expiry, :math:`r` the continuously compounded rate, :math:`q` dividend carry,
+and :math:`\sigma` the Black volatility resolved at :math:`(T,K)`. Let
+:math:`H_{\max}` be the observed running maximum for a call and
+:math:`H_{\min}` the observed running minimum for a put. Runtime spot remains
+part of the observed path state, so define
+
+.. math::
+
+   M = \max(H_{\max},S_0), \qquad
+   m = \min(H_{\min},S_0), \qquad
+   B_C = \max(K,M), \qquad
+   B_P = \min(K,m).
+
+For either boundary :math:`B`, write :math:`b=r-q` and
+
+.. math::
+
+   d_1(B) =
+   \frac{\log(S_0/B)+(b+\tfrac12\sigma^2)T}{\sigma\sqrt{T}},
+   \qquad
+   d_2(B)=d_1(B)-\sigma\sqrt{T}.
+
+For nonzero carry, the correction terms are
+
+.. math::
+
+   \begin{aligned}
+   A_C(B;b) ={}& \frac{\sigma^2}{2b}
+      \left[-\left(\frac{S_0}{B}\right)^{-2b/\sigma^2}
+      \Phi\!\left(d_1(B)-\frac{2b\sqrt{T}}{\sigma}\right)
+      +e^{bT}\Phi(d_1(B))\right], \\
+   A_P(B;b) ={}& \frac{\sigma^2}{2b}
+      \left[\left(\frac{S_0}{B}\right)^{-2b/\sigma^2}
+      \Phi\!\left(-d_1(B)+\frac{2b\sqrt{T}}{\sigma}\right)
+      -e^{bT}\Phi(-d_1(B))\right].
+   \end{aligned}
+
+The per-unit-notional prices are
+
+.. math::
+
+   \begin{aligned}
+   V_C ={}& e^{-rT}(M-K)^+
+      +S_0e^{-qT}\Phi(d_1(B_C))
+      -B_Ce^{-rT}\Phi(d_2(B_C))
+      +S_0e^{-rT}A_C(B_C;b), \\
+   V_P ={}& e^{-rT}(K-m)^+
+      -S_0e^{-qT}\Phi(-d_1(B_P))
+      +B_Pe^{-rT}\Phi(-d_2(B_P))
+      +S_0e^{-rT}A_P(B_P;b).
+   \end{aligned}
+
+The apparent :math:`1/b` singularity is removable. With
+
+.. math::
+
+   d_1^0(B)=
+   \frac{\log(S_0/B)+\tfrac12\sigma^2T}{\sigma\sqrt{T}},
+
+the checked adapter uses the analytic limits
+
+.. math::
+
+   \begin{aligned}
+   A_C(B;0) ={}&
+      \left(\log(S_0/B)+\tfrac12\sigma^2T\right)\Phi(d_1^0(B))
+      +\sigma\sqrt{T}\,\phi(d_1^0(B)), \\
+   A_P(B;0) ={}&
+      \left(-\log(S_0/B)-\tfrac12\sigma^2T\right)\Phi(-d_1^0(B))
+      +\sigma\sqrt{T}\,\phi(d_1^0(B)).
+   \end{aligned}
+
+The historical maximum must be at least contract spot and the historical
+minimum must be at most contract spot. At expiry the adapter settles
+:math:`(M-K)^+` or :math:`(K-m)^+` directly. It rejects floating strike,
+discrete monitoring, non-European exercise, non-positive spot, strike, or
+volatility, unsupported dynamics, and non-finite formula results. Notional is
+applied once after the selected formula. The retained product wrapper is
+independent comparison evidence, not construction authority.
+
+The adapter prefers ``MarketState.spot`` over the contract fallback and updates
+the effective path extreme with that spot. The F011 FinancePy binding uses the
+same product-neutral central ``bump_and_reprice`` Delta policy; no
+lookback-specific Greek helper is required.
+
 Simple chooser composition
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/user_guide/pricing.rst
+++ b/docs/user_guide/pricing.rst
@@ -290,6 +290,22 @@ construction authority.
 Fixed Lookback Composition
 --------------------------
 
+The admitted analytical route is also composed rather than delegated to a
+product pricer. It resolves runtime spot, maturity, rate, dividend carry,
+strike-coordinate Black volatility, and discounting with
+``resolve_scalar_diffusion_market_inputs(...)``; normalizes call or put
+semantics; and evaluates the fixed-strike continuous-lookback formula with
+``standard_normal_cdf(...)``. Generated code owns the running maximum/minimum
+branches, expiry settlement, and notional. When rate minus dividend carry is
+zero, it uses the analytic formula limit instead of perturbing market data.
+
+The observed maximum for a call must be at least the contract spot; the
+observed minimum for a put must be at most the contract spot. A runtime spot
+binding is included in the effective maximum or minimum, which lets the normal
+spot-bump Delta workflow reprice the same path-state contract. The F011
+FinancePy comparison therefore reports both price and Delta without a
+lookback-specific Greek function.
+
 The admitted fixed-strike continuous-lookback Monte Carlo task route is built
 from reusable transition primitives. It binds spot, maturity, rate, carry,
 scalar volatility, and discounting with
@@ -316,9 +332,9 @@ multiple simultaneous stochastic extrema, local or stochastic volatility,
 jumps, and approximate transition schemes need different contracts and fail
 closed before code generation. An omitted or conflicting strike/monitoring
 style also fails closed instead of inheriting ``fixed_strike`` or
-``continuous`` defaults. The functions in ``trellis.models.lookback_option``
-remain available as compatibility and independent-comparison references, not
-generated-route construction authority.
+``continuous`` defaults. The analytical compatibility wrapper and the
+functions in ``trellis.models.lookback_option`` remain available as
+independent-comparison references, not generated-route construction authority.
 
 Variance Swap Composition
 -------------------------

--- a/tests/test_agent/test_api_map.py
+++ b/tests/test_agent/test_api_map.py
@@ -290,13 +290,8 @@ def test_api_map_semantic_selection_reaches_composition_cards():
         assert expected_family in selection.selected_families
 
 
-@pytest.mark.parametrize(
-    "payoff_family",
-    ["lookback_option"],
-)
-def test_api_map_semantic_selection_reaches_gaussian_root_composition(
-    payoff_family,
-):
+def test_api_map_exposes_complete_fixed_lookback_analytical_composition():
+    payoff_family = "lookback_option"
     selection = select_api_map_sections(
         ApiMapQuery(
             payoff_family=payoff_family,
@@ -313,12 +308,15 @@ def test_api_map_semantic_selection_reaches_gaussian_root_composition(
         ),
     )
 
-    assert "analytical_gaussian_composition" in selection.selected_families
+    assert "fixed_lookback_analytical_composition" in selection.selected_families
     assert "standard_normal_cdf" in text
-    assert "bivariate_standard_normal_cdf" in text
-    assert "SolveRequest" in text
-    assert "execute_solve_request" in text
-    assert "from trellis.models.calibration.solve_request import" in text
+    assert "resolve_scalar_diffusion_market_inputs" in text
+    assert "year_fraction" in text
+    assert "normalized_option_type" in text
+    assert "discount_factor_from_zero_rate" in text
+    assert "bivariate_standard_normal_cdf" not in text
+    assert "SolveRequest" not in text
+    assert "price_equity_fixed_lookback_option_analytical" not in text
 
 
 def test_api_map_exposes_complete_chooser_raw_composition():
@@ -524,8 +522,9 @@ def test_api_map_exposes_product_neutral_conditional_extremum_composition():
             method="analytical",
         )
     )
-    assert "analytical_gaussian_composition" in analytical_selection.selected_families
+    assert "fixed_lookback_analytical_composition" in analytical_selection.selected_families
     assert "conditional_extremum_composition" not in analytical_selection.selected_families
+    assert "analytical_gaussian_composition" not in analytical_selection.selected_families
 
 
 def test_api_map_exposes_product_neutral_observation_return_composition():

--- a/tests/test_agent/test_backend_bindings.py
+++ b/tests/test_agent/test_backend_bindings.py
@@ -725,9 +725,7 @@ def test_resolve_backend_binding_spec_uses_quanto_primitive_composition(
                 model_family="equity_diffusion",
             ),
             "analytical",
-            (
-                "trellis.models.analytical.equity_exotics.price_equity_fixed_lookback_option_analytical",
-            ),
+            (),
             (),
             id="lookback",
         ),
@@ -848,6 +846,40 @@ def test_resolve_backend_binding_spec_exposes_complete_chooser_composition():
         "trellis.models.calibration.solve_request.SolveBounds",
         "trellis.models.calibration.solve_request.SolveRequest",
         "trellis.models.calibration.solve_request.execute_solve_request",
+    } <= set(resolved.primitive_refs)
+
+
+def test_resolve_backend_binding_spec_exposes_complete_lookback_composition():
+    catalog = load_backend_binding_catalog()
+    analytical = find_backend_binding_by_route_id("analytical_black76", catalog)
+
+    assert analytical is not None
+
+    resolved = resolve_backend_binding_spec(
+        analytical,
+        product_ir=ProductIR(
+            instrument="lookback_option",
+            payoff_family="lookback_option",
+            payoff_traits=(
+                "continuous_monitoring",
+                "discounting",
+                "fixed_strike",
+                "path_dependent",
+                "vol_surface_dependence",
+            ),
+            exercise_style="european",
+            state_dependence="path_dependent",
+            model_family="equity_diffusion",
+        ),
+    )
+
+    assert resolved.helper_refs == ()
+    assert {
+        "trellis.models.resolution.single_state_diffusion.resolve_scalar_diffusion_market_inputs",
+        "trellis.core.date_utils.year_fraction",
+        "trellis.models.analytical.support.normalized_option_type",
+        "trellis.models.analytical.support.discount_factor_from_zero_rate",
+        "trellis.models.analytical.support.probability.standard_normal_cdf",
     } <= set(resolved.primitive_refs)
 
 

--- a/tests/test_agent/test_financepy_benchmark.py
+++ b/tests/test_agent/test_financepy_benchmark.py
@@ -67,7 +67,7 @@ def test_financepy_benchmark_manifest_includes_tranche_two_families():
     [
         ("F009", ("price",)),
         ("F010", ("price",)),
-        ("F011", ("price",)),
+        ("F011", ("price", "delta")),
         ("F012", ("price", "delta")),
         ("F013", ("price", "delta")),
         ("F014", ("price",)),
@@ -89,6 +89,17 @@ def test_f012_binding_declares_generic_delta_fallback():
 
     binding = load_financepy_bindings(root=ROOT)[
         "financepy.equity.chooser.black_scholes"
+    ]
+
+    assert binding["overlapping_outputs"] == ["price", "delta"]
+    assert binding["greek_fallback"] == {"kind": "bump_and_reprice"}
+
+
+def test_f011_binding_declares_generic_delta_fallback():
+    from trellis.agent.task_manifests import load_financepy_bindings
+
+    binding = load_financepy_bindings(root=ROOT)[
+        "financepy.equity.lookback.fixed"
     ]
 
     assert binding["overlapping_outputs"] == ["price", "delta"]

--- a/tests/test_agent/test_helper_authority_audit.py
+++ b/tests/test_agent/test_helper_authority_audit.py
@@ -334,3 +334,23 @@ def test_current_repository_retires_analytical_compound_helper_authority():
         if item.path == "trellis/instruments/_agent/compoundoption.py"
         and item.symbol == helper_symbol
     ]
+
+
+def test_current_repository_retires_analytical_lookback_helper_authority():
+    from trellis.agent.helper_authority_audit import build_helper_authority_report
+
+    root = Path(__file__).resolve().parents[2]
+    report = build_helper_authority_report(root)
+    helper_symbol = "price_equity_fixed_lookback_option_analytical"
+
+    assert not [
+        item
+        for item in (*report.route_authority, *report.binding_authority)
+        if item.symbol == helper_symbol
+    ]
+    assert not [
+        item
+        for item in report.adapter_calls
+        if item.path == "trellis/instruments/_agent/lookbackoption.py"
+        and item.symbol == helper_symbol
+    ]

--- a/tests/test_agent/test_knowledge_store.py
+++ b/tests/test_agent/test_knowledge_store.py
@@ -735,29 +735,23 @@ class TestKnowledgeStore:
             assert symbol in compound_requirements
         assert "price_equity_compound_option_analytical" not in compound_requirements
 
-        for instrument, helper_symbol in (
-            ("lookback_option", "price_equity_fixed_lookback_option_analytical"),
+        lookback = store._decompositions.get("lookback_option")
+        assert lookback is not None
+        assert lookback.method == "analytical"
+        assert set(lookback.method_modules) >= {
+            "trellis.models.resolution.single_state_diffusion",
+            "trellis.models.analytical.support",
+            "trellis.models.analytical.support.probability",
+        }
+        assert "discount_curve" in lookback.required_market_data
+        assert "black_vol_surface" in lookback.required_market_data
+        lookback_requirements = " ".join(lookback.modeling_requirements)
+        for symbol in (
+            "resolve_scalar_diffusion_market_inputs",
+            "standard_normal_cdf",
         ):
-            decomp = store._decompositions.get(instrument)
-            assert decomp is not None, f"missing analytical decomposition for {instrument}"
-            assert decomp.method == "analytical", (
-                f"{instrument} decomposition must anchor on analytical route, "
-                f"got {decomp.method!r}"
-            )
-            assert "trellis.models.analytical.equity_exotics" in decomp.method_modules, (
-                f"{instrument} must list the shared equity-exotics module"
-            )
-            assert "discount_curve" in decomp.required_market_data
-            assert "black_vol_surface" in decomp.required_market_data
-            # QUA-852 PR #597 Codex P1: the modeling-requirement string MUST
-            # keep the helper identifier contiguous (no whitespace inside the
-            # symbol), otherwise folded YAML produces ``foo_ analytical(...)``
-            # and generated adapters reference a non-existent symbol.
-            joined_requirements = " ".join(decomp.modeling_requirements)
-            assert f"{helper_symbol}(market_state, spec)" in joined_requirements, (
-                f"{instrument} modeling requirement must contain the "
-                f"contiguous helper call {helper_symbol}(market_state, spec)"
-            )
+            assert symbol in lookback_requirements
+        assert "price_equity_fixed_lookback_option_analytical" not in lookback_requirements
 
     def test_retrieve_for_task_uses_runtime_cache(self):
         from trellis.agent.knowledge.schema import RetrievalSpec

--- a/tests/test_agent/test_platform_requests.py
+++ b/tests/test_agent/test_platform_requests.py
@@ -878,11 +878,6 @@ def test_semantic_blueprint_summary_preserves_range_accrual_callability_blockers
             "trellis.models.black.black76_cash_or_nothing_call",
         ),
         (
-            "F011",
-            "analytical",
-            "trellis.models.analytical.equity_exotics.price_equity_fixed_lookback_option_analytical",
-        ),
-        (
             "F012",
             "analytical",
             "trellis.models.black.black76_call",
@@ -940,6 +935,41 @@ def test_compile_build_request_preserves_exact_absorbed_black76_binding_for_fina
 
     if task_id == "F009":
         assert set(compiled.product_ir.candidate_engine_families) >= {"analytical", "pde"}
+
+
+def test_compile_build_request_uses_lookback_primitive_composition_for_f011():
+    from trellis.agent.benchmark_contracts import benchmark_request_description
+    from trellis.agent.platform_requests import compile_build_request
+
+    task = _financepy_benchmark_task("F011")
+    compiled = compile_build_request(
+        benchmark_request_description(task),
+        instrument_type=task["instrument_type"],
+        preferred_method="analytical",
+    )
+
+    assert compiled.generation_plan is not None
+    primitive_plan = compiled.generation_plan.primitive_plan
+    assert primitive_plan is not None
+    primitive_refs = {
+        f"{primitive.module}.{primitive.symbol}"
+        for primitive in primitive_plan.primitives
+    }
+    assert {
+        "trellis.models.resolution.single_state_diffusion.resolve_scalar_diffusion_market_inputs",
+        "trellis.core.date_utils.year_fraction",
+        "trellis.models.analytical.support.normalized_option_type",
+        "trellis.models.analytical.support.discount_factor_from_zero_rate",
+        "trellis.models.analytical.support.probability.standard_normal_cdf",
+    } <= primitive_refs
+    assert not any(
+        "price_equity_fixed_lookback_option_analytical" in ref
+        for ref in primitive_refs
+    )
+    assert not any(
+        "price_equity_fixed_lookback_option_analytical" in ref
+        for ref in compiled.generation_plan.backend_exact_target_refs
+    )
 
 
 def test_compile_build_request_uses_cliquet_primitive_composition_for_f014():

--- a/tests/test_agent/test_route_registry.py
+++ b/tests/test_agent/test_route_registry.py
@@ -1804,15 +1804,35 @@ class TestAnalyticalRoutes:
             ),
         }
 
-    def test_lookback_primitives_use_exact_helper(self, registry):
+    def test_lookback_primitives_use_raw_analytical_composition(self, registry):
         spec = [r for r in registry.routes if r.id == "analytical_black76"][0]
         new_prims = resolve_route_primitives(spec, self.LOOKBACK_IR)
         assert resolve_route_family(spec, self.LOOKBACK_IR) == "analytical"
         assert _prim_set(new_prims) == {
             (
-                "trellis.models.analytical.equity_exotics",
-                "price_equity_fixed_lookback_option_analytical",
-                "route_helper",
+                "trellis.models.resolution.single_state_diffusion",
+                "resolve_scalar_diffusion_market_inputs",
+                "market_binding",
+            ),
+            (
+                "trellis.core.date_utils",
+                "year_fraction",
+                "time_measure",
+            ),
+            (
+                "trellis.models.analytical.support",
+                "normalized_option_type",
+                "payoff_primitive",
+            ),
+            (
+                "trellis.models.analytical.support",
+                "discount_factor_from_zero_rate",
+                "discounting",
+            ),
+            (
+                "trellis.models.analytical.support.probability",
+                "standard_normal_cdf",
+                "probability_kernel",
             ),
         }
 

--- a/tests/test_agent/test_task_runtime.py
+++ b/tests/test_agent/test_task_runtime.py
@@ -1160,13 +1160,21 @@ def test_legacy_lookback_tasks_resolve_identity_independently_of_formula_alias(
     analytical_plan = build_generation_plan(
         pricing_plan=PricingPlan(
             method="analytical",
-            method_modules=["trellis.models.analytical.equity_exotics"],
+            method_modules=[
+                "trellis.models.resolution.single_state_diffusion",
+                "trellis.models.analytical.support",
+                "trellis.models.analytical.support.probability",
+            ],
             required_market_data={"discount_curve", "black_vol_surface"},
             model_to_build="lookback_option",
             reasoning="analytical comparison target",
         ),
         instrument_type="lookback_option",
-        inspected_modules=("trellis.models.analytical.equity_exotics",),
+        inspected_modules=(
+            "trellis.models.resolution.single_state_diffusion",
+            "trellis.models.analytical.support",
+            "trellis.models.analytical.support.probability",
+        ),
         product_ir=product_ir,
     )
 
@@ -1183,9 +1191,17 @@ def test_legacy_lookback_tasks_resolve_identity_independently_of_formula_alias(
         "gsg_analytical": "analytical",
     }
     assert analytical_plan.primitive_plan is not None
+    primitive_refs = {
+        f"{primitive.module}.{primitive.symbol}"
+        for primitive in analytical_plan.primitive_plan.primitives
+    }
     assert (
-        "trellis.models.analytical.equity_exotics.price_equity_fixed_lookback_option_analytical"
-        in analytical_plan.lane_exact_binding_refs
+        "trellis.models.resolution.single_state_diffusion.resolve_scalar_diffusion_market_inputs"
+        in primitive_refs
+    )
+    assert not any(
+        "price_equity_fixed_lookback_option_analytical" in ref
+        for ref in (*primitive_refs, *analytical_plan.lane_exact_binding_refs)
     )
 
 

--- a/tests/test_instruments/test_agent_lookback_option.py
+++ b/tests/test_instruments/test_agent_lookback_option.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+from datetime import date
+from math import isfinite
+from pathlib import Path
+
+import pytest
+
+from trellis.analytics.measures import Delta
+from trellis.core.market_state import MarketState
+from trellis.curves.yield_curve import YieldCurve
+from trellis.instruments._agent.lookbackoption import (
+    LookbackOptionPayoff,
+    LookbackOptionSpec,
+)
+from trellis.models.analytical.equity_exotics import (
+    price_equity_fixed_lookback_option_analytical,
+)
+from trellis.models.vol_surface import FlatVol
+
+
+SETTLEMENT = date(2024, 11, 15)
+EXPIRY = date(2025, 11, 15)
+
+
+def _market_state(
+    *,
+    spot: float | None = None,
+    rate: float = 0.05,
+    volatility: float = 0.2,
+    settlement: date = SETTLEMENT,
+) -> MarketState:
+    return MarketState(
+        as_of=settlement,
+        settlement=settlement,
+        discount=YieldCurve.flat(rate),
+        vol_surface=FlatVol(volatility),
+        spot=spot,
+    )
+
+
+def _spec(
+    *,
+    option_type: str = "call",
+    strike: float = 100.0,
+    running_extreme: float = 100.0,
+    dividend_yield: float = 0.01,
+) -> LookbackOptionSpec:
+    return LookbackOptionSpec(
+        notional=2.0,
+        spot=100.0,
+        strike=strike,
+        expiry_date=EXPIRY,
+        option_type=option_type,
+        running_extreme=running_extreme,
+        dividend_yield=dividend_yield,
+        monitoring_style="continuous",
+        exercise_style="european",
+    )
+
+
+@pytest.mark.parametrize(
+    ("option_type", "strike", "running_extreme"),
+    [
+        ("call", 110.0, 105.0),
+        ("call", 90.0, 110.0),
+        ("put", 110.0, 90.0),
+        ("put", 80.0, 90.0),
+    ],
+)
+def test_checked_lookback_adapter_matches_retained_reference_across_formula_branches(
+    option_type,
+    strike,
+    running_extreme,
+):
+    spec = _spec(
+        option_type=option_type,
+        strike=strike,
+        running_extreme=running_extreme,
+    )
+
+    actual = LookbackOptionPayoff(spec).evaluate(_market_state())
+    expected = price_equity_fixed_lookback_option_analytical(_market_state(), spec)
+
+    assert actual == pytest.approx(expected, rel=2e-10, abs=2e-10)
+
+
+@pytest.mark.parametrize("option_type", ["call", "put"])
+def test_checked_lookback_adapter_has_continuous_zero_carry_limit(option_type):
+    running_extreme = 110.0 if option_type == "call" else 90.0
+    exact = LookbackOptionPayoff(
+        _spec(
+            option_type=option_type,
+            running_extreme=running_extreme,
+            dividend_yield=0.05,
+        )
+    ).evaluate(_market_state(rate=0.05))
+    below = LookbackOptionPayoff(
+        _spec(
+            option_type=option_type,
+            running_extreme=running_extreme,
+            dividend_yield=0.05 - 1e-7,
+        )
+    ).evaluate(_market_state(rate=0.05))
+    above = LookbackOptionPayoff(
+        _spec(
+            option_type=option_type,
+            running_extreme=running_extreme,
+            dividend_yield=0.05 + 1e-7,
+        )
+    ).evaluate(_market_state(rate=0.05))
+
+    assert isfinite(exact)
+    assert exact == pytest.approx((below + above) / 2.0, rel=2e-7, abs=2e-7)
+
+
+def test_checked_lookback_adapter_honors_runtime_spot_for_generic_delta():
+    payoff = LookbackOptionPayoff(_spec(option_type="call", running_extreme=100.0))
+    market_state = _market_state(spot=100.0)
+
+    delta = float(Delta(bump_pct=0.1).compute(payoff, market_state))
+
+    assert delta > 0.0
+    assert payoff.evaluate(_market_state(spot=101.0)) != pytest.approx(
+        payoff.evaluate(_market_state(spot=99.0))
+    )
+
+
+@pytest.mark.parametrize(
+    ("option_type", "running_extreme", "message"),
+    [
+        ("call", 99.0, "running maximum"),
+        ("put", 101.0, "running minimum"),
+    ],
+)
+def test_checked_lookback_adapter_rejects_invalid_historical_extreme(
+    option_type,
+    running_extreme,
+    message,
+):
+    with pytest.raises(ValueError, match=message):
+        LookbackOptionPayoff(
+            _spec(option_type=option_type, running_extreme=running_extreme)
+        ).evaluate(_market_state())
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("lookback_type", "floating_strike", "fixed_strike"),
+        ("monitoring_style", "discrete", "continuous"),
+        ("exercise_style", "american", "European"),
+        ("option_type", "straddle", "call or put"),
+    ],
+)
+def test_checked_lookback_adapter_rejects_unsupported_contract_semantics(
+    field,
+    value,
+    message,
+):
+    spec = _spec()
+    payload = {name: getattr(spec, name) for name in spec.__dataclass_fields__}
+    payload[field] = value
+
+    with pytest.raises(ValueError, match=message):
+        LookbackOptionPayoff(LookbackOptionSpec(**payload)).evaluate(_market_state())
+
+
+@pytest.mark.parametrize(
+    ("option_type", "spot", "running_extreme", "expected"),
+    [
+        ("call", 115.0, 110.0, 30.0),
+        ("put", 85.0, 90.0, 30.0),
+    ],
+)
+def test_checked_lookback_adapter_uses_intrinsic_settlement_at_expiry(
+    option_type,
+    spot,
+    running_extreme,
+    expected,
+):
+    spec = _spec(
+        option_type=option_type,
+        strike=100.0,
+        running_extreme=running_extreme,
+    )
+
+    price = LookbackOptionPayoff(spec).evaluate(
+        _market_state(spot=spot, settlement=EXPIRY)
+    )
+
+    assert price == pytest.approx(expected)
+
+
+def test_checked_lookback_adapter_rejects_nonpositive_volatility_before_expiry():
+    with pytest.raises(ValueError, match="positive volatility"):
+        LookbackOptionPayoff(_spec()).evaluate(_market_state(volatility=0.0))
+
+
+def test_checked_lookback_adapter_source_composes_reusable_primitives():
+    source_path = (
+        Path(__file__).resolve().parents[2]
+        / "trellis/instruments/_agent/lookbackoption.py"
+    )
+    source = source_path.read_text(encoding="utf-8")
+
+    assert "price_equity_fixed_lookback_option_analytical" not in source
+    for symbol in (
+        "resolve_scalar_diffusion_market_inputs",
+        "year_fraction",
+        "normalized_option_type",
+        "discount_factor_from_zero_rate",
+        "standard_normal_cdf",
+    ):
+        assert symbol in source

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -5914,9 +5914,6 @@ def _deterministic_exact_binding_evaluate_body(
         "trellis.models.analytical.equity_exotics.price_equity_digital_option_analytical": (
             "return price_equity_digital_option_analytical(market_state, spec)"
         ),
-        "trellis.models.analytical.equity_exotics.price_equity_fixed_lookback_option_analytical": (
-            "return price_equity_fixed_lookback_option_analytical(market_state, spec)"
-        ),
         "trellis.models.equity_option_pde.price_equity_digital_option_pde": (
             "return price_equity_digital_option_pde(market_state, spec)"
         ),

--- a/trellis/agent/financepy_reference.py
+++ b/trellis/agent/financepy_reference.py
@@ -395,17 +395,30 @@ def _lookback_reference(*, contract: Mapping[str, Any], scenario_inputs: Mapping
     )
     discount_curve = _flat_curve(float(contract["domestic_rate"]), value_dt)
     dividend_curve = _flat_curve(float(contract["dividend_rate"]), value_dt)
-    return {
-        "price": float(
+    spot = float(contract["spot"])
+    historical_extreme = float(contract.get("running_extreme", spot))
+    option_type = str(contract["option_type"]).strip().lower()
+
+    def price_at_spot(stock_level: float) -> float:
+        effective_extreme = (
+            max(historical_extreme, stock_level)
+            if option_type == "call"
+            else min(historical_extreme, stock_level)
+        )
+        return float(
             option.value(
                 value_dt,
-                float(contract["spot"]),
+                stock_level,
                 discount_curve,
                 dividend_curve,
                 float(contract["volatility"]),
-                float(contract["spot"]),
+                effective_extreme,
             )
         )
+
+    return {
+        "price": price_at_spot(spot),
+        "delta": _central_spot_delta(price_at_spot, spot),
     }
 
 

--- a/trellis/agent/knowledge/canonical/api_map.yaml
+++ b/trellis/agent/knowledge/canonical/api_map.yaml
@@ -60,7 +60,7 @@ analytical_gaussian_composition:
   module: trellis.models.analytical.support.probability
   methods: [analytical]
   navigation:
-    aliases: [gaussian_probability, bivariate_gaussian, critical_state, scalar_root, lookback_option]
+    aliases: [gaussian_probability, bivariate_gaussian, critical_state, scalar_root]
   modules:
     probability: trellis.models.analytical.support.probability
     scalar_root: trellis.models.calibration.solve_request
@@ -72,6 +72,31 @@ analytical_gaussian_composition:
     - "For an implicit critical state, define the derivative-specific scalar objective in adapter code and solve it through a bounded root_scalar SolveRequest; do not introduce route-local Newton loops or product helpers"
     - "The generated adapter owns the contractual formula, critical-state equation, discounting, and notional application; this card supplies navigation and reusable numerical pieces only"
     - "The bivariate kernel admits finite thresholds and correlations in the closed interval [-1, 1], handles exact singular boundaries explicitly, and fails closed outside that domain"
+
+# ---------------------------------------------------------------------------
+# Fixed-strike continuous lookback analytical composition
+# ---------------------------------------------------------------------------
+fixed_lookback_analytical_composition:
+  module: trellis.models.resolution.single_state_diffusion
+  methods: [analytical]
+  navigation:
+    aliases: [lookback_option, fixed_lookback_option, fixed_strike_lookback, continuous_lookback, conze_viswanathan]
+  modules:
+    market_binding: trellis.models.resolution.single_state_diffusion
+    time_measure: trellis.core.date_utils
+    analytical_support: trellis.models.analytical.support
+    probability: trellis.models.analytical.support.probability
+  key_imports:
+    - "from trellis.models.resolution.single_state_diffusion import resolve_scalar_diffusion_market_inputs"
+    - "from trellis.core.date_utils import year_fraction"
+    - "from trellis.models.analytical.support import discount_factor_from_zero_rate, normalized_option_type"
+    - "from trellis.models.analytical.support.probability import standard_normal_cdf"
+  notes:
+    - "Admitted scope is a European fixed-strike continuously monitored call or put under one constant rate, dividend yield, and Black volatility resolved at the expiry and strike coordinate"
+    - "Validate positive finite spot, strike, volatility, and running extreme; a call running maximum must be at least contract spot and a put running minimum must be at most contract spot"
+    - "Use runtime MarketState.spot when present and include it in the effective maximum or minimum so generic spot-bump Delta follows the same payoff contract"
+    - "Generated code owns the Conze-Viswanathan call/put branch, discounting, expiry intrinsic settlement, and one-time notional scaling; use the analytic carry-to-zero limit instead of perturbing dividend yield"
+    - "Reject floating strike, discrete monitoring, non-European exercise, non-scalar or non-constant diffusion dynamics, and non-finite formula outputs; do not call a product lookback helper"
 
 # ---------------------------------------------------------------------------
 # Simple chooser option raw composition

--- a/trellis/agent/knowledge/canonical/backend_bindings.yaml
+++ b/trellis/agent/knowledge/canonical/backend_bindings.yaml
@@ -995,9 +995,21 @@ bindings:
             exercise:
               style: european
         primitives:
-          - module: trellis.models.analytical.equity_exotics
-            symbol: price_equity_fixed_lookback_option_analytical
-            role: route_helper
+          - module: trellis.models.resolution.single_state_diffusion
+            symbol: resolve_scalar_diffusion_market_inputs
+            role: market_binding
+          - module: trellis.core.date_utils
+            symbol: year_fraction
+            role: time_measure
+          - module: trellis.models.analytical.support
+            symbol: normalized_option_type
+            role: payoff_primitive
+          - module: trellis.models.analytical.support
+            symbol: discount_factor_from_zero_rate
+            role: discounting
+          - module: trellis.models.analytical.support.probability
+            symbol: standard_normal_cdf
+            role: probability_kernel
       - when:
           contract_pattern:
             payoff:

--- a/trellis/agent/knowledge/canonical/decompositions.yaml
+++ b/trellis/agent/knowledge/canonical/decompositions.yaml
@@ -432,11 +432,16 @@
   features: [lookback, path_dependent, discounting, vol_surface_dependence]
   method: analytical
   method_modules:
-    - trellis.models.analytical.equity_exotics
+    - trellis.models.resolution.single_state_diffusion
+    - trellis.models.analytical.support
+    - trellis.models.analytical.support.probability
   required_market_data: [discount_curve, black_vol_surface]
   modeling_requirements:
-    - "USE THE EXACT HELPER: Call `price_equity_fixed_lookback_option_analytical(market_state, spec)` directly; do not restate the running-extreme formula inside the generated payoff."
-  reasoning: "Fixed-strike lookback options have a Conze-Viswanathan closed form; use the shared analytical helper."
+    - "Admit only European fixed-strike continuous monitoring under constant scalar diffusion inputs; reject floating strike, discrete monitoring, non-European exercise, local/stochastic volatility, and jumps."
+    - "Resolve the runtime spot and strike volatility coordinate with `resolve_scalar_diffusion_market_inputs`, normalize call/put semantics, and use `standard_normal_cdf` plus explicit scalar math for the Conze-Viswanathan formula."
+    - "Validate the historical running maximum/minimum against contract spot, include runtime spot in the effective extreme, apply the analytic zero-carry limit, and own expiry settlement and one-time notional scaling in generated code."
+    - "Do not call a product-specific analytical lookback helper; retained wrappers are compatibility/reference evidence only."
+  reasoning: "The admitted fixed-strike continuous lookback formula is a bounded composition over scalar market, time, discounting, option-normalization, and Gaussian primitives."
   learned: false
 
 - instrument: chooser_option

--- a/trellis/agent/knowledge/canonical/routes.yaml
+++ b/trellis/agent/knowledge/canonical/routes.yaml
@@ -1613,12 +1613,26 @@ routes:
             exercise:
               style: european
         primitives:
-          - module: trellis.models.analytical.equity_exotics
-            symbol: price_equity_fixed_lookback_option_analytical
-            role: route_helper
+          - module: trellis.models.resolution.single_state_diffusion
+            symbol: resolve_scalar_diffusion_market_inputs
+            role: market_binding
+          - module: trellis.core.date_utils
+            symbol: year_fraction
+            role: time_measure
+          - module: trellis.models.analytical.support
+            symbol: normalized_option_type
+            role: payoff_primitive
+          - module: trellis.models.analytical.support
+            symbol: discount_factor_from_zero_rate
+            role: discounting
+          - module: trellis.models.analytical.support.probability
+            symbol: standard_normal_cdf
+            role: probability_kernel
         adapters: []
         notes:
-          - "Use the dedicated lookback helper with `market_state` and `spec`; do not restate the running-extreme formula inside the generated payoff."
+          - "Admit only European fixed-strike continuous monitoring under constant scalar diffusion inputs and use the `fixed_lookback_analytical_composition` API-map card."
+          - "Generated code owns the call/put formula, historical and runtime extreme invariants, analytic zero-carry limit, expiry settlement, and one-time notional scaling."
+          - "Do not call a product-specific analytical lookback helper; retained wrappers are comparison evidence only."
       - when:
           contract_pattern:
             payoff:

--- a/trellis/instruments/_agent/lookbackoption.py
+++ b/trellis/instruments/_agent/lookbackoption.py
@@ -217,7 +217,7 @@ class LookbackOptionPayoff:
                 + spot * rate_discount * correction
             )
 
-        price = notional * unit_price
+        price = float(notional * unit_price)
         if not isfinite(price):
             raise ValueError("analytical lookback formula returned a non-finite price")
-        return float(price)
+        return price

--- a/trellis/instruments/_agent/lookbackoption.py
+++ b/trellis/instruments/_agent/lookbackoption.py
@@ -1,92 +1,58 @@
-"""Agent-generated payoff: Build a pricer for: FinancePy parity: equity fixed lookback option
-
-lookback_option
-
-Spot: 100.0.
-Strike: 100.0.
-Option type: call.
-Lookback type: fixed_strike.
-Running extreme: 100.0.
-Expiry date: 2025-11-15.
-
-Preferred method family: analytical
-FinancePy binding: financepy.equity.lookback.fixed
-Benchmark product: lookback_option
-
-Construct methods: analytical
-Comparison targets: analytical (analytical)
-Cross-validation harness:
-  external targets: financepy
-
-Implementation target: analytical."""
+"""Checked analytical adapter for the FinancePy fixed-lookback parity task."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import date
+from math import exp, isfinite, log, pi, sqrt
 
+from trellis.core.date_utils import year_fraction
 from trellis.core.market_state import MarketState
 from trellis.core.types import DayCountConvention
-from trellis.models.analytical import price_equity_fixed_lookback_option_analytical
-from trellis.core.date_utils import year_fraction
+from trellis.models.analytical.support import (
+    discount_factor_from_zero_rate,
+    normalized_option_type,
+)
+from trellis.models.analytical.support.probability import standard_normal_cdf
+from trellis.models.resolution.single_state_diffusion import (
+    resolve_scalar_diffusion_market_inputs,
+)
 
+
+_CARRY_LIMIT = 1e-8
 
 
 @dataclass(frozen=True)
 class LookbackOptionSpec:
-    """Specification for Build a pricer for: FinancePy parity: equity fixed lookback option
+    """Admitted continuously monitored European fixed-strike contract."""
 
-lookback_option
-
-Spot: 100.0.
-Strike: 100.0.
-Option type: call.
-Lookback type: fixed_strike.
-Running extreme: 100.0.
-Expiry date: 2025-11-15.
-
-Preferred method family: analytical
-FinancePy binding: financepy.equity.lookback.fixed
-Benchmark product: lookback_option
-
-Construct methods: analytical
-Comparison targets: analytical (analytical)
-Cross-validation harness:
-  external targets: financepy
-
-Implementation target: analytical."""
     notional: float
     spot: float
     strike: float
     expiry_date: date
-    option_type: str = 'call'
-    lookback_type: str = 'fixed_strike'
+    option_type: str = "call"
+    lookback_type: str = "fixed_strike"
     running_extreme: float | None = None
+    dividend_yield: float | None = None
+    monitoring_style: str = "continuous"
+    exercise_style: str = "european"
     day_count: DayCountConvention = DayCountConvention.ACT_365
 
 
+@dataclass(frozen=True)
+class _ScalarMarketCoordinate:
+    spot: float
+    expiry_date: date
+    day_count: DayCountConvention
+    dividend_yield: float | None = None
+
+
+def _standard_normal_pdf(value: float) -> float:
+    return exp(-0.5 * value * value) / sqrt(2.0 * pi)
+
+
 class LookbackOptionPayoff:
-    """Build a pricer for: FinancePy parity: equity fixed lookback option
-
-lookback_option
-
-Spot: 100.0.
-Strike: 100.0.
-Option type: call.
-Lookback type: fixed_strike.
-Running extreme: 100.0.
-Expiry date: 2025-11-15.
-
-Preferred method family: analytical
-FinancePy binding: financepy.equity.lookback.fixed
-Benchmark product: lookback_option
-
-Construct methods: analytical
-Comparison targets: analytical (analytical)
-Cross-validation harness:
-  external targets: financepy
-
-Implementation target: analytical."""
+    """Compose the admitted closed form from reusable Trellis primitives."""
 
     def __init__(self, spec: LookbackOptionSpec):
         self._spec = spec
@@ -101,22 +67,157 @@ Implementation target: analytical."""
 
     def evaluate(self, market_state: MarketState) -> float:
         spec = self._spec
-        from trellis.models.analytical import price_equity_fixed_lookback_option_analytical
+        if str(spec.lookback_type).strip().lower() != "fixed_strike":
+            raise ValueError("analytical lookback pricing requires fixed_strike")
+        if str(spec.monitoring_style).strip().lower() != "continuous":
+            raise ValueError(
+                "analytical lookback pricing requires continuous monitoring"
+            )
+        if str(spec.exercise_style).strip().lower() != "european":
+            raise ValueError("analytical lookback pricing requires European exercise")
+        try:
+            option_type = normalized_option_type(spec.option_type)
+        except ValueError as exc:
+            raise ValueError("lookback option_type must be call or put") from exc
 
-        if self._spec.lookback_type != "fixed_strike":
-            raise ValueError(f"Unsupported lookback_type: {self._spec.lookback_type!r}")
-        if self._spec.option_type not in {"call", "put"}:
-            raise ValueError(f"Unsupported option_type: {self._spec.option_type!r}")
-        if not hasattr(market_state, "discount") or market_state.discount is None:
-            raise ValueError("market_state.discount is required")
-        if not hasattr(market_state, "vol_surface") or market_state.vol_surface is None:
-            raise ValueError("market_state.vol_surface is required")
+        settlement = market_state.settlement or market_state.as_of
+        if settlement is None:
+            raise ValueError("lookback pricing requires settlement or as_of")
+        maturity = float(year_fraction(settlement, spec.expiry_date, spec.day_count))
+        if maturity < 0.0:
+            raise ValueError("lookback expiry must not precede settlement")
 
-        t = year_fraction(market_state.as_of, self._spec.expiry_date, self._spec.day_count)
-        if t < 0:
-            raise ValueError("Expiry date must not be before valuation date")
+        contract_spot = float(spec.spot)
+        runtime_spot = market_state.spot
+        spot = float(contract_spot if runtime_spot is None else runtime_spot)
+        strike = float(spec.strike)
+        notional = float(spec.notional)
+        historical_extreme = float(
+            contract_spot if spec.running_extreme is None else spec.running_extreme
+        )
+        if not all(
+            isfinite(value)
+            for value in (contract_spot, spot, strike, notional, historical_extreme)
+        ):
+            raise ValueError("lookback scalar contract values must be finite")
+        if contract_spot <= 0.0 or spot <= 0.0 or strike <= 0.0:
+            raise ValueError("lookback spot and strike must be positive")
+        if historical_extreme <= 0.0:
+            raise ValueError("lookback running extreme must be positive")
 
-        vol = market_state.vol_surface.black_vol(t, self._spec.strike)
-        _ = vol  # keep explicit market binding visible; analytical helper resolves pricing inputs
+        if option_type == "call":
+            if historical_extreme < contract_spot:
+                raise ValueError(
+                    "lookback running maximum must be at least contract spot"
+                )
+            running_extreme = max(historical_extreme, spot)
+        else:
+            if historical_extreme > contract_spot:
+                raise ValueError(
+                    "lookback running minimum must not exceed contract spot"
+                )
+            running_extreme = min(historical_extreme, spot)
 
-        return float(price_equity_fixed_lookback_option_analytical(market_state, self._spec))
+        if maturity == 0.0:
+            intrinsic = (
+                max(running_extreme - strike, 0.0)
+                if option_type == "call"
+                else max(strike - running_extreme, 0.0)
+            )
+            return notional * intrinsic
+
+        coordinate = _ScalarMarketCoordinate(
+            spot=spot,
+            expiry_date=spec.expiry_date,
+            day_count=spec.day_count,
+            dividend_yield=spec.dividend_yield,
+        )
+        resolved = resolve_scalar_diffusion_market_inputs(
+            market_state,
+            coordinate,
+            volatility_coordinate=strike,
+        )
+        rate = resolved.rate
+        dividend_yield = resolved.dividend_yield
+        sigma = resolved.sigma
+        if sigma <= 0.0:
+            raise ValueError("analytical lookback pricing requires positive volatility")
+
+        sigma_squared = sigma * sigma
+        sigma_sqrt_time = sigma * sqrt(maturity)
+        carry = rate - dividend_yield
+        rate_discount = discount_factor_from_zero_rate(rate, maturity)
+        dividend_discount = discount_factor_from_zero_rate(
+            dividend_yield,
+            maturity,
+        )
+
+        def carry_correction(boundary: float) -> tuple[float, float, float]:
+            log_moneyness = log(spot / boundary)
+            d1 = (
+                log_moneyness + (carry + 0.5 * sigma_squared) * maturity
+            ) / sigma_sqrt_time
+            d2 = d1 - sigma_sqrt_time
+            if abs(carry) <= _CARRY_LIMIT:
+                density = _standard_normal_pdf(d1)
+                if option_type == "call":
+                    correction = (
+                        log_moneyness + 0.5 * sigma_squared * maturity
+                    ) * standard_normal_cdf(d1) + sigma_sqrt_time * density
+                else:
+                    correction = (
+                        -log_moneyness - 0.5 * sigma_squared * maturity
+                    ) * standard_normal_cdf(-d1) + sigma_sqrt_time * density
+                return d1, d2, correction
+
+            weight = 2.0 * carry / sigma_squared
+            carry_growth = exp(carry * maturity)
+            shifted_d1 = d1 - 2.0 * carry * sqrt(maturity) / sigma
+            at_boundary = abs(log_moneyness) <= 1e-14
+            if option_type == "call":
+                if at_boundary:
+                    term = -standard_normal_cdf(
+                        shifted_d1
+                    ) + carry_growth * standard_normal_cdf(d1)
+                elif weight > 100.0:
+                    term = carry_growth * standard_normal_cdf(d1)
+                else:
+                    term = -exp(-weight * log_moneyness) * standard_normal_cdf(
+                        shifted_d1
+                    ) + carry_growth * standard_normal_cdf(d1)
+            else:
+                if at_boundary:
+                    term = standard_normal_cdf(
+                        -shifted_d1
+                    ) - carry_growth * standard_normal_cdf(-d1)
+                elif weight < -100.0:
+                    term = -carry_growth * standard_normal_cdf(-d1)
+                else:
+                    term = exp(-weight * log_moneyness) * standard_normal_cdf(
+                        -shifted_d1
+                    ) - carry_growth * standard_normal_cdf(-d1)
+            return d1, d2, sigma_squared * term / (2.0 * carry)
+
+        if option_type == "call":
+            boundary = max(strike, running_extreme)
+            d1, d2, correction = carry_correction(boundary)
+            unit_price = (
+                rate_discount * max(running_extreme - strike, 0.0)
+                + spot * dividend_discount * standard_normal_cdf(d1)
+                - boundary * rate_discount * standard_normal_cdf(d2)
+                + spot * rate_discount * correction
+            )
+        else:
+            boundary = min(strike, running_extreme)
+            d1, d2, correction = carry_correction(boundary)
+            unit_price = (
+                rate_discount * max(strike - running_extreme, 0.0)
+                - spot * dividend_discount * standard_normal_cdf(-d1)
+                + boundary * rate_discount * standard_normal_cdf(-d2)
+                + spot * rate_discount * correction
+            )
+
+        price = notional * unit_price
+        if not isfinite(price):
+            raise ValueError("analytical lookback formula returned a non-finite price")
+        return float(price)


### PR DESCRIPTION
## Summary
- replace fixed-lookback analytical helper authority with reusable scalar market, time, discounting, option, and Gaussian primitives
- make the checked F011 adapter own the admitted call/put formula, exact zero-carry limit, path-extreme invariants, expiry settlement, and runtime-spot Delta behavior
- add builder navigation and quant/developer/user documentation without cookbook mutation
- compare both price and generic bump-and-reprice Delta against FinancePy

## Validation
- `make gate-pr`: 4,601 main tests passed; 32 tier-2 contract tests passed
- strict cached F011 replay: 1/1, first attempt, zero LLM calls/tokens
- FinancePy: price deviation 0.003780%; Delta deviation 0.000862%
- bounded remediation: zero failures
- Sphinx HTML build succeeded with no warnings from changed pages

Linear: QUA-1194