### PR TITLE
QUA-1196 Retire swaption Black76 wrapper authority

### DIFF
--- a/docs/benchmarks/contract_ir_solver_parity.json
+++ b/docs/benchmarks/contract_ir_solver_parity.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-15T09:19:35.932194+00:00",
-  "repo_revision": "4cbdc05b33f1e581d9197ae385d26cf9b2a2ded9",
+  "generated_at": "2026-07-15T17:49:57.950596+00:00",
+  "repo_revision": "3515cb6b1babd7399754593a01152c7877c2b086",
   "status": "completed",
   "families": [
     {
@@ -373,17 +373,17 @@
           "preferred_method": "analytical",
           "expected_source": "semantic_blueprint",
           "expected_shadow_status": "bound",
-          "expected_declaration_id": "helper_swaption_payer_black76",
+          "expected_declaration_id": "swaption_payer_black76_resolved_kernel",
           "source": "semantic_blueprint",
           "shadow_status": "bound",
           "shadow_error": null,
           "legacy_route_id": null,
           "legacy_route_family": "analytical",
           "legacy_exact_target_refs": [
-            "trellis.models.rate_style_swaption.price_swaption_black76"
+            "trellis.models.rate_style_swaption.price_swaption_black76_raw"
           ],
           "legacy_exact_target_contains_structural_callable": true,
-          "selection_declaration_id": "helper_swaption_payer_black76",
+          "selection_declaration_id": "swaption_payer_black76_resolved_kernel",
           "selection_generated_route_authority": true,
           "route_free_authority": true,
           "selection_matches_structural_declaration": true,
@@ -395,8 +395,8 @@
           "product_ir_payoff_family": "swaption",
           "passed": true,
           "structural_contract_ir": "ContractIR(payoff=Scaled(scalar=Annuity(underlier_id='USD-IRS-5Y', schedule=FiniteSchedule(dates=(datetime.date(2026, 11, 15), datetime.date(2027, 11, 15), datetime.date(2028, 11, 15), datetime.date(2029, 11, 15), datetime.date(2030, 11, 15)))), body=Max(args=(Sub(lhs=SwapRate(underlier_id='USD-IRS-5Y', schedule=FiniteSchedule(dates=(datetime.date(2026, 11, 15), datetime.date(2027, 11, 15), datetime.date(2028, 11, 15), datetime.date(2029, 11, 15), datetime.date(2030, 11, 15)))), rhs=Strike(value=0.05)), Constant(value=0.0)))), exercise=Exercise(style='european', schedule=Singleton(t=datetime.date(2025, 11, 15))), observation=Observation(kind='terminal', schedule=Singleton(t=datetime.date(2025, 11, 15))), underlying=Underlying(spec=ForwardRate(name='USD-IRS-5Y', dynamics='lognormal_forward')))",
-          "declaration_id": "helper_swaption_payer_black76",
-          "callable_ref": "trellis.models.rate_style_swaption.price_swaption_black76",
+          "declaration_id": "swaption_payer_black76_resolved_kernel",
+          "callable_ref": "trellis.models.rate_style_swaption.price_swaption_black76_raw",
           "structural_price": 3.782585433884869e-05,
           "reference_price": 3.782585433884869e-05,
           "abs_diff": 0.0,
@@ -410,17 +410,17 @@
           "preferred_method": "analytical",
           "expected_source": "semantic_blueprint",
           "expected_shadow_status": "bound",
-          "expected_declaration_id": "helper_swaption_receiver_black76",
+          "expected_declaration_id": "swaption_receiver_black76_resolved_kernel",
           "source": "semantic_blueprint",
           "shadow_status": "bound",
           "shadow_error": null,
           "legacy_route_id": null,
           "legacy_route_family": "analytical",
           "legacy_exact_target_refs": [
-            "trellis.models.rate_style_swaption.price_swaption_black76"
+            "trellis.models.rate_style_swaption.price_swaption_black76_raw"
           ],
           "legacy_exact_target_contains_structural_callable": true,
-          "selection_declaration_id": "helper_swaption_receiver_black76",
+          "selection_declaration_id": "swaption_receiver_black76_resolved_kernel",
           "selection_generated_route_authority": true,
           "route_free_authority": true,
           "selection_matches_structural_declaration": true,
@@ -432,8 +432,8 @@
           "product_ir_payoff_family": "swaption",
           "passed": true,
           "structural_contract_ir": "ContractIR(payoff=Scaled(scalar=Annuity(underlier_id='USD-IRS-5Y', schedule=FiniteSchedule(dates=(datetime.date(2026, 11, 15), datetime.date(2027, 11, 15), datetime.date(2028, 11, 15), datetime.date(2029, 11, 15), datetime.date(2030, 11, 15)))), body=Max(args=(Sub(lhs=Strike(value=0.05), rhs=SwapRate(underlier_id='USD-IRS-5Y', schedule=FiniteSchedule(dates=(datetime.date(2026, 11, 15), datetime.date(2027, 11, 15), datetime.date(2028, 11, 15), datetime.date(2029, 11, 15), datetime.date(2030, 11, 15))))), Constant(value=0.0)))), exercise=Exercise(style='european', schedule=Singleton(t=datetime.date(2025, 11, 15))), observation=Observation(kind='terminal', schedule=Singleton(t=datetime.date(2025, 11, 15))), underlying=Underlying(spec=ForwardRate(name='USD-IRS-5Y', dynamics='lognormal_forward')))",
-          "declaration_id": "helper_swaption_receiver_black76",
-          "callable_ref": "trellis.models.rate_style_swaption.price_swaption_black76",
+          "declaration_id": "swaption_receiver_black76_resolved_kernel",
+          "callable_ref": "trellis.models.rate_style_swaption.price_swaption_black76_raw",
           "structural_price": 0.0899413945129767,
           "reference_price": 0.0899413945129767,
           "abs_diff": 0.0,

--- a/docs/benchmarks/contract_ir_solver_parity.md
+++ b/docs/benchmarks/contract_ir_solver_parity.md
@@ -1,7 +1,7 @@
 # ContractIR Structural Compiler Parity
 
-- Generated at: `2026-07-15T09:19:35.932194+00:00`
-- Repo revision: `4cbdc05b33f1e581d9197ae385d26cf9b2a2ded9`
+- Generated at: `2026-07-15T17:49:57.950596+00:00`
+- Repo revision: `3515cb6b1babd7399754593a01152c7877c2b086`
 
 ## Family Summary
 
@@ -54,9 +54,9 @@
 
 | Case | Source | Shadow | Declaration | Route | Exact-target contains callable | Passed |
 | --- | --- | --- | --- | --- | --- | --- |
-| swaption_payer | semantic_blueprint | bound | helper_swaption_payer_black76 |  | True | True |
+| swaption_payer | semantic_blueprint | bound | swaption_payer_black76_resolved_kernel |  | True | True |
 - `swaption_payer` value parity: structural=`3.782585433884869e-05` reference=`3.782585433884869e-05` abs_diff=`0.0`
-| swaption_receiver | semantic_blueprint | bound | helper_swaption_receiver_black76 |  | True | True |
+| swaption_receiver | semantic_blueprint | bound | swaption_receiver_black76_resolved_kernel |  | True | True |
 - `swaption_receiver` value parity: structural=`0.0899413945129767` reference=`0.0899413945129767` abs_diff=`0.0`
 
 ## vanilla_option

--- a/docs/developer/contract_ir_solver_compiler.rst
+++ b/docs/developer/contract_ir_solver_compiler.rst
@@ -69,7 +69,7 @@ The design rule is strict:
 
 - do not introduce ``VanillaEconomicTerms`` / ``SwaptionEconomicTerms`` style
   payloads
-- if a helper cannot be bound from ``ContractIR`` plus reusable term groups,
+- if a callable cannot be bound from ``ContractIR`` plus reusable term groups,
   that family is not structurally ready yet
 
 Admitted Families
@@ -79,7 +79,9 @@ The default Phase 3 registry admits:
 
 1. European Black76 call / put ramps
 2. Cash-or-nothing and asset-or-nothing digitals
-3. European payer / receiver swaptions via ``price_swaption_black76``
+3. European payer / receiver swaptions via
+   ``resolve_swaption_black76_inputs(...)`` followed by
+   ``price_swaption_black76_raw(...)``
 4. Two-asset analytical basket / spread call / put helpers
 5. Equity variance swaps via direct structural-solver compatibility
    declarations on ``price_equity_variance_swap_analytical`` and
@@ -100,6 +102,16 @@ They are not generated-task route authority: analytical task construction now
 receives time, linear interpolation, and discounting primitives, with quote
 validation and settlement owned by generated adapter code. The analytical
 reference is not a full option-strip or log-contract replication.
+
+The swaption declarations demonstrate the intended migration shape for a
+previously helper-authoritative family. Structural selection records the raw
+kernel as ``callable_ref``, records the resolver under ``market_binding_refs``,
+and leaves ``helper_refs`` empty. The binding adapter constructs the generic
+rate and accrual terms, calls the public resolver once, and passes only the
+typed ``ResolvedSwaptionBlack76Inputs`` value to the raw kernel. The public
+``price_swaption_black76(...)`` wrapper remains available to compatibility
+callers and independent validation, but it is not structural or generated
+construction authority.
 
 This boundary is machine-readable. ``ContractIRSolverProvenance`` defaults
 ``generated_route_authority`` to true for declarations that may replace route

--- a/docs/quant/contract_ir.rst
+++ b/docs/quant/contract_ir.rst
@@ -455,7 +455,7 @@ The important boundary rule is unchanged:
 
 - if a field changes structural payoff family or pattern match, it belongs in
   ``ContractIR``
-- if it preserves the structural family but changes helper materialization, it
+- if it preserves the structural family but changes callable materialization, it
   may belong in the generic term environment
 
 Phase 3 Families
@@ -468,7 +468,9 @@ The current bounded structural-solver wave covers:
 2. Cash-or-nothing and asset-or-nothing digitals through the same Black76
    basis family
 3. European payer / receiver swaptions through
-   ``trellis.models.rate_style_swaption.price_swaption_black76``
+   ``resolve_swaption_black76_inputs(...)`` and
+   ``price_swaption_black76_raw(...)`` in
+   ``trellis.models.rate_style_swaption``
 4. Two-asset analytical basket / spread call / put payoffs through
    ``trellis.models.basket_option.price_basket_option_analytical``
 5. Equity variance swaps through the bounded FinancePy-compatible smile-slope
@@ -497,10 +499,16 @@ That is the contract Phase 3 shadow-mode parity defends today. A future
 carry-aware lane will need an explicit market capability and a documented
 carry-source policy before it can replace this basis.
 
-Swaptions also keep the current checked helper conventions. When the semantic
-term surface does not provide a more specific payment frequency, the structural
-adapter defaults the fixed leg to semiannual rather than inheriting a coarse
-annualized decomposition schedule.
+Swaptions keep the checked market-binding conventions without making the
+product wrapper a solver declaration. When the semantic term surface does not
+provide a more specific payment frequency, the structural adapter defaults the
+fixed leg to semiannual rather than inheriting a coarse annualized decomposition
+schedule. It then resolves expiry, annuity, forward swap rate, strike, Black
+volatility, direction, and payment count into
+``ResolvedSwaptionBlack76Inputs`` before applying the raw kernel. Thus the
+economic projection and the numerical formula remain separately inspectable.
+The product-level ``price_swaption_black76(...)`` function is retained only for
+compatibility and independent reference comparison.
 
 For the direct Phase 3 structural-solver shadow, variance swaps reuse the
 retained bounded smile-slope compatibility wrapper. The ``VarianceObservable``

--- a/docs/user_guide/pricing.rst
+++ b/docs/user_guide/pricing.rst
@@ -534,8 +534,9 @@ When a pricing request goes through the platform compiler, Trellis now tries to
 draft a typed semantic contract first and only falls back to older family-local
 paths when no checked semantic slice exists or the request is too incomplete.
 
-This means helper-backed requests such as vanilla options, callable bonds,
-rate-style swaptions, ranked-observation baskets, single-name CDS, and
+This means previously helper-backed or exact-bound requests such as vanilla
+options, callable bonds, rate-style swaptions, ranked-observation baskets,
+single-name CDS, and
 nth-to-default basket credit now carry explicit contract, market-binding, and
 route-lowering metadata before pricing or code generation starts.
 
@@ -568,6 +569,15 @@ simulation components as appropriate for the selected method. Backend
 ``helper_refs`` remains empty for these lanes. Compatibility wrappers such as
 ``price_quanto_option_analytical_from_market_state(...)`` remain callable by
 existing applications but do not appear as live build authority.
+
+European analytical swaptions follow the same rule. Generated and structural
+paths receive ``resolve_swaption_black76_inputs(...)`` as the market-binding
+primitive and ``price_swaption_black76_raw(...)`` as the pricing kernel. The
+resolver binds the payment schedule, annuity, forward rate, volatility, and
+payer/receiver direction; generated code then passes the typed resolved value
+to the raw kernel. ``price_swaption_black76(...)`` remains usable as a public
+compatibility and reference function, but it is not advertised as construction
+authority.
 
 The trace boundary also exposes a family-first ``construction_identity``
 summary. For operators, that is now the primary readout:

--- a/tests/test_agent/test_backend_bindings.py
+++ b/tests/test_agent/test_backend_bindings.py
@@ -339,13 +339,20 @@ def test_resolve_backend_binding_spec_uses_route_conditionals_for_exact_targets(
         ),
     )
 
-    assert (
-        swaption_resolved.helper_refs
-        == ("trellis.models.rate_style_swaption.price_swaption_black76",)
+    assert swaption_resolved.helper_refs == ()
+    assert swaption_resolved.market_binding_refs == (
+        "trellis.models.rate_style_swaption.resolve_swaption_black76_inputs",
+    )
+    assert swaption_resolved.pricing_kernel_refs == (
+        "trellis.models.rate_style_swaption.price_swaption_black76_raw",
+    )
+    assert swaption_resolved.primitive_refs == (
+        "trellis.models.rate_style_swaption.resolve_swaption_black76_inputs",
+        "trellis.models.rate_style_swaption.price_swaption_black76_raw",
     )
     assert (
         swaption_resolved.binding_id
-        == "trellis.models.rate_style_swaption.price_swaption_black76"
+        == "trellis.models.rate_style_swaption.price_swaption_black76_raw"
     )
 
 

--- a/tests/test_agent/test_backend_bindings_black76_dsl_parity.py
+++ b/tests/test_agent/test_backend_bindings_black76_dsl_parity.py
@@ -118,8 +118,13 @@ _SWAPTION_BERM_PRIMS: tuple[PrimitiveRef, ...] = (
 _SWAPTION_EUR_PRIMS: tuple[PrimitiveRef, ...] = (
     PrimitiveRef(
         "trellis.models.rate_style_swaption",
-        "price_swaption_black76",
-        "route_helper",
+        "resolve_swaption_black76_inputs",
+        "market_binding",
+    ),
+    PrimitiveRef(
+        "trellis.models.rate_style_swaption",
+        "price_swaption_black76_raw",
+        "pricing_kernel",
     ),
 )
 

--- a/tests/test_agent/test_codegen_guardrails.py
+++ b/tests/test_agent/test_codegen_guardrails.py
@@ -871,7 +871,7 @@ def test_requested_method_augmentation_adds_exercise_family_for_non_european_mc_
     assert "barrier_option" in augmented.route_families
 
 
-def test_generation_route_card_for_swaption_analytical_stays_helper_only():
+def test_generation_route_card_for_swaption_analytical_exposes_resolved_composition():
     compiled = compile_build_request(
         "European swaption on fixed-for-float swap",
         instrument_type="swaption",
@@ -880,8 +880,9 @@ def test_generation_route_card_for_swaption_analytical_stays_helper_only():
 
     text = render_generation_route_card(compiled.generation_plan)
 
-    assert "price_swaption_black76" in text
-    assert "reuse_checked_in_rate_style_swaption_helper" not in text
+    assert "resolve_swaption_black76_inputs" in text
+    assert "price_swaption_black76_raw" in text
+    assert "Helper authority:" not in text
     assert "Hull-White-implied Black vol" not in text
     assert "Backend notes:" not in text
 
@@ -1026,15 +1027,13 @@ def test_review_contract_card_renders_wrapper_route_and_validation_scope():
     assert "trellis.models.black" in text
 
 
-def test_schedule_dependent_route_card_mentions_shared_schedule_builder():
+def test_schedule_dependent_route_card_mentions_swaption_resolver_kernel_composition():
     plan = _analytical_plan()
     card = render_generation_route_card(plan)
 
-    # Under the current positive-filter Black76 match clause a canonical
-    # European swaption dispatches to the swaption-specific helper, which
-    # owns its schedule construction internally rather than surfacing the
-    # generic ``build_payment_timeline`` fallback primitive.
-    assert "price_swaption_black76" in card
+    assert "resolve_swaption_black76_inputs" in card
+    assert "price_swaption_black76_raw" in card
+    assert "Helper authority:" not in card
     assert "Instruction precedence: follow the lane obligations in this card first." in card
 
 

--- a/tests/test_agent/test_contract_ir_solver_compiler.py
+++ b/tests/test_agent/test_contract_ir_solver_compiler.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from datetime import date
 
 import pytest
@@ -61,7 +61,10 @@ from trellis.models.black import (
     black76_put,
     black76_cash_or_nothing_call,
 )
-from trellis.models.rate_style_swaption import price_swaption_black76
+from trellis.models.rate_style_swaption import (
+    price_swaption_black76_raw,
+    resolve_swaption_black76_inputs,
+)
 from trellis.models.analytical.equity_exotics import price_equity_variance_swap_analytical
 from trellis.models.vol_surface import FlatVol
 
@@ -358,6 +361,29 @@ def _swaption_market_state_with_named_forecast_curve() -> MarketState:
     )
 
 
+@dataclass(frozen=True)
+class _SwaptionReferenceSpec:
+    notional: float = 1.0
+    strike: float = 0.05
+    expiry_date: date = date(2025, 11, 15)
+    swap_start: date = date(2025, 11, 15)
+    swap_end: date = date(2030, 11, 15)
+    swap_frequency: Frequency = Frequency.SEMI_ANNUAL
+    day_count: DayCountConvention = DayCountConvention.ACT_360
+    rate_index: str | None = None
+    is_payer: bool = True
+
+
+def _resolved_swaption_reference(
+    market_state: MarketState,
+    **overrides,
+):
+    return resolve_swaption_black76_inputs(
+        market_state,
+        _SwaptionReferenceSpec(**overrides),
+    )
+
+
 def _basket_market_state() -> MarketState:
     return MarketState(
         as_of=date(2025, 1, 1),
@@ -503,10 +529,16 @@ class TestContractIRSolverCompiler:
         assert asset_call_price == pytest.approx(expected_asset_call, rel=1e-12, abs=1e-12)
         assert asset_put_price == pytest.approx(expected_asset_put, rel=1e-12, abs=1e-12)
 
-    def test_swaption_helper_binding_matches_exact_helper(self):
+    def test_swaption_resolver_kernel_binding_exposes_composition_authority(self):
         contract = _swaption_contract_ir()
         market_state = _swaption_market_state()
         context = build_valuation_context(market_snapshot=market_state, requested_outputs=("price",))
+
+        selection = select_contract_ir_solver(
+            contract,
+            valuation_context=context,
+            preferred_method="analytical",
+        )
 
         decision = compile_contract_ir_solver(
             contract,
@@ -515,17 +547,23 @@ class TestContractIRSolverCompiler:
             preferred_method="analytical",
         )
 
-        assert decision.declaration_id == "helper_swaption_payer_black76"
-        spec = decision.call_kwargs["spec"]
-        assert spec.swap_frequency == Frequency.SEMI_ANNUAL
-        assert spec.day_count == DayCountConvention.ACT_360
-        assert execute_contract_ir_solver_decision(decision) == pytest.approx(
-            price_swaption_black76(market_state, spec),
-            rel=1e-12,
-            abs=1e-12,
+        assert selection.declaration_id == "swaption_payer_black76_resolved_kernel"
+        assert selection.callable_ref == (
+            "trellis.models.rate_style_swaption.price_swaption_black76_raw"
         )
+        assert selection.call_style == "raw_kernel_kwargs"
+        assert selection.helper_refs == ()
+        assert selection.market_binding_refs == (
+            "trellis.models.rate_style_swaption.resolve_swaption_black76_inputs",
+        )
+        assert selection.pricing_kernel_refs == (
+            "trellis.models.rate_style_swaption.price_swaption_black76_raw",
+        )
+        assert decision.declaration_id == selection.declaration_id
+        assert set(decision.call_kwargs) == {"resolved"}
+        assert execute_contract_ir_solver_decision(decision) > 0.0
 
-    def test_receiver_swaption_helper_binding_matches_exact_helper(self):
+    def test_receiver_swaption_resolver_kernel_binding_matches_resolved_reference(self):
         contract = _receiver_swaption_contract_ir()
         market_state = _swaption_market_state()
         context = build_valuation_context(market_snapshot=market_state, requested_outputs=("price",))
@@ -537,16 +575,15 @@ class TestContractIRSolverCompiler:
             preferred_method="analytical",
         )
 
-        assert decision.declaration_id == "helper_swaption_receiver_black76"
-        spec = decision.call_kwargs["spec"]
-        assert spec.is_payer is False
+        assert decision.declaration_id == "swaption_receiver_black76_resolved_kernel"
+        resolved = decision.call_kwargs["resolved"]
+        expected = _resolved_swaption_reference(market_state, is_payer=False)
+        assert resolved == expected
         assert execute_contract_ir_solver_decision(decision) == pytest.approx(
-            price_swaption_black76(market_state, spec),
-            rel=1e-12,
-            abs=1e-12,
+            price_swaption_black76_raw(expected), rel=1e-12, abs=1e-12
         )
 
-    def test_swaption_helper_respects_explicit_swap_start_term_field(self):
+    def test_swaption_binding_respects_explicit_swap_start_term_field(self):
         market_state = _swaption_market_state()
         context = build_valuation_context(market_snapshot=market_state, requested_outputs=("price",))
         semantic_contract = make_rate_style_swaption_contract(
@@ -567,15 +604,17 @@ class TestContractIRSolverCompiler:
             preferred_method="analytical",
         )
 
-        spec = decision.call_kwargs["spec"]
-        assert spec.swap_start == date(2026, 5, 15)
+        resolved = decision.call_kwargs["resolved"]
+        expected = _resolved_swaption_reference(
+            market_state,
+            swap_start=date(2026, 5, 15),
+        )
+        assert resolved == expected
         assert execute_contract_ir_solver_decision(decision) == pytest.approx(
-            price_swaption_black76(market_state, spec),
-            rel=1e-12,
-            abs=1e-12,
+            price_swaption_black76_raw(expected), rel=1e-12, abs=1e-12
         )
 
-    def test_swaption_helper_accepts_start_date_alias_and_explicit_swap_end(self):
+    def test_swaption_binding_accepts_start_date_alias_and_explicit_swap_end(self):
         market_state = _swaption_market_state()
         context = build_valuation_context(market_snapshot=market_state, requested_outputs=("price",))
         semantic_contract = make_rate_style_swaption_contract(
@@ -597,12 +636,15 @@ class TestContractIRSolverCompiler:
             preferred_method="analytical",
         )
 
-        spec = decision.call_kwargs["spec"]
-        assert spec.swap_start == date(2026, 5, 15)
-        assert spec.swap_end == date(2031, 5, 15)
-        assert spec.swap_frequency == Frequency.SEMI_ANNUAL
+        resolved = decision.call_kwargs["resolved"]
+        expected = _resolved_swaption_reference(
+            market_state,
+            swap_start=date(2026, 5, 15),
+            swap_end=date(2031, 5, 15),
+        )
+        assert resolved == expected
 
-    def test_swaption_helper_infers_forward_start_from_schedule_when_term_field_missing(self):
+    def test_swaption_binding_infers_forward_start_from_schedule_when_term_field_missing(self):
         market_state = _swaption_market_state()
         context = build_valuation_context(market_snapshot=market_state, requested_outputs=("price",))
 
@@ -613,15 +655,17 @@ class TestContractIRSolverCompiler:
             preferred_method="analytical",
         )
 
-        spec = decision.call_kwargs["spec"]
-        assert spec.swap_start == date(2026, 11, 15)
+        resolved = decision.call_kwargs["resolved"]
+        expected = _resolved_swaption_reference(
+            market_state,
+            swap_start=date(2026, 11, 15),
+        )
+        assert resolved == expected
         assert execute_contract_ir_solver_decision(decision) == pytest.approx(
-            price_swaption_black76(market_state, spec),
-            rel=1e-12,
-            abs=1e-12,
+            price_swaption_black76_raw(expected), rel=1e-12, abs=1e-12
         )
 
-    def test_swaption_helper_preserves_end_of_month_inferred_start(self):
+    def test_swaption_binding_preserves_end_of_month_inferred_start(self):
         market_state = _swaption_market_state()
         context = build_valuation_context(market_snapshot=market_state, requested_outputs=("price",))
 
@@ -632,10 +676,15 @@ class TestContractIRSolverCompiler:
             preferred_method="analytical",
         )
 
-        spec = decision.call_kwargs["spec"]
-        assert spec.swap_start == date(2026, 10, 31)
+        resolved = decision.call_kwargs["resolved"]
+        expected = _resolved_swaption_reference(
+            market_state,
+            swap_start=date(2026, 10, 31),
+            swap_end=date(2028, 10, 31),
+        )
+        assert resolved == expected
 
-    def test_swaption_helper_fails_closed_without_authoritative_start_for_single_payment_schedule(self):
+    def test_swaption_binding_fails_closed_without_authoritative_start_for_single_payment_schedule(self):
         market_state = _swaption_market_state()
         context = build_valuation_context(market_snapshot=market_state, requested_outputs=("price",))
 
@@ -650,10 +699,12 @@ class TestContractIRSolverCompiler:
                 preferred_method="analytical",
             )
 
-        assert exc_info.value.best_diagnostic.declaration_id == "helper_swaption_payer_black76"
+        assert exc_info.value.best_diagnostic.declaration_id == (
+            "swaption_payer_black76_resolved_kernel"
+        )
         assert exc_info.value.best_diagnostic.error_type == "ValueError"
 
-    def test_swaption_helper_uses_forecast_curve_name_when_rate_index_missing(self):
+    def test_swaption_binding_uses_forecast_curve_name_when_rate_index_missing(self):
         market_state = _swaption_market_state_with_named_forecast_curve()
         context = build_valuation_context(market_snapshot=market_state, requested_outputs=("price",))
         semantic_contract = make_rate_style_swaption_contract(
@@ -671,16 +722,19 @@ class TestContractIRSolverCompiler:
             preferred_method="analytical",
         )
 
-        spec = decision.call_kwargs["spec"]
+        resolved = decision.call_kwargs["resolved"]
+        expected = _resolved_swaption_reference(
+            market_state,
+            rate_index="USD-SOFR-3M",
+        )
+        fallback = _resolved_swaption_reference(market_state)
         selected_price = execute_contract_ir_solver_decision(decision)
-        fallback_price = price_swaption_black76(market_state, replace(spec, rate_index=None))
+        fallback_price = price_swaption_black76_raw(fallback)
 
-        assert spec.rate_index == "USD-SOFR-3M"
+        assert resolved == expected
         assert "forecast_curve:USD-SOFR-3M" in decision.resolved_market_coordinates
         assert selected_price == pytest.approx(
-            price_swaption_black76(market_state, spec),
-            rel=1e-12,
-            abs=1e-12,
+            price_swaption_black76_raw(expected), rel=1e-12, abs=1e-12
         )
         assert selected_price != pytest.approx(fallback_price, rel=1e-9, abs=1e-9)
 

--- a/tests/test_agent/test_contract_ir_solver_parity.py
+++ b/tests/test_agent/test_contract_ir_solver_parity.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import date
+from types import SimpleNamespace
 
-from trellis.agent.contract_ir_solver_parity import build_contract_ir_solver_parity_report
+from trellis.agent.contract_ir_solver_parity import (
+    _swaption_reference,
+    build_contract_ir_solver_parity_report,
+)
 from trellis.agent.platform_requests import compile_build_request
 from trellis.core.market_state import MarketState
 from trellis.curves.yield_curve import YieldCurve
+from trellis.models.rate_style_swaption import ResolvedSwaptionBlack76Inputs
 from trellis.models.vol_surface import FlatVol
 
 
@@ -27,6 +33,29 @@ def _swaption_market_state() -> MarketState:
         discount=YieldCurve.flat(0.03),
         vol_surface=FlatVol(0.20),
     )
