### PR TITLE
QUA-1199 Retire European swaption tree helper authority

### DIFF
--- a/doc/plan/active__semantic-task-synthesis-helper-retirement.md
+++ b/doc/plan/active__semantic-task-synthesis-helper-retirement.md
@@ -59,6 +59,7 @@ Status mirror last synced: `2026-07-15`
 | `QUA-1196` | Swaption pricing: retire European Black76 wrapper authority | Done |
 | `QUA-1197` | Swaption pricing: retire Bermudan Black76 lower-bound helper authority | Done |
 | `QUA-1198` | Swaption Monte Carlo: retire European helper and problem-resolver authority | Done |
+| `QUA-1199` | Swaption lattice: retire European tree helper authority | In Progress |
 | `QUA-1102` | Semantic target binding: typed comparison target contracts (related prerequisite) | Done |
 
 ## Current Sequence
@@ -97,9 +98,13 @@ Status mirror last synced: `2026-07-15`
    event/problem contracts, problem compiler, and generic estimator as the
    generated construction surface while retaining product wrappers only as
    compatibility and reference APIs.
-10. Select the next helper-authority family from the machine-readable audit and
+10. Apply QUA-1199 to the European swaption tree lane: retain mean reversion in
+    the resolved tree inputs, construct the one-exercise contract explicitly,
+    and expose generic topology, mesh, calibration, lattice construction,
+    contract compilation, and rollback as the generated surface.
+11. Select the next helper-authority family from the machine-readable audit and
    create a bounded ticket before changing another route.
-11. Run live fresh-generation evidence only with current external-model approval;
+12. Run live fresh-generation evidence only with current external-model approval;
    use it to compare first-pass source selection, retrieved documentation,
    retries, and residual validator findings rather than as pricing authority.
 

--- a/docs/developer/implementation_journey_prompt_to_price.md
+++ b/docs/developer/implementation_journey_prompt_to_price.md
@@ -104,6 +104,16 @@ generation materializes the same sequence. This makes source identity and
 validation evidence describe the estimator that ran rather than a product
 wrapper that hid the assembly.
 
+T73's European rate-tree target is primitive-composed too. The route and exact
+binding identify generic ``price_on_lattice(...)`` as the estimator. Lowering
+records one-exercise contract construction, curve-basis adjustment, resolved
+tree inputs, topology, mesh, calibration target, lattice construction,
+swaption-contract compilation, and rollback as an ordered ``ThenExpr``.
+Deterministic generation preserves the Hull-White/BDT model, explicit
+comparison parameters, conventions, and tree-step controls. The retained
+``price_swaption_tree(...)`` wrapper remains an independent reference rather
+than the source identity of the generated artifact.
+
 Compiled request metadata now also carries a compact semantic-blueprint summary
 for downstream tooling. That summary records the canonical lowered route, the
 helper and primitive references selected by DSL lowering, and any explicit

--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -941,11 +941,14 @@ dependence-family selection on a checked helper path while semantic validation
 treats the helper as the public assembly contract rather than forcing direct
 calls to the lower-level loss-distribution primitives.
 
-For the supported swaption tree slice, the comparison harness now has a
-checked-in helper-backed route for single-exercise European rate-tree
-comparators. That keeps canaries such as ``T65`` on the stable
-``price_swaption_tree(...)`` surface instead of regenerating inline lattice
-exercise code for the comparison target.
+For the supported single-exercise European swaption tree slice, the comparison
+harness now binds an explicit generic lattice composition. The generated
+artifact constructs a one-exercise contract, applies the curve basis, resolves
+the short-rate inputs, builds the calibrated lattice, compiles the swaption
+contract, and calls ``price_on_lattice(...)``. The semantic gate requires
+``swap_start == expiry_date`` and fails closed otherwise. The retained
+``price_swaption_tree(...)`` surface remains independent comparison evidence,
+not the generated artifact identity.
 
 Helper-authority inventory
 --------------------------

--- a/docs/quant/knowledge_maintenance.rst
+++ b/docs/quant/knowledge_maintenance.rst
@@ -133,6 +133,14 @@ ordered derivative-specific composition. The retained product pricing wrapper
 and product-specific problem resolver remain useful comparison evidence but do
 not replace the primitive packet.
 
+The European swaption tree lane follows the same rule through
+``european_swaption_rate_lattice_composition``. Retrieval points the builder
+to the one-exercise contract type, curve-basis binding, resolved schedule and
+Hull-White/BDT inputs, generic topology/mesh/calibration contracts, lattice
+builder, swaption contract compiler, and generic rollback kernel. The retained
+``price_swaption_tree(...)`` wrapper is reference evidence; it does not replace
+that ordered composition packet.
+
 When the available primitives do not yet compose correctly, fail closed with a
 structured capability packet. The packet should distinguish capabilities that
 already exist from the missing glue. For Bermudan swaption Monte Carlo, Trellis

--- a/docs/quant/lattice_algebra.rst
+++ b/docs/quant/lattice_algebra.rst
@@ -348,13 +348,39 @@ tree probabilities, topology, and backward induction. The compatibility
 ``price_vanilla_equity_option_tree(...)`` wrapper remains useful as a reference
 and migration surface, but it is not route authority for generated adapters.
 
+Primitive-Composed European Swaption Trees
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The single-exercise European swaption tree lane also uses the general lattice
+algebra directly. Its admitted boundary requires ``swap_start == expiry_date``
+and composes the following public surfaces:
+
+#. construct a one-exercise ``BermudanSwaptionTreeSpec``;
+#. apply ``resolve_swaption_curve_basis_spread(...)`` to the tree strike;
+#. call ``resolve_bermudan_swaption_tree_inputs(...)`` to bind settlement,
+   schedule, short-rate seed, volatility, mean reversion, horizon, and step
+   count;
+#. build a Hull-White or BDT lattice from ``BINOMIAL_1F_TOPOLOGY``,
+   ``UNIFORM_ADDITIVE_MESH``, ``TERM_STRUCTURE_TARGET(...)``, and
+   ``build_lattice(...)``;
+#. compile the one-exercise swap claim with
+   ``compile_bermudan_swaption_contract_spec(...)``; and
+#. evaluate the compiled contract with ``price_on_lattice(...)``.
+
+``ResolvedBermudanSwaptionTreeInputs`` retains both ``mean_reversion`` and
+``sigma`` so callers do not need to re-enter a product-method builder to
+recover model parameters. ``price_swaption_tree(...)`` and
+``build_swaption_tree_spec(...)`` remain compatibility and independent
+reference surfaces, not generated construction authority.
+
 Current Helper-Backed Routes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The checked helper-backed lattice routes remain:
 
 - ``trellis.models.callable_bond_tree.price_callable_bond_tree``
-- ``trellis.models.bermudan_swaption_tree.price_bermudan_swaption_tree``
+- ``trellis.models.bermudan_swaption_tree.price_bermudan_swaption_tree`` for
+  the separate multi-exercise Bermudan lane
 - ``trellis.models.zcb_option_tree.price_zcb_option_tree``
 
 Target API Design

--- a/docs/quant/pricing_stack.rst
+++ b/docs/quant/pricing_stack.rst
@@ -924,13 +924,16 @@ bounded Hull-White calibration/model contract now survive into the
 method-specific ``ValuationContext`` and ``MarketBindingSpec`` instead of being
 dropped when a multi-method comparison request is compiled.
 
-For the primitive-composed analytical and helper-backed tree and Monte Carlo
-swaption routes, the runtime preserves those comparison-regime bindings when it
-materializes deterministic adapters. The analytical adapter carries the same
-explicit curve/model comparison parameters through the resolver into the raw
-Black76 kernel. Tree and Monte Carlo helper calls preserve those parameters,
-and the Monte Carlo wrapper adds a stable comparison-quality sampling control
-instead of drifting on an unseeded default path.
+For the primitive-composed analytical, tree, and Monte Carlo swaption routes,
+the runtime preserves those comparison-regime bindings when it materializes
+deterministic adapters. The analytical adapter carries explicit curve/model
+comparison parameters through the resolver into the raw Black76 kernel. The
+tree adapter constructs a one-exercise contract, binds the curve basis and
+resolved Hull-White/BDT inputs, builds the generic calibrated lattice, compiles
+the swaption lattice contract, and calls ``price_on_lattice(...)``. The Monte
+Carlo adapter preserves the same model contract and adds stable
+comparison-quality sampling controls instead of drifting on an unseeded
+default path.
 
 Within the valuation layer, migrated calibration workflows now carry a bounded
 ``EngineModelSpec`` surface instead of relying only on a free-form

--- a/docs/user_guide/pricing.rst
+++ b/docs/user_guide/pricing.rst
@@ -590,6 +590,16 @@ and explicit comparison parameters remain visible in that generated source.
 ``resolve_swaption_monte_carlo_problem(...)`` remain callable compatibility and
 reference APIs, but neither is live build authority.
 
+European swaption rate-tree targets use the same primitive-first policy. The
+generated route requires ``swap_start == expiry_date``, constructs a
+one-exercise tree contract, applies the discount/forecast curve basis, resolves
+the Hull-White or BDT inputs, builds the generic calibrated lattice, compiles
+the swaption lattice contract, and calls ``price_on_lattice(...)``. Day count,
+swap frequency, rate index, payer/receiver direction, explicit comparison
+parameters, and tree-step controls remain visible. ``price_swaption_tree(...)``
+and ``build_swaption_tree_spec(...)`` remain callable compatibility/reference
+APIs, but neither is live build authority.
+
 The Bermudan ``black76_european_lower_bound`` comparison reuses those same
 surfaces without pretending Black76 is a Bermudan solver. Generated code
 normalizes the exercise schedule, keeps dates strictly after settlement and

