### PR TITLE
QUA-1200: expose bounded lattice rollback observations

### DIFF
--- a/doc/plan/active__semantic-task-synthesis-helper-retirement.md
+++ b/doc/plan/active__semantic-task-synthesis-helper-retirement.md
@@ -60,6 +60,8 @@ Status mirror last synced: `2026-07-15`
 | `QUA-1197` | Swaption pricing: retire Bermudan Black76 lower-bound helper authority | Done |
 | `QUA-1198` | Swaption Monte Carlo: retire European helper and problem-resolver authority | Done |
 | `QUA-1199` | Swaption lattice: retire European tree helper authority | Done |
+| `QUA-1200` | Lattice rollback: observable node-value phases | In Progress |
+| `QUA-1201` | Bermudan swaption lattice: retire helper and compiler authority | Blocked by QUA-1200 |
 | `QUA-1102` | Semantic target binding: typed comparison target contracts (related prerequisite) | Done |
 
 ## Current Sequence
@@ -102,11 +104,16 @@ Status mirror last synced: `2026-07-15`
     the resolved tree inputs, construct the one-exercise contract explicitly,
     and expose generic topology, mesh, calibration, lattice construction,
     contract compilation, and rollback as the generated surface.
-11. Select the next helper-authority family from the machine-readable audit and
-   create a bounded ticket before changing another route.
-12. Run live fresh-generation evidence only with current external-model approval;
-   use it to compare first-pass source selection, retrieved documentation,
-   retries, and residual validator findings rather than as pricing authority.
+11. Apply QUA-1200 to the shared lattice boundary: expose immutable observations
+    at only the requested rollback steps and distinguish continuation,
+    post-cashflow, and post-control node values without adding product helpers.
+12. After QUA-1200 lands, apply QUA-1201 to the multi-exercise Bermudan
+    swaption lane: compose schedule values and holder control from public
+    lattice primitives while retaining product wrappers only as compatibility
+    and independent reference evidence.
+13. Run live fresh-generation evidence only with current external-model approval;
+    use it to compare first-pass source selection, retrieved documentation,
+    retries, and residual validator findings rather than as pricing authority.
 
 ## Completion Evidence
 

--- a/docs/developer/runtime_agent_orientation.rst
+++ b/docs/developer/runtime_agent_orientation.rst
@@ -74,6 +74,16 @@ Exact symbols remain the import registry's responsibility after family
 selection. Quant and model-validator regression tests reject API-map imports
 or code templates in their resolved context.
 
+The ``equity_tree`` and ``rate_lattice`` cards expose the product-neutral
+``value_on_lattice(..., observation_steps=...)`` surface when generated code
+needs node-level continuation, post-cashflow, and post-control values. The
+low-level rate-lattice card also names the immutable rollback result contracts
+and ``lattice_backward_induction_result(...)``. This lets a small builder
+compose schedule and exercise logic from a bounded numerical result without
+reading private rollback loops or delegating construction to a product helper.
+The ordinary scalar ``price_on_lattice(...)`` remains the preferred entry point
+when intermediate node evidence is unnecessary.
+
 Composition cards may join public primitives from more than one subsystem
 without introducing a new product helper. The general
 ``analytical_gaussian_composition`` card points a builder handling general

--- a/docs/quant/lattice_algebra.rst
+++ b/docs/quant/lattice_algebra.rst
@@ -290,6 +290,40 @@ The lattice lowering validates, at minimum:
 - decision before settlement
 - settlement dates not earlier than decision dates
 
+Bounded Rollback Observations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The one-factor rollback API can expose node values at an explicit, bounded set
+of lattice steps. This is a numerical composition surface, not a product
+pricer. At each requested nonterminal step it distinguishes:
+
+.. math::
+
+   C_m(i) = \sum_k M_m(i,k)V_{m+1}(k), \qquad
+   U_m(i) = C_m(i) + c_m(i), \qquad
+   V_m(i) = \mathcal{G}_m(U_m(i), E_m(i))
+
+where :math:`C_m` is discounted continuation, :math:`U_m` is the value after
+the current node cashflow, and :math:`V_m` is the value after the holder,
+issuer, or identity control. At the terminal step, all three captured vectors
+equal the terminal payoff vector because no rollback phase has occurred.
+
+``lattice_backward_induction_result(..., observation_steps=...)`` exposes this
+contract at the low-level recombining-lattice boundary.
+``value_on_lattice(..., observation_steps=...)`` exposes the same immutable
+``LatticeRollbackResult`` through the generalized lattice algebra. Requested
+steps are validated, deduplicated, sorted, and are the only node vectors kept;
+ordinary ``lattice_backward_induction(...)`` and ``price_on_lattice(...)``
+continue to return scalar root values.
+
+The shipped observation surface is intentionally limited to one-factor
+contracts with node cashflows and a single controller. Edge cashflows, event
+overlays, and multidimensional contracts remain available through scalar
+``price_on_lattice(...)`` but do not claim phase-aware observations. Agents
+should use this bounded result when they need schedule or exercise-state
+composition instead of open-coding backward induction or adding a
+product-specific helper.
+
 Typed Contract Inputs
 ~~~~~~~~~~~~~~~~~~~~~
 
