### PR TITLE
QUA-1198: Retire swaption Monte Carlo helper authority

### DIFF
--- a/doc/plan/active__semantic-task-synthesis-helper-retirement.md
+++ b/doc/plan/active__semantic-task-synthesis-helper-retirement.md
@@ -58,6 +58,7 @@ Status mirror last synced: `2026-07-15`
 | `QUA-1195` | Variance swap pricing: retire analytical helper authority | Done |
 | `QUA-1196` | Swaption pricing: retire European Black76 wrapper authority | Done |
 | `QUA-1197` | Swaption pricing: retire Bermudan Black76 lower-bound helper authority | Done |
+| `QUA-1198` | Swaption Monte Carlo: retire European helper and problem-resolver authority | In Progress |
 | `QUA-1102` | Semantic target binding: typed comparison target contracts (related prerequisite) | Done |
 
 ## Current Sequence
@@ -91,9 +92,14 @@ Status mirror last synced: `2026-07-15`
    swaption resolver and raw kernel, declare the one-sided lower-bound relation,
    and identify target-specific deterministic artifacts from their immutable
    build source when multiple targets share one mutable module path.
-9. Select the next helper-authority family from the machine-readable audit and
+9. Apply the QUA-1198 European swaption Monte Carlo composition: expose the
+   schedule, Hull-White process, discounted swap-PV payload, short-rate reducer,
+   event/problem contracts, problem compiler, and generic estimator as the
+   generated construction surface while retaining product wrappers only as
+   compatibility and reference APIs.
+10. Select the next helper-authority family from the machine-readable audit and
    create a bounded ticket before changing another route.
-10. Run live fresh-generation evidence only with current external-model approval;
+11. Run live fresh-generation evidence only with current external-model approval;
    use it to compare first-pass source selection, retrieved documentation,
    retries, and residual validator findings rather than as pricing authority.
 

--- a/docs/developer/implementation_journey_prompt_to_price.md
+++ b/docs/developer/implementation_journey_prompt_to_price.md
@@ -93,6 +93,17 @@ over the schedule. The retained
 ``price_bermudan_swaption_black76_lower_bound(...)`` function is comparison and
 compatibility evidence, not generated construction authority.
 
+T73 applies the same boundary to a European swaption Monte Carlo target. The
+route and exact binding no longer point at ``price_swaption_monte_carlo(...)``
+or ``resolve_swaption_monte_carlo_problem(...)``. They expose the reusable
+expiry resolver, explicit-start payment timeline, Hull-White process binding,
+discounted swap-PV payload, short-rate discount reducer, event/problem
+contracts, problem compiler, and generic event-aware estimator. DSL lowering
+records those stages as an ordered ``ThenExpr`` and deterministic offline
+generation materializes the same sequence. This makes source identity and
+validation evidence describe the estimator that ran rather than a product
+wrapper that hid the assembly.
+
 Compiled request metadata now also carries a compact semantic-blueprint summary
 for downstream tooling. That summary records the canonical lowered route, the
 helper and primitive references selected by DSL lowering, and any explicit

--- a/docs/quant/knowledge_maintenance.rst
+++ b/docs/quant/knowledge_maintenance.rst
@@ -123,6 +123,16 @@ capability. In particular, a helper that prices a European swaption is not
 authority for a Bermudan swaption merely because both share the broad
 ``swaption`` instrument label.
 
+The admitted European swaption Monte Carlo lane demonstrates the positive
+case. Its selected API-map card is
+``european_swaption_monte_carlo_composition``. The card points the builder
+to the typed swaption resolver, payment timeline, Hull-White process binding,
+discounted swap-PV payload, short-rate discount reducer, event/problem specs,
+problem compiler, and generic estimator. The generated adapter owns that
+ordered derivative-specific composition. The retained product pricing wrapper
+and product-specific problem resolver remain useful comparison evidence but do
+not replace the primitive packet.
+
 When the available primitives do not yet compose correctly, fail closed with a
 structured capability packet. The packet should distinguish capabilities that
 already exist from the missing glue. For Bermudan swaption Monte Carlo, Trellis

--- a/docs/quant/pricing_stack.rst
+++ b/docs/quant/pricing_stack.rst
@@ -211,10 +211,31 @@ problem-assembly layer in ``trellis.models.monte_carlo.event_aware``:
 That runtime layer resolves process-family plugins, compiles deterministic
 event buckets into reduced-state replay requirements, and assembles a
 ``StateAwarePayoff`` on top of the existing Monte Carlo path-state and
-path-event substrate. The generic vanilla MC migration and the final
-schedule-driven proof routes are still separate follow-on slices, but the
-compiler no longer points at an event-aware family without a checked runtime
-problem-spec boundary underneath it.
+path-event substrate. A generated European swaption adapter now composes that
+surface directly:
+
+1. ``resolve_swaption_black76_inputs(...)`` binds the typed expiry and market
+   conventions;
+2. ``build_payment_timeline(...)`` starts the underlying swap schedule at the
+   explicit ``swap_start``;
+3. ``resolve_hull_white_monte_carlo_process_inputs(...)`` binds the short-rate
+   process;
+4. ``build_discounted_swap_pv_payload(...)`` and
+   ``build_short_rate_discount_reducer(...)`` define settlement and reduced
+   discount state;
+5. ``EventAwareMonteCarloEvent`` and ``EventAwareMonteCarloProblemSpec``
+   declare the expiry event program; and
+6. ``build_event_aware_monte_carlo_problem(...)`` plus
+   ``price_event_aware_monte_carlo(...)`` compile and evaluate it.
+
+The adapter retains day count, swap frequency, rate index, path/step/seed
+controls, and any explicitly declared Hull-White comparison parameters. It
+does not substitute an equity GBM process. The product-level
+``price_swaption_monte_carlo(...)`` and
+``resolve_swaption_monte_carlo_problem(...)`` APIs remain compatibility and
+independent-reference surfaces, not generated construction authority. The
+separate Bermudan Monte Carlo exercise-grid and continuation gaps remain
+fail-closed.
 
 Scheduled Weighted Observations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/user_guide/pricing.rst
+++ b/docs/user_guide/pricing.rst
@@ -579,6 +579,17 @@ to the raw kernel. ``price_swaption_black76(...)`` remains usable as a public
 compatibility and reference function, but it is not advertised as construction
 authority.
 
+European swaption Monte Carlo targets are primitive-composed as well. Generated
+code resolves the European expiry basis, starts the payment timeline at the
+contract's explicit ``swap_start``, binds the Hull-White process, builds the
+discounted swap-PV settlement payload and short-rate discount reducer, declares
+the expiry events and typed problem, and calls the generic event-aware Monte
+Carlo estimator. Day count, swap frequency, rate index, path/step/seed controls,
+and explicit comparison parameters remain visible in that generated source.
+``price_swaption_monte_carlo(...)`` and
+``resolve_swaption_monte_carlo_problem(...)`` remain callable compatibility and
+reference APIs, but neither is live build authority.
+
 The Bermudan ``black76_european_lower_bound`` comparison reuses those same
 surfaces without pretending Black76 is a Bermudan solver. Generated code
 normalizes the exercise schedule, keeps dates strictly after settlement and

--- a/tests/test_agent/test_api_map.py
+++ b/tests/test_agent/test_api_map.py
@@ -59,6 +59,10 @@ def test_api_map_contains_expected_core_entries():
         api_map["bermudan_swaption_lower_bound_composition"]["module"]
         == "trellis.models.rate_style_swaption"
     )
+    assert (
+        api_map["european_swaption_monte_carlo_composition"]["module"]
+        == "trellis.models.monte_carlo.event_aware"
+    )
     assert api_map["equity_tree"]["module"] == "trellis.models.trees.algebra"
     assert api_map["rate_lattice"]["module"] == "trellis.models.trees.lattice"
     assert "utilities" in api_map
@@ -89,6 +93,7 @@ def test_api_map_key_imports_are_registry_valid():
         "quanto_option_composition",
         "rate_monte_carlo_composition",
         "bermudan_swaption_lower_bound_composition",
+        "european_swaption_monte_carlo_composition",
         "qmc",
         "pde",
         "fft",
@@ -306,6 +311,15 @@ def test_api_map_semantic_selection_reaches_composition_cards():
             ),
             "bermudan_swaption_lower_bound_composition",
         ),