--- a/tests/test_agent/test_api_map.py
+++ b/tests/test_agent/test_api_map.py
@@ -63,6 +63,10 @@ def test_api_map_contains_expected_core_entries():
         api_map["european_swaption_monte_carlo_composition"]["module"]
         == "trellis.models.monte_carlo.event_aware"
     )
+    assert (
+        api_map["european_swaption_rate_lattice_composition"]["module"]
+        == "trellis.models.trees.algebra"
+    )
     assert api_map["equity_tree"]["module"] == "trellis.models.trees.algebra"
     assert api_map["rate_lattice"]["module"] == "trellis.models.trees.lattice"
     assert "utilities" in api_map
@@ -94,6 +98,7 @@ def test_api_map_key_imports_are_registry_valid():
         "rate_monte_carlo_composition",
         "bermudan_swaption_lower_bound_composition",
         "european_swaption_monte_carlo_composition",
+        "european_swaption_rate_lattice_composition",
         "qmc",
         "pde",
         "fft",
@@ -388,6 +393,35 @@ def test_api_map_exposes_european_swaption_event_aware_monte_carlo_composition()
     assert "compatibility/reference" in text
     assert "price_swaption_monte_carlo(...)" in text
     assert "resolve_swaption_monte_carlo_problem(...)" in text
+
+
+def test_api_map_exposes_european_swaption_rate_lattice_composition():
+    query = ApiMapQuery(
+        instrument_type="swaption",
+        payoff_family="swaption",
+        method="rate_tree",
+        model_family="interest_rate",
+    )
+    selection = select_api_map_sections(query)
+    text = format_api_map_for_prompt(compact=True, query=query)
+
+    assert selection.selected_families[0] == (
+        "european_swaption_rate_lattice_composition"
+    )
+    for symbol in (
+        "BermudanSwaptionTreeSpec",
+        "resolve_swaption_curve_basis_spread",
+        "resolve_bermudan_swaption_tree_inputs",
+        "build_lattice",
+        "compile_bermudan_swaption_contract_spec",
+        "price_on_lattice",
+    ):
+        assert symbol in text
+    notes = "\n".join(
+        get_api_map()["european_swaption_rate_lattice_composition"]["notes"]
+    )
+    assert "price_swaption_tree(...)" in notes
+    assert "reference" in notes.lower()
 
 
 def test_api_map_exposes_complete_fixed_lookback_analytical_composition():

--- a/tests/test_agent/test_backend_bindings.py
+++ b/tests/test_agent/test_backend_bindings.py
@@ -428,6 +428,45 @@ def test_resolve_backend_binding_spec_composes_european_swaption_monte_carlo():
     }
 
 
+def test_resolve_backend_binding_spec_composes_european_swaption_rate_lattice():
+    catalog = load_backend_binding_catalog()
+    binding = find_backend_binding_by_route_id("rate_tree_backward_induction", catalog)
+
+    assert binding is not None
+
+    resolved = resolve_backend_binding_spec(
+        binding,
+        product_ir=ProductIR(
+            instrument="swaption",
+            payoff_family="swaption",
+            exercise_style="european",
+            schedule_dependence=True,
+            state_dependence="schedule_state",
+            model_family="interest_rate",
+        ),
+    )
+
+    assert resolved.helper_refs == ()
+    assert resolved.market_binding_refs == (
+        "trellis.models.bermudan_swaption_tree.resolve_bermudan_swaption_tree_inputs",
+    )
+    assert resolved.exact_target_refs == (
+        "trellis.models.trees.algebra.price_on_lattice",
+    )
+    assert resolved.binding_id == "trellis.models.trees.algebra.price_on_lattice"
+    assert {primitive.symbol: primitive.role for primitive in resolved.primitives} == {
+        "BermudanSwaptionTreeSpec": "contract_spec",
+        "resolve_swaption_curve_basis_spread": "curve_basis_binding",
+        "resolve_bermudan_swaption_tree_inputs": "market_binding",
+        "BINOMIAL_1F_TOPOLOGY": "topology",
+        "UNIFORM_ADDITIVE_MESH": "mesh",
+        "TERM_STRUCTURE_TARGET": "calibration_target",
+        "build_lattice": "lattice_builder",
+        "compile_bermudan_swaption_contract_spec": "contract_compiler",
+        "price_on_lattice": "pricing_kernel",
+    }
+
+
 def test_resolve_backend_binding_spec_uses_basket_option_exact_helpers():
     catalog = load_backend_binding_catalog()
     analytical = find_backend_binding_by_route_id("analytical_black76", catalog)

