### PR TITLE
QUA-1197 Compose Bermudan Black76 lower bound

### DIFF
--- a/CANARY_TASKS.yaml
+++ b/CANARY_TASKS.yaml
@@ -16,13 +16,13 @@ canary_set:
     estimated_cost_usd: 0.12
     record_cassette: false
     replay_mode: deterministic_exact_binding
-    expected_failure_bucket: comparison_semantic_artifact_mismatch
-    rationale: Semantic guard proving the stale shared analytical artifact cannot create a false green for distinct PDE and analytical targets.
+    rationale: Deterministic replay proving independently materialized PDE variants and the analytical reference retain distinct source identities and pass comparison.
     covers:
       - pde
       - deterministic_replay
       - exact_binding
       - semantic_artifact_gate
+      - target_specific_artifact_identity
       - false_green_prevention
 
   - id: T38

--- a/TASKS_PROOF_LEGACY.yaml
+++ b/TASKS_PROOF_LEGACY.yaml
@@ -80,6 +80,9 @@ tasks:
     internal:
     - hw_tree_bermudan
     - black76_european_lower_bound
+    reference_target: hw_tree_bermudan
+    relations:
+      black76_european_lower_bound: <=
     external:
     - quantlib
     - financepy

--- a/docs/developer/dsl_system_design_review.md
+++ b/docs/developer/dsl_system_design_review.md
@@ -233,13 +233,14 @@ boundary is also stricter here: an explicit ``instrument_type`` such as
 ``vanilla_option`` contract when the prose only happens to contain
 generic ``option`` language.
 
-The analytical / PDE / FFT helper cohort now behaves the same way.
-Helper-backed Black76 swaption routes, vanilla-equity PDE / event-aware PDE
-helper branches, and the vanilla-equity transform helper keep only backend
-binding, admissibility, and signature-validation authority. When generated code
-tries to reconstruct spot/strike/time bundles or call those helpers on the
-wrong surface, semantic validation now fails directly instead of leaning on
-route-card repair prose.
+The analytical / PDE / FFT cohort now behaves the same way. Primitive-composed
+Black76 swaption routes, vanilla-equity PDE / event-aware PDE helper branches,
+and the vanilla-equity transform helper keep only the appropriate backend
+binding, admissibility, primitive, and signature-validation authority. When
+generated code reconstructs already-resolved market bundles, uses product
+wrappers as construction authority, or calls a helper on the wrong surface,
+semantic validation fails directly instead of leaning on route-card repair
+prose.
 
 The Monte Carlo compiler now has the matching bounded family surface for the
 next migration tranche:

--- a/docs/developer/implementation_journey_prompt_to_price.md
+++ b/docs/developer/implementation_journey_prompt_to_price.md
@@ -73,26 +73,31 @@ practice this is what lets one semantic contract lower cleanly to an
 analytical kernel, a PDE helper, or a lattice helper based on the selected
 method without changing the contract shape.
 
-The practical follow-on is that comparison routes can now target checked-in
-helper surfaces instead of forcing the builder to reassemble the same
-mathematical glue repeatedly. A recent example is Bermudan swaptions:
+The practical follow-on is that comparison routes can expose the smallest
+stable construction surfaces instead of forcing the builder to rediscover
+market binding or hiding the whole target behind a product wrapper. Bermudan
+swaptions now illustrate both cases:
 
 - the tree lane lowers to ``price_bermudan_swaption_tree(...)``
-- the analytical comparison lane lowers to
-  ``price_bermudan_swaption_black76_lower_bound(...)``
+- the analytical comparison lane normalizes the exercise dates, selects the
+  final date strictly after settlement and before swap end, resolves that
+  European swaption with ``resolve_swaption_black76_inputs(...)``, and passes
+  the typed result to ``price_swaption_black76_raw(...)``
 
 That keeps the comparison target explicit and bounded. The analytical lane is
-no longer "write some Black76-like code for a Bermudan swaption"; it is "call
-the checked-in lower-bound helper that represents the intended comparison
-contract". In this case the intended comparison contract is the European
-swaption exercisable only on the final Bermudan date, not an aggregate or
-max-over-schedule analytical surrogate.
+not "write some Black76-like code for a Bermudan swaption" or "call a product
+wrapper". The adapter owns the small derivative-specific rule: return zero if
+no valid date remains, otherwise price the European swaption exercisable only
+on the final Bermudan date. It must not aggregate or maximize European values
+over the schedule. The retained
+``price_bermudan_swaption_black76_lower_bound(...)`` function is comparison and
+compatibility evidence, not generated construction authority.
 
 Compiled request metadata now also carries a compact semantic-blueprint summary
 for downstream tooling. That summary records the canonical lowered route, the
-helper references selected by DSL lowering, and any explicit control styles so
-trace, review, and UI code do not need to reconstruct those details from the
-full compiler objects.
+helper and primitive references selected by DSL lowering, and any explicit
+control styles so trace, review, and UI code do not need to reconstruct those
+details from the full compiler objects.
 
 ## Comparison Tasks Changed the Architecture
 

--- a/docs/developer/task_diagnostics.rst
+++ b/docs/developer/task_diagnostics.rst
@@ -422,20 +422,21 @@ If the generated adapter hard-codes a smaller path count such as ``50000``
 instead of flowing ``spec.n_paths``, expect a route-specific diagnosis packet
 that fails on internal comparison spread long before reviewer escalation.
 
-For analytical rate-style swaption routes, the deterministic bundle now also
-checks helper consistency against the checked-in
-``trellis.models.rate_style_swaption`` Black76 surface. If a generated adapter
-compiles but misbinds annuity, forward swap rate, or notional, the packet
-should now show a route-specific ``check_rate_style_swaption_helper_consistency``
-failure with sampled scenario prices before the run escalates to critic or
-model-validator review.
+For analytical rate-style swaption routes, the deterministic bundle also checks
+composition consistency against the retained
+``trellis.models.rate_style_swaption`` Black76 reference surface. If a generated
+adapter compiles but misbinds annuity, forward swap rate, notional, or the final
+valid Bermudan comparison date, the packet should show a route-specific
+``check_rate_style_swaption_helper_consistency`` failure with sampled scenario
+prices before the run escalates to critic or model-validator review. The legacy
+check id does not grant construction authority to the reference wrapper.
 
 Eligible single-method routes now also emit a post-bundle
 ``reference_oracle_executed`` event before reviewer escalation. This is the
 next checkpoint after the deterministic bundle for helper-backed exact or
 bound-style routes:
 
-- analytical swaptions against the checked-in Black76 helper
+- analytical swaptions against the retained Black76 reference
 - analytical zero-coupon-bond options against the Jamshidian helper
 - callable and puttable rate-tree bonds against the straight-bond bound helper
 

--- a/docs/quant/analytical_route_cookbook.rst
+++ b/docs/quant/analytical_route_cookbook.rst
@@ -213,6 +213,12 @@ Recent analytical routes in Trellis follow the same resolver-to-raw split:
   ``ResolvedSwaptionBlack76Inputs`` ->
   ``price_swaption_black76_raw(...)`` in
   ``trellis.models.rate_style_swaption``.
+- Bermudan final-exercise Black76 comparator: normalize explicit exercise
+  dates, keep only dates strictly after settlement and before swap end, return
+  zero when none remain, then pass the final valid date as ``expiry_date`` to
+  ``resolve_swaption_black76_inputs(...)`` and price the resolved value once
+  with ``price_swaption_black76_raw(...)``. Do not sum or maximize European
+  values across the schedule; the retained product wrapper is reference-only.
 - Jamshidian zero-coupon bond option:
   ``resolve_zcb_option_hw_inputs(...)`` ->
   ``ResolvedJamshidianInputs`` / ``zcb_option_hw_raw(...)`` under the public