+        (
+            ApiMapQuery(
+                instrument_type="swaption",
+                payoff_family="swaption",
+                method="monte_carlo",
+                model_family="interest_rate",
+            ),
+            "european_swaption_monte_carlo_composition",
+        ),
     )
 
     for query, expected_family in cases:
@@ -343,6 +357,37 @@ def test_api_map_exposes_bermudan_final_exercise_lower_bound_composition():
     assert "Do not sum or maximize European prices" in text
     assert "price_bermudan_swaption_black76_lower_bound(...)" in text
     assert "from trellis.models.rate_style_swaption import " in text
+
+
+def test_api_map_exposes_european_swaption_event_aware_monte_carlo_composition():
+    query = ApiMapQuery(
+        instrument_type="swaption",
+        payoff_family="swaption",
+        method="monte_carlo",
+        model_family="interest_rate",
+    )
+    selection = select_api_map_sections(query)
+    text = format_api_map_for_prompt(compact=True, query=query)
+
+    assert selection.selected_families[0] == (
+        "european_swaption_monte_carlo_composition"
+    )
+    for symbol in (
+        "resolve_swaption_black76_inputs",
+        "build_payment_timeline",
+        "resolve_hull_white_monte_carlo_process_inputs",
+        "build_discounted_swap_pv_payload",
+        "build_short_rate_discount_reducer",
+        "EventAwareMonteCarloEvent",
+        "EventAwareMonteCarloProblemSpec",
+        "build_event_aware_monte_carlo_problem",
+        "price_event_aware_monte_carlo",
+    ):
+        assert symbol in text
+    assert "explicit swap_start" in text
+    assert "compatibility/reference" in text
+    assert "price_swaption_monte_carlo(...)" in text
+    assert "resolve_swaption_monte_carlo_problem(...)" in text
 
 
 def test_api_map_exposes_complete_fixed_lookback_analytical_composition():

--- a/tests/test_agent/test_backend_bindings.py
+++ b/tests/test_agent/test_backend_bindings.py
@@ -384,6 +384,50 @@ def test_resolve_backend_binding_spec_uses_route_conditionals_for_exact_targets(
     )
 
 
+def test_resolve_backend_binding_spec_composes_european_swaption_monte_carlo():
+    catalog = load_backend_binding_catalog()
+    binding = find_backend_binding_by_route_id("monte_carlo_paths", catalog)
+
+    assert binding is not None
+
+    resolved = resolve_backend_binding_spec(
+        binding,
+        product_ir=ProductIR(
+            instrument="swaption",
+            payoff_family="swaption",
+            exercise_style="european",
+            schedule_dependence=True,
+            state_dependence="schedule_state",
+            model_family="interest_rate",
+        ),
+    )
+
+    assert resolved.helper_refs == ()
+    assert resolved.market_binding_refs == (
+        "trellis.models.rate_style_swaption.resolve_swaption_black76_inputs",
+    )
+    assert resolved.schedule_builder_refs == (
+        "trellis.core.date_utils.build_payment_timeline",
+    )
+    assert resolved.exact_target_refs == (
+        "trellis.models.monte_carlo.event_aware.price_event_aware_monte_carlo",
+    )
+    assert resolved.binding_id == (
+        "trellis.models.monte_carlo.event_aware.price_event_aware_monte_carlo"
+    )
+    assert {primitive.symbol: primitive.role for primitive in resolved.primitives} == {
+        "resolve_swaption_black76_inputs": "market_binding",
+        "build_payment_timeline": "schedule_builder",
+        "resolve_hull_white_monte_carlo_process_inputs": "process_binding",
+        "build_discounted_swap_pv_payload": "settlement_payload",
+        "build_short_rate_discount_reducer": "path_reducer",
+        "EventAwareMonteCarloEvent": "event_contract",
+        "EventAwareMonteCarloProblemSpec": "problem_spec",
+        "build_event_aware_monte_carlo_problem": "problem_builder",
+        "price_event_aware_monte_carlo": "monte_carlo_estimator",
+    }
+
+
 def test_resolve_backend_binding_spec_uses_basket_option_exact_helpers():
     catalog = load_backend_binding_catalog()
     analytical = find_backend_binding_by_route_id("analytical_black76", catalog)

--- a/tests/test_agent/test_dsl_lowering.py
+++ b/tests/test_agent/test_dsl_lowering.py
@@ -293,7 +293,6 @@ def test_rate_tree_swaption_lowers_to_checked_in_helper_target():
 
 def test_rate_style_swaption_monte_carlo_lowers_to_event_aware_compilation_steps():
     from trellis.agent.semantic_contract_compiler import compile_semantic_contract
-    from trellis.agent.dsl_algebra import ContractAtom
     from trellis.agent.semantic_contracts import make_rate_style_swaption_contract
 
     contract = make_rate_style_swaption_contract(
@@ -310,13 +309,23 @@ def test_rate_style_swaption_monte_carlo_lowers_to_event_aware_compilation_steps
     assert lowering.route_family == "monte_carlo"
     assert lowering.admissibility_errors == ()
     assert isinstance(lowering.family_ir, EventAwareMonteCarloIR)
-    assert isinstance(lowering.normalized_expr, ContractAtom)
-    assert lowering.binding_id == "trellis.models.rate_style_swaption.price_swaption_monte_carlo"
-    assert lowering.normalized_expr.atom_id == (
-        "trellis.models.rate_style_swaption.price_swaption_monte_carlo:route_helper"
+    assert lowering.family_ir.helper_symbol == ""
+    assert isinstance(lowering.normalized_expr, ThenExpr)
+    assert lowering.binding_id == (
+        "trellis.models.monte_carlo.event_aware.price_event_aware_monte_carlo"
     )
-    assert lowering.normalized_expr.primitive_ref == (
-        "trellis.models.rate_style_swaption.price_swaption_monte_carlo"
+    assert tuple(
+        term.primitive_ref for term in lowering.normalized_expr.terms
+    ) == (
+        "trellis.models.rate_style_swaption.resolve_swaption_black76_inputs",
+        "trellis.core.date_utils.build_payment_timeline",
+        "trellis.models.monte_carlo.event_aware.resolve_hull_white_monte_carlo_process_inputs",
+        "trellis.models.monte_carlo.event_aware.build_discounted_swap_pv_payload",
+        "trellis.models.monte_carlo.event_aware.build_short_rate_discount_reducer",
+        "trellis.models.monte_carlo.event_aware.EventAwareMonteCarloEvent",
+        "trellis.models.monte_carlo.event_aware.EventAwareMonteCarloProblemSpec",
+        "trellis.models.monte_carlo.event_aware.build_event_aware_monte_carlo_problem",
+        "trellis.models.monte_carlo.event_aware.price_event_aware_monte_carlo",
     )
     assert blueprint.lane_plan is not None
     assert blueprint.lane_plan.lane_family == "monte_carlo"

--- a/tests/test_agent/test_executor.py
+++ b/tests/test_agent/test_executor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 from dataclasses import dataclass
 from datetime import date, timedelta
 from contextlib import contextmanager
@@ -5985,8 +5986,26 @@ def test_deterministic_exact_binding_module_composes_european_swaption_monte_car
     assert "n_paths = max(int(getattr(spec, \"n_paths\", 20000)), 2)" in generated.code
     assert "n_steps = max(int(getattr(spec, \"n_steps\", 64)), 1)" in generated.code
     assert "seed = spec.seed if hasattr(spec, \"seed\") else 42" in generated.code
-    assert "mean_reversion=0.05" in generated.code
-    assert "sigma=0.01" in generated.code
+    calls = tuple(
+        node
+        for node in ast.walk(ast.parse(generated.code))
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    )
+    expiry_resolution = next(
+        call for call in calls if call.func.id == "resolve_swaption_black76_inputs"
+    )
+    process_resolution = next(
+        call
+        for call in calls
+        if call.func.id == "resolve_hull_white_monte_carlo_process_inputs"
+    )
+    assert {keyword.arg for keyword in expiry_resolution.keywords} == set()
+    assert {keyword.arg for keyword in process_resolution.keywords} == {
+        "option_horizon",
+        "strike",
+        "mean_reversion",
+        "sigma",
+    }
     assert "price_swaption_monte_carlo(" not in generated.code
     assert "resolve_swaption_monte_carlo_problem(" not in generated.code
     assert "GBM(" not in generated.code

--- a/tests/test_agent/test_executor.py
+++ b/tests/test_agent/test_executor.py
@@ -5794,7 +5794,6 @@ def test_deterministic_exact_binding_module_materializes_credit_loss_distributio
             "price_swaption_black76_raw",
         ),
         ("trellis.models.rate_style_swaption_tree.price_swaption_tree", "price_swaption_tree"),
-        ("trellis.models.rate_style_swaption.price_swaption_monte_carlo", "price_swaption_monte_carlo"),
     ],
 )
 def test_deterministic_exact_binding_module_threads_explicit_swaption_comparison_regime(
@@ -5850,12 +5849,7 @@ def test_deterministic_exact_binding_module_threads_explicit_swaption_comparison
     )
 
     assert generated is not None