@@ -425,6 +459,8 @@ Unified entry points:
 
 - ``build_lattice(topology, mesh, model, calibration_target)``
 - ``price_on_lattice(lattice, contract_spec)``
+- ``value_on_lattice(lattice, contract_spec, observation_steps=...)`` for
+  bounded node-phase evidence on the admitted one-factor path
 
 Implemented Advanced Families
 -----------------------------

--- a/tests/test_agent/test_api_map.py
+++ b/tests/test_agent/test_api_map.py
@@ -824,9 +824,27 @@ def test_equity_tree_api_map_prioritizes_lattice_algebra_primitives():
         "compile_lattice_recipe",
         "build_lattice",
         "price_on_lattice",
+        "value_on_lattice",
     ):
         assert symbol in text
     assert "price_vanilla_equity_option_tree" not in text
+
+
+def test_rate_lattice_api_map_exposes_bounded_rollback_observations():
+    section = get_api_map()["rate_lattice"]
+    text = "\n".join((*section["key_imports"], *section["notes"]))
+
+    for symbol in (
+        "LatticeRollbackObservation",
+        "LatticeRollbackResult",
+        "lattice_backward_induction_result",
+        "value_on_lattice",
+    ):
+        assert symbol in text
+    assert "continuation" in text
+    assert "post-cashflow" in text
+    assert "post-control" in text
+    assert "price_bermudan_swaption_tree" not in text
 
 
 def _assert_import_statements_valid(import_statements: list[str]) -> None:

--- a/tests/test_agent/test_import_registry.py
+++ b/tests/test_agent/test_import_registry.py
@@ -44,7 +44,28 @@ def test_registry_includes_local_exported_values_without_package_reexports():
         "UNIFORM_ADDITIVE_MESH",
         "build_lattice",
         "price_on_lattice",
+        "value_on_lattice",
     } <= set(static_registry["trellis.models.trees.algebra"])
+
+
+def test_lattice_rollback_observation_primitives_are_visible_to_import_registry():
+    module = "trellis.models.trees.lattice"
+    symbols = {
+        "LatticeRollbackObservation",
+        "LatticeRollbackResult",
+        "lattice_backward_induction_result",
+    }
+
+    assert module_exists(module)
+    assert symbols <= set(list_module_exports(module))
+    for symbol in symbols:
+        assert module in find_symbol_modules(symbol)
+        assert is_valid_import(module, symbol)
+
+    static_registry = import_registry._parse_static_registry(
+        import_registry._STATIC_REGISTRY
+    )
+    assert symbols <= set(static_registry[module])
 
 
 def test_find_symbol_modules_returns_known_module():

--- a/tests/test_models/test_trees/test_lattice.py
+++ b/tests/test_models/test_trees/test_lattice.py
@@ -1,5 +1,7 @@
 """Tests for the generic recombining lattice."""
 
+from dataclasses import FrozenInstanceError
+
 import numpy as raw_np
 import pytest
 from scipy.stats import norm
@@ -9,6 +11,7 @@ from trellis.models.trees.lattice import (
     build_rate_lattice,
     build_spot_lattice,
     lattice_backward_induction,
+    lattice_backward_induction_result,
 )
 from trellis.models.trees.control import resolve_lattice_exercise_policy
 from tests.lattice_builders import build_equity_lattice, build_short_rate_lattice
@@ -190,6 +193,114 @@ class TestRateLattice:
 
         assert price > 0.0
 