--- a/docs/quant/extending_trellis.rst
+++ b/docs/quant/extending_trellis.rst
@@ -100,13 +100,17 @@ For schedule-dependent swaptions, split the stable surfaces by solver role:
 
 - Bermudan tree routes should delegate to
   ``trellis.models.bermudan_swaption_tree.price_bermudan_swaption_tree(...)``
-- analytical comparison lanes should delegate to
-  ``trellis.models.rate_style_swaption.price_bermudan_swaption_black76_lower_bound(...)``
+- analytical comparison lanes should normalize explicit exercise dates, select
+  the final date strictly after settlement and before swap end, bind the
+  European claim through ``resolve_swaption_black76_inputs(...)``, and pass its
+  typed result to ``price_swaption_black76_raw(...)``
 
-That analytical helper is intentionally a lower-bound surface. It prices the
-European swaption exercisable only on the final Bermudan date. It is not a
-closed-form Bermudan solver and should not be replaced with an inline loop that
-sums multiple exercise-date European values.
+That analytical composition is intentionally a lower-bound comparator. It
+prices the European swaption exercisable only on the final valid Bermudan date,
+returns zero when no valid date remains, and is not a closed-form Bermudan
+solver. The adapter owns that small schedule-selection rule; it must not sum or
+maximize multiple exercise-date European values. The retained product wrapper
+is compatibility/reference evidence, not generated-route authority.
 
 The same rule now applies to schedule-dependent lattice exercise. Prefer the
 checked-in control helpers in ``trellis.models.trees.control`` over hand-coded

--- a/docs/quant/pricing_stack.rst
+++ b/docs/quant/pricing_stack.rst
@@ -903,12 +903,13 @@ bounded Hull-White calibration/model contract now survive into the
 method-specific ``ValuationContext`` and ``MarketBindingSpec`` instead of being
 dropped when a multi-method comparison request is compiled.
 
-For the helper-backed analytical, tree, and Monte Carlo swaption routes, the
-runtime now also preserves those comparison-regime bindings when it materializes
-deterministic exact wrappers. That means the exact helper calls carry the same
-explicit Hull-White comparison parameters, and the Monte Carlo wrapper adds a
-stable comparison-quality sampling control instead of drifting on an unseeded
-default path.
+For the primitive-composed analytical and helper-backed tree and Monte Carlo
+swaption routes, the runtime preserves those comparison-regime bindings when it
+materializes deterministic adapters. The analytical adapter carries the same
+explicit curve/model comparison parameters through the resolver into the raw
+Black76 kernel. Tree and Monte Carlo helper calls preserve those parameters,
+and the Monte Carlo wrapper adds a stable comparison-quality sampling control
+instead of drifting on an unseeded default path.
 
 Within the valuation layer, migrated calibration workflows now carry a bounded
 ``EngineModelSpec`` surface instead of relying only on a free-form
@@ -989,7 +990,7 @@ does not treat equity/Heston model payloads or generic Black-vol surfaces as
 short-rate model parameters.
 
 The analytical / PDE / FFT support cohort now follows the same rule. The
-helper-backed Black76 swaption routes, the primitive-composed vanilla-equity
+primitive-composed Black76 swaption routes, the primitive-composed vanilla-equity
 PDE route, bounded CEV PDE/tree proof helpers, bounded event-aware PDE helper
 branches, Heston ADI diagnostic scaffold, double-barrier payoff primitives,
 and vanilla-equity transform helper keep backend binding, admissibility, and

--- a/docs/user_guide/pricing.rst
+++ b/docs/user_guide/pricing.rst
@@ -579,6 +579,15 @@ to the raw kernel. ``price_swaption_black76(...)`` remains usable as a public
 compatibility and reference function, but it is not advertised as construction
 authority.
 
+The Bermudan ``black76_european_lower_bound`` comparison reuses those same
+surfaces without pretending Black76 is a Bermudan solver. Generated code
+normalizes the exercise schedule, keeps dates strictly after settlement and
+before swap end, returns zero if none remain, and resolves only the final valid
+date before calling ``price_swaption_black76_raw(...)``. It must not sum or
+maximize European values across the schedule. The retained product-level
+lower-bound wrapper is comparison/reference evidence rather than construction
+authority.
+
 The trace boundary also exposes a family-first ``construction_identity``
 summary. For operators, that is now the primary readout:
 

--- a/tests/test_agent/test_api_map.py
+++ b/tests/test_agent/test_api_map.py
@@ -55,6 +55,10 @@ def test_api_map_contains_expected_core_entries():
         api_map["rate_monte_carlo_composition"]["module"]
         == "trellis.models.monte_carlo.simulation_substrate"
     )
+    assert (
+        api_map["bermudan_swaption_lower_bound_composition"]["module"]
+        == "trellis.models.rate_style_swaption"
+    )
     assert api_map["equity_tree"]["module"] == "trellis.models.trees.algebra"
     assert api_map["rate_lattice"]["module"] == "trellis.models.trees.lattice"
     assert "utilities" in api_map
@@ -84,6 +88,7 @@ def test_api_map_key_imports_are_registry_valid():
         "digital_option_composition",
         "quanto_option_composition",
         "rate_monte_carlo_composition",
+        "bermudan_swaption_lower_bound_composition",
         "qmc",
         "pde",
         "fft",
@@ -292,11 +297,52 @@ def test_api_map_semantic_selection_reaches_composition_cards():
             ),
             "rate_monte_carlo_composition",
         ),
+        (
+            ApiMapQuery(
+                instrument_type="bermudan_swaption",
+                payoff_family="swaption",
+                method="analytical",
+                features=("black76_european_lower_bound",),
+            ),
+            "bermudan_swaption_lower_bound_composition",
+        ),
     )
 
     for query, expected_family in cases:
         selection = select_api_map_sections(query)
         assert expected_family in selection.selected_families
+
+
+def test_api_map_exposes_bermudan_final_exercise_lower_bound_composition():
+    query = ApiMapQuery(
+        instrument_type="bermudan_swaption",
+        payoff_family="swaption",
+        method="analytical",
+        features=("black76_european_lower_bound",),
+    )
+    selection = select_api_map_sections(query)
+    text = format_api_map_for_prompt(compact=True, query=query)
+
+    assert "bermudan_swaption_lower_bound_composition" in (
+        selection.selected_families
+    )
+    assert selection.selected_families[0] == (
+        "bermudan_swaption_lower_bound_composition"
+    )
+    assert "rate_lattice" not in selection.selected_families
+    assert "rate_monte_carlo_composition" not in selection.selected_families
+    for symbol in (
+        "normalize_explicit_dates",
+        "resolve_swaption_black76_inputs",
+        "price_swaption_black76_raw",
+    ):
+        assert symbol in text
+    assert "final normalized exercise date" in text
+    assert "strictly after settlement and before swap end" in text
+    assert "Return zero when no valid exercise date remains" in text
+    assert "Do not sum or maximize European prices" in text
+    assert "price_bermudan_swaption_black76_lower_bound(...)" in text
+    assert "from trellis.models.rate_style_swaption import " in text
 
 
 def test_api_map_exposes_complete_fixed_lookback_analytical_composition():

--- a/tests/test_agent/test_autonomous.py
+++ b/tests/test_agent/test_autonomous.py
@@ -312,6 +312,59 @@ def test_build_with_tracking_forwards_retry_overlays_to_build_payoff(monkeypatch
     ]
 
 