--- a/tests/test_agent/test_dsl_lowering.py
+++ b/tests/test_agent/test_dsl_lowering.py
@@ -266,7 +266,7 @@ def test_bermudan_swaption_lowers_to_explicit_holder_choice_plus_helper_targets(
     assert "trellis.models.bermudan_swaption_tree" in blueprint.route_modules
 
 
-def test_rate_tree_swaption_lowers_to_checked_in_helper_target():
+def test_rate_tree_swaption_lowers_to_generic_lattice_composition():
     from trellis.agent.semantic_contract_compiler import compile_semantic_contract
     from trellis.agent.semantic_contracts import make_rate_style_swaption_contract
 
@@ -284,11 +284,23 @@ def test_rate_tree_swaption_lowers_to_checked_in_helper_target():
     assert lowering.route_family == "rate_lattice"
     assert lowering.family_ir is None
     assert lowering.admissibility_errors == ()
-    assert (
-        "trellis.models.rate_style_swaption_tree.price_swaption_tree"
-        in lowering.helper_refs
+    assert lowering.route_helper_refs == ()
+    assert isinstance(lowering.normalized_expr, ThenExpr)
+    assert tuple(
+        term.primitive_ref for term in lowering.normalized_expr.terms
+    ) == (
+        "trellis.models.bermudan_swaption_tree.BermudanSwaptionTreeSpec",
+        "trellis.models.rate_style_swaption.resolve_swaption_curve_basis_spread",
+        "trellis.models.bermudan_swaption_tree.resolve_bermudan_swaption_tree_inputs",
+        "trellis.models.trees.algebra.BINOMIAL_1F_TOPOLOGY",
+        "trellis.models.trees.algebra.UNIFORM_ADDITIVE_MESH",
+        "trellis.models.trees.algebra.TERM_STRUCTURE_TARGET",
+        "trellis.models.trees.algebra.build_lattice",
+        "trellis.models.bermudan_swaption_tree.compile_bermudan_swaption_contract_spec",
+        "trellis.models.trees.algebra.price_on_lattice",
     )
-    assert "trellis.models.rate_style_swaption_tree" in blueprint.route_modules
+    assert "trellis.models.rate_style_swaption_tree.price_swaption_tree" not in lowering.target_refs
+    assert "trellis.models.trees.algebra" in blueprint.route_modules
 
 
 def test_rate_style_swaption_monte_carlo_lowers_to_event_aware_compilation_steps():

--- a/tests/test_agent/test_executor.py
+++ b/tests/test_agent/test_executor.py
@@ -5787,20 +5787,7 @@ def test_deterministic_exact_binding_module_materializes_credit_loss_distributio
     assert EVALUATE_SENTINEL not in generated.code
 
 
-@pytest.mark.parametrize(
-    ("helper_ref", "expected_call"),
-    [
-        (
-            "trellis.models.rate_style_swaption.price_swaption_black76_raw",
-            "price_swaption_black76_raw",
-        ),
-        ("trellis.models.rate_style_swaption_tree.price_swaption_tree", "price_swaption_tree"),
-    ],
-)
-def test_deterministic_exact_binding_module_threads_explicit_swaption_comparison_regime(
-    helper_ref,
-    expected_call,
-):
+def test_deterministic_exact_binding_module_threads_explicit_swaption_comparison_regime():
     from trellis.agent.executor import (
         _generate_skeleton,
         _materialize_deterministic_exact_binding_module,
@@ -5814,7 +5801,9 @@ def test_deterministic_exact_binding_module_threads_explicit_swaption_comparison
     )
 
     generation_plan = SimpleNamespace(
-        lane_exact_binding_refs=(helper_ref,),
+        lane_exact_binding_refs=(
+            "trellis.models.rate_style_swaption.price_swaption_black76_raw",
+        ),
         primitive_plan=None,
         method="analytical",
         instrument_type="swaption",
@@ -5850,15 +5839,129 @@ def test_deterministic_exact_binding_module_threads_explicit_swaption_comparison
     )
 
     assert generated is not None
-    if expected_call == "price_swaption_black76_raw":
-        assert (
-            "resolve_swaption_black76_inputs("
-            "market_state, spec, mean_reversion=0.05, sigma=0.01)"
-        ) in generated.code
-        assert "return price_swaption_black76_raw(resolved)" in generated.code
-        assert "price_swaption_black76(market_state" not in generated.code
-    else:
-        assert f"{expected_call}(market_state, spec, mean_reversion=0.05, sigma=0.01)" in generated.code
+    assert (
+        "resolve_swaption_black76_inputs("
+        "market_state, spec, mean_reversion=0.05, sigma=0.01)"
+    ) in generated.code
+    assert "return price_swaption_black76_raw(resolved)" in generated.code
+    assert "price_swaption_black76(market_state" not in generated.code
+
+
+def test_deterministic_exact_binding_module_composes_european_swaption_rate_lattice():
+    from trellis.agent.codegen_guardrails import PrimitiveRef
+    from trellis.agent.executor import (
+        EVALUATE_SENTINEL,
+        _generate_skeleton,
+        _materialize_deterministic_exact_binding_module,
+    )
+    from trellis.agent.planner import STATIC_SPECS
+    from trellis.agent.valuation_context import (
+        EngineModelSpec,
+        PotentialSpec,
+        RatesCurveRoleSpec,
+        SourceSpec,
+    )
+
+    primitives = (
+        PrimitiveRef(
+            "trellis.models.bermudan_swaption_tree",
+            "BermudanSwaptionTreeSpec",
+            "contract_spec",
+        ),
+        PrimitiveRef(
+            "trellis.models.rate_style_swaption",
+            "resolve_swaption_curve_basis_spread",
+            "curve_basis_binding",
+        ),
+        PrimitiveRef(
+            "trellis.models.bermudan_swaption_tree",
+            "resolve_bermudan_swaption_tree_inputs",
+            "market_binding",
+        ),
+        PrimitiveRef("trellis.models.trees.algebra", "BINOMIAL_1F_TOPOLOGY", "topology"),
+        PrimitiveRef("trellis.models.trees.algebra", "UNIFORM_ADDITIVE_MESH", "mesh"),
+        PrimitiveRef(
+            "trellis.models.trees.algebra",
+            "TERM_STRUCTURE_TARGET",
+            "calibration_target",
+        ),
+        PrimitiveRef("trellis.models.trees.algebra", "build_lattice", "lattice_builder"),
+        PrimitiveRef(
+            "trellis.models.bermudan_swaption_tree",
+            "compile_bermudan_swaption_contract_spec",
+            "contract_compiler",
+        ),
+        PrimitiveRef("trellis.models.trees.algebra", "price_on_lattice", "pricing_kernel"),
+    )
+    generation_plan = SimpleNamespace(
+        lane_exact_binding_refs=("trellis.models.trees.algebra.price_on_lattice",),
+        primitive_plan=SimpleNamespace(
+            route="rate_tree_backward_induction",
+            primitives=primitives,
+        ),
+        method="rate_tree",
+        instrument_type="swaption",
+    )
+    semantic_blueprint = SimpleNamespace(
+        valuation_context=SimpleNamespace(
+            engine_model_spec=EngineModelSpec(
+                model_family="rates",
+                model_name="hull_white_1f",
+                state_semantics=("short_rate",),
+                potential=PotentialSpec(discount_term="risk_free_rate"),
+                sources=(SourceSpec(source_kind="coupon_stream"),),
+                calibration_requirements=("bootstrap_curve", "fit_hw_strip"),
+                backend_hints=("lattice",),
+                parameter_overrides={"mean_reversion": 0.05, "sigma": 0.01},
+                rates_curve_roles=RatesCurveRoleSpec(
+                    discount_curve_role="discount_curve",
+                    forecast_curve_role="forward_curve",
+                ),
+            )
+        )
+    )
+
+    skeleton = _generate_skeleton(
+        STATIC_SPECS["swaption"],
+        "European payer swaption on a Hull-White tree",
+        generation_plan=generation_plan,
+    )
+    generated = _materialize_deterministic_exact_binding_module(
+        skeleton,
+        generation_plan,
+        semantic_blueprint=semantic_blueprint,
+        comparison_target="hw_tree",
+    )
+
+    assert generated is not None
+    assert EVALUATE_SENTINEL not in generated.code
+    for symbol in (
+        "BermudanSwaptionTreeSpec",
+        "resolve_swaption_curve_basis_spread",
+        "resolve_bermudan_swaption_tree_inputs",
+        "BINOMIAL_1F_TOPOLOGY",
+        "UNIFORM_ADDITIVE_MESH",
+        "TERM_STRUCTURE_TARGET",
+        "build_lattice",
+        "compile_bermudan_swaption_contract_spec",
+        "price_on_lattice",
+    ):
+        assert symbol in generated.code
+    assert "if spec.swap_start != spec.expiry_date:" in generated.code
+    assert "strike=float(spec.strike) - float(curve_basis_spread)" in generated.code
+    assert 'model="hull_white"' in generated.code
+    assert "mean_reversion=0.05" in generated.code
+    assert "sigma=0.01" in generated.code
+    assert "a=resolved.mean_reversion" in generated.code
+    assert "n_steps=resolved.n_steps" in generated.code
+    assert "day_count=spec.day_count" in generated.code
+    assert "swap_frequency=spec.swap_frequency" in generated.code
+    assert "rate_index=spec.rate_index" in generated.code
+    assert "is_payer=bool(spec.is_payer)" in generated.code
+    assert "price_swaption_tree(" not in generated.code
+    assert "build_swaption_tree_spec(" not in generated.code
+    assert "price_bermudan_swaption_tree(" not in generated.code
+    assert "build_bermudan_swaption_lattice(" not in generated.code
 
 
 def test_deterministic_exact_binding_module_composes_european_swaption_monte_carlo():

--- a/tests/test_agent/test_family_lowering_ir.py
+++ b/tests/test_agent/test_family_lowering_ir.py
@@ -647,6 +647,27 @@ def test_bermudan_swaption_compiles_to_exercise_lattice_family_ir():
     assert "par_rate_bindings" in family_ir.derived_quantities
 
 
+def test_european_swaption_tree_uses_primitive_lowering_without_helper_ir():
+    from trellis.agent.semantic_contract_compiler import compile_semantic_contract
+    from trellis.agent.semantic_contracts import make_rate_style_swaption_contract
+
+    contract = make_rate_style_swaption_contract(
+        description="European payer swaption on a Hull-White tree",
+        observation_schedule=("2029-11-15",),
+        preferred_method="rate_tree",
+        exercise_style="european",
+    )
+    blueprint = compile_semantic_contract(contract, preferred_method="rate_tree")
+
+    lowering = blueprint.dsl_lowering
+    assert lowering is not None
+    assert lowering.family_ir is None
+    assert lowering.route_helper_refs == ()
+    assert "trellis.models.rate_style_swaption_tree.price_swaption_tree" not in (
+        lowering.target_refs
+    )
+
+
 def test_exercise_lattice_family_ir_ignores_legacy_settlement_rule_mirror():
     from trellis.agent.semantic_contract_compiler import compile_semantic_contract
     from trellis.agent.semantic_contracts import (

--- a/tests/test_agent/test_helper_authority_audit.py
+++ b/tests/test_agent/test_helper_authority_audit.py
@@ -295,6 +295,26 @@ def test_current_repository_retires_european_swaption_wrapper_authority():
     ]
 
 
+def test_current_repository_retires_european_swaption_tree_helper_authority():
+    from trellis.agent.helper_authority_audit import build_helper_authority_report
+
+    root = Path(__file__).resolve().parents[2]
+    report = build_helper_authority_report(root)
+    retired_symbols = {"price_swaption_tree", "build_swaption_tree_spec"}
+
+    assert not [
+        item
+        for item in (*report.route_authority, *report.binding_authority)
+        if item.symbol in retired_symbols
+    ]
+    assert not [
+        item
+        for item in report.adapter_calls
+        if item.path == "trellis/instruments/_agent/swaption.py"
+        and item.symbol in retired_symbols
+    ]
+
+
 def test_current_repository_retires_bermudan_swaption_lower_bound_helper_authority():
     from trellis.agent.helper_authority_audit import build_helper_authority_report
 

--- a/tests/test_agent/test_import_registry.py
+++ b/tests/test_agent/test_import_registry.py
@@ -23,6 +23,30 @@ def test_list_module_exports_returns_known_symbols():
     assert "theta_method_1d" in exports
 
 
+def test_registry_includes_local_exported_values_without_package_reexports():
+    algebra_exports = set(list_module_exports("trellis.models.trees.algebra"))
+
+    assert {
+        "BINOMIAL_1F_TOPOLOGY",
+        "TERM_STRUCTURE_TARGET",
+        "UNIFORM_ADDITIVE_MESH",
+    } <= algebra_exports
+    assert "price_himalaya_option_monte_carlo" not in list_module_exports(
+        "trellis.models.monte_carlo"
+    )
+
+    static_registry = import_registry._parse_static_registry(
+        import_registry._STATIC_REGISTRY
+    )
+    assert {
+        "BINOMIAL_1F_TOPOLOGY",
+        "TERM_STRUCTURE_TARGET",
+        "UNIFORM_ADDITIVE_MESH",
+        "build_lattice",
+        "price_on_lattice",
+    } <= set(static_registry["trellis.models.trees.algebra"])
+
+
 def test_find_symbol_modules_returns_known_module():
     modules = find_symbol_modules("theta_method_1d")
     assert "trellis.models.pde.theta_method" in modules

--- a/tests/test_agent/test_lite_review.py
+++ b/tests/test_agent/test_lite_review.py
@@ -292,17 +292,17 @@ def price(spec, market_state):
     assert "lite.hardcoded_black_vol_surface" not in issue_codes
 
 
-def test_lite_review_allows_swaption_tree_helper_with_explicit_hull_white_comparison_params():
+def test_lite_review_allows_swaption_tree_binding_with_explicit_hull_white_comparison_params():
     from trellis.agent.codegen_guardrails import GenerationPlan, PrimitivePlan, PrimitiveRef
     from trellis.agent.lite_review import review_generated_code
     from trellis.agent.quant import PricingPlan
 
     source = """\
-from trellis.models.rate_style_swaption_tree import price_swaption_tree
+from trellis.models.bermudan_swaption_tree import resolve_bermudan_swaption_tree_inputs
 
 def price(spec, market_state):
     return float(
-        price_swaption_tree(
+        resolve_bermudan_swaption_tree_inputs(
             market_state,
             spec,
             mean_reversion=0.05,
@@ -314,15 +314,19 @@ def price(spec, market_state):
     plan = GenerationPlan(
         method="rate_tree",
         instrument_type="swaption",
-        inspected_modules=("trellis.models.rate_style_swaption_tree",),
-        approved_modules=("trellis.models.rate_style_swaption_tree",),
-        symbols_to_reuse=("price_swaption_tree",),
+        inspected_modules=("trellis.models.bermudan_swaption_tree",),
+        approved_modules=("trellis.models.bermudan_swaption_tree",),
+        symbols_to_reuse=("resolve_bermudan_swaption_tree_inputs",),
         proposed_tests=("tests/test_agent/test_build_loop.py",),
         primitive_plan=PrimitivePlan(
             route="rate_tree_backward_induction",
             engine_family="lattice",
             primitives=(
-                PrimitiveRef("trellis.models.rate_style_swaption_tree", "price_swaption_tree", "route_helper"),
+                PrimitiveRef(
+                    "trellis.models.bermudan_swaption_tree",
+                    "resolve_bermudan_swaption_tree_inputs",
+                    "market_binding",
+                ),
             ),
             adapters=(),
             blockers=(),
@@ -330,7 +334,7 @@ def price(spec, market_state):
     )
     pricing_plan = PricingPlan(
         method="rate_tree",
-        method_modules=["trellis.models.rate_style_swaption_tree"],
+        method_modules=["trellis.models.bermudan_swaption_tree"],
         required_market_data={"discount_curve", "black_vol_surface", "forward_curve"},
         model_to_build="swaption",
         reasoning="test",

--- a/tests/test_agent/test_platform_requests.py
+++ b/tests/test_agent/test_platform_requests.py
@@ -570,7 +570,7 @@ def test_compile_build_request_preserves_swaption_conventions_and_hw_bindings():
     ("preferred_method", "expected_binding"),
     [
         ("analytical", "trellis.models.rate_style_swaption.price_swaption_black76_raw"),
-        ("rate_tree", "trellis.models.rate_style_swaption_tree.price_swaption_tree"),
+        ("rate_tree", "trellis.models.trees.algebra.price_on_lattice"),
         (
             "monte_carlo",
             "trellis.models.monte_carlo.event_aware.price_event_aware_monte_carlo",

--- a/tests/test_agent/test_prompts.py
+++ b/tests/test_agent/test_prompts.py
@@ -1637,7 +1637,7 @@ def test_executor_swaption_analytical_retry_pins_resolver_kernel_route():
     assert "annuity" in text
 
 
-def test_executor_swaption_rate_tree_retry_pins_helper_backed_route():
+def test_executor_swaption_rate_tree_retry_pins_generic_lattice_composition():
     from types import SimpleNamespace
 
     from trellis.agent.executor import KnowledgeRetrievalRequest, _route_specific_retry_lines
@@ -1656,7 +1656,13 @@ def test_executor_swaption_rate_tree_retry_pins_helper_backed_route():
 
     text = "\n".join(_route_specific_retry_lines(request))
 
+    assert "BermudanSwaptionTreeSpec" in text
+    assert "resolve_bermudan_swaption_tree_inputs" in text
+    assert "build_lattice" in text
+    assert "compile_bermudan_swaption_contract_spec" in text
+    assert "price_on_lattice" in text
     assert "price_swaption_tree" in text
+    assert "not generated construction authority" in text
     assert "single-exercise European" in text
     assert "swap_start == expiry_date" in text
 

--- a/tests/test_agent/test_route_registry.py
+++ b/tests/test_agent/test_route_registry.py
@@ -1453,15 +1453,39 @@ class TestRateTreeRoutes:
         notes = resolve_route_notes(spec, self.BERMUDAN_IR)
         assert notes == ()
 
-    def test_rate_tree_swaption_primitives(self, registry):
+    def test_rate_tree_swaption_primitives_are_generic_lattice_composition(self, registry):
         spec = [r for r in registry.routes if r.id == "rate_tree_backward_induction"][0]
         new_prims = resolve_route_primitives(spec, self.EUROPEAN_SWAPTION_IR)
         expected_prims = {
-            ("trellis.models.rate_style_swaption_tree", "price_swaption_tree", "route_helper"),
+            (
+                "trellis.models.bermudan_swaption_tree",
+                "BermudanSwaptionTreeSpec",
+                "contract_spec",
+            ),
+            (
+                "trellis.models.rate_style_swaption",
+                "resolve_swaption_curve_basis_spread",
+                "curve_basis_binding",
+            ),
+            (
+                "trellis.models.bermudan_swaption_tree",
+                "resolve_bermudan_swaption_tree_inputs",
+                "market_binding",
+            ),
+            ("trellis.models.trees.algebra", "BINOMIAL_1F_TOPOLOGY", "topology"),
+            ("trellis.models.trees.algebra", "UNIFORM_ADDITIVE_MESH", "mesh"),
+            ("trellis.models.trees.algebra", "TERM_STRUCTURE_TARGET", "calibration_target"),
+            ("trellis.models.trees.algebra", "build_lattice", "lattice_builder"),
+            (
+                "trellis.models.bermudan_swaption_tree",
+                "compile_bermudan_swaption_contract_spec",
+                "contract_compiler",
+            ),
+            ("trellis.models.trees.algebra", "price_on_lattice", "pricing_kernel"),
         }
         assert _prim_set(new_prims) == expected_prims
 
-    def test_rate_tree_swaption_helper_route_is_thin(self, registry):
+    def test_rate_tree_swaption_composition_route_has_no_helper_notes(self, registry):
         spec = [r for r in registry.routes if r.id == "rate_tree_backward_induction"][0]
         notes = resolve_route_notes(spec, self.EUROPEAN_SWAPTION_IR)
         assert notes == ()

--- a/tests/test_agent/test_semantic_validation.py
+++ b/tests/test_agent/test_semantic_validation.py
@@ -598,6 +598,26 @@ def test_extracts_rate_lattice_engine_family_from_rate_lattice_imports():
     assert signals.engine_families == ("rate_lattice",)
 
 
+def test_extracts_resolved_references_to_declarative_lattice_primitives():
+    from trellis.agent.semantic_validation import extract_semantic_signals
+
+    signals = extract_semantic_signals(
+        """
+from trellis.models.trees.algebra import BINOMIAL_1F_TOPOLOGY, UNIFORM_ADDITIVE_MESH
+
+def build(builder):
+    return builder(BINOMIAL_1F_TOPOLOGY, UNIFORM_ADDITIVE_MESH)
+"""
+    )
+
+    assert "trellis.models.trees.algebra.BINOMIAL_1F_TOPOLOGY" in (
+        signals.resolved_references
+    )
+    assert "trellis.models.trees.algebra.UNIFORM_ADDITIVE_MESH" in (
+        signals.resolved_references
+    )
+
+
 def test_extracts_lattice_policy_contract_from_policy_helper():
     from trellis.agent.semantic_validation import extract_semantic_signals
 

--- a/tests/test_agent/test_semantic_validation.py
+++ b/tests/test_agent/test_semantic_validation.py
@@ -618,6 +618,29 @@ def build(builder):
     )
 
 
+def test_extracts_qualified_declarative_references_through_module_alias():
+    from trellis.agent.semantic_validation import extract_semantic_signals
+
+    signals = extract_semantic_signals(
+        """
+import trellis.models.trees.algebra as lattice_algebra
+
+def build(builder):
+    return builder(
+        lattice_algebra.BINOMIAL_1F_TOPOLOGY,
+        lattice_algebra.UNIFORM_ADDITIVE_MESH,
+    )
+"""
+    )
+
+    assert "trellis.models.trees.algebra.BINOMIAL_1F_TOPOLOGY" in (
+        signals.resolved_references
+    )
+    assert "trellis.models.trees.algebra.UNIFORM_ADDITIVE_MESH" in (
+        signals.resolved_references
+    )
+
+
 def test_extracts_lattice_policy_contract_from_policy_helper():
     from trellis.agent.semantic_validation import extract_semantic_signals
 

--- a/tests/test_agent/test_semantic_validators.py
+++ b/tests/test_agent/test_semantic_validators.py
@@ -818,7 +818,7 @@ def evaluate(self, market_state):
         findings = validator.validate(source, _make_plan("exercise_lattice", "lattice"), spec)
         assert any(f.category == "route_helper_signature_mismatch" for f in findings)
 
-    def test_flags_rate_tree_swaption_helper_signature_mismatch(self, registry):
+    def test_flags_rate_tree_swaption_missing_required_composition_primitive(self, registry):
         spec = [r for r in registry.routes if r.id == "rate_tree_backward_induction"][0]
         swaption_ir = ProductIR(
             instrument="swaption",
@@ -828,16 +828,25 @@ def evaluate(self, market_state):
         )
         spec = replace(spec, primitives=resolve_route_primitives(spec, swaption_ir))
         source = '''
-from trellis.models.rate_style_swaption_tree import price_swaption_tree
+from trellis.models.bermudan_swaption_tree import BermudanSwaptionTreeSpec
 
 def evaluate(self, market_state):
-    return price_swaption_tree(spec=self._spec, market_state=market_state, exercise_steps=12)
+    return BermudanSwaptionTreeSpec(
+        notional=self._spec.notional,
+        strike=self._spec.strike,
+        exercise_dates=(self._spec.expiry_date,),
+        swap_end=self._spec.swap_end,
+    )
 '''
         validator = AlgorithmContractValidator()
         findings = validator.validate(source, _make_plan("rate_tree_backward_induction", "lattice"), spec)
-        assert any(f.category == "route_helper_signature_mismatch" for f in findings)
+        assert any(
+            f.category == "required_primitive_not_called"
+            and "resolve_swaption_curve_basis_spread" in f.message
+            for f in findings
+        )
 
-    def test_accepts_rate_tree_swaption_helper_surface(self, registry):
+    def test_accepts_rate_tree_swaption_generic_lattice_composition(self, registry):
         spec = [r for r in registry.routes if r.id == "rate_tree_backward_induction"][0]
         swaption_ir = ProductIR(
             instrument="swaption",
@@ -847,14 +856,81 @@ def evaluate(self, market_state):
         )
         spec = replace(spec, primitives=resolve_route_primitives(spec, swaption_ir))
         source = '''
-from trellis.models.rate_style_swaption_tree import price_swaption_tree
+from trellis.models.bermudan_swaption_tree import (
+    BermudanSwaptionTreeSpec,
+    compile_bermudan_swaption_contract_spec,
+    resolve_bermudan_swaption_tree_inputs,
+)
+from trellis.models.rate_style_swaption import resolve_swaption_curve_basis_spread
+from trellis.models.trees.algebra import (
+    BINOMIAL_1F_TOPOLOGY,
+    TERM_STRUCTURE_TARGET,
+    UNIFORM_ADDITIVE_MESH,
+    build_lattice,
+    price_on_lattice,
+)
 
 def evaluate(self, market_state):
-    return price_swaption_tree(market_state, self._spec, model="hull_white", mean_reversion=0.05)
+    spread = resolve_swaption_curve_basis_spread(market_state, self._spec)
+    spec = BermudanSwaptionTreeSpec(
+        notional=self._spec.notional,
+        strike=self._spec.strike - spread,
+        exercise_dates=(self._spec.expiry_date,),
+        swap_end=self._spec.swap_end,
+    )
+    resolved = resolve_bermudan_swaption_tree_inputs(market_state, spec)
+    lattice = build_lattice(
+        BINOMIAL_1F_TOPOLOGY,
+        UNIFORM_ADDITIVE_MESH,
+        "hull_white",
+        TERM_STRUCTURE_TARGET(market_state.discount),
+        r0=resolved.r0,
+        sigma=resolved.sigma,
+        a=resolved.mean_reversion,
+        T=resolved.tree_horizon,
+        n_steps=resolved.n_steps,
+    )
+    contract = compile_bermudan_swaption_contract_spec(
+        lattice,
+        spec=spec,
+        settlement=resolved.settlement,
+    )
+    return price_on_lattice(lattice, contract)
 '''
         validator = AlgorithmContractValidator()
         findings = validator.validate(source, _make_plan("rate_tree_backward_induction", "lattice"), spec)
-        assert not any(f.category == "route_helper_signature_mismatch" for f in findings)
+        assert not any(f.severity == "error" for f in findings)
+
+    def test_rate_tree_swaption_function_reference_does_not_satisfy_composition(
+        self, registry
+    ):
+        spec = [r for r in registry.routes if r.id == "rate_tree_backward_induction"][0]
+        swaption_ir = ProductIR(
+            instrument="swaption",
+            payoff_family="swaption",
+            exercise_style="european",
+            model_family="interest_rate",
+        )
+        spec = replace(spec, primitives=resolve_route_primitives(spec, swaption_ir))
+        source = '''
+from trellis.models.trees.algebra import price_on_lattice
+
+def evaluate(self, market_state):
+    unused_kernel = price_on_lattice
+    return 0.0
+'''
+        validator = AlgorithmContractValidator()
+        findings = validator.validate(
+            source,
+            _make_plan("rate_tree_backward_induction", "lattice"),
+            spec,
+        )
+
+        assert any(
+            finding.category == "required_primitive_not_called"
+            and "price_on_lattice" in finding.message
+            for finding in findings
+        )
 
     def test_flags_zcb_option_tree_helper_signature_mismatch(self, registry):
         # QUA-915: ZCB-option family collapsed into ``short_rate_bond_option``.

--- a/tests/test_models/test_bermudan_swaption_tree.py
+++ b/tests/test_models/test_bermudan_swaption_tree.py
@@ -12,6 +12,7 @@ from trellis.models.bermudan_swaption_tree import (
     compile_bermudan_swaption_contract_spec,
     price_bermudan_swaption_on_lattice,
     price_bermudan_swaption_tree,
+    resolve_bermudan_swaption_tree_inputs,
 )
 from trellis.models.vol_surface import FlatVol
 
@@ -133,6 +134,47 @@ def test_compile_bermudan_swaption_contract_spec_matches_helper_price():
         lattice,
         contract_spec=contract,
     )
+
+
+def test_resolved_bermudan_swaption_tree_inputs_retain_mean_reversion():
+    resolved = resolve_bermudan_swaption_tree_inputs(
+        _market_state(),
+        _Spec(),
+        model="hull_white",
+        mean_reversion=0.0375,
+        sigma=0.0125,
+        n_steps=144,
+    )
+
+    assert resolved.mean_reversion == pytest.approx(0.0375)
+    assert resolved.sigma == pytest.approx(0.0125)
+    assert resolved.n_steps == 144
+
+
+def test_bermudan_swaption_lattice_uses_resolved_mean_reversion(monkeypatch):
+    import trellis.models.bermudan_swaption_tree as module
+
+    captured = {}
+
+    def fake_build_lattice(topology, mesh, model, calibration_target=None, **params):
+        captured.update(params)
+        return object()
+
+    monkeypatch.setattr(module, "build_lattice", fake_build_lattice)
+
+    lattice = module.build_bermudan_swaption_lattice(
+        _market_state(),
+        _Spec(),
+        model="hull_white",
+        mean_reversion=0.0625,
+        sigma=0.009,
+        n_steps=96,
+    )
+
+    assert lattice is not None
+    assert captured["a"] == pytest.approx(0.0625)
+    assert captured["sigma"] == pytest.approx(0.009)
+    assert captured["n_steps"] == 96
 
 
 def test_price_bermudan_swaption_tree_ignores_expired_exercise_dates_after_settlement():

--- a/trellis/agent/dsl_lowering.py
+++ b/trellis/agent/dsl_lowering.py
@@ -453,6 +453,17 @@ def _build_expr_for_route(
 ) -> tuple[ContractExpr | None, tuple[str, ...]]:
     """Build the semantic DSL fragment for one resolved route."""
     market_signature = _market_signature(contract)
+    if (
+        route_id == "rate_tree_backward_induction"
+        and getattr(contract.product, "payoff_family", "") == "swaption"
+        and getattr(contract.product, "exercise_style", "") == "european"
+    ):
+        return _build_european_swaption_rate_lattice_expr(
+            route_id=route_id,
+            binding_id=binding_id,
+            market_signature=market_signature,
+            bindings=bindings,
+        )
     route_helper = next(
         (binding for binding in bindings if binding.role == "route_helper"),
         None,
@@ -531,6 +542,153 @@ def _build_expr_for_route(
         ),
     )
     return helper_atom, ()
+
+
+def _build_european_swaption_rate_lattice_expr(
+    *,
+    route_id: str,
+    binding_id: str,
+    market_signature: ContractSignature,
+    bindings: tuple[DslTargetBinding, ...],
+) -> tuple[ContractExpr | None, tuple[str, ...]]:
+    """Build the explicit one-exercise swaption lattice composition."""
+    stages = (
+        (
+            "contract_spec",
+            "BermudanSwaptionTreeSpec",
+            market_signature.inputs,
+            ("tree_contract:state", *market_signature.inputs),
+            "Narrow the European swaption into a one-exercise tree contract.",
+        ),
+        (
+            "curve_basis_binding",
+            "resolve_swaption_curve_basis_spread",
+            ("tree_contract:state", *market_signature.inputs),
+            ("basis_adjusted_contract:state", *market_signature.inputs),
+            "Project the discount/forecast curve basis into the tree strike.",
+        ),
+        (
+            "tree_input_binding",
+            "resolve_bermudan_swaption_tree_inputs",
+            ("basis_adjusted_contract:state", *market_signature.inputs),
+            (
+                "resolved_tree_inputs:state",
+                "basis_adjusted_contract:state",
+                *market_signature.inputs,
+            ),
+            "Resolve schedule, volatility, mean reversion, and lattice horizon inputs.",
+        ),
+        (
+            "topology",
+            "BINOMIAL_1F_TOPOLOGY",
+            (
+                "resolved_tree_inputs:state",
+                "basis_adjusted_contract:state",
+                *market_signature.inputs,
+            ),
+            (
+                "topology:state",
+                "resolved_tree_inputs:state",
+                "basis_adjusted_contract:state",
+                *market_signature.inputs,
+            ),
+            "Select the admitted one-factor binomial topology.",
+        ),
+        (
+            "mesh",
+            "UNIFORM_ADDITIVE_MESH",
+            (
+                "topology:state",
+                "resolved_tree_inputs:state",
+                "basis_adjusted_contract:state",
+                *market_signature.inputs,
+            ),
+            (
+                "mesh:state",
+                "topology:state",
+                "resolved_tree_inputs:state",
+                "basis_adjusted_contract:state",
+                *market_signature.inputs,
+            ),
+            "Select the admitted uniform additive mesh.",
+        ),
+        (
+            "calibration_target",
+            "TERM_STRUCTURE_TARGET",
+            (
+                "mesh:state",
+                "topology:state",
+                "resolved_tree_inputs:state",
+                "basis_adjusted_contract:state",
+                *market_signature.inputs,
+            ),
+            (
+                "calibration_target:state",
+                "mesh:state",
+                "topology:state",
+                "resolved_tree_inputs:state",
+                "basis_adjusted_contract:state",
+            ),
+            "Bind the discount curve as the term-structure calibration target.",
+        ),
+        (
+            "lattice_builder",
+            "build_lattice",
+            (
+                "calibration_target:state",
+                "mesh:state",
+                "topology:state",
+                "resolved_tree_inputs:state",
+                "basis_adjusted_contract:state",
+            ),
+            (
+                "rate_lattice:state",
+                "basis_adjusted_contract:state",
+                "resolved_tree_inputs:state",
+            ),
+            "Build and calibrate the generic short-rate lattice.",
+        ),
+        (
+            "contract_compiler",
+            "compile_bermudan_swaption_contract_spec",
+            (
+                "rate_lattice:state",
+                "basis_adjusted_contract:state",
+                "resolved_tree_inputs:state",
+            ),
+            ("rate_lattice:state", "lattice_contract:state"),
+            "Compile the one-exercise swap claim and holder control contract.",
+        ),
+        (
+            "pricing_kernel",
+            "price_on_lattice",
+            ("rate_lattice:state", "lattice_contract:state"),
+            ("price:scalar",),
+            "Roll the compiled contract back on the calibrated lattice.",
+        ),
+    )
+    by_symbol = {binding.symbol: binding for binding in bindings if binding.required}
+    missing = tuple(symbol for _, symbol, *_ in stages if symbol not in by_symbol)
+    if missing:
+        return None, tuple(
+            _missing_primitive_message(route_id, binding_id, "lattice composition", symbol)
+            for symbol in missing
+        )
+    atoms = tuple(
+        ContractAtom(
+            atom_id=_binding_atom_id(route_id, binding_id, role),
+            primitive_ref=by_symbol[symbol].primitive_ref,
+            description=description,
+            signature=ContractSignature(
+                inputs=inputs,
+                outputs=outputs,
+                timeline_roles=market_signature.timeline_roles,
+                market_data_requirements=market_signature.market_data_requirements,
+            ),
+        )
+        for role, symbol, inputs, outputs, description in stages
+    )
+    return ThenExpr(terms=atoms), ()
 
 
 def _build_resolved_pricing_kernel_expr(

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -4191,6 +4191,19 @@ def _swaption_comparison_helper_kwargs(semantic_blueprint) -> str:
     return f", mean_reversion={float(mean_reversion)!r}, sigma={float(sigma)!r}"
 
 
+def _swaption_tree_model_name(semantic_blueprint, comparison_target: str | None) -> str:
+    """Return the admitted short-rate lattice model for a swaption target."""
+    normalized_target = str(comparison_target or "").strip().lower().replace("-", "_")
+    if normalized_target in {"bdt", "bdt_tree", "black_derman_toy"}:
+        return "bdt"
+    valuation_context = getattr(semantic_blueprint, "valuation_context", None)
+    engine_model_spec = getattr(valuation_context, "engine_model_spec", None)
+    model_name = str(getattr(engine_model_spec, "model_name", "") or "").strip().lower()
+    if model_name in {"bdt", "black_derman_toy"}:
+        return "bdt"
+    return "hull_white"
+
+
 def _vanilla_equity_monte_carlo_helper_kwargs(comparison_target: str | None) -> str:
     """Return deterministic helper kwargs for vanilla-equity Monte Carlo comparison targets."""
     target = str(comparison_target or "").strip().lower()
@@ -5283,6 +5296,7 @@ def _deterministic_exact_binding_evaluate_body(
     refs = set(_exact_binding_refs(generation_plan))
     refs.update(_declared_primitive_refs(generation_plan))
     swaption_comparison_kwargs = _swaption_comparison_helper_kwargs(semantic_blueprint)
+    swaption_tree_model = _swaption_tree_model_name(semantic_blueprint, comparison_target)
     vanilla_equity_mc_kwargs = _vanilla_equity_monte_carlo_helper_kwargs(comparison_target)
     vanilla_equity_mc_call_kwargs = (
         vanilla_equity_mc_kwargs.lstrip(", ")
@@ -5369,6 +5383,55 @@ def _deterministic_exact_binding_evaluate_body(
         )
         if variance_swap_body is not None:
             return variance_swap_body
+    if (
+        instrument_type == "swaption"
+        and primitive_route == "rate_tree_backward_induction"
+        and "trellis.models.trees.algebra.price_on_lattice" in refs
+    ):
+        return textwrap.dedent(
+            f"""\
+            if spec.swap_start != spec.expiry_date:
+                raise ValueError(
+                    "Rate-tree swaption composition requires swap_start == expiry_date "
+                    "for the single-exercise forward-start contract."
+                )
+            curve_basis_spread = resolve_swaption_curve_basis_spread(market_state, spec)
+            tree_spec = BermudanSwaptionTreeSpec(
+                notional=float(spec.notional),
+                strike=float(spec.strike) - float(curve_basis_spread),
+                exercise_dates=(spec.expiry_date,),
+                swap_end=spec.swap_end,
+                swap_frequency=spec.swap_frequency,
+                day_count=spec.day_count,
+                rate_index=spec.rate_index,
+                is_payer=bool(spec.is_payer),
+            )
+            tree_steps = getattr(spec, "tree_steps", getattr(spec, "n_steps", None))
+            resolved = resolve_bermudan_swaption_tree_inputs(
+                market_state,
+                tree_spec,
+                model="{swaption_tree_model}"{swaption_comparison_kwargs},
+                n_steps=tree_steps,
+            )
+            lattice = build_lattice(
+                BINOMIAL_1F_TOPOLOGY,
+                UNIFORM_ADDITIVE_MESH,
+                "{swaption_tree_model}",
+                calibration_target=TERM_STRUCTURE_TARGET(market_state.discount),
+                r0=resolved.r0,
+                sigma=resolved.sigma,
+                a=resolved.mean_reversion,
+                T=resolved.tree_horizon,
+                n_steps=resolved.n_steps,
+            )
+            lattice_contract = compile_bermudan_swaption_contract_spec(
+                lattice,
+                spec=tree_spec,
+                settlement=resolved.settlement,
+            )
+            return float(price_on_lattice(lattice, lattice_contract))
+            """
+        ).rstrip()
     if (
         primitive_route == "equity_quanto"
         and {
@@ -6296,10 +6359,6 @@ def _deterministic_exact_binding_evaluate_body(
             f"{swaption_comparison_kwargs})\n"
             "return price_swaption_black76_raw(resolved)"
         ),
-        "trellis.models.rate_style_swaption_tree.price_swaption_tree": (
-            "return price_swaption_tree(market_state, spec"
-            f"{swaption_comparison_kwargs})"
-        ),
         "trellis.models.bermudan_swaption_tree.price_bermudan_swaption_tree": (
             "return price_bermudan_swaption_tree(market_state, spec)"
         ),
@@ -6850,6 +6909,29 @@ def _deterministic_exact_binding_import_lines(body: str) -> tuple[str, ...]:
         imports.append(
             "from trellis.models.rate_style_swaption import "
             "resolve_swaption_black76_inputs"
+        )
+    if "resolve_swaption_curve_basis_spread(" in body:
+        imports.append(
+            "from trellis.models.rate_style_swaption import "
+            "resolve_swaption_curve_basis_spread"
+        )
+    if "BermudanSwaptionTreeSpec(" in body:
+        imports.append(
+            "from trellis.models.bermudan_swaption_tree import (\n"
+            "    BermudanSwaptionTreeSpec,\n"
+            "    compile_bermudan_swaption_contract_spec,\n"
+            "    resolve_bermudan_swaption_tree_inputs,\n"
+            ")"
+        )
+    if "BINOMIAL_1F_TOPOLOGY" in body and "price_on_lattice(" in body:
+        imports.append(
+            "from trellis.models.trees.algebra import (\n"
+            "    BINOMIAL_1F_TOPOLOGY,\n"
+            "    TERM_STRUCTURE_TARGET,\n"
+            "    UNIFORM_ADDITIVE_MESH,\n"
+            "    build_lattice,\n"
+            "    price_on_lattice,\n"
+            ")"
         )
     if "price_heston_option_monte_carlo(" in body:
         imports.append(
@@ -9103,10 +9185,13 @@ def _route_specific_retry_lines(
         and stage in {"code_generation_failed", "semantic_validation_failed", "validation_failed", "actual_market_smoke_failed", "import_validation_failed"}
     ):
         return (
-            "European rate-style swaption tree routes should stay on the checked-in helper-backed surface.",
-            "Prefer `from trellis.models.rate_style_swaption_tree import price_swaption_tree` and delegate to that helper from the adapter.",
-            "This helper-backed tree route is for the single-exercise European comparison surface where `swap_start == expiry_date`.",
-            "Do not rebuild exercise-step selection, swap rollback, or lattice payoff glue inline when the checked-in helper already owns the route.",
+            "European rate-style swaption tree routes should compose the checked public lattice primitives directly.",
+            "Require the single-exercise forward-start boundary `swap_start == expiry_date`, then construct `BermudanSwaptionTreeSpec` with that one exercise date.",
+            "Apply `resolve_swaption_curve_basis_spread(...)` to the tree strike, then call `resolve_bermudan_swaption_tree_inputs(...)` so schedule, volatility, mean reversion, horizon, and step controls stay on one resolved basis.",
+            "Build the calibrated lattice with `build_lattice(BINOMIAL_1F_TOPOLOGY, UNIFORM_ADDITIVE_MESH, model, calibration_target=TERM_STRUCTURE_TARGET(market_state.discount), ...)`.",
+            "Compile the claim with `compile_bermudan_swaption_contract_spec(...)` and evaluate it with generic `price_on_lattice(...)`.",
+            "Preserve model, explicit comparison parameters, tree steps, day count, swap frequency, rate index, and payer/receiver direction.",
+            "`price_swaption_tree(...)` and `build_swaption_tree_spec(...)` remain compatibility/reference APIs, not generated construction authority.",
             "Keep cap/floor-style period loops separate. This route is for a single-exercise European swaption comparison target, not for caplet or floorlet strips.",
         )
     if (

--- a/trellis/agent/knowledge/canonical/api_map.yaml
+++ b/trellis/agent/knowledge/canonical/api_map.yaml
@@ -444,6 +444,26 @@ european_swaption_monte_carlo_composition:
     - "For a single-exercise European swaption, resolve the typed expiry basis, build the payment schedule from explicit swap_start, bind the Hull-White process, and assemble the discounted swap-PV payload, discount reducer, expiry events, problem spec, runtime problem, and generic estimator in that order."
     - "Preserve day count, swap frequency, rate index, explicit comparison parameters, and path/step/seed controls. Do not substitute an equity GBM process."
 
+european_swaption_rate_lattice_composition:
+  module: trellis.models.trees.algebra
+  methods: [rate_tree]
+  navigation:
+    aliases: [swaption, european_swaption, hull_white_swaption_tree, hw_tree, bdt_tree]
+  modules:
+    contract: trellis.models.bermudan_swaption_tree
+    curve_basis: trellis.models.rate_style_swaption
+    lattice_algebra: trellis.models.trees.algebra
+  key_imports:
+    - "from trellis.models.bermudan_swaption_tree import BermudanSwaptionTreeSpec, resolve_bermudan_swaption_tree_inputs, compile_bermudan_swaption_contract_spec"
+    - "from trellis.models.rate_style_swaption import resolve_swaption_curve_basis_spread"
+    - "from trellis.models.trees.algebra import BINOMIAL_1F_TOPOLOGY, UNIFORM_ADDITIVE_MESH, TERM_STRUCTURE_TARGET, build_lattice, price_on_lattice"
+  notes:
+    - "Admitted scope is the single-exercise forward-starting European swaption where swap_start equals expiry_date"
+    - "Construct a one-exercise BermudanSwaptionTreeSpec, apply the discount/forecast curve basis to its strike, and resolve schedule, volatility, mean reversion, horizon, and step controls with resolve_bermudan_swaption_tree_inputs(...)"
+    - "Build the calibrated Hull-White or BDT lattice from the generic topology, mesh, term-structure target, and build_lattice(...) surfaces; pass resolved.mean_reversion as `a=`"
+    - "Compile the lattice contract with compile_bermudan_swaption_contract_spec(...) and evaluate it with generic price_on_lattice(...)"
+    - "price_swaption_tree(...) and build_swaption_tree_spec(...) remain compatibility/reference APIs and are not generated construction authority"
+
 bermudan_swaption_lower_bound_composition:
   module: trellis.models.rate_style_swaption
   methods: [analytical]

--- a/trellis/agent/knowledge/canonical/backend_bindings.yaml
+++ b/trellis/agent/knowledge/canonical/backend_bindings.yaml
@@ -775,9 +775,33 @@ bindings:
           payoff_family: swaption
           exercise_style: [european]
         primitives:
-          - module: trellis.models.rate_style_swaption_tree
-            symbol: price_swaption_tree
-            role: route_helper
+          - module: trellis.models.bermudan_swaption_tree
+            symbol: BermudanSwaptionTreeSpec
+            role: contract_spec
+          - module: trellis.models.rate_style_swaption
+            symbol: resolve_swaption_curve_basis_spread
+            role: curve_basis_binding
+          - module: trellis.models.bermudan_swaption_tree
+            symbol: resolve_bermudan_swaption_tree_inputs
+            role: market_binding
+          - module: trellis.models.trees.algebra
+            symbol: BINOMIAL_1F_TOPOLOGY
+            role: topology
+          - module: trellis.models.trees.algebra
+            symbol: UNIFORM_ADDITIVE_MESH
+            role: mesh
+          - module: trellis.models.trees.algebra
+            symbol: TERM_STRUCTURE_TARGET
+            role: calibration_target
+          - module: trellis.models.trees.algebra
+            symbol: build_lattice
+            role: lattice_builder
+          - module: trellis.models.bermudan_swaption_tree
+            symbol: compile_bermudan_swaption_contract_spec
+            role: contract_compiler
+          - module: trellis.models.trees.algebra
+            symbol: price_on_lattice
+            role: pricing_kernel
       - when: default
         primitives:
           - module: trellis.models.trees.lattice

--- a/trellis/agent/knowledge/canonical/routes.yaml
+++ b/trellis/agent/knowledge/canonical/routes.yaml
@@ -1264,9 +1264,33 @@ routes:
           payoff_family: swaption
           exercise_style: [european]
         primitives:
-          - module: trellis.models.rate_style_swaption_tree
-            symbol: price_swaption_tree
-            role: route_helper
+          - module: trellis.models.bermudan_swaption_tree
+            symbol: BermudanSwaptionTreeSpec
+            role: contract_spec
+          - module: trellis.models.rate_style_swaption
+            symbol: resolve_swaption_curve_basis_spread
+            role: curve_basis_binding
+          - module: trellis.models.bermudan_swaption_tree
+            symbol: resolve_bermudan_swaption_tree_inputs
+            role: market_binding
+          - module: trellis.models.trees.algebra
+            symbol: BINOMIAL_1F_TOPOLOGY
+            role: topology
+          - module: trellis.models.trees.algebra
+            symbol: UNIFORM_ADDITIVE_MESH
+            role: mesh
+          - module: trellis.models.trees.algebra
+            symbol: TERM_STRUCTURE_TARGET
+            role: calibration_target
+          - module: trellis.models.trees.algebra
+            symbol: build_lattice
+            role: lattice_builder
+          - module: trellis.models.bermudan_swaption_tree
+            symbol: compile_bermudan_swaption_contract_spec
+            role: contract_compiler
+          - module: trellis.models.trees.algebra
+            symbol: price_on_lattice
+            role: pricing_kernel
         adapters: []
         notes: []
       - when: default

--- a/trellis/agent/knowledge/import_registry.py
+++ b/trellis/agent/knowledge/import_registry.py
@@ -587,6 +587,9 @@ from trellis.models.short_rate_bond import ResolvedShortRateBondInputs, price_ci
 from trellis.models.sabr_option import ResolvedSabrForwardOptionInputs, SabrForwardOptionMonteCarloResult, price_sabr_forward_option_hagan, price_sabr_forward_option_monte_carlo, price_sabr_forward_option_monte_carlo_result, resolve_sabr_forward_option_inputs
 
 ### Models — Trees
+from trellis.models.bermudan_swaption_tree import BermudanSwaptionTreeSpec, compile_bermudan_swaption_contract_spec, resolve_bermudan_swaption_tree_inputs
+from trellis.models.rate_style_swaption import resolve_swaption_curve_basis_spread
+from trellis.models.trees.algebra import BINOMIAL_1F_TOPOLOGY, TERM_STRUCTURE_TARGET, UNIFORM_ADDITIVE_MESH, build_lattice, price_on_lattice
 from trellis.models.equity_option_tree import build_vanilla_equity_lattice, compile_vanilla_equity_contract_spec, price_cev_option_tree, price_vanilla_equity_option_on_lattice, price_vanilla_equity_option_tree, resolve_vanilla_equity_tree_inputs
 from trellis.models.trees.lattice import build_rate_lattice, build_spot_lattice, lattice_backward_induction, build_generic_lattice, calibrate_lattice
 from trellis.models.trees.binomial import BinomialTree

--- a/trellis/agent/lite_review.py
+++ b/trellis/agent/lite_review.py
@@ -273,7 +273,7 @@ def _capability_literal_is_subsumed_by_route_binding(
         return False
     binding_by_route = {
         "analytical_black76": "resolve_swaption_black76_inputs",
-        "rate_tree_backward_induction": "price_swaption_tree",
+        "rate_tree_backward_induction": "resolve_bermudan_swaption_tree_inputs",
         "monte_carlo_paths": "resolve_hull_white_monte_carlo_process_inputs",
     }
     binding_name = binding_by_route.get(primitive_plan.route)

--- a/trellis/agent/prompts.py
+++ b/trellis/agent/prompts.py
@@ -590,9 +590,11 @@ def _render_family_route_guidance(
     if instrument_type == "swaption" and method == "rate_tree":
         lines.append("## Family Route Guidance")
         lines.extend([
-            "- For single-exercise European rate-style swaptions on the rate-tree route, prefer `price_swaption_tree(market_state, self._spec, model=\"hull_white\"|\"bdt\")` from `trellis.models.rate_style_swaption_tree`.",
-            "- Treat the generated route as a thin adapter over the checked-in helper; do not rebuild exercise-step selection, swap rollback, or lattice payoff glue inline.",
-            "- This helper-backed route assumes the forward-starting European surface where `spec.swap_start == spec.expiry_date`.",
+            "- For single-exercise European rate-style swaptions, require `spec.swap_start == spec.expiry_date` and construct a one-exercise `BermudanSwaptionTreeSpec` directly.",
+            "- Apply `resolve_swaption_curve_basis_spread(...)`, then bind schedule, Hull-White/BDT parameters, horizon, and tree steps with `resolve_bermudan_swaption_tree_inputs(...)`.",
+            "- Compose `BINOMIAL_1F_TOPOLOGY`, `UNIFORM_ADDITIVE_MESH`, `TERM_STRUCTURE_TARGET(market_state.discount)`, and generic `build_lattice(...)`; preserve explicit comparison parameters and conventions.",
+            "- Compile with `compile_bermudan_swaption_contract_spec(...)` and evaluate with generic `price_on_lattice(...)`.",
+            "- `price_swaption_tree(...)` and `build_swaption_tree_spec(...)` are compatibility/reference APIs, not generated construction authority.",
             "- Keep cap/floor-style period loops separate. This route is for a single-exercise European swaption comparison target, not for caplet or floorlet strips.",
         ])
 

--- a/trellis/agent/semantic_validation.py
+++ b/trellis/agent/semantic_validation.py
@@ -169,6 +169,17 @@ class _SemanticVisitor(ast.NodeVisitor):
             self.resolved_references.add(resolved)
         self.generic_visit(node)
 
+    def visit_Attribute(self, node: ast.Attribute) -> None:
+        """Record qualified references rooted at an imported module alias."""
+        root = node
+        while isinstance(root, ast.Attribute):
+            root = root.value
+        if isinstance(root, ast.Name) and root.id in self.aliases:
+            resolved = _resolve_call_name(node, self.aliases)
+            if resolved:
+                self.resolved_references.add(resolved)
+        self.generic_visit(node)
+
     def visit_Assign(self, node: ast.Assign) -> None:
         """Track variables bound to Monte Carlo engines for later call-site analysis."""
         call_name = _resolve_call_name(node.value, self.aliases)

--- a/trellis/agent/semantic_validation.py
+++ b/trellis/agent/semantic_validation.py
@@ -52,6 +52,7 @@ _ROUTE_HELPER_SUBSUMED_PRIMITIVE_ROLES = frozenset({
 _CHECKED_ROUTE_HELPER_CALLS = frozenset({
     "trellis.models.monte_carlo.stochastic_vol.price_heston_option_monte_carlo",
 })
+_DECLARATIVE_PRIMITIVE_ROLES = frozenset({"mesh", "topology"})
 
 
 @dataclass(frozen=True)
@@ -73,6 +74,7 @@ class SemanticSignals:
 
     engine_families: tuple[str, ...]
     resolved_calls: tuple[str, ...]
+    resolved_references: tuple[str, ...]
     monte_carlo_methods: tuple[str, ...]
     exercise_control_primitives: tuple[str, ...]
     laguerre_import_modules: tuple[str, ...]
@@ -118,6 +120,7 @@ class _SemanticVisitor(ast.NodeVisitor):
         self.function_defs: dict[str, ast.FunctionDef] = {}
         self.engine_families: set[str] = set()
         self.resolved_calls: set[str] = set()
+        self.resolved_references: set[str] = set()
         self.monte_carlo_methods: list[str] = []
         self.exercise_control_primitives: set[str] = set()
         self.laguerre_import_modules: list[str] = []
@@ -157,6 +160,13 @@ class _SemanticVisitor(ast.NodeVisitor):
         self.function_defs[node.name] = node
         if node.name in {"char_fn", "psi"} and _function_uses_scalar_math(node, self.aliases):
             self.scalar_math_functions.add(node.name)
+        self.generic_visit(node)
+
+    def visit_Name(self, node: ast.Name) -> None:
+        """Record resolved references to imported declarative primitives."""
+        resolved = self.aliases.get(node.id)
+        if resolved:
+            self.resolved_references.add(resolved)
         self.generic_visit(node)
 
     def visit_Assign(self, node: ast.Assign) -> None:
@@ -289,6 +299,7 @@ def extract_semantic_signals(source: str) -> SemanticSignals:
     return SemanticSignals(
         engine_families=tuple(sorted(visitor.engine_families)),
         resolved_calls=tuple(sorted(visitor.resolved_calls)),
+        resolved_references=tuple(sorted(visitor.resolved_references)),
         monte_carlo_methods=tuple(visitor.monte_carlo_methods),
         exercise_control_primitives=tuple(sorted(visitor.exercise_control_primitives)),
         laguerre_import_modules=tuple(visitor.laguerre_import_modules),
@@ -388,10 +399,16 @@ def validate_semantics(
                 and primitive.role in _ROUTE_HELPER_SUBSUMED_PRIMITIVE_ROLES
             )
         )
+        resolved_calls = set(signals.resolved_calls)
+        resolved_references = set(signals.resolved_references)
         called_primitives = {
             f"{primitive.module}.{primitive.symbol}"
             for primitive in required_primitives
-            if f"{primitive.module}.{primitive.symbol}" in signals.resolved_calls
+            if f"{primitive.module}.{primitive.symbol}" in resolved_calls
+            or (
+                primitive.role in _DECLARATIVE_PRIMITIVE_ROLES
+                and f"{primitive.module}.{primitive.symbol}" in resolved_references
+            )
         }
         role_to_primitives: dict[str, list[object]] = {}
         for primitive in required_primitives:
@@ -421,7 +438,14 @@ def validate_semantics(
             f"{primitive.module}.{primitive.symbol}"
             for primitive in primitive_plan.primitives
             if primitive.excluded
-            and f"{primitive.module}.{primitive.symbol}" in signals.resolved_calls
+            and (
+                f"{primitive.module}.{primitive.symbol}" in resolved_calls
+                or (
+                    primitive.role in _DECLARATIVE_PRIMITIVE_ROLES
+                    and f"{primitive.module}.{primitive.symbol}"
+                    in resolved_references
+                )
+            )
         ]
         if excluded_primitives:
             issues.append(SemanticIssue(
@@ -761,6 +785,7 @@ def _empty_signals() -> SemanticSignals:
     return SemanticSignals(
         engine_families=(),
         resolved_calls=(),
+        resolved_references=(),
         monte_carlo_methods=(),
         exercise_control_primitives=(),
         laguerre_import_modules=(),

--- a/trellis/agent/semantic_validators/algorithm_contract.py
+++ b/trellis/agent/semantic_validators/algorithm_contract.py
@@ -20,7 +20,14 @@ from trellis.agent.semantic_validators.base import SemanticFinding
 _ENGINE_SIGNATURES = {
     "monte_carlo": ("MonteCarloEngine", "monte_carlo"),
     "exercise": ("MonteCarloEngine", "longstaff_schwartz", "tsitsiklis_van_roy"),
-    "lattice": ("build_rate_lattice", "BinomialTree", "backward_induction", "lattice_backward_induction"),
+    "lattice": (
+        "build_lattice",
+        "price_on_lattice",
+        "build_rate_lattice",
+        "BinomialTree",
+        "backward_induction",
+        "lattice_backward_induction",
+    ),
     "analytical": (
         "black76_call",
         "black76_put",
@@ -56,6 +63,7 @@ _HELPER_OWNED_ROUTE_SYMBOLS = _CHECKED_ROUTE_HELPER_SYMBOLS | frozenset({
     "price_double_barrier_option_pde_result",
     "price_double_barrier_option_monte_carlo_result",
 })
+_DECLARATIVE_PRIMITIVE_ROLES = frozenset({"mesh", "topology"})
 
 _EXACT_HELPER_SIGNATURES = {
     "price_double_barrier_option_pde_result": {
@@ -290,23 +298,6 @@ _EXACT_HELPER_SIGNATURES = {
             "instead of rebuilding lattice rollback or exercise glue inline."
         ),
     },
-    "price_swaption_tree": {
-        "min_positional_args": 2,
-        "max_positional_args": 2,
-        "required_parameters": ("market_state", "spec"),
-        "required_keyword_groups": (frozenset({"market_state", "spec"}),),
-        "allowed_keywords": frozenset({"market_state", "spec", "model", "mean_reversion", "sigma", "n_steps"}),
-        "required_positional_markers": (
-            frozenset({"market_state"}),
-            frozenset({"spec", "_spec"}),
-        ),
-        "message": (
-            "`price_swaption_tree(...)` expects `(market_state, spec, *, "
-            "model=..., mean_reversion=..., sigma=..., n_steps=...)`. "
-            "Pass the live market state and the original European rate-style swaption spec "
-            "instead of inventing exercise-step or lattice-builder keywords."
-        ),
-    },
     "price_fx_vanilla_analytical": {
         "min_positional_args": 2,
         "max_positional_args": 2,
@@ -517,6 +508,19 @@ def _calls_symbol(source: str, symbol: str) -> bool:
     )
 
 
+def _references_symbol(source: str, symbol: str) -> bool:
+    """Return whether parsed source calls or names ``symbol``."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return False
+    return any(
+        (isinstance(node, ast.Name) and node.id == symbol)
+        or (isinstance(node, ast.Attribute) and node.attr == symbol)
+        for node in ast.walk(tree)
+    )
+
+
 def _calls_checked_route_helper(
     source: str,
     plan: GenerationPlan | None = None,
@@ -702,14 +706,17 @@ class AlgorithmContractValidator:
         exact_surface_primitives,
     ) -> list[SemanticFinding]:
         """Require explicit primitive composition for helper-retired routes."""
-        if route_spec.id != "equity_quanto":
+        if route_spec.id not in {"equity_quanto", "rate_tree_backward_induction"}:
             return []
 
         findings: list[SemanticFinding] = []
         for primitive in exact_surface_primitives:
             if not primitive.required or primitive.excluded:
                 continue
-            if _calls_symbol(source, primitive.symbol):
+            if _calls_symbol(source, primitive.symbol) or (
+                primitive.role in _DECLARATIVE_PRIMITIVE_ROLES
+                and _references_symbol(source, primitive.symbol)
+            ):
                 continue
             findings.append(
                 SemanticFinding(

--- a/trellis/models/bermudan_swaption_tree.py
+++ b/trellis/models/bermudan_swaption_tree.py
@@ -94,6 +94,7 @@ class ResolvedBermudanSwaptionTreeInputs:
     tree_horizon: float
     option_horizon: float
     r0: float
+    mean_reversion: float
     sigma: float
     n_steps: int
 
@@ -158,6 +159,7 @@ def resolve_bermudan_swaption_tree_inputs(
         tree_horizon=tree_horizon,
         option_horizon=option_horizon,
         r0=r0,
+        mean_reversion=float(resolved_mean_reversion),
         sigma=float(resolved_sigma),
         n_steps=step_count,
     )
@@ -189,13 +191,7 @@ def build_bermudan_swaption_lattice(
         calibration_target=lattice_algebra.TERM_STRUCTURE_TARGET(market_state.discount),
         r0=resolved.r0,
         sigma=resolved.sigma,
-        a=float(resolve_hull_white_parameters(
-            market_state,
-            mean_reversion=mean_reversion,
-            sigma=resolved.sigma,
-            default_mean_reversion=0.1,
-            default_sigma=resolved.sigma,
-        )[0]),
+        a=resolved.mean_reversion,
         T=resolved.tree_horizon,
         n_steps=resolved.n_steps,
     )


### PR DESCRIPTION
## Summary
- replace European swaption tree helper authority with explicit one-exercise generic lattice composition
- retain resolved mean reversion for direct lattice construction and keep compatibility wrappers reference-only
- update route/binding knowledge, validators, tests, and official docs without adding helpers or cookbook entries

## Validation
- strict fresh/offline T73 passed with three distinct artifacts and zero model calls
- helper audit: route 51, binding 55, adapter authority 11, drift 4/8
- make gate-release: 4701 primary, 32 tier-two contracts, 487 comparison/verification/task, 2 freshness tests; deterministic T13 replay passed

Linear: QUA-1199