+
+class TestLatticeRollbackObservations:
+    @staticmethod
+    def _two_step_lattice() -> RecombiningLattice:
+        lattice = RecombiningLattice(2, 1.0, branching=2, state_dim=1)
+        for step in range(3):
+            for node in range(lattice.n_nodes(step)):
+                lattice.set_state(step, node, float(node))
+        lattice.set_probabilities(0, 0, [0.5, 0.5])
+        lattice.set_probabilities(1, 0, [0.5, 0.5])
+        lattice.set_probabilities(1, 1, [0.5, 0.5])
+        lattice.set_discount(0, 0, 1.0)
+        lattice.set_discount(1, 0, 1.0)
+        lattice.set_discount(1, 1, 1.0)
+        return lattice
+
+    def test_result_captures_continuation_cashflow_and_control_phases(self):
+        lattice = self._two_step_lattice()
+
+        result = lattice_backward_induction_result(
+            lattice,
+            terminal_payoff=lambda step, node, lattice_: 100.0 + 10.0 * node,
+            cashflow_at_node=lambda step, node, lattice_: 5.0 if step == 1 else 0.0,
+            exercise_value=lambda step, node, lattice_, continuation: (
+                110.0 if node == 0 else 130.0
+            ),
+            exercise_type="bermudan",
+            exercise_steps=[1],
+            observation_steps=[1],
+        )
+
+        observation = result.observation_at(1)
+        assert observation.continuation_values == pytest.approx((105.0, 115.0))
+        assert observation.post_cashflow_values == pytest.approx((110.0, 120.0))
+        assert observation.post_control_values == pytest.approx((110.0, 130.0))
+        assert result.root_value == pytest.approx(120.0)
+
+    def test_result_normalizes_requested_steps_and_captures_terminal_values(self):
+        lattice = self._two_step_lattice()
+
+        result = lattice_backward_induction_result(
+            lattice,
+            terminal_payoff=lambda step, node, lattice_: 100.0 + 10.0 * node,
+            observation_steps=[2, 0, 1, 1],
+        )
+
+        assert tuple(observation.step for observation in result.observations) == (0, 1, 2)
+        terminal = result.observation_at(2)
+        assert terminal.continuation_values == pytest.approx((100.0, 110.0, 120.0))
+        assert terminal.post_cashflow_values == terminal.continuation_values
+        assert terminal.post_control_values == terminal.continuation_values
+
+    @pytest.mark.parametrize("observation_steps", [(-1,), (3,), (0.5,), (True,)])
+    def test_result_rejects_invalid_observation_steps(self, observation_steps):
+        lattice = self._two_step_lattice()
+
+        error = TypeError if observation_steps in {(0.5,), (True,)} else ValueError
+        with pytest.raises(error):
+            lattice_backward_induction_result(
+                lattice,
+                terminal_payoff=0.0,
+                observation_steps=observation_steps,
+            )
+
+    def test_result_is_immutable_and_missing_observations_fail_closed(self):
+        lattice = self._two_step_lattice()
+        result = lattice_backward_induction_result(
+            lattice,
+            terminal_payoff=1.0,
+            observation_steps=(1,),
+        )
+
+        with pytest.raises(FrozenInstanceError):
+            result.root_value = 2.0
+        with pytest.raises(TypeError):
+            result.observation_at(1).continuation_values[0] = 2.0
+        with pytest.raises(KeyError, match="No lattice rollback observation"):
+            result.observation_at(0)
+
+    @pytest.mark.parametrize(
+        ("exercise_fn", "exercise_value"),
+        [
+            (max, 130.0),
+            (min, 90.0),
+        ],
+    )
+    def test_result_root_matches_scalar_backward_induction(self, exercise_fn, exercise_value):
+        lattice = self._two_step_lattice()
+        kwargs = {
+            "terminal_payoff": lambda step, node, lattice_: 100.0 + 10.0 * node,
+            "cashflow_at_node": lambda step, node, lattice_: 2.0 if step == 1 else 0.0,
+            "exercise_value": lambda step, node, lattice_, continuation: exercise_value,
+            "exercise_type": "bermudan",
+            "exercise_steps": [1],
+            "exercise_fn": exercise_fn,
+        }
+
+        result = lattice_backward_induction_result(
+            lattice,
+            observation_steps=(1,),
+            **kwargs,
+        )
+        scalar = lattice_backward_induction(lattice, **kwargs)
+
+        assert result.root_value == pytest.approx(scalar)
+
+
+class TestLatticeBackwardInductionCompatibility:
     @pytest.mark.legacy_compat
     def test_lattice_backward_induction_accepts_legacy_callable_signatures(self):
         lattice = build_rate_lattice(0.05, 0.01, 0.1, 1.0, 4)

--- a/tests/test_models/test_trees/test_lattice_algebra.py
+++ b/tests/test_models/test_trees/test_lattice_algebra.py
@@ -196,6 +196,68 @@ def test_price_on_lattice_matches_legacy_american_put():
     assert built == pytest.approx(legacy)
 
 