+def test_build_with_tracking_preserves_deterministic_source_metadata(monkeypatch):
+    from trellis.agent.knowledge.autonomous import _build_with_tracking
+    from trellis.agent.knowledge.gap_check import GapReport
+    from trellis.agent.knowledge.schema import ProductDecomposition
+
+    decomposition = ProductDecomposition(
+        instrument="bermudan_swaption",
+        features=("bermudan_exercise",),
+        method="analytical",
+        learned=False,
+    )
+    deterministic_source = "class DeterministicPayoff:\n    pass\n"
+
+    def fake_build_payoff(*args, **kwargs):
+        kwargs["build_meta"]["code"] = deterministic_source
+        return type("DeterministicPayoff", (), {})
+
+    monkeypatch.setattr("trellis.agent.executor.build_payoff", fake_build_payoff)
+    monkeypatch.setattr(
+        "trellis.agent.knowledge.retrieve_for_product_ir",
+        lambda *args, **kwargs: [],
+    )
+    monkeypatch.setattr(
+        "trellis.agent.knowledge.build_shared_knowledge_payload",
+        lambda knowledge: {
+            "summary": {},
+            "builder_text_distilled": "",
+            "builder_text": "",
+            "builder_text_expanded": "",
+            "review_text_distilled": "",
+            "review_text_expanded": "",
+        },
+    )
+
+    payoff_cls, meta = _build_with_tracking(
+        description="Bermudan swaption lower bound",
+        instrument_type="bermudan_swaption",
+        decomposition=decomposition,
+        product_ir=SimpleNamespace(instrument="bermudan_swaption"),
+        gap_report=GapReport(confidence=0.8, retrieved_lesson_ids=[]),
+        model="test-model",
+        market_state=None,
+        max_retries=1,
+        validation="standard",
+        force_rebuild=True,
+        preferred_method="analytical",
+    )
+
+    assert payoff_cls.__name__ == "DeterministicPayoff"
+    assert meta["attempts"] == 0
+    assert meta["code"] == deterministic_source
+
+
 def test_build_with_tracking_scopes_live_knowledge_to_compiled_route(monkeypatch):
     from trellis.agent.knowledge.autonomous import _build_with_tracking
     from trellis.agent.knowledge.gap_check import GapReport

--- a/tests/test_agent/test_backend_bindings.py
+++ b/tests/test_agent/test_backend_bindings.py
@@ -355,6 +355,34 @@ def test_resolve_backend_binding_spec_uses_route_conditionals_for_exact_targets(
         == "trellis.models.rate_style_swaption.price_swaption_black76_raw"
     )
 
+    bermudan_resolved = resolve_backend_binding_spec(
+        binding,
+        product_ir=ProductIR(
+            instrument="bermudan_swaption",
+            payoff_family="swaption",
+            exercise_style="bermudan",
+            schedule_dependence=True,
+            state_dependence="schedule_state",
+        ),
+    )
+
+    assert bermudan_resolved.helper_refs == ()
+    assert bermudan_resolved.schedule_builder_refs == (
+        "trellis.core.date_utils.normalize_explicit_dates",
+    )
+    assert bermudan_resolved.market_binding_refs == (
+        "trellis.models.rate_style_swaption.resolve_swaption_black76_inputs",
+    )
+    assert bermudan_resolved.pricing_kernel_refs == (
+        "trellis.models.rate_style_swaption.price_swaption_black76_raw",
+    )
+    assert bermudan_resolved.exact_target_refs == (
+        "trellis.models.rate_style_swaption.price_swaption_black76_raw",
+    )
+    assert bermudan_resolved.binding_id == (
+        "trellis.models.rate_style_swaption.price_swaption_black76_raw"
+    )
+
 
 def test_resolve_backend_binding_spec_uses_basket_option_exact_helpers():
     catalog = load_backend_binding_catalog()

--- a/tests/test_agent/test_backend_bindings_black76_dsl_parity.py
+++ b/tests/test_agent/test_backend_bindings_black76_dsl_parity.py
@@ -109,9 +109,20 @@ _BASKET_PRIMS: tuple[PrimitiveRef, ...] = (
 
 _SWAPTION_BERM_PRIMS: tuple[PrimitiveRef, ...] = (
     PrimitiveRef(
+        "trellis.core.date_utils",
+        "normalize_explicit_dates",
+        "schedule_builder",
+        required=False,
+    ),
+    PrimitiveRef(
         "trellis.models.rate_style_swaption",
-        "price_bermudan_swaption_black76_lower_bound",
-        "route_helper",
+        "resolve_swaption_black76_inputs",
+        "market_binding",
+    ),
+    PrimitiveRef(
+        "trellis.models.rate_style_swaption",
+        "price_swaption_black76_raw",
+        "pricing_kernel",
     ),
 )
 

--- a/tests/test_agent/test_comparison_target_contracts.py
+++ b/tests/test_agent/test_comparison_target_contracts.py
@@ -27,6 +27,17 @@ def _contracts_for(task_id: str):
     }
 
 
+def test_t04_declares_tree_reference_and_european_lower_bound_relation():
+    from trellis.agent.assembly_tools import build_comparison_harness_plan
+
+    plan = build_comparison_harness_plan(_proof_tasks()["T04"])
+    targets = {target.target_id: target for target in plan.targets}
+
+    assert plan.reference_target == "hw_tree_bermudan"
+    assert targets["hw_tree_bermudan"].is_reference is True
+    assert targets["black76_european_lower_bound"].relation == "<="
+
+
 def test_declared_option_comparison_targets_preserve_method_variants_and_axes():
     t27 = _contracts_for("T27")
     assert t27["polynomial"].method == "monte_carlo"
@@ -805,6 +816,25 @@ def test_cross_validation_rejects_equivalence_group_for_different_contracts():
         report["status"] == "unbound_shared_artifact"
         for report in comparison["artifact_coherence"].values()
     )
+
+
+def test_generated_artifact_identity_prefers_build_source_over_mutable_module_file():
+    from trellis.agent.task_runtime import _comparison_artifact_identity
+
+    class GeneratedPayoff:
+        pass
+
+    first_identity, first_artifact = _comparison_artifact_identity(
+        SimpleNamespace(payoff_cls=GeneratedPayoff, code="first generated target")
+    )
+    second_identity, second_artifact = _comparison_artifact_identity(
+        SimpleNamespace(payoff_cls=GeneratedPayoff, code="second generated target")
+    )
+
+    assert first_artifact["module_name"] == second_artifact["module_name"]
+    assert first_artifact["class_name"] == second_artifact["class_name"]
+    assert first_artifact["code_hash"] != second_artifact["code_hash"]
+    assert first_identity != second_identity
 
 
 def test_cross_validation_uses_persisted_contract_method_for_legacy_result():

--- a/tests/test_agent/test_dsl_lowering.py
+++ b/tests/test_agent/test_dsl_lowering.py
@@ -571,7 +571,7 @@ def test_rate_style_swaption_receiver_analytical_uses_same_resolved_composition(
     )
 
 
-def test_bermudan_swaption_analytical_lowers_to_lower_bound_helper():
+def test_bermudan_swaption_analytical_lowers_to_resolver_then_raw_kernel():
     from trellis.agent.semantic_contract_compiler import compile_semantic_contract
     from trellis.agent.semantic_contracts import make_rate_style_swaption_contract
 
@@ -587,9 +587,16 @@ def test_bermudan_swaption_analytical_lowers_to_lower_bound_helper():
     assert lowering is not None
     assert lowering.route_id == "analytical_black76"
     assert lowering.admissibility_errors == ()