-    if expected_call == "price_swaption_monte_carlo":
-        assert (
-            "price_swaption_monte_carlo("
-            "market_state, spec, n_paths=20000, seed=42, mean_reversion=0.05, sigma=0.01)"
-        ) in generated.code
-    elif expected_call == "price_swaption_black76_raw":
+    if expected_call == "price_swaption_black76_raw":
         assert (
             "resolve_swaption_black76_inputs("
             "market_state, spec, mean_reversion=0.05, sigma=0.01)"
@@ -5864,6 +5858,138 @@ def test_deterministic_exact_binding_module_threads_explicit_swaption_comparison
         assert "price_swaption_black76(market_state" not in generated.code
     else:
         assert f"{expected_call}(market_state, spec, mean_reversion=0.05, sigma=0.01)" in generated.code
+
+
+def test_deterministic_exact_binding_module_composes_european_swaption_monte_carlo():
+    from trellis.agent.codegen_guardrails import PrimitiveRef
+    from trellis.agent.executor import (
+        EVALUATE_SENTINEL,
+        _generate_skeleton,
+        _materialize_deterministic_exact_binding_module,
+    )
+    from trellis.agent.planner import STATIC_SPECS
+    from trellis.agent.valuation_context import (
+        EngineModelSpec,
+        PotentialSpec,
+        RatesCurveRoleSpec,
+        SourceSpec,
+    )
+
+    primitives = (
+        PrimitiveRef(
+            "trellis.models.rate_style_swaption",
+            "resolve_swaption_black76_inputs",
+            "market_binding",
+        ),
+        PrimitiveRef(
+            "trellis.core.date_utils",
+            "build_payment_timeline",
+            "schedule_builder",
+        ),
+        PrimitiveRef(
+            "trellis.models.monte_carlo.event_aware",
+            "resolve_hull_white_monte_carlo_process_inputs",
+            "process_binding",
+        ),
+        PrimitiveRef(
+            "trellis.models.monte_carlo.event_aware",
+            "build_discounted_swap_pv_payload",
+            "settlement_payload",
+        ),
+        PrimitiveRef(
+            "trellis.models.monte_carlo.event_aware",
+            "build_short_rate_discount_reducer",
+            "path_reducer",
+        ),
+        PrimitiveRef(
+            "trellis.models.monte_carlo.event_aware",
+            "EventAwareMonteCarloEvent",
+            "event_contract",
+        ),
+        PrimitiveRef(
+            "trellis.models.monte_carlo.event_aware",
+            "EventAwareMonteCarloProblemSpec",
+            "problem_spec",
+        ),
+        PrimitiveRef(
+            "trellis.models.monte_carlo.event_aware",
+            "build_event_aware_monte_carlo_problem",
+            "problem_builder",
+        ),
+        PrimitiveRef(
+            "trellis.models.monte_carlo.event_aware",
+            "price_event_aware_monte_carlo",
+            "monte_carlo_estimator",
+        ),
+    )
+    generation_plan = SimpleNamespace(
+        lane_exact_binding_refs=(
+            "trellis.models.monte_carlo.event_aware.price_event_aware_monte_carlo",
+        ),
+        primitive_plan=SimpleNamespace(
+            route="monte_carlo_paths",
+            primitives=primitives,
+        ),
+        method="monte_carlo",
+        instrument_type="swaption",
+    )
+    semantic_blueprint = SimpleNamespace(
+        valuation_context=SimpleNamespace(
+            engine_model_spec=EngineModelSpec(
+                model_family="rates",
+                model_name="hull_white_1f",
+                state_semantics=("short_rate",),
+                potential=PotentialSpec(discount_term="risk_free_rate"),
+                sources=(SourceSpec(source_kind="coupon_stream"),),
+                calibration_requirements=("bootstrap_curve", "fit_hw_strip"),
+                backend_hints=("monte_carlo",),
+                parameter_overrides={"mean_reversion": 0.05, "sigma": 0.01},
+                rates_curve_roles=RatesCurveRoleSpec(
+                    discount_curve_role="discount_curve",
+                    forecast_curve_role="forward_curve",
+                ),
+            )
+        )
+    )
+
+    skeleton = _generate_skeleton(
+        STATIC_SPECS["swaption"],
+        "European payer swaption under Hull-White Monte Carlo",
+        generation_plan=generation_plan,
+    )
+    generated = _materialize_deterministic_exact_binding_module(
+        skeleton,
+        generation_plan,
+        semantic_blueprint=semantic_blueprint,
+        comparison_target="hw_mc",
+    )
+
+    assert generated is not None
+    assert EVALUATE_SENTINEL not in generated.code
+    for symbol in (
+        "resolve_swaption_black76_inputs",
+        "build_payment_timeline",
+        "resolve_hull_white_monte_carlo_process_inputs",
+        "build_discounted_swap_pv_payload",
+        "build_short_rate_discount_reducer",
+        "EventAwareMonteCarloEvent",
+        "EventAwareMonteCarloProblemSpec",
+        "build_event_aware_monte_carlo_problem",
+        "price_event_aware_monte_carlo",
+    ):
+        assert symbol in generated.code
+    assert "swap_start = getattr(spec, \"swap_start\", None) or resolved.expiry_date" in generated.code
+    assert "spec.swap_frequency" in generated.code
+    assert "day_count=spec.day_count" in generated.code
+    assert "forecast_forward_curve(rate_index)" in generated.code
+    assert "n_paths = max(int(getattr(spec, \"n_paths\", 20000)), 2)" in generated.code
+    assert "n_steps = max(int(getattr(spec, \"n_steps\", 64)), 1)" in generated.code
+    assert "seed = spec.seed if hasattr(spec, \"seed\") else 42" in generated.code
+    assert "mean_reversion=0.05" in generated.code
+    assert "sigma=0.01" in generated.code
+    assert "price_swaption_monte_carlo(" not in generated.code
+    assert "resolve_swaption_monte_carlo_problem(" not in generated.code
+    assert "GBM(" not in generated.code
 
 
 @pytest.mark.parametrize(

--- a/tests/test_agent/test_family_lowering_ir.py
+++ b/tests/test_agent/test_family_lowering_ir.py
@@ -260,6 +260,11 @@ def test_rate_style_swaption_monte_carlo_compiles_to_event_aware_family_ir():
     assert "recombining_safe" in family_ir.state_spec.state_tags
     assert family_ir.process_spec.process_family == "hull_white_1f"
     assert family_ir.process_spec.simulation_scheme == "exact_ou"
+    assert family_ir.helper_symbol == ""
+    assert (
+        family_ir.market_mapping
+        == "discount_curve_forward_curve_black_vol_to_short_rate_mc"
+    )
     assert family_ir.control_spec.control_style == "identity"
     assert family_ir.control_spec.controller_role == "holder"
     assert family_ir.control_program.control_style == "holder_max"

--- a/tests/test_agent/test_helper_authority_audit.py
+++ b/tests/test_agent/test_helper_authority_audit.py
@@ -315,6 +315,29 @@ def test_current_repository_retires_bermudan_swaption_lower_bound_helper_authori
     ]
 
 
+def test_current_repository_retires_european_swaption_monte_carlo_helper_authority():
+    from trellis.agent.helper_authority_audit import build_helper_authority_report
+
+    root = Path(__file__).resolve().parents[2]
+    report = build_helper_authority_report(root)
+    retired_symbols = {
+        "price_swaption_monte_carlo",
+        "resolve_swaption_monte_carlo_problem",
+    }
+
+    assert not [
+        item
+        for item in (*report.route_authority, *report.binding_authority)
+        if item.symbol in retired_symbols
+    ]
+    assert not [
+        item
+        for item in report.adapter_calls
+        if item.path == "trellis/instruments/_agent/swaption.py"
+        and item.symbol in retired_symbols
+    ]
+
+
 def test_current_repository_retires_analytical_digital_helper_authority():
     from trellis.agent.helper_authority_audit import build_helper_authority_report
 

--- a/tests/test_agent/test_lite_review.py
+++ b/tests/test_agent/test_lite_review.py
@@ -346,37 +346,40 @@ def price(spec, market_state):
     assert "lite.hardcoded_black_vol_surface" not in issue_codes
 
 
-def test_lite_review_allows_swaption_monte_carlo_helper_with_explicit_hull_white_comparison_params():
+def test_lite_review_allows_swaption_monte_carlo_process_binding_with_explicit_comparison_params():
     from trellis.agent.codegen_guardrails import GenerationPlan, PrimitivePlan, PrimitiveRef
     from trellis.agent.lite_review import review_generated_code
     from trellis.agent.quant import PricingPlan
 
     source = """\
-from trellis.models.rate_style_swaption import price_swaption_monte_carlo
+from trellis.models.monte_carlo.event_aware import resolve_hull_white_monte_carlo_process_inputs
 
 def price(spec, market_state):
-    return float(
-        price_swaption_monte_carlo(
-            market_state,
-            spec,
-            mean_reversion=0.05,
-            sigma=0.01,
-        )
+    return resolve_hull_white_monte_carlo_process_inputs(
+        market_state,
+        option_horizon=5.0,
+        strike=spec.strike,
+        mean_reversion=0.05,
+        sigma=0.01,
     )
 """
 
     plan = GenerationPlan(
         method="monte_carlo",
         instrument_type="swaption",
-        inspected_modules=("trellis.models.rate_style_swaption",),
-        approved_modules=("trellis.models.rate_style_swaption",),
-        symbols_to_reuse=("price_swaption_monte_carlo",),
+        inspected_modules=("trellis.models.monte_carlo.event_aware",),
+        approved_modules=("trellis.models.monte_carlo.event_aware",),
+        symbols_to_reuse=("resolve_hull_white_monte_carlo_process_inputs",),
         proposed_tests=("tests/test_agent/test_build_loop.py",),
         primitive_plan=PrimitivePlan(
             route="monte_carlo_paths",
             engine_family="monte_carlo",
             primitives=(
-                PrimitiveRef("trellis.models.rate_style_swaption", "price_swaption_monte_carlo", "route_helper"),
+                PrimitiveRef(
+                    "trellis.models.monte_carlo.event_aware",
+                    "resolve_hull_white_monte_carlo_process_inputs",
+                    "process_binding",
+                ),
             ),
             adapters=(),
             blockers=(),
@@ -384,7 +387,7 @@ def price(spec, market_state):
     )
     pricing_plan = PricingPlan(
         method="monte_carlo",
-        method_modules=["trellis.models.rate_style_swaption"],
+        method_modules=["trellis.models.monte_carlo.event_aware"],
         required_market_data={"discount_curve", "black_vol_surface", "forward_curve"},
         model_to_build="swaption",
         reasoning="test",

--- a/tests/test_agent/test_platform_requests.py
+++ b/tests/test_agent/test_platform_requests.py
@@ -571,7 +571,10 @@ def test_compile_build_request_preserves_swaption_conventions_and_hw_bindings():
     [
         ("analytical", "trellis.models.rate_style_swaption.price_swaption_black76_raw"),
         ("rate_tree", "trellis.models.rate_style_swaption_tree.price_swaption_tree"),
-        ("monte_carlo", "trellis.models.rate_style_swaption.price_swaption_monte_carlo"),
+        (
+            "monte_carlo",
+            "trellis.models.monte_carlo.event_aware.price_event_aware_monte_carlo",
+        ),
     ],
 )
 def test_compile_build_request_bootstraps_title_only_swaption_task_into_hw_comparison_regime(

--- a/tests/test_agent/test_prompts.py
+++ b/tests/test_agent/test_prompts.py
@@ -1661,7 +1661,7 @@ def test_executor_swaption_rate_tree_retry_pins_helper_backed_route():
     assert "swap_start == expiry_date" in text
 
 
-def test_executor_swaption_monte_carlo_retry_pins_event_aware_route():
+def test_executor_swaption_monte_carlo_retry_pins_primitive_composition():
     from types import SimpleNamespace
 
     from trellis.agent.executor import KnowledgeRetrievalRequest, _route_specific_retry_lines
@@ -1680,11 +1680,18 @@ def test_executor_swaption_monte_carlo_retry_pins_event_aware_route():
 
     text = "\n".join(_route_specific_retry_lines(request))
 
-    assert "price_swaption_monte_carlo" in text
-    assert "thin adapter" in text or "Keep the route thin" in text
+    assert "resolve_swaption_black76_inputs" in text
+    assert "build_payment_timeline" in text
+    assert "resolve_hull_white_monte_carlo_process_inputs" in text
+    assert "build_discounted_swap_pv_payload" in text
+    assert "build_short_rate_discount_reducer" in text
+    assert "build_event_aware_monte_carlo_problem" in text
+    assert "price_event_aware_monte_carlo" in text
     assert "swap_start" in text
     assert "do not hardcode `sigma = 0.01`" in text
     assert "do not synthesize a GBM equity path" in text
+    assert "price_swaption_monte_carlo" in text
+    assert "compatibility/reference" in text
 
 
 def test_executor_zcb_option_analytical_retry_mentions_jamshidian_raw_lane():

--- a/tests/test_agent/test_route_registry.py
+++ b/tests/test_agent/test_route_registry.py
@@ -863,6 +863,14 @@ class TestMonteCarloPathsRoutes:
         exercise_style="european",
         model_family="generic",
     )
+    EUROPEAN_SWAPTION_IR = ProductIR(
+        instrument="swaption",
+        payoff_family="swaption",
+        exercise_style="european",
+        state_dependence="schedule_state",
+        schedule_dependence=True,
+        model_family="interest_rate",
+    )
 
     def test_candidate(self, registry):
         new = _new_routes(registry, "monte_carlo", self.EUROPEAN_IR)
@@ -941,6 +949,70 @@ class TestMonteCarloPathsRoutes:
             ),
         }
         assert _prim_set(new_prims) == expected_prims