+
+
+def test_swaption_parity_reference_preserves_raw_kernel_degenerate_zero_contract():
+    resolved = ResolvedSwaptionBlack76Inputs(
+        expiry_date=date(2025, 11, 15),
+        expiry_years=1.0,
+        annuity=1.0,
+        forward_swap_rate=0.06,
+        strike=0.05,
+        vol=0.20,
+        notional=1.0,
+        is_payer=True,
+        payment_count=10,
+    )
+    degenerate_cases = (
+        replace(resolved, expiry_years=0.0),
+        replace(resolved, annuity=-1.0),
+        replace(resolved, payment_count=0),
+    )
+
+    for case in degenerate_cases:
+        decision = SimpleNamespace(call_kwargs={"resolved": case})
+        assert _swaption_reference(decision, _swaption_market_state(), None) == 0.0
 
 
 def _basket_market_state() -> MarketState:

--- a/tests/test_agent/test_dsl_lowering.py
+++ b/tests/test_agent/test_dsl_lowering.py
@@ -528,10 +528,10 @@ def test_vanilla_option_pde_lowers_to_event_aware_primitive_composition():
     )
 
 
-def test_rate_style_swaption_analytical_lowers_to_black76_family_helper():
+def test_rate_style_swaption_analytical_lowers_to_resolver_then_raw_kernel():
     from trellis.agent.semantic_contract_compiler import compile_semantic_contract
     from trellis.agent.semantic_contracts import make_rate_style_swaption_contract
