### PR TITLE
Sync variance swap helper retirement plan

### DIFF
--- a/doc/plan/active__semantic-task-synthesis-helper-retirement.md
+++ b/doc/plan/active__semantic-task-synthesis-helper-retirement.md
@@ -55,7 +55,7 @@ Status mirror last synced: `2026-07-15`
 | `QUA-1191` | Chooser option pricing: retire analytical helper authority | Done |
 | `QUA-1193` | Compound option pricing: retire analytical helper authority | Done |
 | `QUA-1194` | Fixed lookback pricing: retire analytical helper authority | Done |
-| `QUA-1195` | Variance swap pricing: retire analytical helper authority | In Progress |
+| `QUA-1195` | Variance swap pricing: retire analytical helper authority | Done |
 
 ## Current Sequence
 
@@ -71,9 +71,10 @@ Status mirror last synced: `2026-07-15`
 4. Apply the reviewed QUA-1194 fixed-lookback precedent: compose the admitted
    analytical formula from scalar market, time, Gaussian, and discounting
    primitives while retaining the product wrapper only as comparison evidence.
-5. Complete QUA-1195 by composing the admitted analytical variance-swap
-   smile-slope approximation from time, interpolation, and discounting
-   primitives while retaining wrappers only as comparison evidence.
+5. Apply the reviewed QUA-1195 variance-swap precedent: compose the admitted
+   analytical smile-slope approximation from time, interpolation, and
+   discounting primitives while retaining wrappers only as comparison
+   evidence.
 6. Select the next helper-authority family from the machine-readable audit and
    create a bounded ticket before changing another route.
 7. Run live fresh-generation evidence only with current external-model approval;


### PR DESCRIPTION
## Summary
- mark QUA-1195 Done in the local execution mirror after PR #803 merged
- restate the variance-swap implementation as a reviewed precedent

## Validation
- documentation-only diff review
- git diff --check

Linear: QUA-1195