+
+    def test_european_swaption_primitives_compose_event_aware_hull_white_problem(
+        self,
+        registry,
+    ):
+        spec = [r for r in registry.routes if r.id == "monte_carlo_paths"][0]
+        new_prims = resolve_route_primitives(spec, self.EUROPEAN_SWAPTION_IR)
+
+        assert _prim_set(new_prims) == {
+            (
+                "trellis.models.rate_style_swaption",
+                "resolve_swaption_black76_inputs",
+                "market_binding",
+            ),
+            (
+                "trellis.core.date_utils",
+                "build_payment_timeline",
+                "schedule_builder",
+            ),
+            (
+                "trellis.models.monte_carlo.event_aware",
+                "resolve_hull_white_monte_carlo_process_inputs",
+                "process_binding",
+            ),
+            (
+                "trellis.models.monte_carlo.event_aware",
+                "build_discounted_swap_pv_payload",
+                "settlement_payload",
+            ),
+            (
+                "trellis.models.monte_carlo.event_aware",
+                "build_short_rate_discount_reducer",
+                "path_reducer",
+            ),
+            (
+                "trellis.models.monte_carlo.event_aware",
+                "EventAwareMonteCarloEvent",
+                "event_contract",
+            ),
+            (
+                "trellis.models.monte_carlo.event_aware",
+                "EventAwareMonteCarloProblemSpec",
+                "problem_spec",
+            ),
+            (
+                "trellis.models.monte_carlo.event_aware",
+                "build_event_aware_monte_carlo_problem",
+                "problem_builder",
+            ),
+            (
+                "trellis.models.monte_carlo.event_aware",
+                "price_event_aware_monte_carlo",
+                "monte_carlo_estimator",
+            ),
+        }
+        assert not {
+            "price_swaption_monte_carlo",
+            "resolve_swaption_monte_carlo_problem",
+        } & {primitive.symbol for primitive in new_prims}
+
+        notes = "\n".join(resolve_route_notes(spec, self.EUROPEAN_SWAPTION_IR))
+        assert "explicit `swap_start`" in notes
+        assert "price_event_aware_monte_carlo" in notes
+        assert "compatibility/reference" in notes
 
     def test_heston_primitives_use_stochastic_vol_monte_carlo_helper(self, registry):
         spec = [r for r in registry.routes if r.id == "monte_carlo_paths"][0]