-    assert isinstance(lowering.normalized_expr, ContractAtom)
-    assert lowering.normalized_expr.primitive_ref == (
-        "trellis.models.rate_style_swaption.price_bermudan_swaption_black76_lower_bound"
+    assert isinstance(lowering.normalized_expr, ThenExpr)
+    assert tuple(term.primitive_ref for term in lowering.normalized_expr.terms) == (
+        "trellis.models.rate_style_swaption.resolve_swaption_black76_inputs",
+        "trellis.models.rate_style_swaption.price_swaption_black76_raw",
+    )
+    assert lowering.route_helper_refs == ()
+    assert lowering.target_refs == (
+        "trellis.core.date_utils.normalize_explicit_dates",
+        "trellis.models.rate_style_swaption.resolve_swaption_black76_inputs",
+        "trellis.models.rate_style_swaption.price_swaption_black76_raw",
     )
 
 

--- a/tests/test_agent/test_executor.py
+++ b/tests/test_agent/test_executor.py
@@ -1034,6 +1034,60 @@ def test_admitted_swaption_adapter_composes_resolved_inputs_with_raw_kernel():
     assert "price_swaption_black76(market_state" not in source
 
 
+def test_deterministic_exact_binding_module_materializes_bermudan_lower_bound_composition():
+    from trellis.agent.executor import (
+        EVALUATE_SENTINEL,
+        _generate_skeleton,
+        _materialize_deterministic_exact_binding_module,
+    )
+    from trellis.agent.planner import STATIC_SPECS
+
+    generation_plan = SimpleNamespace(
+        lane_exact_binding_refs=(
+            "trellis.models.rate_style_swaption.price_swaption_black76_raw",
+        ),
+        primitive_plan=SimpleNamespace(route="analytical_black76"),
+        method="analytical",
+        instrument_type="bermudan_swaption",
+    )
+
+    skeleton = _generate_skeleton(
+        STATIC_SPECS["bermudan_swaption"],
+        "Bermudan payer swaption analytical lower bound",
+        generation_plan=generation_plan,
+    )
+    generated = _materialize_deterministic_exact_binding_module(
+        skeleton,
+        generation_plan,
+        comparison_target="black76_european_lower_bound",
+    )
+
+    assert generated is not None
+    assert "normalize_explicit_dates(spec.exercise_dates)" in generated.code
+    assert "market_state.settlement < exercise_date < spec.swap_end" in generated.code
+    assert "if not valid_exercise_dates:" in generated.code
+    assert "return 0.0" in generated.code
+    assert "final_exercise_date = valid_exercise_dates[-1]" in generated.code
+    assert "expiry_date=final_exercise_date" in generated.code
+    assert "return price_swaption_black76_raw(resolved)" in generated.code
+    assert "price_bermudan_swaption_black76_lower_bound" not in generated.code
+    assert EVALUATE_SENTINEL not in generated.code
+
+
+def test_admitted_bermudan_swaption_adapter_composes_final_exercise_lower_bound():
+    source = (
+        Path(__file__).resolve().parents[2]
+        / "trellis/instruments/_agent/bermudanswaption.py"
+    ).read_text()
+
+    assert "normalize_explicit_dates(spec.exercise_dates)" in source
+    assert "market_state.settlement < exercise_date < spec.swap_end" in source
+    assert "final_exercise_date = valid_exercise_dates[-1]" in source
+    assert "expiry_date=final_exercise_date" in source
+    assert "price_swaption_black76_raw(resolved)" in source
+    assert "price_bermudan_swaption_black76_lower_bound" not in source
+
+
 def test_deterministic_exact_binding_module_materializes_bermudan_tree_compat_wrapper():
     from trellis.agent.executor import (
         EVALUATE_SENTINEL,

--- a/tests/test_agent/test_helper_authority_audit.py
+++ b/tests/test_agent/test_helper_authority_audit.py
@@ -295,6 +295,26 @@ def test_current_repository_retires_european_swaption_wrapper_authority():
     ]
 
 
+def test_current_repository_retires_bermudan_swaption_lower_bound_helper_authority():
+    from trellis.agent.helper_authority_audit import build_helper_authority_report
+
+    root = Path(__file__).resolve().parents[2]
+    report = build_helper_authority_report(root)
+    helper_symbol = "price_bermudan_swaption_black76_lower_bound"
+
+    assert not [
+        item
+        for item in (*report.route_authority, *report.binding_authority)
+        if item.symbol == helper_symbol
+    ]
+    assert not [
+        item
+        for item in report.adapter_calls
+        if item.path == "trellis/instruments/_agent/bermudanswaption.py"
+        and item.symbol == helper_symbol
+    ]
+
+
 def test_current_repository_retires_analytical_digital_helper_authority():
     from trellis.agent.helper_authority_audit import build_helper_authority_report
 

--- a/tests/test_agent/test_knowledge_store.py
+++ b/tests/test_agent/test_knowledge_store.py
@@ -443,7 +443,7 @@ class TestKnowledgeStore:
         lesson_ids = [lesson.id for lesson in k["lessons"]]
         assert "md_114" in lesson_ids
 
-    def test_retrieve_swaption_ir_includes_helper_backed_black76_guidance(self):
+    def test_retrieve_swaption_ir_includes_composed_black76_guidance(self):
         from trellis.agent.knowledge import retrieve_for_product_ir
         from trellis.agent.knowledge.decompose import build_product_ir
 
@@ -473,7 +473,7 @@ class TestKnowledgeStore:
         assert "price_swaption_black76_raw" in k["cookbook"].template
         assert k["method_requirements"] is not None
         requirements_text = "\n".join(k["method_requirements"].requirements)
-        assert "RATE-STYLE SWAPTION HELPER CONTRACT" in requirements_text
+        assert "RATE-STYLE SWAPTION COMPOSITION CONTRACT" in requirements_text
         assert "price_swaption_black76_raw" in requirements_text
 
     def test_retrieve_zcb_option_ir_includes_jamshidian_raw_guidance(self):

--- a/tests/test_agent/test_primitive_planning.py
+++ b/tests/test_agent/test_primitive_planning.py
@@ -913,7 +913,7 @@ def test_builds_exercise_lattice_plan_for_bermudan_swaption():
     assert plan.primitive_plan.blockers == ()
 
 
-def test_builds_analytical_plan_for_bermudan_swaption_lower_bound():
+def test_builds_analytical_plan_for_bermudan_swaption_lower_bound_composition():
     from trellis.agent.codegen_guardrails import build_generation_plan
     from trellis.agent.knowledge.decompose import decompose_to_ir
 
@@ -938,8 +938,15 @@ def test_builds_analytical_plan_for_bermudan_swaption_lower_bound():
     assert plan.primitive_plan is not None
     assert plan.primitive_plan.route == "analytical_black76"
     assert plan.primitive_plan.engine_family == "analytical"
-    primitive_symbols = {primitive.symbol for primitive in plan.primitive_plan.primitives}
-    assert primitive_symbols == {"price_bermudan_swaption_black76_lower_bound"}
+    primitives = {
+        (primitive.symbol, primitive.role, primitive.required)
+        for primitive in plan.primitive_plan.primitives
+    }
+    assert primitives == {
+        ("normalize_explicit_dates", "schedule_builder", False),
+        ("resolve_swaption_black76_inputs", "market_binding", True),
+        ("price_swaption_black76_raw", "pricing_kernel", True),
+    }
     assert plan.primitive_plan.adapters == ()
     assert plan.primitive_plan.blockers == ()
 

--- a/tests/test_agent/test_prompts.py
+++ b/tests/test_agent/test_prompts.py
@@ -1584,7 +1584,7 @@ def test_executor_bermudan_swaption_rate_tree_retry_pins_helper_and_bermudan_con
     assert "price_callable_bond_tree" in text
 
 
-def test_executor_bermudan_swaption_analytical_retry_pins_lower_bound_helper():
+def test_executor_bermudan_swaption_analytical_retry_pins_final_exercise_composition():
     from types import SimpleNamespace
 
     from trellis.agent.executor import KnowledgeRetrievalRequest, _route_specific_retry_lines
@@ -1603,7 +1603,10 @@ def test_executor_bermudan_swaption_analytical_retry_pins_lower_bound_helper():
 
     text = "\n".join(_route_specific_retry_lines(request))
 
-    assert "price_bermudan_swaption_black76_lower_bound" in text
+    assert "normalize_explicit_dates" in text
+    assert "resolve_swaption_black76_inputs" in text
+    assert "price_swaption_black76_raw" in text
+    assert "price_bermudan_swaption_black76_lower_bound" not in text
     assert "European swaption exercisable only on the final Bermudan date" in text
     assert "Do not sum one European Black76 price per exercise date" in text
 

--- a/tests/test_agent/test_route_registry.py
+++ b/tests/test_agent/test_route_registry.py
@@ -1733,20 +1733,41 @@ class TestAnalyticalRoutes:
         assert resolve_route_notes(spec, self.SWAPTION_IR) == ()
         assert resolve_route_adapters(spec, self.SWAPTION_IR) == ()
 
-    def test_bermudan_swaption_primitives_use_lower_bound_helper(self, registry):
+    def test_bermudan_swaption_primitives_compose_final_exercise_resolved_kernel(self, registry):
         spec = [r for r in registry.routes if r.id == "analytical_black76"][0]
         new_prims = resolve_route_primitives(spec, self.BERMUDAN_SWAPTION_IR)
         assert _prim_set(new_prims) == {
             (
+                "trellis.core.date_utils",
+                "normalize_explicit_dates",
+                "schedule_builder",
+            ),
+            (
                 "trellis.models.rate_style_swaption",
-                "price_bermudan_swaption_black76_lower_bound",
-                "route_helper",
+                "resolve_swaption_black76_inputs",
+                "market_binding",
+            ),
+            (
+                "trellis.models.rate_style_swaption",
+                "price_swaption_black76_raw",
+                "pricing_kernel",
             ),
         }
+        normalizer = next(
+            primitive
+            for primitive in new_prims
+            if primitive.symbol == "normalize_explicit_dates"
+        )
+        assert normalizer.required is False
 
-    def test_bermudan_swaption_analytical_route_is_thin(self, registry):
+    def test_bermudan_swaption_analytical_route_records_final_date_obligations(self, registry):
         spec = [r for r in registry.routes if r.id == "analytical_black76"][0]
-        assert resolve_route_notes(spec, self.BERMUDAN_SWAPTION_IR) == ()
+        notes = "\n".join(resolve_route_notes(spec, self.BERMUDAN_SWAPTION_IR))
+        assert "strictly after settlement and before swap end" in notes
+        assert "Return zero when no valid exercise date remains" in notes
+        assert "resolve_swaption_black76_inputs" in notes
+        assert "price_swaption_black76_raw" in notes
+        assert "Do not sum or maximize European values" in notes
         assert resolve_route_adapters(spec, self.BERMUDAN_SWAPTION_IR) == ()
 
     def test_barrier_primitives_use_exact_helper(self, registry):

--- a/tests/test_agent/test_route_registry_black76_dsl_parity.py
+++ b/tests/test_agent/test_route_registry_black76_dsl_parity.py
@@ -96,10 +96,26 @@ _BASKET_PRIMS: tuple[PrimitiveRef, ...] = (
 
 _SWAPTION_BERM_PRIMS: tuple[PrimitiveRef, ...] = (
     PrimitiveRef(
-        "trellis.models.rate_style_swaption",
-        "price_bermudan_swaption_black76_lower_bound",
-        "route_helper",
+        "trellis.core.date_utils",
+        "normalize_explicit_dates",
+        "schedule_builder",
+        required=False,
     ),
+    PrimitiveRef(
+        "trellis.models.rate_style_swaption",
+        "resolve_swaption_black76_inputs",
+        "market_binding",
+    ),
+    PrimitiveRef(
+        "trellis.models.rate_style_swaption",
+        "price_swaption_black76_raw",
+        "pricing_kernel",
+    ),
+)
+_SWAPTION_BERM_NOTES: tuple[str, ...] = (
+    "For the black76_european_lower_bound comparator, normalize the Bermudan exercise dates, keep only dates strictly after settlement and before swap end, and select the final valid date.",
+    "Return zero when no valid exercise date remains; otherwise pass the final date as expiry_date to resolve_swaption_black76_inputs(...) and price the resolved basis once with price_swaption_black76_raw(...).",
+    "Do not sum or maximize European values across exercise dates, and do not use the product-level lower-bound wrapper as generated construction authority.",
 )
 
 _SWAPTION_EUR_PRIMS: tuple[PrimitiveRef, ...] = (
@@ -235,7 +251,7 @@ def _legacy_clauses() -> tuple[ConditionalPrimitive, ...]:
             },
             primitives=_SWAPTION_BERM_PRIMS,
             adapters=(),
-            notes=(),
+            notes=_SWAPTION_BERM_NOTES,
         ),
         ConditionalPrimitive(
             when={
@@ -294,7 +310,7 @@ def _dsl_clauses() -> tuple[ConditionalPrimitive, ...]:
             ),
             primitives=_SWAPTION_BERM_PRIMS,
             adapters=(),
-            notes=(),
+            notes=_SWAPTION_BERM_NOTES,
         ),
         ConditionalPrimitive(
             when={},

--- a/tests/test_agent/test_semantic_contracts.py
+++ b/tests/test_agent/test_semantic_contracts.py
@@ -1610,7 +1610,7 @@ class TestAmbiguousResolutionBlocksBuild:
         assert gap.semantic_concept_resolution_kind == "reuse_existing_concept"
 
 
-def test_bermudan_swaption_analytical_contract_uses_lower_bound_target():
+def test_bermudan_swaption_analytical_contract_uses_resolved_lower_bound_composition():
     from trellis.agent.semantic_contract_compiler import compile_semantic_contract
     from trellis.agent.semantic_contracts import make_rate_style_swaption_contract
     from trellis.agent.semantic_contract_validation import validate_semantic_contract
@@ -1629,9 +1629,11 @@ def test_bermudan_swaption_analytical_contract_uses_lower_bound_target():
     assert compiled.primitive_routes == ("analytical_black76",)
     assert "trellis.models.rate_style_swaption" in compiled.target_modules
     assert compiled.dsl_lowering is not None
-    assert (
-        "trellis.models.rate_style_swaption.price_bermudan_swaption_black76_lower_bound"
-        in compiled.dsl_lowering.helper_refs
+    assert compiled.dsl_lowering.route_helper_refs == ()
+    assert compiled.dsl_lowering.target_refs == (
+        "trellis.core.date_utils.normalize_explicit_dates",
+        "trellis.models.rate_style_swaption.resolve_swaption_black76_inputs",
+        "trellis.models.rate_style_swaption.price_swaption_black76_raw",
     )
 
 

--- a/tests/test_instruments/test_agent_bermudan_swaption.py
+++ b/tests/test_instruments/test_agent_bermudan_swaption.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from trellis.core.market_state import MarketState
+from trellis.curves.yield_curve import YieldCurve
+from trellis.instruments._agent.bermudanswaption import (
+    BermudanSwaptionPayoff,
+    BermudanSwaptionSpec,
+)
+from trellis.models.rate_style_swaption import (
+    price_bermudan_swaption_black76_lower_bound,
+)
+from trellis.models.vol_surface import FlatVol
+
+
+def _market_state() -> MarketState:
+    return MarketState(
+        as_of=date(2025, 1, 1),
+        settlement=date(2025, 1, 1),
+        discount=YieldCurve.flat(0.03),
+        vol_surface=FlatVol(0.20),
+    )
+
+
+def test_admitted_bermudan_lower_bound_matches_retained_reference():
+    market_state = _market_state()
+    spec = BermudanSwaptionSpec(
+        notional=1_000_000.0,
+        strike=0.04,
+        exercise_dates=(
+            date(2027, 1, 1),
+            date(2025, 1, 1),
+            date(2026, 1, 1),
+            date(2027, 1, 1),
+            date(2031, 1, 1),
+        ),
+        swap_end=date(2030, 1, 1),
+    )
+
+    actual = BermudanSwaptionPayoff(spec).evaluate(market_state)
+    expected = price_bermudan_swaption_black76_lower_bound(market_state, spec)
+
+    assert actual == pytest.approx(expected, rel=1e-12, abs=1e-12)
+
+
+def test_admitted_bermudan_lower_bound_returns_zero_without_valid_exercise_date():
+    market_state = _market_state()
+    spec = BermudanSwaptionSpec(
+        notional=1_000_000.0,
+        strike=0.04,
+        exercise_dates=(date(2025, 1, 1), date(2030, 1, 1)),
+        swap_end=date(2030, 1, 1),
+    )
+
+    assert BermudanSwaptionPayoff(spec).evaluate(market_state) == 0.0

--- a/trellis/agent/dsl_lowering.py
+++ b/trellis/agent/dsl_lowering.py
@@ -608,29 +608,6 @@ def _build_black76_expr(
     )
     if (
         payoff_family == "swaption"
-        and getattr(contract.product, "exercise_style", "") == "bermudan"
-        and route_helper is not None
-    ):
-        return (
-            ContractAtom(
-                atom_id=_binding_atom_id(route_id, binding_id, "route_helper"),
-                primitive_ref=route_helper.primitive_ref,
-                description=(
-                    "Checked-in analytical lower-bound helper for a Bermudan "
-                    "rate-style swaption."
-                ),
-                signature=ContractSignature(
-                    inputs=market_signature.inputs,
-                    outputs=("price:scalar",),
-                    timeline_roles=market_signature.timeline_roles,
-                    market_data_requirements=market_signature.market_data_requirements,
-                ),
-            ),
-            (),
-        )
-
-    if (
-        payoff_family == "swaption"
         and getattr(contract.product, "exercise_style", "") == "european"
         and route_helper is not None
     ):

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -1940,6 +1940,8 @@ def build_payoff(
                 generation_token_usage = summarize_llm_usage(usage_records)
                 enforce_llm_token_budget(stage="code_generation")
             code = generated_module.code
+            if build_meta is not None:
+                build_meta["code"] = code
         except Exception as exc:
             failure_text = f"attempt {attempt_number}: {type(exc).__name__}: {exc}"
             previous_failures.append(failure_text)
@@ -6142,6 +6144,30 @@ def _deterministic_exact_binding_evaluate_body(
                 raise ValueError(f"Unsupported payout_type {getattr(spec, 'payout_type', None)!r}")
                 """
             ).rstrip()
+    if (
+        instrument_type == "bermudan_swaption"
+        and "trellis.models.rate_style_swaption.price_swaption_black76_raw" in refs
+    ):
+        return textwrap.dedent(
+            """\
+            spec = self._spec
+            exercise_dates = normalize_explicit_dates(spec.exercise_dates)
+            valid_exercise_dates = tuple(
+                exercise_date
+                for exercise_date in exercise_dates
+                if market_state.settlement < exercise_date < spec.swap_end
+            )
+            if not valid_exercise_dates:
+                return 0.0
+            final_exercise_date = valid_exercise_dates[-1]
+            resolved = resolve_swaption_black76_inputs(
+                market_state,
+                spec,
+                expiry_date=final_exercise_date,
+            )
+            return price_swaption_black76_raw(resolved)
+            """
+        ).rstrip()
     helper_bodies = {
         "trellis.models.fx_vanilla.price_fx_vanilla_analytical": (
             "return price_fx_vanilla_analytical(market_state, spec)"
@@ -6716,6 +6742,8 @@ def _deterministic_exact_binding_import_lines(body: str) -> tuple[str, ...]:
         imports.append("from math import sqrt")
     if "year_fraction(" in body:
         imports.append("from trellis.core.date_utils import year_fraction")
+    if "normalize_explicit_dates(" in body:
+        imports.append("from trellis.core.date_utils import normalize_explicit_dates")
     if "resolve_swaption_black76_inputs(" in body:
         imports.append(
             "from trellis.models.rate_style_swaption import "
@@ -8948,11 +8976,11 @@ def _route_specific_retry_lines(
         and stage in {"code_generation_failed", "semantic_validation_failed", "validation_failed", "actual_market_smoke_failed", "import_validation_failed"}
     ):
         return (
-            "Bermudan swaption analytical comparators should stay on the checked-in lower-bound helper surface.",
-            "Prefer `from trellis.models.rate_style_swaption import price_bermudan_swaption_black76_lower_bound` and delegate to that helper from the adapter.",
+            "Bermudan swaption analytical comparators should compose the final-exercise European lower bound from public schedule, binding, and kernel surfaces.",
+            "Import `normalize_explicit_dates` from `trellis.core.date_utils` plus `resolve_swaption_black76_inputs` and `price_swaption_black76_raw` from `trellis.models.rate_style_swaption`.",
             "Interpret `black76_european_lower_bound` as the European swaption exercisable only on the final Bermudan date.",
-            "Do not sum one European Black76 price per exercise date, and do not rebuild forward-swap-rate or annuity loops inline when the checked-in helper already owns the route.",
-            "Keep the adapter minimal: validate `market_state.discount` and `market_state.vol_surface`, then call the helper and return `float(...)`.",
+            "Normalize the exercise schedule, keep dates strictly after `market_state.settlement` and before `spec.swap_end`, return zero when none remain, then resolve once with `expiry_date=valid_exercise_dates[-1]` and call the raw kernel.",
+            "Do not sum one European Black76 price per exercise date, do not rebuild forward-swap-rate or annuity loops inline, and do not use the product-level lower-bound helper as construction authority.",
         )
     if (
         instrument == "swaption"

--- a/trellis/agent/knowledge/api_map.py
+++ b/trellis/agent/knowledge/api_map.py
@@ -416,9 +416,11 @@ def _query_cues(query: ApiMapQuery) -> tuple[tuple[str, int], ...]:
         (query.model_family, 40),
         (query.description, 30),
     ]
-    cues.extend((str(item), 100) for item in query.features)
-    cues.extend((str(item), 80) for item in query.route_ids)
-    cues.extend((str(item), 80) for item in query.route_families)
+    # Compiled route identity and typed features are more specific than broad
+    # instrument/payoff labels, so exact specialized cards must rank first.
+    cues.extend((str(item), 160) for item in query.features)
+    cues.extend((str(item), 180) for item in query.route_ids)
+    cues.extend((str(item), 140) for item in query.route_families)
     return tuple((value, weight) for value, weight in cues if value.strip())
 
 

--- a/trellis/agent/knowledge/autonomous.py
+++ b/trellis/agent/knowledge/autonomous.py
@@ -809,7 +809,7 @@ def _build_with_tracking(
         )
 
         meta["attempts"] = attempt_count[0]
-        meta["code"] = last_code[0]
+        meta["code"] = last_code[0] or str(meta.get("code") or "")
         meta["platform_trace_path"] = platform_trace_path[0]
         meta["platform_request_id"] = platform_request_id[0]
         return payoff_cls, meta
@@ -817,7 +817,8 @@ def _build_with_tracking(
     except Exception as e:
         meta["attempts"] = attempt_count[0] if 'attempt_count' in dir() else 0
         meta["failures"] = [str(e)]
-        meta["code"] = last_code[0] if 'last_code' in dir() else ""
+        tracked_code = last_code[0] if 'last_code' in dir() else ""
+        meta["code"] = tracked_code or str(meta.get("code") or "")
         meta["platform_trace_path"] = platform_trace_path[0] if 'platform_trace_path' in dir() else None
         meta["platform_request_id"] = platform_request_id[0] if 'platform_request_id' in dir() else None
         raise BuildTrackingFailure(str(e), meta=meta, cause=e) from e

--- a/trellis/agent/knowledge/canonical/api_map.yaml
+++ b/trellis/agent/knowledge/canonical/api_map.yaml
@@ -249,6 +249,7 @@ equity_tree:
 
 rate_lattice:
   module: trellis.models.trees.lattice
+  methods: [rate_tree]
   navigation:
     aliases: [rate_tree, callable_bond, puttable_bond, bermudan_swaption]
   key_imports:
@@ -401,6 +402,7 @@ observation_return_composition:
 
 rate_monte_carlo_composition:
   module: trellis.models.monte_carlo.simulation_substrate
+  methods: [monte_carlo]
   navigation:
     aliases: [rate_monte_carlo, bermudan_swaption, callable_rate_product]
   key_imports:
@@ -416,6 +418,7 @@ rate_monte_carlo_composition:
 
 rate_style_swaption_composition:
   module: trellis.models.rate_style_swaption
+  methods: [analytical]
   navigation:
     aliases: [swaption, european_swaption, black76_swaption, rate_style_swaption]
   key_imports:
@@ -425,6 +428,18 @@ rate_style_swaption_composition:
     - "The raw kernel applies notional and annuity exactly once. Do not reapply discounting, notional, or annuity in generated adapter code."
     - "The product-level price_swaption_black76(...) wrapper remains a compatibility/reference API and is not generated-route construction authority."
     - "Pass Hull-White comparison parameters to the resolver only when the task contract explicitly requests that comparison regime; ordinary Black76 benchmark tasks use the bound market volatility surface."
+
+bermudan_swaption_lower_bound_composition:
+  module: trellis.models.rate_style_swaption
+  methods: [analytical]
+  navigation:
+    aliases: [bermudan_swaption, black76_european_lower_bound, final_exercise_lower_bound]
+  key_imports:
+    - "from trellis.core.date_utils import normalize_explicit_dates"
+    - "from trellis.models.rate_style_swaption import resolve_swaption_black76_inputs, price_swaption_black76_raw"
+  notes:
+    - "This comparator is not Bermudan analytical pricing. It is the European swaption exercisable only on the final normalized exercise date strictly after settlement and before swap end."
+    - "Return zero when no valid exercise date remains; otherwise pass the final date as expiry_date to resolve_swaption_black76_inputs(...) and price the resolved basis exactly once with price_swaption_black76_raw(...). Do not sum or maximize European prices across the exercise schedule, and do not use price_bermudan_swaption_black76_lower_bound(...) as generated construction authority."
 
 qmc:
   module: trellis.models.qmc
@@ -511,7 +526,7 @@ analytical:
     - "from trellis.models.analytical.fx import garman_kohlhagen_price_raw"
     - "from trellis.models.fx_barrier_option import resolve_fx_barrier_inputs"
     - "from trellis.models.analytical.barrier import barrier_option_price"
-    - "from trellis.models.rate_style_swaption import ResolvedSwaptionBlack76Inputs, resolve_swaption_black76_inputs, price_swaption_black76_raw, price_bermudan_swaption_black76_lower_bound"
+    - "from trellis.models.rate_style_swaption import ResolvedSwaptionBlack76Inputs, resolve_swaption_black76_inputs, price_swaption_black76_raw"
   notes:
     - "For FX vanilla analytics, resolve spot, domestic/foreign discount factors, volatility, and contract terms, then call `garman_kohlhagen_price_raw(...)` on the resolved basis and apply notional"
     - "For FX single-barrier analytics, resolve FX spot, domestic/foreign rates, volatility, monitoring, and payoff terms, then call `barrier_option_price(...)` with foreign rate as `q` and apply notional"
@@ -547,9 +562,9 @@ utilities:
     module: trellis.models.rate_style_swaption
     imports:
       - "from trellis.models.rate_style_swaption import ResolvedSwaptionBlack76Inputs, resolve_swaption_black76_inputs, price_swaption_black76_raw"
-      - "from trellis.models.rate_style_swaption import price_bermudan_swaption_black76_lower_bound"
     notes:
       - "For European Black76 construction, bind with resolve_swaption_black76_inputs(...) and price only the typed result with price_swaption_black76_raw(...); the product wrapper is reference-only"
+      - "For the Bermudan final-exercise lower-bound comparator, normalize/filter the exercise schedule first and pass only the final valid date to the same resolver/raw-kernel composition"
   jamshidian_zcb_option:
     module: trellis.models.zcb_option
     imports:

--- a/trellis/agent/knowledge/canonical/backend_bindings.yaml
+++ b/trellis/agent/knowledge/canonical/backend_bindings.yaml
@@ -951,9 +951,16 @@ bindings:
             exercise:
               style: bermudan
         primitives:
+          - module: trellis.core.date_utils
+            symbol: normalize_explicit_dates
+            role: schedule_builder
+            required: false
           - module: trellis.models.rate_style_swaption
-            symbol: price_bermudan_swaption_black76_lower_bound
-            role: route_helper
+            symbol: resolve_swaption_black76_inputs
+            role: market_binding
+          - module: trellis.models.rate_style_swaption
+            symbol: price_swaption_black76_raw
+            role: pricing_kernel
       - when:
           contract_pattern:
             payoff:

--- a/trellis/agent/knowledge/canonical/method_requirements.yaml
+++ b/trellis/agent/knowledge/canonical/method_requirements.yaml
@@ -27,13 +27,13 @@ analytical:
     call or put on the forward rate fixing at period start, discounted to settlement
     at period end. Valid under lognormal forward rate with deterministic discount
     factors.'
-  - 'RATE-STYLE SWAPTION HELPER CONTRACT: For a single-exercise European swaption,
-    prefer the checked helper-backed path `resolve_swaption_black76_inputs(market_state, spec)`
+  - 'RATE-STYLE SWAPTION COMPOSITION CONTRACT: For a single-exercise European swaption,
+    prefer the checked primitive path `resolve_swaption_black76_inputs(market_state, spec)`
     -> `ResolvedSwaptionBlack76Inputs` -> `price_swaption_black76_raw(resolved)`
     from `trellis.models.rate_style_swaption` instead of reassembling annuity,
     forward-swap-rate, expiry, and payment-count binding inline.'
   - 'CAP/FLOOR LOOP CONTRACT: Keep the explicit payment-timeline loop for caplet/floorlet
-    strips. Do not force the single-exercise swaption helper onto period-by-period
+    strips. Do not force the single-exercise swaption composition onto period-by-period
     cap/floor routes.'
   - 'FORWARD-RATE MARKET DATA CONTRACT: Requires discount curve, forward curve (via
     forecast_forward_curve), and Black vol surface. Rate fixing dates and payment

--- a/trellis/agent/knowledge/canonical/routes.yaml
+++ b/trellis/agent/knowledge/canonical/routes.yaml
@@ -1394,7 +1394,7 @@ routes:
       non_european_penalty: -4.0
     match:
       methods: [analytical]
-      # QUA-900 / QUA-909 / QUA-910: Black76 now hosts the helper-backed
+      # QUA-900 / QUA-909 / QUA-910: Black76 now hosts the checked
       # closed-form equity exotics that still live on the same vol-surface-
       # driven analytical lane. The absorbed exotic cohorts expose specific
       # payoff-family labels, so this positive filter stays structural and
@@ -1411,7 +1411,7 @@ routes:
       # IR pricing-method selector to pick ``analytical`` over the true
       # Monte-Carlo / rate-tree / PDE solvers. Black76's ``when`` clauses
       # only handle ``european`` (vanilla, basket, absorbed exotics, swaption),
-      # ``bermudan`` (swaption via the lower-bound helper), and ``none``
+      # ``bermudan`` (swaption final-exercise lower-bound composition), and ``none``
       # (variance swaps), so restricting the match clause to those exercise
       # styles matches the concrete capability surface.
       #
@@ -1511,11 +1511,21 @@ routes:
             exercise:
               style: bermudan
         primitives:
+          - module: trellis.core.date_utils
+            symbol: normalize_explicit_dates
+            role: schedule_builder
+            required: false
           - module: trellis.models.rate_style_swaption
-            symbol: price_bermudan_swaption_black76_lower_bound
-            role: route_helper
+            symbol: resolve_swaption_black76_inputs
+            role: market_binding
+          - module: trellis.models.rate_style_swaption
+            symbol: price_swaption_black76_raw
+            role: pricing_kernel
         adapters: []
-        notes: []
+        notes:
+          - "For the black76_european_lower_bound comparator, normalize the Bermudan exercise dates, keep only dates strictly after settlement and before swap end, and select the final valid date."
+          - "Return zero when no valid exercise date remains; otherwise pass the final date as expiry_date to resolve_swaption_black76_inputs(...) and price the resolved basis once with price_swaption_black76_raw(...)."
+          - "Do not sum or maximize European values across exercise dates, and do not use the product-level lower-bound wrapper as generated construction authority."
       - when:
           contract_pattern:
             payoff:

--- a/trellis/agent/knowledge/decompose.py
+++ b/trellis/agent/knowledge/decompose.py
@@ -3729,9 +3729,9 @@ def _augment_ir_with_promoted_route_support(ir: ProductIR) -> ProductIR:
         # first-class candidate engine family against rate-tree / PDE /
         # Monte-Carlo routes that are the true method for those products
         # (e.g. Bermudan swaption selects rate_tree, not the Black76
-        # lower-bound helper). Skip the augmentation contribution for such
-        # routes; their direct ``match_candidate_routes`` dispatch via the
-        # scorer still works.
+        # final-exercise comparison lane). Skip the augmentation contribution
+        # for such routes; their direct ``match_candidate_routes`` dispatch
+        # via the scorer still works.
         if exercise_style and exercise_style != "european":
             score_hints = getattr(route, "score_hints", None) or {}
             non_european_penalty = float(

--- a/trellis/agent/prompts.py
+++ b/trellis/agent/prompts.py
@@ -572,10 +572,10 @@ def _render_family_route_guidance(
     if instrument_type == "bermudan_swaption" and method == "analytical":
         lines.append("## Family Route Guidance")
         lines.extend([
-            "- For the analytical comparator lane, prefer `price_bermudan_swaption_black76_lower_bound(market_state, spec)` from `trellis.models.rate_style_swaption`.",
+            "- For the analytical comparator lane, import `normalize_explicit_dates` from `trellis.core.date_utils` plus `resolve_swaption_black76_inputs` and `price_swaption_black76_raw` from `trellis.models.rate_style_swaption`.",
             "- Interpret `black76_european_lower_bound` as the European swaption exercisable only on the final Bermudan date.",
-            "- Keep the adapter thin: validate discount/vol access, then delegate to the checked-in helper. Do not sum one European Black76 price per exercise date.",
-            "- Do not rebuild co-terminal swap schedule loops, annuity extraction, or forward-swap-rate assembly inline when the checked-in helper already owns that route.",
+            "- Normalize the exercise schedule, keep dates strictly after `market_state.settlement` and before `self._spec.swap_end`, return zero when none remain, then resolve once with `expiry_date=valid_exercise_dates[-1]` and pass the typed result to the raw kernel.",
+            "- Do not sum or maximize one European Black76 price per exercise date. Do not rebuild co-terminal swap schedule loops, annuity extraction, or forward-swap-rate assembly inline, and do not use the product-level lower-bound helper as construction authority.",
         ])
 
     if instrument_type == "swaption" and method == "analytical":

--- a/trellis/agent/task_runtime.py
+++ b/trellis/agent/task_runtime.py
@@ -3431,7 +3431,12 @@ def _generated_artifact_from_result(result: Any) -> dict[str, Any]:
     module = sys.modules.get(module_name)
     file_path = ""
     module_path = ""
-    code_hash = ""
+    generated_code = str(getattr(result, "code", "") or "")
+    code_hash = (
+        hashlib.sha256(generated_code.encode("utf-8")).hexdigest()
+        if generated_code
+        else ""
+    )
     if module is not None:
         module_file = getattr(module, "__file__", None)
         if module_file:
@@ -3441,15 +3446,11 @@ def _generated_artifact_from_result(result: Any) -> dict[str, Any]:
                 module_path = str(resolved.relative_to(ROOT)).replace("\\", "/")
             except ValueError:
                 module_path = str(resolved)
-            try:
-                code_hash = hashlib.sha256(resolved.read_bytes()).hexdigest()
-            except OSError:
-                code_hash = ""
-
-    if not code_hash:
-        code = str(getattr(result, "code", "") or "")
-        if code:
-            code_hash = hashlib.sha256(code.encode("utf-8")).hexdigest()
+            if not code_hash:
+                try:
+                    code_hash = hashlib.sha256(resolved.read_bytes()).hexdigest()
+                except OSError:
+                    code_hash = ""
 
     normalized_module_path = module_path.replace("\\", "/")
     normalized_file_path = file_path.replace("\\", "/")

--- a/trellis/instruments/_agent/bermudanswaption.py
+++ b/trellis/instruments/_agent/bermudanswaption.py
@@ -17,10 +17,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import date
 
+from trellis.core.date_utils import normalize_explicit_dates
 from trellis.core.market_state import MarketState
 from trellis.core.types import DayCountConvention, Frequency
-from trellis.models.rate_style_swaption import price_bermudan_swaption_black76_lower_bound
-
+from trellis.models.rate_style_swaption import (
+    price_swaption_black76_raw,
+    resolve_swaption_black76_inputs,
+)
 
 
 @dataclass(frozen=True)
@@ -76,4 +79,18 @@ Implementation target: black76_european_lower_bound."""
 
     def evaluate(self, market_state: MarketState) -> float:
         spec = self._spec
-        return float(price_bermudan_swaption_black76_lower_bound(market_state, spec))
+        exercise_dates = normalize_explicit_dates(spec.exercise_dates)
+        valid_exercise_dates = tuple(
+            exercise_date
+            for exercise_date in exercise_dates
+            if market_state.settlement < exercise_date < spec.swap_end
+        )
+        if not valid_exercise_dates:
+            return 0.0
+        final_exercise_date = valid_exercise_dates[-1]
+        resolved = resolve_swaption_black76_inputs(
+            market_state,
+            spec,
+            expiry_date=final_exercise_date,
+        )
+        return float(price_swaption_black76_raw(resolved))

--- a/trellis/models/rate_style_swaption.py
+++ b/trellis/models/rate_style_swaption.py
@@ -472,12 +472,15 @@ def price_bermudan_swaption_black76_lower_bound(
     market_state: MarketState,
     spec: BermudanSwaptionLowerBoundSpecLike,
 ) -> float:
-    """Return the final-exercise European Black76 lower bound.
+    """Return the compatibility/reference final-exercise Black76 lower bound.
 
     The Bermudan task comparator is defined as the European swaption that may
     only exercise on the final Bermudan date. That keeps the comparison stable
     and guarantees it remains a lower bound to the Bermudan tree price in the
-    checked-in T04 contract.
+    checked-in T04 contract. New generated adapters should compose
+    ``normalize_explicit_dates``, ``resolve_swaption_black76_inputs``, and
+    ``price_swaption_black76_raw`` instead of using this wrapper as construction
+    authority.
     """
     exercise_dates = tuple(
         exercise_date


### PR DESCRIPTION
## Summary
- replace Bermudan lower-bound helper authority with schedule normalization, swaption input resolution, and the raw Black76 kernel
- make T04 comparison semantics explicit and preserve target-specific deterministic source identity
- update agent navigation, route/binding metadata, admitted adapter code, tests, and official docs without changing canonical cookbooks or adding pricing helpers

## Validation
- 768 affected tests passed
- strict fresh/offline T04 replay passed with zero LLM calls
- helper authority audit: 53 route refs, 57 binding refs, 11 adapter authority calls, unchanged 4/8 drift
- make gate-release passed, including gate-pr, tier-2 contracts, cross-validation, verification, task proofs, cassette freshness, and zero-token T13 replay

## Notes
- strict reuse fails closed because the single admitted analytical adapter cannot bind the tree target
- LIMITATIONS.md is neutral because public pricing support did not change
- T38 replay remains explicitly unsupported and skipped by policy