+def test_value_on_lattice_exposes_bounded_rollback_observations():
+    from trellis.models.trees.algebra import (
+        LatticeContractSpec,
+        LatticeControlSpec,
+        LatticeLinearClaimSpec,
+        value_on_lattice,
+    )
+
+    lattice = RecombiningLattice(2, 1.0, branching=2, state_dim=1)
+    for step in range(3):
+        for node in range(lattice.n_nodes(step)):
+            lattice.set_state(step, node, float(node))
+    lattice.set_probabilities(0, 0, [0.5, 0.5])
+    lattice.set_probabilities(1, 0, [0.5, 0.5])
+    lattice.set_probabilities(1, 1, [0.5, 0.5])
+    lattice.set_discount(0, 0, 1.0)
+    lattice.set_discount(1, 0, 1.0)
+    lattice.set_discount(1, 1, 1.0)
+    contract = LatticeContractSpec(
+        claim=LatticeLinearClaimSpec(
+            terminal_payoff=lambda step, node, lattice_, obs: 100.0 + 10.0 * node,
+            node_cashflow_fn=lambda step, node, lattice_, obs: 5.0 if step == 1 else 0.0,
+        ),
+        control=LatticeControlSpec(
+            objective="holder_max",
+            exercise_steps=(1,),
+            exercise_value_fn=lambda step, node, lattice_, obs: 110.0 if node == 0 else 130.0,
+        ),
+    )
+
+    result = value_on_lattice(lattice, contract, observation_steps=(1,))
+
+    assert result.root_value == pytest.approx(price_on_lattice(lattice, contract))
+    assert result.observation_at(1).continuation_values == pytest.approx((105.0, 115.0))
+    assert result.observation_at(1).post_cashflow_values == pytest.approx((110.0, 120.0))
+    assert result.observation_at(1).post_control_values == pytest.approx((110.0, 130.0))
+
+
+def test_value_on_lattice_rejects_edge_cashflow_observations():
+    from trellis.models.trees.algebra import (
+        LatticeContractSpec,
+        LatticeLinearClaimSpec,
+        value_on_lattice,
+    )
+
+    lattice = RecombiningLattice(1, 1.0, branching=2, state_dim=1)
+    lattice.set_state(0, 0, 0.0)
+    lattice.set_state(1, 0, 0.0)
+    lattice.set_state(1, 1, 0.0)
+    lattice.set_probabilities(0, 0, [0.5, 0.5])
+    lattice.set_discount(0, 0, 1.0)
+    contract = LatticeContractSpec(
+        claim=LatticeLinearClaimSpec(
+            terminal_payoff=lambda step, node, lattice_, obs: 1.0,
+            edge_cashflow_fn=lambda step, parent, child, lattice_, parent_obs, child_obs: 1.0,
+        )
+    )
+
+    with pytest.raises(ValueError, match="edge cashflows"):
+        value_on_lattice(lattice, contract, observation_steps=(0,))
+
+
 def test_price_on_lattice_supports_edge_aware_knock_out_overlay():
     from trellis.models.trees.algebra import (
         EventOverlaySpec,

--- a/trellis/agent/knowledge/canonical/api_map.yaml
+++ b/trellis/agent/knowledge/canonical/api_map.yaml
@@ -240,11 +240,12 @@ equity_tree:
     aliases: [equity_tree, american_option, bermudan_option]
   key_imports:
     - "from trellis.models.resolution.single_state_diffusion import resolve_single_state_diffusion_inputs, terminal_intrinsic_from_resolved"
-    - "from trellis.models.trees.algebra import equity_tree, with_control, compile_lattice_recipe, build_lattice, price_on_lattice"
+    - "from trellis.models.trees.algebra import equity_tree, with_control, compile_lattice_recipe, build_lattice, price_on_lattice, value_on_lattice"
     - "from trellis.models.equity_option_tree import price_cev_option_tree"
   notes:
     - "American/Bermudan vanilla equity adapters should compose the neutral market resolver with the declarative lattice recipe, control, compiler, builder, and pricing primitives"
     - "Bermudan adapters map contractual exercise dates to lattice steps before attaching control"
+    - "Use value_on_lattice(..., observation_steps=...) only when node-level continuation, post-cashflow, or post-control evidence is required; price_on_lattice(...) remains the scalar entry point"
     - "CEV tree comparison targets should prefer the checked-in spot-lattice helper `price_cev_option_tree(...)`"
 
 rate_lattice:
@@ -253,11 +254,15 @@ rate_lattice:
   navigation:
     aliases: [rate_tree, callable_bond, puttable_bond, bermudan_swaption]
   key_imports:
-    - "from trellis.models.trees.lattice import build_rate_lattice, lattice_backward_induction"
+    - "from trellis.models.trees.lattice import LatticeRollbackObservation, LatticeRollbackResult, build_rate_lattice, lattice_backward_induction, lattice_backward_induction_result"
+    - "from trellis.models.trees.algebra import value_on_lattice"
     - "from trellis.models.zcb_option_tree import price_zcb_option_tree"
   notes:
     - "Callable bonds, puttable bonds, and Bermudan swaptions use a calibrated rate lattice from a TreeModel specification such as Hull-White or Black-Derman-Toy"
     - "lattice_backward_induction handles cashflow_at_node and exercise_fn"
+    - "lattice_backward_induction_result(..., observation_steps=...) and value_on_lattice(..., observation_steps=...) capture only requested steps as immutable LatticeRollbackObservation values"
+    - "Each nonterminal observation separates discounted continuation, post-cashflow, and post-control node vectors; terminal observations use the terminal payoff vector for all three phases"
+    - "Use the bounded observation result to compose schedule and exercise state; do not open-code rollback or introduce a product-specific observation helper"
     - "Zero-coupon bond option tree routes should prefer `price_zcb_option_tree(...)` instead of rebuilding nested backward induction inline"
 
 # ---------------------------------------------------------------------------

--- a/trellis/agent/knowledge/import_registry.py
+++ b/trellis/agent/knowledge/import_registry.py
@@ -589,9 +589,9 @@ from trellis.models.sabr_option import ResolvedSabrForwardOptionInputs, SabrForw
 ### Models — Trees
 from trellis.models.bermudan_swaption_tree import BermudanSwaptionTreeSpec, compile_bermudan_swaption_contract_spec, resolve_bermudan_swaption_tree_inputs
 from trellis.models.rate_style_swaption import resolve_swaption_curve_basis_spread
-from trellis.models.trees.algebra import BINOMIAL_1F_TOPOLOGY, TERM_STRUCTURE_TARGET, UNIFORM_ADDITIVE_MESH, build_lattice, price_on_lattice
+from trellis.models.trees.algebra import BINOMIAL_1F_TOPOLOGY, TERM_STRUCTURE_TARGET, UNIFORM_ADDITIVE_MESH, build_lattice, price_on_lattice, value_on_lattice
 from trellis.models.equity_option_tree import build_vanilla_equity_lattice, compile_vanilla_equity_contract_spec, price_cev_option_tree, price_vanilla_equity_option_on_lattice, price_vanilla_equity_option_tree, resolve_vanilla_equity_tree_inputs
-from trellis.models.trees.lattice import build_rate_lattice, build_spot_lattice, lattice_backward_induction, build_generic_lattice, calibrate_lattice
+from trellis.models.trees.lattice import LatticeRollbackObservation, LatticeRollbackResult, build_rate_lattice, build_spot_lattice, lattice_backward_induction, lattice_backward_induction_result, build_generic_lattice, calibrate_lattice
 from trellis.models.trees.binomial import BinomialTree
 from trellis.models.trees.backward_induction import backward_induction
 

--- a/trellis/models/trees/__init__.py
+++ b/trellis/models/trees/__init__.py
@@ -4,14 +4,18 @@ from trellis.models.trees.binomial import BinomialTree
 from trellis.models.trees.trinomial import TrinomialTree
 from trellis.models.trees.backward_induction import backward_induction
 from trellis.models.trees.lattice import (
+    LatticeRollbackObservation,
+    LatticeRollbackResult,
     RecombiningLattice,
     build_lattice,
     build_generic_lattice,
     lattice_backward_induction,
+    lattice_backward_induction_result,
     build_rate_lattice,
     build_spot_lattice,
     price_on_lattice,
 )
+from trellis.models.trees.algebra import value_on_lattice
 from trellis.models.trees.control import (
     ExerciseObjective,
     LatticeExercisePolicy,

--- a/trellis/models/trees/algebra.py
+++ b/trellis/models/trees/algebra.py
@@ -4,12 +4,16 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field, replace
 from math import exp, log, sqrt
-from typing import Any, Callable, Mapping, Protocol
+from typing import Any, Callable, Iterable, Mapping, Protocol
 import warnings
 
 import numpy as raw_np
 
 from trellis.models._numba import NUMBA_AVAILABLE
+from trellis.models.trees.lattice import (
+    LatticeRollbackResult,
+    lattice_backward_induction_result,
+)
 from trellis.models.trees.models import MODEL_REGISTRY as LEGACY_MODEL_REGISTRY
 
 
@@ -963,6 +967,87 @@ def _price_general_contract(lattice, contract: LatticeContractSpec) -> float:
     return float(values[state_index[initial_state], 0])
 
 
+def value_on_lattice(
+    lattice,
+    contract: LatticeContractSpec,
+    *,
+    observation_steps: Iterable[int] = (),
+) -> LatticeRollbackResult:
+    """Value a one-factor contract and capture bounded rollback phases.
+
+    The observation result is intentionally limited to the one-factor path
+    where continuation, node cashflow, and control phases are unambiguous.
+    Overlay, edge-cashflow, and multidimensional contracts remain available
+    through scalar ``price_on_lattice(...)`` but are not admitted here.
+    """
+    claim = contract.claim
+    control = contract.control
+    if contract.overlay is not None:
+        raise ValueError("value_on_lattice() does not support overlay observations")
+    if claim.edge_cashflow_fn is not None:
+        raise ValueError("value_on_lattice() does not support edge cashflows")
+    if getattr(lattice, "state_dim", 1) != 1:
+        raise ValueError("value_on_lattice() requires a one-factor lattice")
+
+    policy = _control_policy(control)
+
+    def terminal_payoff(step: int, node: int, lattice_):
+        return float(
+            claim.terminal_payoff(
+                step,
+                node,
+                lattice_,
+                _base_observable(lattice_, step, node),
+            )
+        )
+
+    cashflow_at_node = None
+    if claim.node_cashflow_fn is not None:
+
+        def cashflow_at_node(step: int, node: int, lattice_):
+            return float(
+                claim.node_cashflow_fn(
+                    step,
+                    node,
+                    lattice_,
+                    _base_observable(lattice_, step, node),
+                )
+            )
+
+    exercise_value = None
+    if (
+        control is not None
+        and control.objective != "identity"
+        and control.exercise_value_fn is not None
+    ):
+
+        def exercise_value(step: int, node: int, lattice_, continuation):
+            del continuation
+            return float(
+                control.exercise_value_fn(
+                    step,
+                    node,
+                    lattice_,
+                    _base_observable(lattice_, step, node),
+                )
+            )
+
+    lattice._lattice_last_pricing_path = (
+        f"fast_{'obstacle' if control is not None and control.objective != 'identity' else 'linear'}_"
+        f"{'numba' if NUMBA_AVAILABLE else 'numpy'}"
+    )
+    return lattice_backward_induction_result(
+        lattice,
+        terminal_payoff,
+        exercise_value=exercise_value,
+        exercise_type="european" if policy is None else policy["exercise_type"],
+        exercise_steps=None if policy is None else list(policy["exercise_steps"]),
+        cashflow_at_node=cashflow_at_node,
+        exercise_fn=None if policy is None else policy["exercise_fn"],
+        observation_steps=observation_steps,
+    )
+
+
 def price_on_lattice(lattice, contract: LatticeContractSpec) -> float:
     """Price a compiled lattice contract on a built lattice."""
     claim = contract.claim
@@ -1000,37 +1085,7 @@ def price_on_lattice(lattice, contract: LatticeContractSpec) -> float:
         _set_path(path)
         return _price_general_contract(lattice, contract)
 
-    policy = _control_policy(control)
-
-    def terminal_payoff(step: int, node: int, lattice_):
-        return float(claim.terminal_payoff(step, node, lattice_, _base_observable(lattice_, step, node)))
-
-    cashflow_at_node = None
-    if claim.node_cashflow_fn is not None:
-        def cashflow_at_node(step: int, node: int, lattice_):
-            return float(claim.node_cashflow_fn(step, node, lattice_, _base_observable(lattice_, step, node)))
-
-    exercise_value = None
-    if control is not None and control.objective != "identity" and control.exercise_value_fn is not None:
-        def exercise_value(step: int, node: int, lattice_):
-            return float(control.exercise_value_fn(step, node, lattice_, _base_observable(lattice_, step, node)))
-
-    from trellis.models.trees.lattice import lattice_backward_induction
-
-    _set_path(
-        f"fast_{'obstacle' if control is not None and control.objective != 'identity' else 'linear'}_{'numba' if NUMBA_AVAILABLE else 'numpy'}"
-    )
-    return float(
-        lattice_backward_induction(
-            lattice,
-            terminal_payoff,
-            exercise_value=exercise_value,
-            exercise_type="european" if policy is None else policy["exercise_type"],
-            exercise_steps=None if policy is None else list(policy["exercise_steps"]),
-            cashflow_at_node=cashflow_at_node,
-            exercise_fn=None if policy is None else policy["exercise_fn"],
-        )
-    )
+    return float(value_on_lattice(lattice, contract).root_value)
 
 
 def short_rate_tree(
@@ -1276,6 +1331,7 @@ __all__ = [
     "equity_tree",
     "lattice_algebra_eligible",
     "price_on_lattice",
+    "value_on_lattice",
     "short_rate_tree",
     "with_control",
     "with_overlay",

--- a/trellis/models/trees/lattice.py
+++ b/trellis/models/trees/lattice.py
@@ -11,7 +11,10 @@ This separates the tree structure from the financial model.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 import inspect
+from operator import index as integer_index
+from typing import Iterable
 import warnings
 import numpy as raw_np
 
@@ -107,6 +110,73 @@ class RecombiningLattice:
         else:
             # Trinomial: down, mid, up relative to center
             return [node, node + 1, node + 2]
+
+
+@dataclass(frozen=True)
+class LatticeRollbackObservation:
+    """Immutable node values captured at one rollback step."""
+
+    step: int
+    continuation_values: tuple[float, ...]
+    post_cashflow_values: tuple[float, ...]
+    post_control_values: tuple[float, ...]
+
+
+@dataclass(frozen=True)
+class LatticeRollbackResult:
+    """Root value plus bounded, phase-aware rollback observations."""
+
+    root_value: float
+    observations: tuple[LatticeRollbackObservation, ...] = ()
+
+    def observation_at(self, step: int) -> LatticeRollbackObservation:
+        """Return the captured observation for ``step`` or fail closed."""
+        normalized_step = _coerce_observation_step(step)
+        for observation in self.observations:
+            if observation.step == normalized_step:
+                return observation
+        raise KeyError(f"No lattice rollback observation at step {normalized_step}")
+
+
+def _coerce_observation_step(step: object) -> int:
+    """Return one exact integer observation step."""
+    if isinstance(step, bool):
+        raise TypeError("lattice observation steps must be integers, not bool")
+    try:
+        return int(integer_index(step))
+    except TypeError as exc:
+        raise TypeError("lattice observation steps must be integers") from exc
+
+
+def _normalize_observation_steps(
+    observation_steps: Iterable[int],
+    *,
+    n_steps: int,
+) -> tuple[int, ...]:
+    """Validate and deterministically normalize requested rollback steps."""
+    normalized = {_coerce_observation_step(step) for step in observation_steps}
+    invalid = tuple(step for step in sorted(normalized) if step < 0 or step > int(n_steps))
+    if invalid:
+        raise ValueError(
+            f"lattice observation steps must be between 0 and {int(n_steps)} inclusive; "
+            f"received {invalid}"
+        )
+    return tuple(sorted(normalized))
+
+
+def _rollback_observation(
+    step: int,
+    continuation_values,
+    post_cashflow_values,
+    post_control_values,
+) -> LatticeRollbackObservation:
+    """Freeze one set of rollback phase vectors."""
+    return LatticeRollbackObservation(
+        step=int(step),
+        continuation_values=tuple(float(value) for value in continuation_values),
+        post_cashflow_values=tuple(float(value) for value in post_cashflow_values),
+        post_control_values=tuple(float(value) for value in post_control_values),
+    )
 
 
 @maybe_njit(cache=False)
@@ -386,7 +456,7 @@ def _discount_array(
     )
 
 
-def lattice_backward_induction(
+def lattice_backward_induction_result(
     lattice: RecombiningLattice,
     terminal_payoff=None,
     exercise_value=None,
@@ -397,8 +467,9 @@ def lattice_backward_induction(
     exercise_policy: LatticeExercisePolicy | None = None,
     terminal_value: float | None = None,
     exercise_value_fn=None,
-) -> float:
-    """Generic backward induction on a RecombiningLattice.
+    observation_steps: Iterable[int] = (),
+) -> LatticeRollbackResult:
+    """Run generic backward induction and capture requested node-value phases.
 
     Parameters
     ----------
@@ -425,11 +496,16 @@ def lattice_backward_induction(
         Compatibility alias for a constant terminal payoff.
     exercise_value_fn : callable or None
         Compatibility alias for ``exercise_value``.
+    observation_steps : iterable[int]
+        Bounded set of steps to capture. Each observation records discounted
+        continuation values, values after the current node cashflow, and values
+        after exercise/control. At the terminal step all three vectors equal the
+        terminal payoff vector.
 
     Returns
     -------
-    float
-        Price at root node (step=0, node=0).
+    LatticeRollbackResult
+        Root price and immutable observations sorted by step.
     """
     if terminal_payoff is not None and not callable(terminal_payoff):
         if terminal_value is not None:
@@ -458,6 +534,11 @@ def lattice_backward_induction(
     if exercise_fn is None:
         exercise_fn = max
     n = lattice.n_steps
+    requested_steps = _normalize_observation_steps(
+        observation_steps,
+        n_steps=n,
+    )
+    requested_step_set = set(requested_steps)
     branching = lattice.branching
     exercise_set = {int(step) for step in effective_exercise_steps}
     terminal_payoff = _terminal_payoff_adapter(terminal_payoff)
@@ -472,34 +553,86 @@ def lattice_backward_induction(
         n_terminal,
         (terminal_payoff(n, j, lattice) for j in range(n_terminal)),
     )
+    observations: dict[int, LatticeRollbackObservation] = {}
+    if n in requested_step_set:
+        observations[n] = _rollback_observation(n, values, values, values)
 
     # Roll back
     for i in range(n - 1, -1, -1):
         n_nodes_i = lattice.n_nodes(i)
         discounts = lattice._discounts[i, :n_nodes_i]
         probs = lattice._probs[i, :n_nodes_i, :branching]
-        new_values = _rollback_continuation(values, discounts, probs, branching)
+        continuation_values = _rollback_continuation(values, discounts, probs, branching)
 
         if cashflow_at_node is not None:
-            new_values = new_values + _node_values(
+            post_cashflow_values = continuation_values + _node_values(
                 n_nodes_i,
                 (cashflow_at_node(i, j, lattice) for j in range(n_nodes_i)),
             )
+        else:
+            post_cashflow_values = continuation_values
 
         # Exercise decisions
+        post_control_values = post_cashflow_values
         if exercise_value is not None and (
             exercise_type == "american"
             or (exercise_type == "bermudan" and i in exercise_set)
         ):
             exercise = _node_values(
                 n_nodes_i,
-                (exercise_value(i, j, lattice, float(new_values[j])) for j in range(n_nodes_i)),
+                (
+                    exercise_value(i, j, lattice, float(post_cashflow_values[j]))
+                    for j in range(n_nodes_i)
+                ),
             )
-            new_values = _apply_exercise_rule(new_values, exercise, exercise_fn)
+            post_control_values = _apply_exercise_rule(
+                post_cashflow_values,
+                exercise,
+                exercise_fn,
+            )
 
-        values = new_values
+        if i in requested_step_set:
+            observations[i] = _rollback_observation(
+                i,
+                continuation_values,
+                post_cashflow_values,
+                post_control_values,
+            )
 
-    return float(values[0])
+        values = post_control_values
+
+    return LatticeRollbackResult(
+        root_value=float(values[0]),
+        observations=tuple(observations[step] for step in requested_steps),
+    )
+
+
+def lattice_backward_induction(
+    lattice: RecombiningLattice,
+    terminal_payoff=None,
+    exercise_value=None,
+    exercise_type: str = "european",
+    exercise_steps: list[int] | None = None,
+    cashflow_at_node=None,
+    exercise_fn=None,
+    exercise_policy: LatticeExercisePolicy | None = None,
+    terminal_value: float | None = None,
+    exercise_value_fn=None,
+) -> float:
+    """Return the root value from generic lattice backward induction."""
+    result = lattice_backward_induction_result(
+        lattice,
+        terminal_payoff=terminal_payoff,
+        exercise_value=exercise_value,
+        exercise_type=exercise_type,
+        exercise_steps=exercise_steps,
+        cashflow_at_node=cashflow_at_node,
+        exercise_fn=exercise_fn,
+        exercise_policy=exercise_policy,
+        terminal_value=terminal_value,
+        exercise_value_fn=exercise_value_fn,
+    )
+    return float(result.root_value)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- expose immutable continuation, post-cashflow, and post-control node vectors at requested lattice steps
- preserve scalar lattice APIs through the same rollback implementation
- add builder API-map/import-registry navigation and quant/developer documentation
- add no product helper and make no cookbook change

## Validation
- focused: 187 passed
- regional: 182 passed after redirecting FinancePy Numba cache to /tmp
- gate-pr: 4,715 core + 32 tier-2 contracts passed
- gate-release: 487 crossval/verification/task + 2 freshness passed; T13 replay passed with zero LLM attempts
- Sphinx dummy build succeeded (pre-existing warnings remain)

Linear: QUA-1200