--- a/tests/test_agent/test_semantic_validation.py
+++ b/tests/test_agent/test_semantic_validation.py
@@ -291,20 +291,84 @@ def build_price(self, market_state):
 HULL_WHITE_EVENT_AWARE_MC_SOURCE = """\
 from __future__ import annotations
 
-from trellis.models.rate_style_swaption import price_swaption_monte_carlo
+from trellis.core.date_utils import build_payment_timeline
+from trellis.models.rate_style_swaption import resolve_swaption_black76_inputs
+from trellis.models.monte_carlo.event_aware import (
+    EventAwareMonteCarloEvent,
+    EventAwareMonteCarloProblemSpec,
+    build_discounted_swap_pv_payload,
+    build_event_aware_monte_carlo_problem,
+    build_short_rate_discount_reducer,
+    price_event_aware_monte_carlo,
+    resolve_hull_white_monte_carlo_process_inputs,
+)
 
 
 def build_price(self, market_state):
-    return float(
-        price_swaption_monte_carlo(
-            market_state,
-            self._spec,
-            n_paths=32,
-            seed=7,
-            mean_reversion=0.05,
-            sigma=0.01,
+    spec = self._spec
+    resolved = resolve_swaption_black76_inputs(
+        market_state,
+        spec,
+        mean_reversion=0.05,
+        sigma=0.01,
+    )
+    payment_timeline = build_payment_timeline(
+        spec.swap_start,
+        spec.swap_end,
+        spec.swap_frequency,
+        day_count=spec.day_count,
+        time_origin=market_state.settlement,
+    )
+    process_spec, initial_state = resolve_hull_white_monte_carlo_process_inputs(
+        market_state,
+        option_horizon=resolved.expiry_years,
+        strike=spec.strike,
+        mean_reversion=0.05,
+        sigma=0.01,
+    )
+    payload = build_discounted_swap_pv_payload(
+        payment_timeline=payment_timeline,
+        discount_curve=market_state.discount,
+        forward_curve=market_state.forecast_forward_curve(spec.rate_index),
+        exercise_time=resolved.expiry_years,
+        discount_reducer_name="discount_to_expiry",
+        mean_reversion=process_spec.mean_reversion,
+        strike=spec.strike,
+        notional=spec.notional,
+        is_payer=spec.is_payer,
+        anchor_short_rate=initial_state,
+    )
+    problem = build_event_aware_monte_carlo_problem(
+        EventAwareMonteCarloProblemSpec(
+            process_spec=process_spec,
+            initial_state=initial_state,
+            maturity=resolved.expiry_years,
+            path_requirement_kind="event_replay",
+            reducer_kind="compiled_schedule_payoff",
+            path_reducers=(
+                build_short_rate_discount_reducer(
+                    name="discount_to_expiry",
+                    maturity=resolved.expiry_years,
+                ),
+            ),
+            settlement_event="swaption_settlement",
+            event_specs=(
+                EventAwareMonteCarloEvent(
+                    time=resolved.expiry_years,
+                    name="swaption_observation",
+                    kind="observation",
+                ),
+                EventAwareMonteCarloEvent(
+                    time=resolved.expiry_years,
+                    name="swaption_settlement",
+                    kind="settlement",
+                    payload=payload,
+                ),
+            ),
         )
     )
+    result = price_event_aware_monte_carlo(problem, n_paths=32, seed=7)
+    return float(result["price"])
 """
 
 
@@ -1298,7 +1362,7 @@ def test_accepts_helper_backed_cdo_tranche_route_without_internal_copula_calls()
     assert report.ok
 
 