-    from trellis.agent.dsl_algebra import ContractAtom
+    from trellis.agent.dsl_algebra import ThenExpr
 
     contract = make_rate_style_swaption_contract(
         description="5Yx10Y USD payer swaption Black-76",
@@ -543,16 +543,18 @@ def test_rate_style_swaption_analytical_lowers_to_black76_family_helper():
     assert lowering is not None
     assert lowering.route_id == "analytical_black76"
     assert lowering.admissibility_errors == ()
-    assert isinstance(lowering.normalized_expr, ContractAtom)
-    assert lowering.normalized_expr.primitive_ref == (
-        "trellis.models.rate_style_swaption.price_swaption_black76"
+    assert isinstance(lowering.normalized_expr, ThenExpr)
+    assert tuple(term.primitive_ref for term in lowering.normalized_expr.terms) == (
+        "trellis.models.rate_style_swaption.resolve_swaption_black76_inputs",
+        "trellis.models.rate_style_swaption.price_swaption_black76_raw",
     )
+    assert lowering.route_helper_refs == ()
 
 
-def test_rate_style_swaption_receiver_analytical_lowers_to_black76_family_helper():
+def test_rate_style_swaption_receiver_analytical_uses_same_resolved_composition():
     from trellis.agent.semantic_contract_compiler import compile_semantic_contract
     from trellis.agent.semantic_contracts import make_rate_style_swaption_contract
-    from trellis.agent.dsl_algebra import ContractAtom
+    from trellis.agent.dsl_algebra import ThenExpr
 
     contract = make_rate_style_swaption_contract(
         description="5Yx10Y USD receiver swaption Black-76",
@@ -562,9 +564,10 @@ def test_rate_style_swaption_receiver_analytical_lowers_to_black76_family_helper
 
     lowering = blueprint.dsl_lowering
     assert lowering is not None
-    assert isinstance(lowering.normalized_expr, ContractAtom)
-    assert lowering.normalized_expr.primitive_ref == (
-        "trellis.models.rate_style_swaption.price_swaption_black76"
+    assert isinstance(lowering.normalized_expr, ThenExpr)
+    assert tuple(term.primitive_ref for term in lowering.normalized_expr.terms) == (
+        "trellis.models.rate_style_swaption.resolve_swaption_black76_inputs",
+        "trellis.models.rate_style_swaption.price_swaption_black76_raw",
     )
 
 

--- a/tests/test_agent/test_executor.py
+++ b/tests/test_agent/test_executor.py
@@ -979,7 +979,7 @@ def test_hydrate_spec_schema_defaults_from_swaption_semantics():
     assert "rate_index: str | None = 'USD-SOFR-3M'" in skeleton
 
 
-def test_deterministic_exact_binding_module_materializes_swaption_helper_wrapper():
+def test_deterministic_exact_binding_module_materializes_swaption_resolver_and_raw_kernel():
     from trellis.agent.comparison_target_contracts import ComparisonTargetContract
     from trellis.agent.executor import (
         _generate_skeleton,
@@ -989,7 +989,9 @@ def test_deterministic_exact_binding_module_materializes_swaption_helper_wrapper
     from trellis.agent.planner import STATIC_SPECS
 
     generation_plan = SimpleNamespace(
-        lane_exact_binding_refs=("trellis.models.rate_style_swaption.price_swaption_black76",),
+        lane_exact_binding_refs=(
+            "trellis.models.rate_style_swaption.price_swaption_black76_raw",
+        ),
         primitive_plan=None,
         method="analytical",
         instrument_type="swaption",
@@ -1012,11 +1014,24 @@ def test_deterministic_exact_binding_module_materializes_swaption_helper_wrapper
     )
 
     assert generated is not None
-    assert "return price_swaption_black76(market_state, spec)" in generated.code
+    assert "resolved = resolve_swaption_black76_inputs(market_state, spec)" in generated.code
+    assert "return price_swaption_black76_raw(resolved)" in generated.code
+    assert "price_swaption_black76(market_state" not in generated.code
     assert "__trellis_comparison_bindings__" in generated.code
     assert repr(target_contract) in generated.code
     assert "sigma=0.01" not in generated.code
     assert EVALUATE_SENTINEL not in generated.code
+
+
+def test_admitted_swaption_adapter_composes_resolved_inputs_with_raw_kernel():
+    source = (
+        Path(__file__).resolve().parents[2]
+        / "trellis/instruments/_agent/swaption.py"
+    ).read_text()
+
+    assert "resolve_swaption_black76_inputs(market_state, spec)" in source
+    assert "price_swaption_black76_raw(resolved)" in source
+    assert "price_swaption_black76(market_state" not in source
 
 
 def test_deterministic_exact_binding_module_materializes_bermudan_tree_compat_wrapper():
@@ -5720,7 +5735,10 @@ def test_deterministic_exact_binding_module_materializes_credit_loss_distributio
 @pytest.mark.parametrize(
     ("helper_ref", "expected_call"),
     [
-        ("trellis.models.rate_style_swaption.price_swaption_black76", "price_swaption_black76"),
+        (
+            "trellis.models.rate_style_swaption.price_swaption_black76_raw",
+            "price_swaption_black76_raw",
+        ),
         ("trellis.models.rate_style_swaption_tree.price_swaption_tree", "price_swaption_tree"),
         ("trellis.models.rate_style_swaption.price_swaption_monte_carlo", "price_swaption_monte_carlo"),
     ],
@@ -5783,6 +5801,13 @@ def test_deterministic_exact_binding_module_threads_explicit_swaption_comparison
             "price_swaption_monte_carlo("
             "market_state, spec, n_paths=20000, seed=42, mean_reversion=0.05, sigma=0.01)"
         ) in generated.code
+    elif expected_call == "price_swaption_black76_raw":
+        assert (
+            "resolve_swaption_black76_inputs("
+            "market_state, spec, mean_reversion=0.05, sigma=0.01)"
+        ) in generated.code
+        assert "return price_swaption_black76_raw(resolved)" in generated.code
+        assert "price_swaption_black76(market_state" not in generated.code
     else:
         assert f"{expected_call}(market_state, spec, mean_reversion=0.05, sigma=0.01)" in generated.code
 

--- a/tests/test_agent/test_helper_authority_audit.py
+++ b/tests/test_agent/test_helper_authority_audit.py
@@ -276,6 +276,25 @@ def test_current_repository_retires_arithmetic_asian_helper_authority():
     ]
 
 
+def test_current_repository_retires_european_swaption_wrapper_authority():
+    from trellis.agent.helper_authority_audit import build_helper_authority_report
+
+    root = Path(__file__).resolve().parents[2]
+    report = build_helper_authority_report(root)
+
+    assert not [
+        item
+        for item in (*report.route_authority, *report.binding_authority)
+        if item.symbol == "price_swaption_black76"
+    ]
+    assert not [
+        item
+        for item in report.adapter_calls
+        if item.path == "trellis/instruments/_agent/swaption.py"
+        and item.symbol == "price_swaption_black76"
+    ]
+
+
 def test_current_repository_retires_analytical_digital_helper_authority():
     from trellis.agent.helper_authority_audit import build_helper_authority_report
 

--- a/tests/test_agent/test_instruction_lifecycle.py
+++ b/tests/test_agent/test_instruction_lifecycle.py
@@ -218,16 +218,15 @@ def test_generation_plan_materializes_resolved_instructions():
 
     assert plan.resolved_instructions is not None
     assert plan.resolved_instructions.route == "analytical_black76"
-    # QUA-909: with a canonical ``payoff_family="swaption"`` +
-    # ``exercise_style="european"`` ProductIR the specific swaption when
-    # clause activates, routing through
-    # ``price_swaption_black76`` as a ``route_helper``. The route-helper
-    # instruction lands first because the specific-helper clause preempts
-    # the shared schedule-builder primitive that only appears on the
-    # ``when: default`` fallback clause.
-    instruction_ids = [
-        instruction.id
-        for instruction in plan.resolved_instructions.effective_instructions
-    ]
-    assert instruction_ids[0] == "analytical_black76:route-helper"
+    primitives = {
+        (primitive.symbol, primitive.role)
+        for primitive in plan.primitive_plan.primitives
+    }
+    assert (
+        "resolve_swaption_black76_inputs",
+        "market_binding",
+    ) in primitives
+    assert ("price_swaption_black76_raw", "pricing_kernel") in primitives
+    assert not any(role == "route_helper" for _symbol, role in primitives)
+    assert plan.resolved_instructions.effective_instructions == ()
     assert plan.resolved_instructions.conflicts == ()

--- a/tests/test_agent/test_lite_review.py
+++ b/tests/test_agent/test_lite_review.py
@@ -224,23 +224,25 @@ def price(spec, market_state):
     assert "lite.analytical_black76_black_vol_surface_access_missing" in issue_codes
 
 
-def test_lite_review_allows_swaption_black76_helper_with_explicit_hull_white_comparison_params():
+def test_lite_review_allows_swaption_black76_binding_with_explicit_hull_white_comparison_params():
     from trellis.agent.codegen_guardrails import GenerationPlan, PrimitivePlan, PrimitiveRef
     from trellis.agent.lite_review import review_generated_code
     from trellis.agent.quant import PricingPlan
 
     source = """\
-from trellis.models.rate_style_swaption import price_swaption_black76
+from trellis.models.rate_style_swaption import (
+    price_swaption_black76_raw,
+    resolve_swaption_black76_inputs,
+)
 
 def price(spec, market_state):
-    return float(
-        price_swaption_black76(
-            market_state,
-            spec,
-            mean_reversion=0.05,
-            sigma=0.01,
-        )
+    resolved = resolve_swaption_black76_inputs(
+        market_state,
+        spec,
+        mean_reversion=0.05,
+        sigma=0.01,
     )
+    return price_swaption_black76_raw(resolved)
 """
 
     plan = GenerationPlan(
@@ -248,13 +250,25 @@ def price(spec, market_state):
         instrument_type="swaption",
         inspected_modules=("trellis.models.rate_style_swaption",),
         approved_modules=("trellis.models.rate_style_swaption",),
-        symbols_to_reuse=("price_swaption_black76",),
+        symbols_to_reuse=(
+            "resolve_swaption_black76_inputs",
+            "price_swaption_black76_raw",
+        ),
         proposed_tests=("tests/test_agent/test_build_loop.py",),
         primitive_plan=PrimitivePlan(
             route="analytical_black76",
             engine_family="analytical",
             primitives=(
-                PrimitiveRef("trellis.models.rate_style_swaption", "price_swaption_black76", "route_helper"),
+                PrimitiveRef(
+                    "trellis.models.rate_style_swaption",
+                    "resolve_swaption_black76_inputs",
+                    "market_binding",
+                ),
+                PrimitiveRef(
+                    "trellis.models.rate_style_swaption",
+                    "price_swaption_black76_raw",
+                    "pricing_kernel",
+                ),
             ),
             adapters=(),
             blockers=(),

--- a/tests/test_agent/test_platform_requests.py
+++ b/tests/test_agent/test_platform_requests.py
@@ -569,7 +569,7 @@ def test_compile_build_request_preserves_swaption_conventions_and_hw_bindings():
 @pytest.mark.parametrize(
     ("preferred_method", "expected_binding"),
     [
-        ("analytical", "trellis.models.rate_style_swaption.price_swaption_black76"),
+        ("analytical", "trellis.models.rate_style_swaption.price_swaption_black76_raw"),
         ("rate_tree", "trellis.models.rate_style_swaption_tree.price_swaption_tree"),
         ("monte_carlo", "trellis.models.rate_style_swaption.price_swaption_monte_carlo"),
     ],
@@ -2197,7 +2197,7 @@ def test_request_contract_ir_compiler_summary_surfaces_binding_diagnostic(monkey
     )
     generation_plan = SimpleNamespace(inspected_modules=("trellis.models.rate_style_swaption",))
     diagnostic = ContractIRSolverBindingDiagnostic(
-        declaration_id="helper_swaption_payer_black76",
+        declaration_id="swaption_payer_black76_resolved_kernel",
         precedence=44,
         error_type="ValueError",
         message="Swaption adapter requires explicit swap_start or a multi-date schedule for structural binding",
@@ -2231,7 +2231,9 @@ def test_request_contract_ir_compiler_summary_surfaces_binding_diagnostic(monkey
     assert summary["source"] == "request_decomposition"
     assert summary["shadow_status"] == "no_match"
     assert summary["shadow_error"]["error_type"] == "ContractIRSolverBindingError"
-    assert summary["shadow_error"]["declaration_id"] == "helper_swaption_payer_black76"
+    assert summary["shadow_error"]["declaration_id"] == (
+        "swaption_payer_black76_resolved_kernel"
+    )
     assert summary["shadow_error"]["adapter_error_type"] == "ValueError"
     assert (
         summary["shadow_error"]["adapter_error_message"]

--- a/tests/test_agent/test_primitive_planning.py
+++ b/tests/test_agent/test_primitive_planning.py
@@ -486,8 +486,16 @@ def test_builds_primitive_plan_for_swaption():
 
     assert plan.primitive_plan is not None
     assert plan.primitive_plan.route == "analytical_black76"
-    primitive_symbols = {primitive.symbol for primitive in plan.primitive_plan.primitives}
-    assert {"price_swaption_black76"} <= primitive_symbols
+    primitives = {
+        (primitive.symbol, primitive.role)
+        for primitive in plan.primitive_plan.primitives
+    }
+    primitive_symbols = {symbol for symbol, _role in primitives}
+    assert (
+        "resolve_swaption_black76_inputs",
+        "market_binding",
+    ) in primitives
+    assert ("price_swaption_black76_raw", "pricing_kernel") in primitives
     assert "black76_call" not in primitive_symbols
     assert plan.primitive_plan.adapters == ()
     assert plan.primitive_plan.notes == ()

--- a/tests/test_agent/test_prompts.py
+++ b/tests/test_agent/test_prompts.py
@@ -1136,7 +1136,7 @@ def test_evaluate_prompt_compact_surface_mentions_fx_route_helper():
     assert "route helper" in prompt
 
 
-def test_evaluate_prompt_compact_surface_mentions_swaption_helper_route():
+def test_evaluate_prompt_compact_surface_mentions_swaption_resolver_kernel_route():
     from trellis.agent.codegen_guardrails import GenerationPlan, PrimitivePlan, PrimitiveRef
     from trellis.agent.prompts import evaluate_prompt
     from trellis.agent.quant import PricingPlan
@@ -1147,14 +1147,24 @@ def test_evaluate_prompt_compact_surface_mentions_swaption_helper_route():
         inspected_modules=("trellis.models.rate_style_swaption",),
         approved_modules=("trellis.models.rate_style_swaption",),
         symbols_to_reuse=(
-            "price_swaption_black76",
+            "resolve_swaption_black76_inputs",
+            "price_swaption_black76_raw",
         ),
         proposed_tests=("tests/test_agent/test_build_loop.py",),
         primitive_plan=PrimitivePlan(
             route="analytical_black76",
             engine_family="analytical",
             primitives=(
-                PrimitiveRef("trellis.models.rate_style_swaption", "price_swaption_black76", "route_helper"),
+                PrimitiveRef(
+                    "trellis.models.rate_style_swaption",
+                    "resolve_swaption_black76_inputs",
+                    "market_binding",
+                ),
+                PrimitiveRef(
+                    "trellis.models.rate_style_swaption",
+                    "price_swaption_black76_raw",
+                    "pricing_kernel",
+                ),
             ),
             adapters=(),
             blockers=(),
@@ -1177,7 +1187,9 @@ def test_evaluate_prompt_compact_surface_mentions_swaption_helper_route():
         prompt_surface="compact",
     )
 
-    assert "price_swaption_black76" in prompt
+    assert "resolve_swaption_black76_inputs" in prompt
+    assert "price_swaption_black76_raw" in prompt
+    assert "price_swaption_black76(market_state" not in prompt
     assert "Hull-White-implied Black vol" in prompt
     assert "annuity" in prompt
 
@@ -1596,7 +1608,7 @@ def test_executor_bermudan_swaption_analytical_retry_pins_lower_bound_helper():
     assert "Do not sum one European Black76 price per exercise date" in text
 
 
-def test_executor_swaption_analytical_retry_pins_helper_backed_route():
+def test_executor_swaption_analytical_retry_pins_resolver_kernel_route():
     from types import SimpleNamespace
 
     from trellis.agent.executor import KnowledgeRetrievalRequest, _route_specific_retry_lines
@@ -1615,7 +1627,9 @@ def test_executor_swaption_analytical_retry_pins_helper_backed_route():
 
     text = "\n".join(_route_specific_retry_lines(request))
 
-    assert "price_swaption_black76" in text
+    assert "resolve_swaption_black76_inputs" in text
+    assert "price_swaption_black76_raw" in text
+    assert "price_swaption_black76(market_state" not in text
     assert "Hull-White-implied Black vol" in text
     assert "annuity" in text
 

--- a/tests/test_agent/test_route_learning.py
+++ b/tests/test_agent/test_route_learning.py
@@ -82,7 +82,9 @@ def test_extract_route_feature_map_matches_minimized_live_scorer_contract():
     )
 
     assert feature_map["family_capability_ok"] == 1.0
-    assert feature_map["binding_role:route_helper"] == 1.0
+    assert feature_map["binding_role:market_binding"] == 1.0
+    assert feature_map["binding_role:pricing_kernel"] == 1.0
+    assert "binding_role:route_helper" not in feature_map
     assert feature_map["binding_has_exact_surface"] == 1.0
     assert "route_family_matches_ir" not in feature_map
     assert "route:analytical_black76" not in feature_map

--- a/tests/test_agent/test_route_registry.py
+++ b/tests/test_agent/test_route_registry.py
@@ -1712,18 +1712,23 @@ class TestAnalyticalRoutes:
             ),
         }
 
-    def test_default_primitives_without_vanilla(self, registry):
+    def test_swaption_primitives_compose_resolved_inputs_with_raw_kernel(self, registry):
         spec = [r for r in registry.routes if r.id == "analytical_black76"][0]
         new_prims = resolve_route_primitives(spec, self.SWAPTION_IR)
         assert _prim_set(new_prims) == {
             (
                 "trellis.models.rate_style_swaption",
-                "price_swaption_black76",
-                "route_helper",
+                "resolve_swaption_black76_inputs",
+                "market_binding",
+            ),
+            (
+                "trellis.models.rate_style_swaption",
+                "price_swaption_black76_raw",
+                "pricing_kernel",
             ),
         }
 
-    def test_swaption_helper_route_is_thin(self, registry):
+    def test_swaption_composition_route_is_thin(self, registry):
         spec = [r for r in registry.routes if r.id == "analytical_black76"][0]
         assert resolve_route_notes(spec, self.SWAPTION_IR) == ()
         assert resolve_route_adapters(spec, self.SWAPTION_IR) == ()

--- a/tests/test_agent/test_route_registry_black76_dsl_parity.py
+++ b/tests/test_agent/test_route_registry_black76_dsl_parity.py
@@ -105,8 +105,13 @@ _SWAPTION_BERM_PRIMS: tuple[PrimitiveRef, ...] = (
 _SWAPTION_EUR_PRIMS: tuple[PrimitiveRef, ...] = (
     PrimitiveRef(
         "trellis.models.rate_style_swaption",
-        "price_swaption_black76",
-        "route_helper",
+        "resolve_swaption_black76_inputs",
+        "market_binding",
+    ),
+    PrimitiveRef(
+        "trellis.models.rate_style_swaption",
+        "price_swaption_black76_raw",
+        "pricing_kernel",
     ),
 )
 

--- a/tests/test_agent/test_route_scorer.py
+++ b/tests/test_agent/test_route_scorer.py
@@ -54,7 +54,9 @@ class TestFeatureExtraction:
         assert features["exercise:european"] == 1.0
         assert features["payoff:swaption"] == 1.0
         assert features["family_capability_ok"] == 1.0
-        assert features["binding_role:route_helper"] == 1.0
+        assert features["binding_role:market_binding"] == 1.0
+        assert features["binding_role:pricing_kernel"] == 1.0
+        assert "binding_role:route_helper" not in features
         assert features["binding_has_exact_surface"] == 1.0
         assert "route:analytical_black76" not in features
         assert "route_family:analytical" not in features

--- a/tests/test_agent/test_timeline_adoption.py
+++ b/tests/test_agent/test_timeline_adoption.py
@@ -158,7 +158,8 @@ def test_generated_schedule_heavy_routes_no_longer_reconstruct_period_starts_man
             "build_payment_timeline",
         ),
         REPO_ROOT / "trellis" / "instruments" / "_agent" / "swaption.py": (
-            "price_swaption_black76",
+            "resolve_swaption_black76_inputs",
+            "price_swaption_black76_raw",
         ),
     }
 

--- a/trellis/agent/contract_ir_solver_compiler.py
+++ b/trellis/agent/contract_ir_solver_compiler.py
@@ -66,6 +66,7 @@ from trellis.agent.valuation_context import ValuationContext
 from trellis.core.date_utils import add_months, year_fraction
 from trellis.core.market_state import MarketState
 from trellis.core.types import DayCountConvention, Frequency
+from trellis.models.rate_style_swaption import resolve_swaption_black76_inputs
 
 
 def _freeze_mapping(mapping: Mapping[str, object] | None) -> Mapping[str, object]:
@@ -1120,7 +1121,7 @@ class _StructuralSwaptionSpec:
     is_payer: bool
 
 
-def _swaption_helper_adapter(
+def _swaption_resolved_kernel_adapter(
     *,
     contract_ir: ContractIR,
     term_environment: ContractIRTermEnvironment,
@@ -1136,7 +1137,7 @@ def _swaption_helper_adapter(
     strike = float(bindings["k"])
     inferred_frequency = _rate_curve_frequency(schedule)
     # The current ContractIR decomposition uses coarse yearly coupon dates for
-    # swaptions. Preserve the checked helper contract by defaulting to the
+    # swaptions. Preserve the checked market-binding contract by defaulting to the
     # market-standard semi-annual fixed leg unless a more specific convention is
     # explicitly carried in the generic term environment or the structural
     # schedule is already finer than annual.
@@ -1203,11 +1204,9 @@ def _swaption_helper_adapter(
         coordinates.append(f"discount_curve:{discount_curve_name}")
     if rate_index:
         coordinates.append(f"forecast_curve:{rate_index}")
+    resolved = resolve_swaption_black76_inputs(market_state, spec)
     return {
-        "call_kwargs": {
-            "market_state": market_state,
-            "spec": spec,
-        },
+        "call_kwargs": {"resolved": resolved},
         "value_scale": 1.0,
         "resolved_market_coordinates": tuple(coordinates),
     }
@@ -1842,14 +1841,19 @@ def _default_registry() -> ContractIRSolverRegistry:
                 required_term_groups=("cash_settlement", "accrual_conventions", "floating_rate_reference"),
             ),
             materialization=ContractIRSolverMaterialization(
-                callable_ref="trellis.models.rate_style_swaption.price_swaption_black76",
-                call_style="helper_call",
-                adapter_ref="trellis.agent.contract_ir_solver_compiler._payer_swaption_adapter",
+                callable_ref="trellis.models.rate_style_swaption.price_swaption_black76_raw",
+                call_style="raw_kernel_kwargs",
+                adapter_ref="trellis.agent.contract_ir_solver_compiler._payer_swaption_resolved_kernel_adapter",
             ),
             provenance=ContractIRSolverProvenance(
-                declaration_id="helper_swaption_payer_black76",
+                declaration_id="swaption_payer_black76_resolved_kernel",
                 validation_bundle_id="rate_style_swaption_contract",
-                helper_refs=("trellis.models.rate_style_swaption.price_swaption_black76",),
+                pricing_kernel_refs=(
+                    "trellis.models.rate_style_swaption.price_swaption_black76_raw",
+                ),
+                market_binding_refs=(
+                    "trellis.models.rate_style_swaption.resolve_swaption_black76_inputs",
+                ),
             ),
             precedence=44,
         ),
@@ -1882,14 +1886,19 @@ def _default_registry() -> ContractIRSolverRegistry:
                 required_term_groups=("cash_settlement", "accrual_conventions", "floating_rate_reference"),
             ),
             materialization=ContractIRSolverMaterialization(
-                callable_ref="trellis.models.rate_style_swaption.price_swaption_black76",
-                call_style="helper_call",
-                adapter_ref="trellis.agent.contract_ir_solver_compiler._receiver_swaption_adapter",
+                callable_ref="trellis.models.rate_style_swaption.price_swaption_black76_raw",
+                call_style="raw_kernel_kwargs",
+                adapter_ref="trellis.agent.contract_ir_solver_compiler._receiver_swaption_resolved_kernel_adapter",
             ),
             provenance=ContractIRSolverProvenance(
-                declaration_id="helper_swaption_receiver_black76",
+                declaration_id="swaption_receiver_black76_resolved_kernel",
                 validation_bundle_id="rate_style_swaption_contract",
-                helper_refs=("trellis.models.rate_style_swaption.price_swaption_black76",),
+                pricing_kernel_refs=(
+                    "trellis.models.rate_style_swaption.price_swaption_black76_raw",
+                ),
+                market_binding_refs=(
+                    "trellis.models.rate_style_swaption.resolve_swaption_black76_inputs",
+                ),
             ),
             precedence=43,
         ),
@@ -2232,12 +2241,12 @@ def _digital_asset_put_adapter(**kwargs) -> dict[str, object]:
     return _digital_asset_adapter(call=False, **kwargs)
 
 
-def _payer_swaption_adapter(**kwargs) -> dict[str, object]:
-    return _swaption_helper_adapter(is_payer=True, **kwargs)
+def _payer_swaption_resolved_kernel_adapter(**kwargs) -> dict[str, object]:
+    return _swaption_resolved_kernel_adapter(is_payer=True, **kwargs)
 
 
-def _receiver_swaption_adapter(**kwargs) -> dict[str, object]:
-    return _swaption_helper_adapter(is_payer=False, **kwargs)
+def _receiver_swaption_resolved_kernel_adapter(**kwargs) -> dict[str, object]:
+    return _swaption_resolved_kernel_adapter(is_payer=False, **kwargs)
 
 
 def _basket_call_adapter(**kwargs) -> dict[str, object]:

--- a/trellis/agent/contract_ir_solver_parity.py
+++ b/trellis/agent/contract_ir_solver_parity.py
@@ -44,7 +44,6 @@ from trellis.models.black import (
     black76_cash_or_nothing_call,
     black76_put,
 )
-from trellis.models.rate_style_swaption import price_swaption_black76
 from trellis.models.vol_surface import FlatVol
 
 
@@ -144,7 +143,18 @@ def _digital_reference(decision, market_state: MarketState, contract_ir) -> floa
 
 
 def _swaption_reference(decision, market_state: MarketState, contract_ir) -> float:
-    return float(price_swaption_black76(market_state, decision.call_kwargs["spec"]))
+    resolved = decision.call_kwargs["resolved"]
+    kernel = black76_call if resolved.is_payer else black76_put
+    return float(
+        resolved.notional
+        * resolved.annuity
+        * kernel(
+            resolved.forward_swap_rate,
+            resolved.strike,
+            resolved.vol,
+            resolved.expiry_years,
+        )
+    )
 
 
 def _basket_reference(decision, market_state: MarketState, contract_ir) -> float:
@@ -261,7 +271,7 @@ def _parity_cases() -> tuple[ContractIRSolverParityCase, ...]:
             preferred_method="analytical",
             expected_source="semantic_blueprint",
             expected_shadow_status="bound",
-            expected_declaration_id="helper_swaption_payer_black76",
+            expected_declaration_id="swaption_payer_black76_resolved_kernel",
             reference_price=_swaption_reference,
             market_state_factory=_swaption_market_state,
         ),
@@ -273,7 +283,7 @@ def _parity_cases() -> tuple[ContractIRSolverParityCase, ...]:
             preferred_method="analytical",
             expected_source="semantic_blueprint",
             expected_shadow_status="bound",
-            expected_declaration_id="helper_swaption_receiver_black76",
+            expected_declaration_id="swaption_receiver_black76_resolved_kernel",
             reference_price=_swaption_reference,
             market_state_factory=_swaption_market_state,
         ),

--- a/trellis/agent/contract_ir_solver_parity.py
+++ b/trellis/agent/contract_ir_solver_parity.py
@@ -144,6 +144,12 @@ def _digital_reference(decision, market_state: MarketState, contract_ir) -> floa
 
 def _swaption_reference(decision, market_state: MarketState, contract_ir) -> float:
     resolved = decision.call_kwargs["resolved"]
+    if (
+        resolved.expiry_years <= 0.0
+        or resolved.annuity <= 0.0
+        or resolved.payment_count <= 0
+    ):
+        return 0.0
     kernel = black76_call if resolved.is_payer else black76_put
     return float(
         resolved.notional

--- a/trellis/agent/dsl_lowering.py
+++ b/trellis/agent/dsl_lowering.py
@@ -465,6 +465,14 @@ def _build_expr_for_route(
             market_signature=market_signature,
             bindings=bindings,
         )
+    resolved_kernel_expr = _build_resolved_pricing_kernel_expr(
+        route_id=route_id,
+        binding_id=binding_id,
+        market_signature=market_signature,
+        bindings=bindings,
+    )
+    if resolved_kernel_expr is not None:
+        return resolved_kernel_expr, ()
     if route_helper is None:
         return None, (_missing_helper_target_message(route_id, binding_id),)
 
@@ -523,6 +531,59 @@ def _build_expr_for_route(
         ),
     )
     return helper_atom, ()
+
+
+def _build_resolved_pricing_kernel_expr(
+    *,
+    route_id: str,
+    binding_id: str,
+    market_signature: ContractSignature,
+    bindings: tuple[DslTargetBinding, ...],
+) -> ContractExpr | None:
+    """Compose one required market resolver with one required pricing kernel."""
+    market_bindings = tuple(
+        binding
+        for binding in bindings
+        if binding.required and binding.role == "market_binding"
+    )
+    pricing_kernels = tuple(
+        binding
+        for binding in bindings
+        if binding.required and binding.role == "pricing_kernel"
+    )
+    required_bindings = tuple(binding for binding in bindings if binding.required)
+    if (
+        len(market_bindings) != 1
+        or len(pricing_kernels) != 1
+        or len(required_bindings) != 2
+    ):
+        return None
+
+    market_binding = market_bindings[0]
+    pricing_kernel = pricing_kernels[0]
+    binding_atom = ContractAtom(
+        atom_id=_binding_atom_id(route_id, binding_id, "market_binding"),
+        primitive_ref=market_binding.primitive_ref,
+        description="Resolve contractual and market inputs into a typed pricing basis.",
+        signature=ContractSignature(
+            inputs=market_signature.inputs,
+            outputs=("resolved_state:state",),
+            timeline_roles=market_signature.timeline_roles,
+            market_data_requirements=market_signature.market_data_requirements,
+        ),
+    )
+    kernel_atom = ContractAtom(
+        atom_id=_binding_atom_id(route_id, binding_id, "pricing_kernel"),
+        primitive_ref=pricing_kernel.primitive_ref,
+        description="Evaluate the resolved pricing basis with the selected raw kernel.",
+        signature=ContractSignature(
+            inputs=("resolved_state:state",),
+            outputs=("price:scalar",),
+            timeline_roles=market_signature.timeline_roles,
+            market_data_requirements=market_signature.market_data_requirements,
+        ),
+    )
+    return ThenExpr(terms=(binding_atom, kernel_atom))
 
 
 def _build_black76_expr(

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -6158,9 +6158,10 @@ def _deterministic_exact_binding_evaluate_body(
         "trellis.models.callable_bond_tree.price_callable_bond_tree": (
             'return price_callable_bond_tree(market_state, spec, model="hull_white")'
         ),
-        "trellis.models.rate_style_swaption.price_swaption_black76": (
-            "return price_swaption_black76(market_state, spec"
-            f"{swaption_comparison_kwargs})"
+        "trellis.models.rate_style_swaption.price_swaption_black76_raw": (
+            "resolved = resolve_swaption_black76_inputs(market_state, spec"
+            f"{swaption_comparison_kwargs})\n"
+            "return price_swaption_black76_raw(resolved)"
         ),
         "trellis.models.rate_style_swaption_tree.price_swaption_tree": (
             "return price_swaption_tree(market_state, spec"
@@ -6715,6 +6716,11 @@ def _deterministic_exact_binding_import_lines(body: str) -> tuple[str, ...]:
         imports.append("from math import sqrt")
     if "year_fraction(" in body:
         imports.append("from trellis.core.date_utils import year_fraction")
+    if "resolve_swaption_black76_inputs(" in body:
+        imports.append(
+            "from trellis.models.rate_style_swaption import "
+            "resolve_swaption_black76_inputs"
+        )
     if "price_heston_option_monte_carlo(" in body:
         imports.append(
             "from trellis.models.monte_carlo.stochastic_vol import price_heston_option_monte_carlo"
@@ -8978,11 +8984,11 @@ def _route_specific_retry_lines(
         and stage in {"code_generation_failed", "semantic_validation_failed", "validation_failed", "actual_market_smoke_failed", "import_validation_failed"}
     ):
         return (
-            "European rate-style swaption analytical routes should stay on the checked helper-backed Black76 surface.",
-            "Prefer `from trellis.models.rate_style_swaption import price_swaption_black76` and delegate to that helper from the adapter.",
-            "When the request supplies explicit Hull-White comparison parameters, pass `mean_reversion=` and `sigma=` into `price_swaption_black76(...)` so the analytical lane uses a Hull-White-implied Black vol instead of drifting to an unrelated market vol surface.",
-            "Do not rebuild annuity, forward-swap-rate, expiry year-fraction, payment-count loops, or swaption-vol normalization inline when the checked helper already owns that binding.",
-            "Keep cap/floor-style period loops separate. This helper-backed shortcut is for single-exercise European swaptions, not for caplet or floorlet strips.",
+            "European rate-style swaption analytical routes should preserve the resolved-input Black76 composition.",
+            "Import `resolve_swaption_black76_inputs` and `price_swaption_black76_raw` from `trellis.models.rate_style_swaption`; resolve once, then pass the typed result to the raw kernel.",
+            "When the request supplies explicit Hull-White comparison parameters, pass `mean_reversion=` and `sigma=` to `resolve_swaption_black76_inputs(...)` so the analytical lane uses a Hull-White-implied Black vol instead of drifting to an unrelated market vol surface.",
+            "Do not rebuild annuity, forward-swap-rate, expiry year-fraction, payment-count loops, or swaption-vol normalization inline, and do not use the product-level compatibility wrapper as construction authority.",
+            "Keep cap/floor-style period loops separate. This composition is for single-exercise European swaptions, not for caplet or floorlet strips.",
         )
     if (
         instrument == "zcb_option"

--- a/trellis/agent/knowledge/canonical/api_map.yaml
+++ b/trellis/agent/knowledge/canonical/api_map.yaml
@@ -414,6 +414,18 @@ rate_monte_carlo_composition:
     - "Until those three capabilities are admitted, Bermudan swaption Monte Carlo must block as a semantic_method_composition_gap instead of falling back to the European swaption helper"
     - "A task-shaped pricing helper is not a substitute for a missing reusable composition capability"
 
+rate_style_swaption_composition:
+  module: trellis.models.rate_style_swaption
+  navigation:
+    aliases: [swaption, european_swaption, black76_swaption, rate_style_swaption]
+  key_imports:
+    - "from trellis.models.rate_style_swaption import ResolvedSwaptionBlack76Inputs, resolve_swaption_black76_inputs, price_swaption_black76_raw"
+  notes:
+    - "For a single-exercise European payer or receiver swaption, resolve the payment timeline, annuity, forward swap rate, strike, Black volatility, and direction with resolve_swaption_black76_inputs(...), then pass the typed result to price_swaption_black76_raw(...)."
+    - "The raw kernel applies notional and annuity exactly once. Do not reapply discounting, notional, or annuity in generated adapter code."
+    - "The product-level price_swaption_black76(...) wrapper remains a compatibility/reference API and is not generated-route construction authority."
+    - "Pass Hull-White comparison parameters to the resolver only when the task contract explicitly requests that comparison regime; ordinary Black76 benchmark tasks use the bound market volatility surface."
+
 qmc:
   module: trellis.models.qmc
   key_imports:
@@ -534,8 +546,10 @@ utilities:
   rate_style_swaption:
     module: trellis.models.rate_style_swaption
     imports:
-      - "from trellis.models.rate_style_swaption import ResolvedSwaptionBlack76Inputs, resolve_swaption_black76_inputs, price_swaption_black76_raw, price_swaption_black76"
+      - "from trellis.models.rate_style_swaption import ResolvedSwaptionBlack76Inputs, resolve_swaption_black76_inputs, price_swaption_black76_raw"
       - "from trellis.models.rate_style_swaption import price_bermudan_swaption_black76_lower_bound"
+    notes:
+      - "For European Black76 construction, bind with resolve_swaption_black76_inputs(...) and price only the typed result with price_swaption_black76_raw(...); the product wrapper is reference-only"
   jamshidian_zcb_option:
     module: trellis.models.zcb_option
     imports:

--- a/trellis/agent/knowledge/canonical/backend_bindings.yaml
+++ b/trellis/agent/knowledge/canonical/backend_bindings.yaml
@@ -962,8 +962,11 @@ bindings:
               style: european
         primitives:
           - module: trellis.models.rate_style_swaption
-            symbol: price_swaption_black76
-            role: route_helper
+            symbol: resolve_swaption_black76_inputs
+            role: market_binding
+          - module: trellis.models.rate_style_swaption
+            symbol: price_swaption_black76_raw
+            role: pricing_kernel
       - when:
           contract_pattern:
             payoff:

--- a/trellis/agent/knowledge/canonical/routes.yaml
+++ b/trellis/agent/knowledge/canonical/routes.yaml
@@ -1524,8 +1524,11 @@ routes:
               style: european
         primitives:
           - module: trellis.models.rate_style_swaption
-            symbol: price_swaption_black76
-            role: route_helper
+            symbol: resolve_swaption_black76_inputs
+            role: market_binding
+          - module: trellis.models.rate_style_swaption
+            symbol: price_swaption_black76_raw
+            role: pricing_kernel
         adapters: []
         notes: []
       - when:

--- a/trellis/agent/lite_review.py
+++ b/trellis/agent/lite_review.py
@@ -217,7 +217,7 @@ def _capability_literal_issue(
     *,
     generation_plan=None,
 ) -> LiteReviewIssue | None:
-    if _capability_literal_is_subsumed_by_helper(
+    if _capability_literal_is_subsumed_by_route_binding(
         capability,
         signals,
         generation_plan=generation_plan,
@@ -259,25 +259,25 @@ def _capability_literal_issue(
     )
 
 
-def _capability_literal_is_subsumed_by_helper(
+def _capability_literal_is_subsumed_by_route_binding(
     capability: str,
     signals: LiteReviewSignals,
     *,
     generation_plan=None,
 ) -> bool:
-    """Return whether a helper-backed route legitimately owns the literal."""
+    """Return whether an admitted route binding legitimately owns the literal."""
     if capability != "black_vol_surface":
         return False
     primitive_plan = getattr(generation_plan, "primitive_plan", None)
     if primitive_plan is None:
         return False
-    helper_by_route = {
-        "analytical_black76": "price_swaption_black76",
+    binding_by_route = {
+        "analytical_black76": "resolve_swaption_black76_inputs",
         "rate_tree_backward_induction": "price_swaption_tree",
         "monte_carlo_paths": "price_swaption_monte_carlo",
     }
-    helper_name = helper_by_route.get(primitive_plan.route)
-    if helper_name is None or helper_name not in signals.call_names:
+    binding_name = binding_by_route.get(primitive_plan.route)
+    if binding_name is None or binding_name not in signals.call_names:
         return False
     return (
         any(item.startswith("mean_reversion=") for item in signals.literal_assignments)

--- a/trellis/agent/prompts.py
+++ b/trellis/agent/prompts.py
@@ -581,10 +581,10 @@ def _render_family_route_guidance(
     if instrument_type == "swaption" and method == "analytical":
         lines.append("## Family Route Guidance")
         lines.extend([
-            "- For European rate-style swaptions, prefer `price_swaption_black76(market_state, self._spec, ...)` from `trellis.models.rate_style_swaption`.",
-            "- Keep the adapter thin: validate discount/vol access, then delegate to the family helper instead of rebuilding a resolve-plus-kernel split inline.",
-            "- When the request supplies explicit Hull-White comparison parameters, pass `mean_reversion=` and `sigma=` into `price_swaption_black76(...)` so the analytical comparator uses a Hull-White-implied Black vol instead of an unrelated market surface quote.",
-            "- Do not rebuild annuity, forward-swap-rate, expiry year-fraction, payment-count loops, or swaption-vol normalization inline when the checked-in helper already owns that binding.",
+            "- For European rate-style swaptions, import `resolve_swaption_black76_inputs` and `price_swaption_black76_raw` from `trellis.models.rate_style_swaption`.",
+            "- Resolve once with `resolved = resolve_swaption_black76_inputs(market_state, self._spec, ...)`, then return `price_swaption_black76_raw(resolved)`. The resolver owns the market and schedule binding; the raw kernel owns only the Black76 formula and scaling.",
+            "- When the request supplies explicit Hull-White comparison parameters, pass `mean_reversion=` and `sigma=` to `resolve_swaption_black76_inputs(...)` so the resolved inputs carry a Hull-White-implied Black vol instead of an unrelated market surface quote.",
+            "- Do not rebuild annuity, forward-swap-rate, expiry year-fraction, payment-count loops, or swaption-vol normalization inline. Do not use the product-level `price_swaption_black76(...)` compatibility wrapper as generated construction authority.",
         ])
 
     if instrument_type == "swaption" and method == "rate_tree":

--- a/trellis/instruments/_agent/swaption.py
+++ b/trellis/instruments/_agent/swaption.py
@@ -8,8 +8,10 @@ from datetime import date
 from trellis.core.market_state import MarketState
 from trellis.core.payoff import PricingValue
 from trellis.core.types import DayCountConvention, Frequency
-from trellis.models.rate_style_swaption import price_swaption_black76
-
+from trellis.models.rate_style_swaption import (
+    price_swaption_black76_raw,
+    resolve_swaption_black76_inputs,
+)
 
 
 @dataclass(frozen=True)
@@ -42,4 +44,5 @@ class SwaptionPayoff:
 
     def evaluate(self, market_state: MarketState) -> PricingValue:
         spec = self._spec
-        return price_swaption_black76(market_state, spec)
+        resolved = resolve_swaption_black76_inputs(market_state, spec)
+        return price_swaption_black76_raw(resolved)


### PR DESCRIPTION
## Summary

- replace European analytical swaption wrapper authority with `resolve_swaption_black76_inputs(...)` followed by `price_swaption_black76_raw(...)`
- preserve the composition across canonical route/binding metadata, DSL lowering, structural ContractIR compilation, deterministic generation, prompts, review policy, and the admitted F006 adapter
- update developer, quant, user, and parity benchmark documentation while leaving cookbooks and public compatibility APIs unchanged

## Validation

- strict offline F006: passed expectation at `45741.97548118981`, zero retries, zero LLM calls/tokens
- helper-authority audit: route refs 54, binding refs 58, adapter authority calls 12; unrelated drift unchanged at 4/8
- ContractIR/compiler/instruction slice: 42 passed
- regional agent suite: 830 passed
- knowledge store: 85 passed
- `NUMBA_CACHE_DIR=/tmp/trellis-numba-cache make gate-pr`: 4,677 main tests plus 32 tier-2 contract tests passed
- `NUMBA_CACHE_DIR=/tmp/trellis-numba-cache make gate-release`: green, including 487 cross-validation/verification/task proofs and 2 freshness tests
- post-self-review adapter checks: 3 passed
- `git diff --check`

## Scope Notes

- `price_swaption_black76(...)` remains available for compatibility and independent reference validation only
- no cookbook, lesson, experience, or new pricing-helper change
- `LIMITATIONS.md` is neutral because product support, numerical behavior, and the public compatibility surface do not change

Linear: QUA-1196