-def test_accepts_one_required_state_process_when_route_declares_role_alternatives():
+def test_accepts_european_swaption_event_aware_monte_carlo_composition():
     from trellis.agent.semantic_validation import validate_semantics
 
     pricing_plan = PricingPlan(

--- a/tests/test_agent/test_semantic_validation.py
+++ b/tests/test_agent/test_semantic_validation.py
@@ -309,8 +309,6 @@ def build_price(self, market_state):
     resolved = resolve_swaption_black76_inputs(
         market_state,
         spec,
-        mean_reversion=0.05,
-        sigma=0.01,
     )
     payment_timeline = build_payment_timeline(
         spec.swap_start,

--- a/tests/test_models/test_rate_style_swaption.py
+++ b/tests/test_models/test_rate_style_swaption.py
@@ -5,6 +5,7 @@ from datetime import date
 
 import pytest
 
+from trellis.core.date_utils import year_fraction
 from trellis.core.differentiable import gradient
 from trellis.core.market_state import MarketState
 from trellis.core.types import DayCountConvention
@@ -17,6 +18,7 @@ from trellis.models.rate_style_swaption import (
     price_swaption_black76_raw,
     price_swaption_black76,
     resolve_swaption_black76_inputs,
+    resolve_swaption_monte_carlo_problem,
 )
 from trellis.models.rate_style_swaption_tree import (
     build_swaption_tree_spec,
@@ -238,6 +240,33 @@ def test_price_swaption_monte_carlo_stays_close_to_black76_and_tree():
     assert mc_price > 0.0
     assert mc_price == pytest.approx(tree_price, rel=0.15)
     assert mc_price == pytest.approx(black76_price, rel=0.35)
+
+
+def test_swaption_monte_carlo_problem_starts_payment_schedule_at_explicit_swap_start():
+    class _DelayedStartSpec(_EuropeanSpec):
+        swap_start = date(2030, 5, 15)
+
+    problem = resolve_swaption_monte_carlo_problem(
+        _market_state(),
+        _DelayedStartSpec(),
+        n_steps=64,
+        mean_reversion=0.05,
+        sigma=0.01,
+    )
+
+    assert problem.event_timeline is not None
+    settlement_event = next(
+        event
+        for event in problem.event_timeline.events
+        if event.name == "swaption_settlement"
+    )
+    assert settlement_event.payload["payment_times"][0] == pytest.approx(
+        year_fraction(
+            SETTLE,
+            date(2030, 11, 15),
+            _DelayedStartSpec.day_count,
+        )
+    )
 
 
 def test_price_swaption_black76_with_hull_white_comparison_vol_matches_tree_and_mc():

--- a/trellis/agent/backend_bindings.py
+++ b/trellis/agent/backend_bindings.py
@@ -613,6 +613,10 @@ def _exact_target_refs_for(
         role: _primitive_refs_for_role(primitives, role)
         for role in prioritized_roles
     }
+    if _primitive_refs_for_role(primitives, "problem_builder"):
+        estimator_refs = _primitive_refs_for_role(primitives, "monte_carlo_estimator")
+        if estimator_refs:
+            return estimator_refs
     for role in prioritized_roles:
         refs = refs_by_role[role]
         if refs:

--- a/trellis/agent/dsl_lowering.py
+++ b/trellis/agent/dsl_lowering.py
@@ -869,6 +869,119 @@ def _build_event_aware_monte_carlo_expr_from_family_ir(
         )
         return helper_atom, ()
 
+    if family_ir.payoff_family == "swaption":
+        required_bindings = {
+            symbol: next(
+                (binding for binding in bindings if binding.symbol == symbol),
+                None,
+            )
+            for symbol in (
+                "resolve_swaption_black76_inputs",
+                "build_payment_timeline",
+                "resolve_hull_white_monte_carlo_process_inputs",
+                "build_discounted_swap_pv_payload",
+                "build_short_rate_discount_reducer",
+                "EventAwareMonteCarloEvent",
+                "EventAwareMonteCarloProblemSpec",
+                "build_event_aware_monte_carlo_problem",
+                "price_event_aware_monte_carlo",
+            )
+        }
+        missing = tuple(
+            symbol for symbol, binding in required_bindings.items() if binding is None
+        )
+        if missing:
+            return None, tuple(
+                _missing_primitive_message(
+                    route_id,
+                    binding_id,
+                    "European swaption Monte Carlo",
+                    symbol,
+                )
+                for symbol in missing
+            )
+
+        stages = (
+            (
+                "market_binding",
+                "resolve_swaption_black76_inputs",
+                market_signature.inputs,
+                ("resolved_swaption:state",),
+                "Resolve the European expiry, schedule basis, and market conventions.",
+            ),
+            (
+                "schedule_builder",
+                "build_payment_timeline",
+                ("resolved_swaption:state",),
+                ("payment_timeline:state",),
+                "Build the underlying swap payment timeline from explicit swap start.",
+            ),
+            (
+                "process_binding",
+                "resolve_hull_white_monte_carlo_process_inputs",
+                ("payment_timeline:state",),
+                ("mc_process_binding:state",),
+                "Bind the Hull-White process to market or explicit comparison parameters.",
+            ),
+            (
+                "settlement_payload",
+                "build_discounted_swap_pv_payload",
+                ("mc_process_binding:state",),
+                ("settlement_payload:state",),
+                "Build the discounted swap-PV settlement payload.",
+            ),
+            (
+                "path_reducer",
+                "build_short_rate_discount_reducer",
+                ("settlement_payload:state",),
+                ("discount_reducer:state",),
+                "Build the reduced-state short-rate discount accumulator.",
+            ),
+            (
+                "event_contract",
+                "EventAwareMonteCarloEvent",
+                ("discount_reducer:state",),
+                ("event_specs:state",),
+                "Declare the expiry observation and settlement events.",
+            ),
+            (
+                "problem_spec",
+                "EventAwareMonteCarloProblemSpec",
+                ("event_specs:state",),
+                ("mc_problem_spec:state",),
+                "Declare the typed event-aware Monte Carlo problem.",
+            ),
+            (
+                "problem_builder",
+                "build_event_aware_monte_carlo_problem",
+                ("mc_problem_spec:state",),
+                ("mc_problem:state",),
+                "Compile process, events, reducer, and payoff into the runtime problem.",
+            ),
+            (
+                "monte_carlo_estimator",
+                "price_event_aware_monte_carlo",
+                ("mc_problem:state",),
+                ("price:scalar",),
+                "Evaluate the compiled problem with explicit path, step, and seed controls.",
+            ),
+        )
+        atoms = tuple(
+            ContractAtom(
+                atom_id=_binding_atom_id(route_id, binding_id, role),
+                primitive_ref=required_bindings[symbol].primitive_ref,
+                description=description,
+                signature=ContractSignature(
+                    inputs=inputs,
+                    outputs=outputs,
+                    timeline_roles=market_signature.timeline_roles,
+                    market_data_requirements=market_signature.market_data_requirements,
+                ),
+            )
+            for role, symbol, inputs, outputs, description in stages
+        )
+        return ThenExpr(terms=atoms), ()
+
     terminal_estimator = next(
         (
             binding

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -6189,7 +6189,7 @@ def _deterministic_exact_binding_evaluate_body(
 
             resolved = resolve_swaption_black76_inputs(
                 market_state,
-                spec{swaption_comparison_kwargs},
+                spec,
             )
             settlement = getattr(market_state, "settlement", None) or market_state.as_of
             swap_start = getattr(spec, "swap_start", None) or resolved.expiry_date
@@ -6206,7 +6206,7 @@ def _deterministic_exact_binding_evaluate_body(
                 if period.end_date > settlement
             )
             if not payment_timeline:
-                raise ValueError("Rate-style swaption Monte Carlo pricing requires payments after swap start")
+                raise ValueError("Rate-style swaption Monte Carlo pricing requires future payments after settlement")
 
             process_spec, initial_state = resolve_hull_white_monte_carlo_process_inputs(
                 market_state,

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -6168,6 +6168,113 @@ def _deterministic_exact_binding_evaluate_body(
             return price_swaption_black76_raw(resolved)
             """
         ).rstrip()
+    swaption_monte_carlo_refs = {
+        "trellis.models.rate_style_swaption.resolve_swaption_black76_inputs",
+        "trellis.core.date_utils.build_payment_timeline",
+        "trellis.models.monte_carlo.event_aware.resolve_hull_white_monte_carlo_process_inputs",
+        "trellis.models.monte_carlo.event_aware.build_discounted_swap_pv_payload",
+        "trellis.models.monte_carlo.event_aware.build_short_rate_discount_reducer",
+        "trellis.models.monte_carlo.event_aware.EventAwareMonteCarloEvent",
+        "trellis.models.monte_carlo.event_aware.EventAwareMonteCarloProblemSpec",
+        "trellis.models.monte_carlo.event_aware.build_event_aware_monte_carlo_problem",
+        "trellis.models.monte_carlo.event_aware.price_event_aware_monte_carlo",
+    }
+    if instrument_type == "swaption" and swaption_monte_carlo_refs.issubset(refs):
+        return textwrap.dedent(
+            f"""\
+            if market_state.discount is None:
+                raise ValueError("Rate-style swaption Monte Carlo pricing requires market_state.discount")
+            if market_state.vol_surface is None:
+                raise ValueError("Rate-style swaption Monte Carlo pricing requires market_state.vol_surface")
+
+            resolved = resolve_swaption_black76_inputs(
+                market_state,
+                spec{swaption_comparison_kwargs},
+            )
+            settlement = getattr(market_state, "settlement", None) or market_state.as_of
+            swap_start = getattr(spec, "swap_start", None) or resolved.expiry_date
+            payment_timeline = tuple(
+                period
+                for period in build_payment_timeline(
+                    swap_start,
+                    spec.swap_end,
+                    spec.swap_frequency,
+                    day_count=spec.day_count,
+                    time_origin=settlement,
+                    label="rate_style_swaption_monte_carlo",
+                )
+                if period.end_date > settlement
+            )
+            if not payment_timeline:
+                raise ValueError("Rate-style swaption Monte Carlo pricing requires payments after swap start")
+
+            process_spec, initial_state = resolve_hull_white_monte_carlo_process_inputs(
+                market_state,
+                option_horizon=max(float(resolved.expiry_years), 1e-6),
+                strike=float(spec.strike){swaption_comparison_kwargs},
+            )
+            forward_curve = None
+            rate_index = getattr(spec, "rate_index", None)
+            if rate_index and hasattr(market_state, "forecast_forward_curve"):
+                forward_curve = market_state.forecast_forward_curve(rate_index)
+            if forward_curve is None:
+                forward_curve = getattr(market_state, "forward_curve", None)
+
+            settlement_payload = build_discounted_swap_pv_payload(
+                payment_timeline=payment_timeline,
+                discount_curve=market_state.discount,
+                forward_curve=forward_curve,
+                exercise_time=float(resolved.expiry_years),
+                discount_reducer_name="discount_to_expiry",
+                mean_reversion=float(process_spec.mean_reversion or 0.0),
+                strike=float(spec.strike),
+                notional=float(spec.notional),
+                is_payer=bool(spec.is_payer),
+                anchor_short_rate=float(initial_state),
+            )
+            n_paths = max(int(getattr(spec, "n_paths", 20000)), 2)
+            n_steps = max(int(getattr(spec, "n_steps", 64)), 1)
+            seed = spec.seed if hasattr(spec, "seed") else 42
+            problem = build_event_aware_monte_carlo_problem(
+                EventAwareMonteCarloProblemSpec(
+                    process_spec=process_spec,
+                    initial_state=float(initial_state),
+                    maturity=float(resolved.expiry_years),
+                    n_steps=n_steps,
+                    path_requirement_kind="event_replay",
+                    reducer_kind="compiled_schedule_payoff",
+                    path_reducers=(
+                        build_short_rate_discount_reducer(
+                            name="discount_to_expiry",
+                            maturity=float(resolved.expiry_years),
+                        ),
+                    ),
+                    settlement_event="swaption_settlement",
+                    event_specs=(
+                        EventAwareMonteCarloEvent(
+                            time=float(resolved.expiry_years),
+                            name="swaption_observation",
+                            kind="observation",
+                        ),
+                        EventAwareMonteCarloEvent(
+                            time=float(resolved.expiry_years),
+                            name="swaption_settlement",
+                            kind="settlement",
+                            priority=1,
+                            payload=settlement_payload,
+                        ),
+                    ),
+                )
+            )
+            result = price_event_aware_monte_carlo(
+                problem,
+                n_paths=n_paths,
+                seed=seed,
+                return_paths=False,
+            )
+            return float(result["price"])
+            """
+        ).rstrip()
     helper_bodies = {
         "trellis.models.fx_vanilla.price_fx_vanilla_analytical": (
             "return price_fx_vanilla_analytical(market_state, spec)"
@@ -6195,11 +6302,6 @@ def _deterministic_exact_binding_evaluate_body(
         ),
         "trellis.models.bermudan_swaption_tree.price_bermudan_swaption_tree": (
             "return price_bermudan_swaption_tree(market_state, spec)"
-        ),
-        "trellis.models.rate_style_swaption.price_swaption_monte_carlo": (
-            "return price_swaption_monte_carlo("
-            "market_state, spec, n_paths=20000, seed=42"
-            f"{swaption_comparison_kwargs})"
         ),
         "trellis.models.monte_carlo.single_state_diffusion.price_single_state_terminal_claim_monte_carlo_result": (
             "result = price_single_state_terminal_claim_monte_carlo_result(\n"
@@ -8988,11 +9090,12 @@ def _route_specific_retry_lines(
         and stage in {"code_generation_failed", "semantic_validation_failed", "validation_failed", "actual_market_smoke_failed", "import_validation_failed"}
     ):
         return (
-            "European rate-style swaption Monte Carlo routes should stay on the checked family helper instead of assembling the event-aware problem inline.",
-            "Prefer `from trellis.models.rate_style_swaption import price_swaption_monte_carlo` and delegate to that helper from the adapter.",
-            "Keep the route thin: validate discount/vol access, preserve the contract conventions on `self._spec` including any explicit `swap_start`, then call the helper and return `float(...)`.",
-            "do not hardcode `sigma = 0.01` and do not synthesize a GBM equity path. The helper resolves the Hull-White process from `market_state` on the bounded calibration/model path.",
-            "If you truly need the lower-level runtime for debugging, the authoritative pieces remain `resolve_hull_white_monte_carlo_process_inputs(...)`, `build_discounted_swap_pv_payload(...)`, `build_short_rate_discount_reducer(...)`, and `price_event_aware_monte_carlo(...)` in `trellis.models.monte_carlo.event_aware`.",
+            "European rate-style swaption Monte Carlo routes should compose the checked public event-aware primitives directly.",
+            "Use `resolve_swaption_black76_inputs(...)` for the typed expiry basis and `build_payment_timeline(...)` from explicit `swap_start` through `swap_end`.",
+            "Bind `resolve_hull_white_monte_carlo_process_inputs(...)`, then assemble `build_discounted_swap_pv_payload(...)`, `build_short_rate_discount_reducer(...)`, `EventAwareMonteCarloEvent`, and `EventAwareMonteCarloProblemSpec`.",
+            "Compile with `build_event_aware_monte_carlo_problem(...)` and evaluate with `price_event_aware_monte_carlo(...)`, preserving day count, swap frequency, rate index, path/step/seed controls, and explicit comparison parameters.",
+            "do not hardcode `sigma = 0.01` unless the semantic comparison contract supplies it, and do not synthesize a GBM equity path. Resolve Hull-White parameters through the bounded market/model path.",
+            "`price_swaption_monte_carlo(...)` and `resolve_swaption_monte_carlo_problem(...)` are compatibility/reference surfaces, not generated construction authority.",
         )
     if (
         instrument == "swaption"

--- a/trellis/agent/family_lowering_ir.py
+++ b/trellis/agent/family_lowering_ir.py
@@ -806,7 +806,6 @@ _MC_MARKET_MAPPINGS = {
 _MC_HELPER_BINDINGS = {
     ("heston", "vanilla_option", "european"): "price_heston_option_monte_carlo",
     ("hull_white_1f", "period_rate_option_strip", ""): "price_rate_cap_floor_strip_monte_carlo",
-    ("hull_white_1f", "swaption", ""): "price_swaption_monte_carlo",
 }
 
 
@@ -1110,6 +1109,16 @@ def _binding_supports_event_aware_monte_carlo(
         "payoff_primitive",
     ):
         return True
+    if all(
+        _binding_has_role(binding_spec, role)
+        for role in (
+            "monte_carlo_estimator",
+            "problem_builder",
+            "process_binding",
+            "settlement_payload",
+        )
+    ):
+        return True
     if _binding_has_role(binding_spec, "path_simulation") and _binding_has_role(binding_spec, "state_process"):
         return True
     if _binding_has_any_symbol(
@@ -1119,7 +1128,6 @@ def _binding_supports_event_aware_monte_carlo(
         "price_heston_option_monte_carlo",
         "price_rate_cap_floor_strip_monte_carlo",
         "price_vanilla_equity_option_monte_carlo",
-        "price_swaption_monte_carlo",
     ):
         return True
     return False

--- a/trellis/agent/knowledge/canonical/api_map.yaml
+++ b/trellis/agent/knowledge/canonical/api_map.yaml
@@ -429,6 +429,21 @@ rate_style_swaption_composition:
     - "The product-level price_swaption_black76(...) wrapper remains a compatibility/reference API and is not generated-route construction authority."
     - "Pass Hull-White comparison parameters to the resolver only when the task contract explicitly requests that comparison regime; ordinary Black76 benchmark tasks use the bound market volatility surface."
 
+european_swaption_monte_carlo_composition:
+  module: trellis.models.monte_carlo.event_aware
+  methods: [monte_carlo]
+  navigation:
+    aliases: [swaption, european_swaption, hull_white_swaption_monte_carlo, hw_mc]
+  key_imports:
+    - "from trellis.models.rate_style_swaption import resolve_swaption_black76_inputs"
+    - "from trellis.core.date_utils import build_payment_timeline"
+    - "from trellis.models.monte_carlo.event_aware import resolve_hull_white_monte_carlo_process_inputs, build_discounted_swap_pv_payload, build_short_rate_discount_reducer"
+    - "from trellis.models.monte_carlo.event_aware import EventAwareMonteCarloEvent, EventAwareMonteCarloProblemSpec, build_event_aware_monte_carlo_problem, price_event_aware_monte_carlo"
+  notes:
+    - "price_swaption_monte_carlo(...) and resolve_swaption_monte_carlo_problem(...) remain compatibility/reference APIs and are not generated construction authority."
+    - "For a single-exercise European swaption, resolve the typed expiry basis, build the payment schedule from explicit swap_start, bind the Hull-White process, and assemble the discounted swap-PV payload, discount reducer, expiry events, problem spec, runtime problem, and generic estimator in that order."
+    - "Preserve day count, swap frequency, rate index, explicit comparison parameters, and path/step/seed controls. Do not substitute an equity GBM process."
+
 bermudan_swaption_lower_bound_composition:
   module: trellis.models.rate_style_swaption
   methods: [analytical]

--- a/trellis/agent/knowledge/canonical/backend_bindings.yaml
+++ b/trellis/agent/knowledge/canonical/backend_bindings.yaml
@@ -514,8 +514,32 @@ bindings:
           model_family: [interest_rate, short_rate]
         primitives:
           - module: trellis.models.rate_style_swaption
-            symbol: price_swaption_monte_carlo
-            role: route_helper
+            symbol: resolve_swaption_black76_inputs
+            role: market_binding
+          - module: trellis.core.date_utils
+            symbol: build_payment_timeline
+            role: schedule_builder
+          - module: trellis.models.monte_carlo.event_aware
+            symbol: resolve_hull_white_monte_carlo_process_inputs
+            role: process_binding
+          - module: trellis.models.monte_carlo.event_aware
+            symbol: build_discounted_swap_pv_payload
+            role: settlement_payload
+          - module: trellis.models.monte_carlo.event_aware
+            symbol: build_short_rate_discount_reducer
+            role: path_reducer
+          - module: trellis.models.monte_carlo.event_aware
+            symbol: EventAwareMonteCarloEvent
+            role: event_contract
+          - module: trellis.models.monte_carlo.event_aware
+            symbol: EventAwareMonteCarloProblemSpec
+            role: problem_spec
+          - module: trellis.models.monte_carlo.event_aware
+            symbol: build_event_aware_monte_carlo_problem
+            role: problem_builder
+          - module: trellis.models.monte_carlo.event_aware
+            symbol: price_event_aware_monte_carlo
+            role: monte_carlo_estimator
       - when:
           payoff_family: basket_option
           exercise_style: [european]

--- a/trellis/agent/knowledge/canonical/routes.yaml
+++ b/trellis/agent/knowledge/canonical/routes.yaml
@@ -786,10 +786,48 @@ routes:
           model_family: [interest_rate, short_rate]
         primitives:
           - module: trellis.models.rate_style_swaption
-            symbol: price_swaption_monte_carlo
-            role: route_helper
+            symbol: resolve_swaption_black76_inputs
+            role: market_binding
+          - module: trellis.core.date_utils
+            symbol: build_payment_timeline
+            role: schedule_builder
+          - module: trellis.models.monte_carlo.event_aware
+            symbol: resolve_hull_white_monte_carlo_process_inputs
+            role: process_binding
+          - module: trellis.models.monte_carlo.event_aware
+            symbol: build_discounted_swap_pv_payload
+            role: settlement_payload
+          - module: trellis.models.monte_carlo.event_aware
+            symbol: build_short_rate_discount_reducer
+            role: path_reducer
+          - module: trellis.models.monte_carlo.event_aware
+            symbol: EventAwareMonteCarloEvent
+            role: event_contract
+          - module: trellis.models.monte_carlo.event_aware
+            symbol: EventAwareMonteCarloProblemSpec
+            role: problem_spec
+          - module: trellis.models.monte_carlo.event_aware
+            symbol: build_event_aware_monte_carlo_problem
+            role: problem_builder
+          - module: trellis.models.monte_carlo.event_aware
+            symbol: price_event_aware_monte_carlo
+            role: monte_carlo_estimator
         adapters: []
-        notes: []
+        notes:
+          - >-
+            Resolve the European expiry basis, start the payment schedule at
+            explicit `swap_start`, bind the Hull-White process, and assemble the
+            discounted swap-PV settlement payload, discount reducer, events,
+            typed problem, and generic `price_event_aware_monte_carlo(...)`
+            estimator in generated adapter code.
+          - >-
+            Preserve day count, swap frequency, rate index, path/step/seed
+            controls, and any explicit comparison-regime Hull-White parameters.
+            Do not synthesize an equity GBM path.
+          - >-
+            `price_swaption_monte_carlo(...)` and
+            `resolve_swaption_monte_carlo_problem(...)` remain
+            compatibility/reference APIs; neither is generated-route authority.
       - when:
           payoff_family: basket_option
           exercise_style: [european]

--- a/trellis/agent/lite_review.py
+++ b/trellis/agent/lite_review.py
@@ -274,7 +274,7 @@ def _capability_literal_is_subsumed_by_route_binding(
     binding_by_route = {
         "analytical_black76": "resolve_swaption_black76_inputs",
         "rate_tree_backward_induction": "price_swaption_tree",
-        "monte_carlo_paths": "price_swaption_monte_carlo",
+        "monte_carlo_paths": "resolve_hull_white_monte_carlo_process_inputs",
     }
     binding_name = binding_by_route.get(primitive_plan.route)
     if binding_name is None or binding_name not in signals.call_names:

--- a/trellis/agent/prompts.py
+++ b/trellis/agent/prompts.py
@@ -599,11 +599,12 @@ def _render_family_route_guidance(
     if instrument_type == "swaption" and method == "monte_carlo":
         lines.append("## Family Route Guidance")
         lines.extend([
-            "- For European rate-style swaptions, prefer `price_swaption_monte_carlo(market_state, self._spec, ...)` from `trellis.models.rate_style_swaption`.",
-            "- Treat the generated route as a thin adapter over that family helper; do not rebuild Hull-White process resolution, event payload assembly, or event-aware Monte Carlo plumbing inline.",
-            "- The helper already preserves `day_count`, `swap_frequency`, `rate_index`, and any explicit European `swap_start` carried on `self._spec`.",
-            "- Do not hardcode `sigma = 0.01` or fall back to a GBM equity path. The helper resolves the Hull-White process from `market_state` on the bounded calibration/model path.",
-            "- If you need the lower-level assembly surface for debugging, the authoritative pieces remain `resolve_hull_white_monte_carlo_process_inputs(...)`, `build_discounted_swap_pv_payload(...)`, `build_short_rate_discount_reducer(...)`, and `price_event_aware_monte_carlo(...)` under `trellis.models.monte_carlo.event_aware`.",
+            "- For European rate-style swaptions, compose the public market, schedule, process, event, problem, and estimator primitives directly. Use `resolve_swaption_black76_inputs(...)` for the typed European expiry basis and `build_payment_timeline(...)` from the explicit `swap_start` to `swap_end`.",
+            "- Bind `resolve_hull_white_monte_carlo_process_inputs(...)`, then build the settlement with `build_discounted_swap_pv_payload(...)` and the path state with `build_short_rate_discount_reducer(...)`.",
+            "- Declare `EventAwareMonteCarloEvent` values inside `EventAwareMonteCarloProblemSpec`, compile with `build_event_aware_monte_carlo_problem(...)`, and evaluate with `price_event_aware_monte_carlo(...)`.",
+            "- Preserve `day_count`, `swap_frequency`, `rate_index`, explicit `swap_start`, path/step/seed controls, and any explicit Hull-White comparison parameters carried by the task contract.",
+            "- Do not hardcode `sigma = 0.01` unless the semantic comparison contract explicitly supplies it, and do not synthesize a GBM equity path. Hull-White process parameters must flow through the bounded market/model resolver.",
+            "- `price_swaption_monte_carlo(...)` and `resolve_swaption_monte_carlo_problem(...)` remain compatibility/reference APIs. Do not use either as generated construction authority.",
         ])
 
     if instrument_type == "zcb_option":

--- a/trellis/models/rate_style_swaption.py
+++ b/trellis/models/rate_style_swaption.py
@@ -367,10 +367,11 @@ def resolve_swaption_monte_carlo_problem(
 
     resolved = resolve_swaption_black76_inputs(market_state, spec)
     settlement = getattr(market_state, "settlement", None) or market_state.as_of
+    swap_start = getattr(spec, "swap_start", None) or resolved.expiry_date
     payment_timeline = tuple(
         period
         for period in build_payment_timeline(
-            resolved.expiry_date,
+            swap_start,
             spec.swap_end,
             spec.swap_frequency,
             day_count=spec.day_count,
@@ -380,7 +381,7 @@ def resolve_swaption_monte_carlo_problem(
         if period.end_date > settlement
     )
     if not payment_timeline:
-        raise ValueError("Rate-style swaption Monte Carlo pricing requires payments after expiry")
+        raise ValueError("Rate-style swaption Monte Carlo pricing requires payments after swap start")
 
     process_spec, initial_state = resolve_hull_white_monte_carlo_process_inputs(
         market_state,

--- a/trellis/models/rate_style_swaption.py
+++ b/trellis/models/rate_style_swaption.py
@@ -381,7 +381,7 @@ def resolve_swaption_monte_carlo_problem(
         if period.end_date > settlement
     )
     if not payment_timeline:
-        raise ValueError("Rate-style swaption Monte Carlo pricing requires payments after swap start")
+        raise ValueError("Rate-style swaption Monte Carlo pricing requires future payments after settlement")
 
     process_spec, initial_state = resolve_hull_white_monte_carlo_process_inputs(
         market_state,


### PR DESCRIPTION
## Summary
- compose European swaption Monte Carlo from typed market, schedule, Hull-White process, event, problem, and estimator primitives
- remove product helper/problem resolver from generated route authority while retaining compatibility/reference APIs
- preserve explicit swap start and update route metadata, prompts, API navigation, tests, and docs

## Validation
- strict offline fresh T73 replay: passed, zero LLM calls, zero recovery attempts
- helper authority audit: retired APIs absent from route/binding authority
- make gate-pr: passed
- make gate-release: passed

Linear: QUA-1198