### PR TITLE
QUA-1201 retire Bermudan lattice helper authority

### DIFF
--- a/doc/plan/active__semantic-task-synthesis-helper-retirement.md
+++ b/doc/plan/active__semantic-task-synthesis-helper-retirement.md
@@ -61,7 +61,8 @@ Status mirror last synced: `2026-07-16`
 | `QUA-1198` | Swaption Monte Carlo: retire European helper and problem-resolver authority | Done |
 | `QUA-1199` | Swaption lattice: retire European tree helper authority | Done |
 | `QUA-1200` | Lattice rollback: observable node-value phases | Done |
-| `QUA-1201` | Bermudan swaption lattice: retire helper and compiler authority | Backlog |
+| `QUA-1201` | Bermudan swaption lattice: retire helper and compiler authority | In Progress |
+| `QUA-1202` | Semantic proving: distinguish fresh artifacts from agent synthesis | Backlog |
 | `QUA-1102` | Semantic target binding: typed comparison target contracts (related prerequisite) | Done |
 
 ## Current Sequence
@@ -111,7 +112,10 @@ Status mirror last synced: `2026-07-16`
     swaption lane: compose schedule values and holder control from public
     lattice primitives while retaining product wrappers only as compatibility
     and independent reference evidence.
-13. Run live fresh-generation evidence only with current external-model approval;
+13. Apply QUA-1202 to separate isolated fresh-artifact construction from
+    builder-agent synthesis, record artifact origin, and require an explicit
+    synthesis policy before making agent-learning claims.
+14. Run live fresh-generation evidence only with current external-model approval;
     use it to compare first-pass source selection, retrieved documentation,
     retries, and residual validator findings rather than as pricing authority.
 

--- a/docs/developer/runtime_agent_orientation.rst
+++ b/docs/developer/runtime_agent_orientation.rst
@@ -84,6 +84,28 @@ reading private rollback loops or delegating construction to a product helper.
 The ordinary scalar ``price_on_lattice(...)`` remains the preferred entry point
 when intermediate node evidence is unnecessary.
 
+The specialized ``bermudan_swaption_rate_lattice_composition`` card is the
+complete small-context packet for the multi-exercise rate-tree lane. It contains
+date normalization, payment scheduling, market/model resolution, topology,
+mesh, term-structure calibration, step mapping, linear-claim and contract
+types, bounded observation rollback, holder control, and scalar pricing. Its
+compact notes identify ``continuation_values`` as the fixed-leg evidence used
+for payer/receiver exercise algebra. Instrument eligibility prevents a
+Bermudan query from also retrieving the single-exercise European swaption card
+and its different contract construction.
+
+The route and backend catalogs keep the retired product pricer only as an
+optional, explicitly excluded compatibility reference. Excluded references do
+not enter DSL target bindings, construction cards, or import/semantic-repair
+cards. Repair prompts list admitted construction primitives before the broader
+public export catalog so a bounded card cannot omit the terminal kernel while
+showing unrelated module exports. Deterministic semantic validation rejects
+generated calls to excluded references with
+``assembly.excluded_primitive_used``. It also recognizes
+``LatticeControlSpec(objective="holder_max", exercise_steps=...)`` as the
+generic Bermudan schedule and objective contract, rather than requiring the
+legacy ``lattice_backward_induction(...)`` keyword surface.
+
 Composition cards may join public primitives from more than one subsystem
 without introducing a new product helper. The general
 ``analytical_gaussian_composition`` card points a builder handling general

--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -923,12 +923,15 @@ vector vol fields on that generated spec as the volatility authority when it
 runs vega checks, so the proof validates the actual shim inputs instead of a
 market-state flat-vol field the shim does not consume.
 
-Fresh-build proving keeps a stricter boundary than ordinary supported-route
-reuse. When a task or canary is run with ``fresh_build=True``, the executor
-now skips deterministic exact-binding materialization so the run still has to
-exercise live code generation. Ordinary supported-route runs can still reuse
-exact helper wrappers for stability, but fresh-build canaries no longer get a
-free pass from executor-side deterministic module synthesis.
+Fresh-build proving keeps a stricter artifact boundary than ordinary
+supported-route reuse. When a task or canary is run with
+``fresh_build=True``, the executor bypasses the admitted checked-in adapter and
+writes the result to an isolated fresh-build path. Fresh build does not by
+itself prove agent synthesis: an admitted deterministic exact binding may still
+materialize that isolated adapter with zero model calls. A report may claim
+fresh artifact construction from this mode, but it may claim fresh agent
+synthesis only when its execution policy also bypasses deterministic
+materialization and the trace records an actual code-generation call.
 
 The same rule now applies to tranche-style basket-credit and typed
 loss-distribution comparison routes.

--- a/docs/quant/lattice_algebra.rst
+++ b/docs/quant/lattice_algebra.rst
@@ -324,6 +324,51 @@ should use this bounded result when they need schedule or exercise-state
 composition instead of open-coding backward induction or adding a
 product-specific helper.
 
+Bermudan Swaption Composition
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The admitted Bermudan swaption tree lane is a concrete example of composing a
+product from the generic lattice boundary. Generated construction follows this
+order:
+
+1. Normalize the live exercise dates and build the underlying fixed-leg payment
+   timeline.
+2. Resolve settlement, model parameters, horizon, and step controls once with
+   ``resolve_bermudan_swaption_tree_inputs(...)``.
+3. Build the calibrated one-factor rate lattice from
+   ``BINOMIAL_1F_TOPOLOGY``, ``UNIFORM_ADDITIVE_MESH``,
+   ``TERM_STRUCTURE_TARGET``, and ``build_lattice(...)``.
+4. Map exercise and payment times with ``lattice_step_from_time(...)``.
+5. Represent fixed coupons and principal as a ``LatticeLinearClaimSpec`` and
+   value that claim with
+   ``value_on_lattice(..., observation_steps=exercise_steps)``.
+6. Form payer or receiver swap values in the generated adapter, attach
+   ``LatticeControlSpec(objective="holder_max", ...)``, and evaluate the option
+   ``LatticeContractSpec`` with ``price_on_lattice(...)``.
+
+Let :math:`C_m^{\mathrm{fixed}}(i)` denote the discounted fixed-leg continuation
+value at exercise step :math:`m`, consistent with the phase notation above.
+Under the admitted par-floating-leg representation, the payer and receiver
+exercise underlyings are
+
+.. math::
+
+   S_m^{\mathrm{payer}}(i) = N - C_m^{\mathrm{fixed}}(i), \qquad
+   S_m^{\mathrm{receiver}}(i) = -S_m^{\mathrm{payer}}(i).
+
+The immediate holder value is :math:`\max(S_m(i), 0)`. The fixed-leg value must
+come from ``LatticeRollbackObservation.continuation_values``. Using
+``post_cashflow_values`` would include a fixed coupon paid at the exercise step
+and can double count that coupon in the exercise underlying.
+
+The builder navigation entry is
+``bermudan_swaption_rate_lattice_composition`` in the canonical API map. The
+retained product pricing wrapper and product contract compiler are compatibility
+and independent reference surfaces only; neither is admitted as generated
+construction authority. The separate Bermudan rates Monte Carlo limitation
+remains unchanged because this composition proves only the one-factor lattice
+lane.
+
 Typed Contract Inputs
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/test_agent/test_api_map.py
+++ b/tests/test_agent/test_api_map.py
@@ -67,6 +67,10 @@ def test_api_map_contains_expected_core_entries():
         api_map["european_swaption_rate_lattice_composition"]["module"]
         == "trellis.models.trees.algebra"
     )
+    assert (
+        api_map["bermudan_swaption_rate_lattice_composition"]["module"]
+        == "trellis.models.trees.algebra"
+    )
     assert api_map["equity_tree"]["module"] == "trellis.models.trees.algebra"
     assert api_map["rate_lattice"]["module"] == "trellis.models.trees.lattice"
     assert "utilities" in api_map
@@ -99,6 +103,7 @@ def test_api_map_key_imports_are_registry_valid():
         "bermudan_swaption_lower_bound_composition",
         "european_swaption_monte_carlo_composition",
         "european_swaption_rate_lattice_composition",
+        "bermudan_swaption_rate_lattice_composition",
         "qmc",
         "pde",
         "fft",
@@ -422,6 +427,43 @@ def test_api_map_exposes_european_swaption_rate_lattice_composition():
     )
     assert "price_swaption_tree(...)" in notes
     assert "reference" in notes.lower()
+
+
+def test_api_map_exposes_bermudan_swaption_rate_lattice_composition():
+    query = ApiMapQuery(
+        instrument_type="bermudan_swaption",
+        payoff_family="swaption",
+        method="rate_tree",
+        model_family="interest_rate",
+    )
+    selection = select_api_map_sections(query)
+    text = format_api_map_for_prompt(compact=True, query=query)
+
+    assert selection.selected_families[0] == (
+        "bermudan_swaption_rate_lattice_composition"
+    )
+    for symbol in (
+        "normalize_explicit_dates",
+        "year_fraction",
+        "build_payment_timeline",
+        "resolve_bermudan_swaption_tree_inputs",
+        "BINOMIAL_1F_TOPOLOGY",
+        "UNIFORM_ADDITIVE_MESH",
+        "TERM_STRUCTURE_TARGET",
+        "build_lattice",
+        "lattice_step_from_time",
+        "LatticeLinearClaimSpec",
+        "LatticeContractSpec",
+        "value_on_lattice",
+        "LatticeControlSpec",
+        "price_on_lattice",
+    ):
+        assert symbol in text
+    assert "continuation_values" in text
+    assert "payer/receiver" in text
+    assert "holder_max" in text
+    assert "price_bermudan_swaption_tree" not in text
+    assert "compile_bermudan_swaption_contract_spec" not in text
 
 
 def test_api_map_exposes_complete_fixed_lookback_analytical_composition():

--- a/tests/test_agent/test_backend_bindings.py
+++ b/tests/test_agent/test_backend_bindings.py
@@ -1545,6 +1545,57 @@ def test_exercise_lattice_binding_adds_bermudan_schedule_mapping_primitives():
     }.issubset(resolved.primitive_refs)
 
 
+def test_exercise_lattice_binding_resolves_bermudan_swaption_composition():
+    catalog = load_backend_binding_catalog()
+    binding = find_backend_binding_by_route_id("exercise_lattice", catalog)
+    assert binding is not None
+
+    resolved = resolve_backend_binding_spec(
+        binding,
+        product_ir=ProductIR(
+            instrument="bermudan_swaption",
+            payoff_family="swaption",
+            exercise_style="bermudan",
+            model_family="interest_rate",
+            schedule_dependence=True,
+            state_dependence="schedule_state",
+        ),
+    )
+
+    assert resolved.helper_refs == ()
+    assert resolved.market_binding_refs == (
+        "trellis.models.bermudan_swaption_tree.resolve_bermudan_swaption_tree_inputs",
+    )
+    assert resolved.exact_target_refs == (
+        "trellis.models.trees.algebra.price_on_lattice",
+    )
+    assert resolved.binding_id == "trellis.models.trees.algebra.price_on_lattice"
+    assert {primitive.symbol: primitive.role for primitive in resolved.primitives} == {
+        "normalize_explicit_dates": "schedule_normalizer",
+        "year_fraction": "timeline_mapping",
+        "build_payment_timeline": "payment_timeline_builder",
+        "resolve_bermudan_swaption_tree_inputs": "market_binding",
+        "BINOMIAL_1F_TOPOLOGY": "topology",
+        "UNIFORM_ADDITIVE_MESH": "mesh",
+        "TERM_STRUCTURE_TARGET": "calibration_target",
+        "build_lattice": "lattice_builder",
+        "lattice_step_from_time": "schedule_mapping",
+        "LatticeLinearClaimSpec": "linear_claim",
+        "LatticeContractSpec": "contract_spec",
+        "value_on_lattice": "observation_rollback",
+        "LatticeControlSpec": "exercise_control",
+        "price_on_lattice": "pricing_kernel",
+        "price_bermudan_swaption_tree": "compatibility_reference",
+    }
+    retired_helper = next(
+        primitive
+        for primitive in resolved.primitives
+        if primitive.symbol == "price_bermudan_swaption_tree"
+    )
+    assert not retired_helper.required
+    assert retired_helper.excluded
+
+
 def test_binding_catalog_cache_tracks_binding_catalog_freshness(monkeypatch):
     clear_backend_binding_catalog_cache()
 

--- a/tests/test_agent/test_build_loop.py
+++ b/tests/test_agent/test_build_loop.py
@@ -1135,65 +1135,6 @@ class SmokePayoff:
             max_retries=2,
         )
 
-GOOD_BERMUDAN_RATE_TREE_MODULE_CODE = '''\
-"""Agent-generated payoff: Bermudan swaption on HW tree."""
-
-from __future__ import annotations
-
-from dataclasses import dataclass
-from datetime import date
-
-from trellis.core.market_state import MarketState
-from trellis.core.types import DayCountConvention, Frequency
-
-
-@dataclass(frozen=True)
-class BermudanSwaptionSpec:
-    notional: float
-    strike: float
-    exercise_dates: tuple[date, ...]
-    swap_end: date
-    swap_frequency: Frequency = Frequency.SEMI_ANNUAL
-    day_count: DayCountConvention = DayCountConvention.ACT_360
-    rate_index: str | None = None
-    is_payer: bool = True
-
-
-class BermudanSwaptionPayoff:
-    def __init__(self, spec: BermudanSwaptionSpec):
-        self._spec = spec
-
-    @property
-    def spec(self) -> BermudanSwaptionSpec:
-        return self._spec
-
-    @property
-    def requirements(self) -> set[str]:
-        return {"black_vol_surface", "discount_curve", "forward_curve"}
-
-    def evaluate(self, market_state: MarketState) -> float:
-        from trellis.models.bermudan_swaption_tree import price_bermudan_swaption_tree
-
-        return float(price_bermudan_swaption_tree(market_state, self._spec, model="hull_white"))
-'''
-
-BERMUDAN_SPEC_SCHEMA = SpecSchema(
-    class_name="BermudanSwaptionPayoff",
-    spec_name="BermudanSwaptionSpec",
-    requirements=["black_vol", "discount", "forward_rate"],
-    fields=[
-        FieldDef("notional", "float", "Swaption notional"),
-        FieldDef("strike", "float", "Fixed strike rate"),
-        FieldDef("exercise_dates", "tuple[date, ...]", "Ordered Bermudan exercise dates"),
-        FieldDef("swap_end", "date", "Underlying swap end date"),
-        FieldDef("swap_frequency", "Frequency", "Swap payment frequency", "Frequency.SEMI_ANNUAL"),
-        FieldDef("day_count", "DayCountConvention", "Day count convention", "DayCountConvention.ACT_360"),
-        FieldDef("rate_index", "str | None", "Forecast curve key", "None"),
-        FieldDef("is_payer", "bool", "Payer or receiver swaption", "True"),
-    ],
-)
-
-
 class TestBuildLoop:
 
     def _fx_market_state(self) -> MarketState:
@@ -1868,9 +1809,7 @@ class QuantoOptionAnalyticalPayoff:
         mock_gen_mod,
         tmp_path,
     ):
-        """A rebuilt Bermudan swaption follows the rate-tree route and prices near the task reference."""
-        mock_design_spec.return_value = BERMUDAN_SPEC_SCHEMA
-        mock_gen_mod.return_value = GOOD_BERMUDAN_RATE_TREE_MODULE_CODE
+        """A rebuilt Bermudan swaption composes the admitted route without LLM codegen."""
 
         from trellis.agent.executor import build_payoff
 
@@ -1909,3 +1848,5 @@ class QuantoOptionAnalyticalPayoff:
         pv = price_payoff(payoff_cls(spec), market_state)
         assert pv > 1.0
         assert pv < 4.0
+        mock_design_spec.assert_not_called()
+        mock_gen_mod.assert_not_called()

--- a/tests/test_agent/test_codegen_guardrails.py
+++ b/tests/test_agent/test_codegen_guardrails.py
@@ -12,6 +12,7 @@ from trellis.agent.codegen_guardrails import (
     build_generation_plan,
     rank_primitive_routes,
     render_generation_plan,
+    render_import_repair_card,
     render_review_contract_card,
     render_generation_route_card,
     render_semantic_repair_card,
@@ -798,6 +799,35 @@ def test_generation_route_card_for_fx_analytical_composes_resolver_and_kernel():
     assert "garman_kohlhagen_price_raw" in text
     assert "price_fx_vanilla_analytical" not in text
     assert "map_fx_spot_and_curves_to_garman_kohlhagen_inputs" not in text
+
+
+def test_bermudan_builder_cards_hide_excluded_compatibility_reference():
+    compiled = compile_build_request(
+        "Bermudan payer swaption with annual exercise dates under a calibrated rate tree",
+        instrument_type="bermudan_swaption",
+        preferred_method="rate_tree",
+    )
+
+    primitive_plan = compiled.generation_plan.primitive_plan
+    assert primitive_plan is not None
+    compatibility_reference = next(
+        primitive
+        for primitive in primitive_plan.primitives
+        if primitive.role == "compatibility_reference"
+    )
+    assert compatibility_reference.excluded
+
+    for card in (
+        render_generation_plan(compiled.generation_plan),
+        render_generation_route_card(compiled.generation_plan),
+        render_import_repair_card(compiled.generation_plan),
+        render_review_contract_card(compiled.generation_plan),
+        render_semantic_repair_card(compiled.generation_plan),
+    ):
+        assert "price_bermudan_swaption_tree" not in card
+        assert "compatibility_reference" not in card
+        assert "value_on_lattice" in card
+        assert "price_on_lattice" in card
 
 
 def test_requested_method_augmentation_adds_route_family_hints_for_stale_decompositions():

--- a/tests/test_agent/test_dsl_lowering.py
+++ b/tests/test_agent/test_dsl_lowering.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 from trellis.agent.codegen_guardrails import PrimitiveRef
-from trellis.agent.dsl_algebra import ChoiceExpr, ContractAtom, ThenExpr, ControlStyle
+from trellis.agent.dsl_algebra import (
+    ChoiceExpr,
+    ContractAtom,
+    ControlStyle,
+    ThenExpr,
+    collect_primitive_refs,
+)
 from trellis.agent.family_lowering_ir import (
     AnalyticalBlack76IR,
     CorrelatedBasketMonteCarloIR,
@@ -235,7 +241,7 @@ def test_holder_max_equity_pde_lowers_to_event_aware_helper():
     assert "event_transform:project_max" in blueprint.lane_plan.control_obligations
 
 
-def test_bermudan_swaption_lowers_to_explicit_holder_choice_plus_helper_targets():
+def test_bermudan_swaption_lowers_to_explicit_generic_lattice_composition():
     from trellis.agent.semantic_contract_compiler import compile_semantic_contract
     from trellis.agent.semantic_contracts import make_rate_style_swaption_contract
 
@@ -253,17 +259,44 @@ def test_bermudan_swaption_lowers_to_explicit_holder_choice_plus_helper_targets(
     assert lowering.route_family == "rate_lattice"
     assert lowering.admissibility_errors == ()
     assert isinstance(lowering.family_ir, ExerciseLatticeIR)
-    assert lowering.family_ir.helper_symbol == "price_bermudan_swaption_tree"
+    assert lowering.family_ir.helper_symbol == ""
     assert lowering.family_ir.control_style == "holder_max"
-    assert "par_rate_bindings" in lowering.family_ir.derived_quantities
-    assert isinstance(lowering.normalized_expr, ChoiceExpr)
-    assert lowering.normalized_expr.style == ControlStyle.HOLDER_MAX
-    assert lowering.control_styles == (ControlStyle.HOLDER_MAX,)
-    assert (
-        "trellis.models.bermudan_swaption_tree.price_bermudan_swaption_tree"
-        in lowering.helper_refs
+    assert "fixed_leg_continuation_observations" in (
+        lowering.family_ir.derived_quantities
     )
-    assert "trellis.models.bermudan_swaption_tree" in blueprint.route_modules
+    assert "par_rate_bindings" in lowering.family_ir.derived_quantities
+    assert isinstance(lowering.normalized_expr, ThenExpr)
+    assert lowering.control_styles == (ControlStyle.HOLDER_MAX,)
+    assert lowering.route_helper_refs == ()
+    primitive_refs = set(collect_primitive_refs(lowering.normalized_expr))
+    assert primitive_refs == {
+        "trellis.core.date_utils.normalize_explicit_dates",
+        "trellis.core.date_utils.year_fraction",
+        "trellis.core.date_utils.build_payment_timeline",
+        "trellis.models.bermudan_swaption_tree.resolve_bermudan_swaption_tree_inputs",
+        "trellis.models.trees.algebra.BINOMIAL_1F_TOPOLOGY",
+        "trellis.models.trees.algebra.UNIFORM_ADDITIVE_MESH",
+        "trellis.models.trees.algebra.TERM_STRUCTURE_TARGET",
+        "trellis.models.trees.algebra.build_lattice",
+        "trellis.models.trees.control.lattice_step_from_time",
+        "trellis.models.trees.algebra.LatticeLinearClaimSpec",
+        "trellis.models.trees.algebra.LatticeContractSpec",
+        "trellis.models.trees.algebra.value_on_lattice",
+        "trellis.models.trees.algebra.LatticeControlSpec",
+        "trellis.models.trees.algebra.price_on_lattice",
+    }
+    assert not any(
+        "price_bermudan_swaption_tree" in primitive_ref
+        or "compile_bermudan_swaption_contract_spec" in primitive_ref
+        for primitive_ref in primitive_refs
+    )
+    holder_choice = next(
+        term
+        for term in lowering.normalized_expr.terms
+        if isinstance(term, ChoiceExpr)
+    )
+    assert holder_choice.style == ControlStyle.HOLDER_MAX
+    assert "trellis.models.trees.algebra" in blueprint.route_modules
 
 
 def test_rate_tree_swaption_lowers_to_generic_lattice_composition():

--- a/tests/test_agent/test_executor.py
+++ b/tests/test_agent/test_executor.py
@@ -1089,7 +1089,8 @@ def test_admitted_bermudan_swaption_adapter_composes_final_exercise_lower_bound(
     assert "price_bermudan_swaption_black76_lower_bound" not in source
 
 
-def test_deterministic_exact_binding_module_materializes_bermudan_tree_compat_wrapper():
+def test_deterministic_exact_binding_module_composes_bermudan_swaption_lattice():
+    from trellis.agent.codegen_guardrails import PrimitiveRef
     from trellis.agent.executor import (
         EVALUATE_SENTINEL,
         _generate_skeleton,
@@ -1097,13 +1098,43 @@ def test_deterministic_exact_binding_module_materializes_bermudan_tree_compat_wr
     )
     from trellis.agent.planner import STATIC_SPECS
 
+    primitives = (
+        PrimitiveRef("trellis.core.date_utils", "normalize_explicit_dates", "schedule_normalizer"),
+        PrimitiveRef("trellis.core.date_utils", "year_fraction", "timeline_mapping"),
+        PrimitiveRef("trellis.core.date_utils", "build_payment_timeline", "payment_timeline_builder"),
+        PrimitiveRef(
+            "trellis.models.bermudan_swaption_tree",
+            "resolve_bermudan_swaption_tree_inputs",
+            "market_binding",
+        ),
+        PrimitiveRef("trellis.models.trees.algebra", "BINOMIAL_1F_TOPOLOGY", "topology"),
+        PrimitiveRef("trellis.models.trees.algebra", "UNIFORM_ADDITIVE_MESH", "mesh"),
+        PrimitiveRef("trellis.models.trees.algebra", "TERM_STRUCTURE_TARGET", "calibration_target"),
+        PrimitiveRef("trellis.models.trees.algebra", "build_lattice", "lattice_builder"),
+        PrimitiveRef("trellis.models.trees.control", "lattice_step_from_time", "schedule_mapping"),
+        PrimitiveRef("trellis.models.trees.algebra", "LatticeLinearClaimSpec", "linear_claim"),
+        PrimitiveRef("trellis.models.trees.algebra", "LatticeContractSpec", "contract_spec"),
+        PrimitiveRef("trellis.models.trees.algebra", "value_on_lattice", "observation_rollback"),
+        PrimitiveRef("trellis.models.trees.algebra", "LatticeControlSpec", "exercise_control"),
+        PrimitiveRef("trellis.models.trees.algebra", "price_on_lattice", "pricing_kernel"),
+        PrimitiveRef(
+            "trellis.models.bermudan_swaption_tree",
+            "price_bermudan_swaption_tree",
+            "compatibility_reference",
+            required=False,
+            excluded=True,
+        ),
+    )
     generation_plan = SimpleNamespace(
         lane_exact_binding_refs=(
-            "trellis.models.bermudan_swaption_tree.price_bermudan_swaption_tree",
+            "trellis.models.trees.algebra.price_on_lattice",
         ),
-        primitive_plan=SimpleNamespace(route="exercise_lattice"),
+        primitive_plan=SimpleNamespace(
+            route="exercise_lattice",
+            primitives=primitives,
+        ),
         method="rate_tree",
-        instrument_type="swaption",
+        instrument_type="bermudan_swaption",
     )
 
     skeleton = _generate_skeleton(
@@ -1117,8 +1148,71 @@ def test_deterministic_exact_binding_module_materializes_bermudan_tree_compat_wr
     )
 
     assert generated is not None
-    assert "return price_bermudan_swaption_tree(market_state, spec)" in generated.code
     assert EVALUATE_SENTINEL not in generated.code
+    for symbol in (
+        "normalize_explicit_dates",
+        "year_fraction",
+        "build_payment_timeline",
+        "resolve_bermudan_swaption_tree_inputs",
+        "BINOMIAL_1F_TOPOLOGY",
+        "UNIFORM_ADDITIVE_MESH",
+        "TERM_STRUCTURE_TARGET",
+        "build_lattice",
+        "lattice_step_from_time",
+        "LatticeLinearClaimSpec",
+        "LatticeContractSpec",
+        "value_on_lattice",
+        "LatticeControlSpec",
+        "price_on_lattice",
+    ):
+        assert symbol in generated.code
+    assert "continuation_values" in generated.code
+    assert 'objective="holder_max"' in generated.code
+    assert "notional - fixed_leg_value" in generated.code
+    assert "period.t_payment" in generated.code
+    assert "payment_step = lattice_step_from_time" in generated.code
+    assert "payment_index * steps_per_coupon" not in generated.code
+    assert "price_bermudan_swaption_tree(" not in generated.code
+    assert "compile_bermudan_swaption_contract_spec(" not in generated.code
+    assert "BermudanSwaptionTreeSpec(" not in generated.code
+
+    from trellis.core.market_state import MarketState
+    from trellis.core.types import DayCountConvention, Frequency
+    from trellis.curves.yield_curve import YieldCurve
+    from trellis.models.bermudan_swaption_tree import price_bermudan_swaption_tree
+    from trellis.models.vol_surface import FlatVol
+
+    namespace: dict[str, object] = {}
+    exec(compile(generated.code, "<qua_1201_bermudan>", "exec"), namespace)  # noqa: S102
+    spec = namespace["BermudanSwaptionSpec"](
+        notional=100.0,
+        strike=0.05,
+        exercise_dates=(
+            date(2025, 11, 15),
+            date(2026, 11, 15),
+            date(2027, 11, 15),
+            date(2028, 11, 15),
+            date(2029, 11, 15),
+        ),
+        swap_end=date(2030, 11, 15),
+        swap_frequency=Frequency.SEMI_ANNUAL,
+        day_count=DayCountConvention.ACT_360,
+        rate_index=None,
+        is_payer=True,
+    )
+    market_state = MarketState(
+        as_of=date(2024, 11, 15),
+        settlement=date(2024, 11, 15),
+        discount=YieldCurve.flat(0.05, max_tenor=31.0),
+        vol_surface=FlatVol(0.20),
+    )
+    payoff = namespace["BermudanSwaptionPayoff"](spec)
+
+    assert payoff.evaluate(market_state) == pytest.approx(
+        price_bermudan_swaption_tree(market_state, spec, model="hull_white"),
+        rel=1e-12,
+        abs=1e-12,
+    )
 
 
 def test_deterministic_exact_binding_module_materializes_cap_strip_helper_wrapper():

--- a/tests/test_agent/test_executor.py
+++ b/tests/test_agent/test_executor.py
@@ -1170,6 +1170,8 @@ def test_deterministic_exact_binding_module_composes_bermudan_swaption_lattice()
     assert 'objective="holder_max"' in generated.code
     assert "notional - fixed_leg_value" in generated.code
     assert "period.t_payment" in generated.code
+    assert "swap_tenor = float(" in generated.code
+    assert "first_exercise_step * lattice.dt + quantized_tenor" in generated.code
     assert "payment_step = lattice_step_from_time" in generated.code
     assert "payment_index * steps_per_coupon" not in generated.code
     assert "price_bermudan_swaption_tree(" not in generated.code
@@ -1210,6 +1212,32 @@ def test_deterministic_exact_binding_module_composes_bermudan_swaption_lattice()
 
     assert payoff.evaluate(market_state) == pytest.approx(
         price_bermudan_swaption_tree(market_state, spec, model="hull_white"),
+        rel=1e-12,
+        abs=1e-12,
+    )
+
+    misaligned_spec = namespace["BermudanSwaptionSpec"](
+        notional=100.0,
+        strike=0.05,
+        exercise_dates=(
+            date(2025, 2, 15),
+            date(2025, 5, 15),
+            date(2025, 8, 15),
+        ),
+        swap_end=date(2030, 8, 15),
+        swap_frequency=Frequency.SEMI_ANNUAL,
+        day_count=DayCountConvention.ACT_360,
+        rate_index=None,
+        is_payer=True,
+    )
+    misaligned_payoff = namespace["BermudanSwaptionPayoff"](misaligned_spec)
+
+    assert misaligned_payoff.evaluate(market_state) == pytest.approx(
+        price_bermudan_swaption_tree(
+            market_state,
+            misaligned_spec,
+            model="hull_white",
+        ),
         rel=1e-12,
         abs=1e-12,
     )
@@ -1352,6 +1380,30 @@ def test_exact_binding_refs_collect_backend_helper_refs_from_mapping_plan():
     assert "trellis.models.rate_cap_floor.price_rate_cap_floor_strip_analytical" in refs
     assert "trellis.models.rate_cap_floor.price_rate_cap_floor_strip_monte_carlo" in refs
     assert "trellis.models.black.black76_call" in refs
+
+
+def test_exact_binding_refs_collect_fallback_lane_primitives():
+    from trellis.agent.executor import _exact_binding_refs
+
+    refs = _exact_binding_refs(
+        SimpleNamespace(
+            lane_exact_binding_refs=(),
+            lane_reusable_primitives=(
+                "trellis.models.bermudan_swaption_tree.resolve_bermudan_swaption_tree_inputs",
+                "trellis.models.trees.algebra.build_lattice",
+                "trellis.models.trees.algebra.value_on_lattice",
+                "trellis.models.trees.algebra.price_on_lattice",
+            ),
+            primitive_plan=None,
+        )
+    )
+
+    assert refs == (
+        "trellis.models.bermudan_swaption_tree.resolve_bermudan_swaption_tree_inputs",
+        "trellis.models.trees.algebra.build_lattice",
+        "trellis.models.trees.algebra.value_on_lattice",
+        "trellis.models.trees.algebra.price_on_lattice",
+    )
 
 
 def test_deterministic_exact_binding_module_materializes_period_rate_strip_from_backend_refs():

--- a/tests/test_agent/test_family_lowering_ir.py
+++ b/tests/test_agent/test_family_lowering_ir.py
@@ -642,8 +642,9 @@ def test_bermudan_swaption_compiles_to_exercise_lattice_family_ir():
     assert family_ir.route_id == "exercise_lattice"
     assert family_ir.product_instrument == "swaption"
     assert family_ir.control_style == "holder_max"
-    assert family_ir.helper_symbol == "price_bermudan_swaption_tree"
+    assert family_ir.helper_symbol == ""
     assert "forward_rate" in family_ir.observable_types
+    assert "fixed_leg_continuation_observations" in family_ir.derived_quantities
     assert "par_rate_bindings" in family_ir.derived_quantities
 
 
@@ -709,7 +710,7 @@ def test_exercise_lattice_family_ir_ignores_legacy_settlement_rule_mirror():
     swaption_bp = compile_semantic_contract(swaption_contract, preferred_method="rate_tree")
 
     assert isinstance(swaption_bp.dsl_lowering.family_ir, ExerciseLatticeIR)
-    assert swaption_bp.dsl_lowering.family_ir.helper_symbol == "price_bermudan_swaption_tree"
+    assert swaption_bp.dsl_lowering.family_ir.helper_symbol == ""
 
 
 def test_exercise_lattice_family_ir_rejects_settlement_before_decision_dates():

--- a/tests/test_agent/test_helper_authority_audit.py
+++ b/tests/test_agent/test_helper_authority_audit.py
@@ -335,6 +335,26 @@ def test_current_repository_retires_bermudan_swaption_lower_bound_helper_authori
     ]
 
 
+def test_current_repository_retires_bermudan_swaption_tree_helper_authority():
+    from trellis.agent.helper_authority_audit import build_helper_authority_report
+
+    root = Path(__file__).resolve().parents[2]
+    report = build_helper_authority_report(root)
+    helper_symbol = "price_bermudan_swaption_tree"
+
+    assert not [
+        item
+        for item in (*report.route_authority, *report.binding_authority)
+        if item.symbol == helper_symbol
+    ]
+    assert not [
+        item
+        for item in report.adapter_calls
+        if item.path == "trellis/instruments/_agent/bermudanswaption.py"
+        and item.symbol == helper_symbol
+    ]
+
+
 def test_current_repository_retires_european_swaption_monte_carlo_helper_authority():
     from trellis.agent.helper_authority_audit import build_helper_authority_report
 

--- a/tests/test_agent/test_lane_obligations.py
+++ b/tests/test_agent/test_lane_obligations.py
@@ -179,6 +179,41 @@ def test_terminal_claim_monte_carlo_fallback_emits_payoff_and_control_steps():
     assert "variance-reduction" in steps
 
 
+def test_fallback_lane_excludes_compatibility_references():
+    primitive_plan = PrimitivePlan(
+        route="exercise_lattice",
+        route_family="rate_tree",
+        engine_family="lattice",
+        primitives=(
+            PrimitiveRef(
+                module="trellis.models.trees.algebra",
+                symbol="price_on_lattice",
+                role="pricing_kernel",
+            ),
+            PrimitiveRef(
+                module="trellis.models.bermudan_swaption_tree",
+                symbol="price_bermudan_swaption_tree",
+                role="compatibility_reference",
+                required=False,
+                excluded=True,
+            ),
+        ),
+        adapters=(),
+        blockers=(),
+    )
+
+    plan = compile_fallback_lane_construction_plan(
+        preferred_method="rate_tree",
+        primitive_plan=primitive_plan,
+        instrument_type="bermudan_swaption",
+    )
+
+    assert plan is not None
+    assert tuple(binding.primitive_ref for binding in plan.reusable_bindings) == (
+        "trellis.models.trees.algebra.price_on_lattice",
+    )
+
+
 def test_transform_lane_plan_emits_terminal_characteristic_contract():
     family_ir = TransformPricingIR(
         route_id="transform_fft",

--- a/tests/test_agent/test_lite_review.py
+++ b/tests/test_agent/test_lite_review.py
@@ -293,6 +293,8 @@ def price(spec, market_state):
 
 
 def test_lite_review_allows_swaption_tree_binding_with_explicit_hull_white_comparison_params():
+    from dataclasses import replace
+
     from trellis.agent.codegen_guardrails import GenerationPlan, PrimitivePlan, PrimitiveRef
     from trellis.agent.lite_review import review_generated_code
     from trellis.agent.quant import PricingPlan
@@ -340,14 +342,19 @@ def price(spec, market_state):
         reasoning="test",
     )
 
-    report = review_generated_code(
-        source,
-        pricing_plan=pricing_plan,
-        generation_plan=plan,
-    )
+    for route in ("rate_tree_backward_induction", "exercise_lattice"):
+        route_plan = replace(
+            plan,
+            primitive_plan=replace(plan.primitive_plan, route=route),
+        )
+        report = review_generated_code(
+            source,
+            pricing_plan=pricing_plan,
+            generation_plan=route_plan,
+        )
 
-    issue_codes = {issue.code for issue in report.issues}
-    assert "lite.hardcoded_black_vol_surface" not in issue_codes
+        issue_codes = {issue.code for issue in report.issues}
+        assert "lite.hardcoded_black_vol_surface" not in issue_codes
 
 
 def test_lite_review_allows_swaption_monte_carlo_process_binding_with_explicit_comparison_params():

--- a/tests/test_agent/test_primitive_planning.py
+++ b/tests/test_agent/test_primitive_planning.py
@@ -907,8 +907,38 @@ def test_builds_exercise_lattice_plan_for_bermudan_swaption():
     assert plan.primitive_plan is not None
     assert plan.primitive_plan.route == "exercise_lattice"
     assert plan.primitive_plan.engine_family == "lattice"
-    primitive_symbols = {primitive.symbol for primitive in plan.primitive_plan.primitives}
-    assert primitive_symbols == {"price_bermudan_swaption_tree"}
+    required_symbols = {
+        primitive.symbol
+        for primitive in plan.primitive_plan.primitives
+        if primitive.required
+    }
+    assert required_symbols == {
+        "normalize_explicit_dates",
+        "year_fraction",
+        "build_payment_timeline",
+        "resolve_bermudan_swaption_tree_inputs",
+        "BINOMIAL_1F_TOPOLOGY",
+        "UNIFORM_ADDITIVE_MESH",
+        "TERM_STRUCTURE_TARGET",
+        "build_lattice",
+        "lattice_step_from_time",
+        "LatticeLinearClaimSpec",
+        "LatticeContractSpec",
+        "value_on_lattice",
+        "LatticeControlSpec",
+        "price_on_lattice",
+    }
+    retired_helper = next(
+        primitive
+        for primitive in plan.primitive_plan.primitives
+        if primitive.symbol == "price_bermudan_swaption_tree"
+    )
+    assert not retired_helper.required
+    assert retired_helper.excluded
+    assert plan.primitive_plan.backend_exact_target_refs == (
+        "trellis.models.trees.algebra.price_on_lattice",
+    )
+    assert plan.primitive_plan.backend_helper_refs == ()
     assert plan.primitive_plan.adapters == ()
     assert plan.primitive_plan.blockers == ()
 

--- a/tests/test_agent/test_prompts.py
+++ b/tests/test_agent/test_prompts.py
@@ -1558,7 +1558,7 @@ def test_executor_callable_bond_rate_tree_retry_pins_vol_surface_and_control_pol
     assert 'resolve_lattice_exercise_policy("issuer_call"' in text
 
 
-def test_executor_bermudan_swaption_rate_tree_retry_pins_helper_and_bermudan_control():
+def test_executor_bermudan_swaption_rate_tree_retry_pins_explicit_lattice_composition():
     from types import SimpleNamespace
 
     from trellis.agent.executor import KnowledgeRetrievalRequest, _route_specific_retry_lines
@@ -1577,11 +1577,24 @@ def test_executor_bermudan_swaption_rate_tree_retry_pins_helper_and_bermudan_con
 
     text = "\n".join(_route_specific_retry_lines(request))
 
-    assert "price_bermudan_swaption_tree" in text
-    assert "market_state.vol_surface.black_vol" in text
-    assert "market_state.discount.zero_rate" in text
-    assert 'resolve_lattice_exercise_policy("bermudan"' in text
-    assert "price_callable_bond_tree" in text
+    for symbol in (
+        "normalize_explicit_dates",
+        "build_payment_timeline",
+        "resolve_bermudan_swaption_tree_inputs",
+        "lattice_step_from_time",
+        "LatticeLinearClaimSpec",
+        "LatticeContractSpec",
+        "value_on_lattice",
+        "LatticeControlSpec",
+        "price_on_lattice",
+    ):
+        assert symbol in text
+    assert "continuation_values" in text
+    assert "holder_max" in text
+    assert "payer/receiver" in text
+    assert "price_bermudan_swaption_tree" not in text
+    assert "compile_bermudan_swaption_contract_spec" not in text
+    assert "price_callable_bond_tree" not in text
 
 
 def test_executor_bermudan_swaption_analytical_retry_pins_final_exercise_composition():

--- a/tests/test_agent/test_rate_tree_generation.py
+++ b/tests/test_agent/test_rate_tree_generation.py
@@ -19,44 +19,6 @@ from trellis.models.vol_surface import FlatVol
 
 ROOT = Path(__file__).resolve().parents[2]
 AGENT_ARTIFACTS = ROOT / "trellis" / "instruments" / "_agent"
-BERMUDAN_RATE_TREE_SOURCE = """
-from __future__ import annotations
-
-from dataclasses import dataclass
-from datetime import date
-
-from trellis.core.market_state import MarketState
-from trellis.core.types import DayCountConvention, Frequency
-from trellis.models.bermudan_swaption_tree import price_bermudan_swaption_tree
-
-
-@dataclass(frozen=True)
-class BermudanSwaptionSpec:
-    notional: float
-    strike: float
-    exercise_dates: tuple[date, ...]
-    swap_end: date
-    swap_frequency: Frequency = Frequency.SEMI_ANNUAL
-    day_count: DayCountConvention = DayCountConvention.ACT_360
-    rate_index: str | None = None
-    is_payer: bool = True
-
-
-class BermudanSwaptionPayoff:
-    def __init__(self, spec: BermudanSwaptionSpec):
-        self._spec = spec
-
-    @property
-    def requirements(self) -> set[str]:
-        return {"discount_curve", "black_vol_surface", "forward_curve"}
-
-    def evaluate(self, market_state: MarketState) -> float:
-        if market_state.discount is None:
-            raise ValueError("discount curve required")
-        if market_state.vol_surface is None:
-            raise ValueError("black vol surface required")
-        return float(price_bermudan_swaption_tree(market_state, self._spec, model="hull_white"))
-"""
 
 
 def _artifact_source(name: str) -> str:
@@ -99,6 +61,24 @@ def _bermudan_plan():
     )
 
 
+def _bermudan_rate_tree_source() -> str:
+    from trellis.agent.executor import (
+        _generate_skeleton,
+        _materialize_deterministic_exact_binding_module,
+    )
+    from trellis.agent.planner import STATIC_SPECS
+
+    plan = _bermudan_plan()
+    skeleton = _generate_skeleton(
+        STATIC_SPECS["bermudan_swaption"],
+        "Bermudan payer swaption",
+        generation_plan=plan,
+    )
+    generated = _materialize_deterministic_exact_binding_module(skeleton, plan)
+    assert generated is not None
+    return generated.code
+
+
 def test_callable_artifact_is_rate_tree_route_compliant():
     report = validate_semantics(
         _artifact_source("callablebond.py"),
@@ -113,7 +93,7 @@ def test_callable_artifact_is_rate_tree_route_compliant():
 
 def test_bermudan_artifact_is_rate_tree_route_compliant():
     report = validate_semantics(
-        BERMUDAN_RATE_TREE_SOURCE,
+        _bermudan_rate_tree_source(),
         product_ir=decompose_to_ir(
             "Bermudan swaption: tree vs LSM MC",
             instrument_type="bermudan_swaption",
@@ -211,7 +191,6 @@ def test_bermudan_artifact_prices_plausibly_against_reference_tree():
         T_SWAP_TENOR,
         _price_bermudan_swaption_on_tree,
     )
-    from trellis.models.bermudan_swaption_tree import price_bermudan_swaption_tree
     from trellis.models.trees.lattice import build_generic_lattice
     from trellis.models.trees.models import MODEL_REGISTRY
 
@@ -239,8 +218,21 @@ def test_bermudan_artifact_prices_plausibly_against_reference_tree():
         rate_index = None
         is_payer = True
 
-    spec = _Spec()
-    artifact_price = price_bermudan_swaption_tree(market_state, spec, model="hull_white")
+    namespace: dict[str, object] = {}
+    source = _bermudan_rate_tree_source()
+    exec(compile(source, "<bermudan_rate_tree>", "exec"), namespace)  # noqa: S102
+    spec = namespace["BermudanSwaptionSpec"](
+        notional=_Spec.notional,
+        strike=_Spec.strike,
+        exercise_dates=_Spec.exercise_dates,
+        swap_end=_Spec.swap_end,
+        swap_frequency=_Spec.swap_frequency,
+        day_count=_Spec.day_count,
+        rate_index=_Spec.rate_index,
+        is_payer=_Spec.is_payer,
+    )
+    payoff = namespace["BermudanSwaptionPayoff"](spec)
+    artifact_price = price_payoff(payoff, market_state)
 
     lattice = build_generic_lattice(
         MODEL_REGISTRY["hull_white"],

--- a/tests/test_agent/test_route_registry.py
+++ b/tests/test_agent/test_route_registry.py
@@ -1444,14 +1444,46 @@ class TestRateTreeRoutes:
         spec = [r for r in registry.routes if r.id == "exercise_lattice"][0]
         new_prims = resolve_route_primitives(spec, self.BERMUDAN_IR)
         expected_prims = {
-            ("trellis.models.bermudan_swaption_tree", "price_bermudan_swaption_tree", "route_helper"),
+            ("trellis.core.date_utils", "normalize_explicit_dates", "schedule_normalizer"),
+            ("trellis.core.date_utils", "year_fraction", "timeline_mapping"),
+            ("trellis.core.date_utils", "build_payment_timeline", "payment_timeline_builder"),
+            (
+                "trellis.models.bermudan_swaption_tree",
+                "resolve_bermudan_swaption_tree_inputs",
+                "market_binding",
+            ),
+            ("trellis.models.trees.algebra", "BINOMIAL_1F_TOPOLOGY", "topology"),
+            ("trellis.models.trees.algebra", "UNIFORM_ADDITIVE_MESH", "mesh"),
+            ("trellis.models.trees.algebra", "TERM_STRUCTURE_TARGET", "calibration_target"),
+            ("trellis.models.trees.algebra", "build_lattice", "lattice_builder"),
+            ("trellis.models.trees.control", "lattice_step_from_time", "schedule_mapping"),
+            ("trellis.models.trees.algebra", "LatticeLinearClaimSpec", "linear_claim"),
+            ("trellis.models.trees.algebra", "LatticeContractSpec", "contract_spec"),
+            ("trellis.models.trees.algebra", "value_on_lattice", "observation_rollback"),
+            ("trellis.models.trees.algebra", "LatticeControlSpec", "exercise_control"),
+            ("trellis.models.trees.algebra", "price_on_lattice", "pricing_kernel"),
+            (
+                "trellis.models.bermudan_swaption_tree",
+                "price_bermudan_swaption_tree",
+                "compatibility_reference",
+            ),
         }
         assert _prim_set(new_prims) == expected_prims
+        compatibility = next(
+            primitive
+            for primitive in new_prims
+            if primitive.symbol == "price_bermudan_swaption_tree"
+        )
+        assert not compatibility.required
+        assert compatibility.excluded
 
-    def test_bermudan_swaption_helper_route_is_thin(self, registry):
+    def test_bermudan_swaption_route_documents_explicit_lattice_composition(self, registry):
         spec = [r for r in registry.routes if r.id == "exercise_lattice"][0]
         notes = resolve_route_notes(spec, self.BERMUDAN_IR)
-        assert notes == ()
+        text = "\n".join(notes)
+        assert "continuation_values" in text
+        assert "holder_max" in text
+        assert "reference-only" in text
 
     def test_rate_tree_swaption_primitives_are_generic_lattice_composition(self, registry):
         spec = [r for r in registry.routes if r.id == "rate_tree_backward_induction"][0]

--- a/tests/test_agent/test_semantic_validation.py
+++ b/tests/test_agent/test_semantic_validation.py
@@ -467,6 +467,36 @@ def build_price(self, market_state):
     return float(price_bermudan_swaption_tree(market_state, spec, model="hull_white"))
 """
 
+
+GENERIC_BERMUDAN_LATTICE_CONTRACT_SOURCE = """\
+from __future__ import annotations
+
+from trellis.models.trees.algebra import (
+    LatticeContractSpec,
+    LatticeControlSpec,
+    LatticeLinearClaimSpec,
+    price_on_lattice,
+)
+
+
+def price_swaption(lattice, swap_values, valid_exercise_steps):
+    def exercise_value(step, node, lattice_, obs):
+        del lattice_, obs
+        return max(swap_values[step][node], 0.0)
+
+    contract = LatticeContractSpec(
+        claim=LatticeLinearClaimSpec(
+            terminal_payoff=lambda step, node, lattice_, obs: 0.0,
+        ),
+        control=LatticeControlSpec(
+            objective="holder_max",
+            exercise_steps=valid_exercise_steps,
+            exercise_value_fn=exercise_value,
+        ),
+    )
+    return price_on_lattice(lattice, contract)
+"""
+
 RAW_STRING_BERMUDAN_SPEC_SOURCE = """\
 from __future__ import annotations
 
@@ -945,7 +975,7 @@ def test_rejects_schedule_dependent_lattice_without_exercise_steps():
     assert "lattice.exercise_schedule_missing" in issue_codes
 
 
-def test_accepts_helper_only_bermudan_swaption_route_without_low_level_tree_contract():
+def test_rejects_retired_bermudan_swaption_helper_as_construction_authority():
     from trellis.agent.semantic_validation import validate_semantics
 
     pricing_plan = PricingPlan(
@@ -973,8 +1003,36 @@ def test_accepts_helper_only_bermudan_swaption_route_without_low_level_tree_cont
     )
 
     issue_codes = {issue.code for issue in report.issues}
-    assert "engine.family_incompatible_with_ir" not in issue_codes
+    assert "assembly.excluded_primitive_used" in issue_codes
+    assert "assembly.required_primitive_missing" in issue_codes
+    assert not report.ok
+
+
+def test_accepts_generic_lattice_control_spec_for_bermudan_exercise():
+    from types import SimpleNamespace
+
+    from trellis.agent.semantic_validation import validate_semantics
+
+    report = validate_semantics(
+        GENERIC_BERMUDAN_LATTICE_CONTRACT_SOURCE,
+        product_ir=decompose_to_ir(
+            "Bermudan swaption: tree vs LSM MC",
+            instrument_type="bermudan_swaption",
+        ),
+        generation_plan=SimpleNamespace(
+            method="rate_tree",
+            primitive_plan=SimpleNamespace(
+                route="exercise_lattice",
+                blockers=(),
+                primitives=(),
+            ),
+        ),
+    )
+
+    issue_codes = {issue.code for issue in report.issues}
+    assert "lattice.exercise_type_mismatch" not in issue_codes
     assert "lattice.exercise_schedule_missing" not in issue_codes
+    assert "lattice.exercise_objective_mismatch" not in issue_codes
     assert report.ok
 
 

--- a/trellis/agent/codegen_guardrails.py
+++ b/trellis/agent/codegen_guardrails.py
@@ -644,6 +644,65 @@ def _exact_binding_signature_lines(plan: GenerationPlan, *, compact: bool) -> li
     return lines
 
 
+def _construction_primitives(plan: GenerationPlan) -> tuple[PrimitiveRef, ...]:
+    """Return backend primitives that generated construction may use."""
+    primitive_plan = plan.primitive_plan
+    if primitive_plan is None:
+        return ()
+    return tuple(
+        primitive
+        for primitive in primitive_plan.primitives
+        if not primitive.excluded
+    )
+
+
+def _mentions_excluded_primitive(plan: GenerationPlan, text: str) -> bool:
+    """Return whether prompt text names an audit-only excluded primitive."""
+    primitive_plan = plan.primitive_plan
+    if primitive_plan is None:
+        return False
+    return any(
+        primitive.excluded
+        and (
+            primitive.symbol in text
+            or f"{primitive.module}.{primitive.symbol}" in text
+        )
+        for primitive in primitive_plan.primitives
+    )
+
+
+def _construction_notes(plan: GenerationPlan) -> tuple[str, ...]:
+    """Return route notes that do not advertise excluded compatibility paths."""
+    primitive_plan = plan.primitive_plan
+    if primitive_plan is None:
+        return ()
+    return tuple(
+        note
+        for note in primitive_plan.notes
+        if not _mentions_excluded_primitive(plan, note)
+    )
+
+
+def _construction_symbols(plan: GenerationPlan) -> tuple[str, ...]:
+    """Return route primitives first, excluding audit-only references."""
+    excluded_symbols = {
+        primitive.symbol
+        for primitive in (plan.primitive_plan.primitives if plan.primitive_plan else ())
+        if primitive.excluded
+    }
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for symbol in (
+        *(primitive.symbol for primitive in _construction_primitives(plan)),
+        *plan.symbols_to_reuse,
+    ):
+        if symbol in excluded_symbols or symbol in seen:
+            continue
+        seen.add(symbol)
+        ordered.append(symbol)
+    return tuple(ordered)
+
+
 def _render_backend_binding_lines(plan: GenerationPlan, *, compact: bool) -> list[str]:
     """Render route/helper bindings as a secondary backend-binding section."""
     if plan.primitive_plan is None:
@@ -660,20 +719,30 @@ def _render_backend_binding_lines(plan: GenerationPlan, *, compact: bool) -> lis
         lines.append(f"  - Route family: `{display_route_family}`")
     if not compact:
         lines.append(f"  - Route score: `{plan.primitive_plan.score:.2f}`")
-    if plan.primitive_plan.primitives:
+    construction_primitives = _construction_primitives(plan)
+    if construction_primitives:
         lines.append("  - Selected primitives:")
         lines.extend(
             f"    - `{primitive.module}.{primitive.symbol}` ({primitive.role})"
-            for primitive in plan.primitive_plan.primitives
+            for primitive in construction_primitives
         )
     resolved_instructions = _resolve_generation_instructions(plan)
-    if resolved_instructions.effective_instructions:
+    visible_instructions = tuple(
+        instruction
+        for instruction in resolved_instructions.effective_instructions
+        if not _mentions_excluded_primitive(plan, instruction.statement)
+    )
+    if visible_instructions:
         lines.append("  - Resolved instructions:")
         lines.extend(
             f"    - [{instruction.instruction_type}] {instruction.statement}"
-            for instruction in resolved_instructions.effective_instructions[: (8 if compact else 12)]
+            for instruction in visible_instructions[: (8 if compact else 12)]
         )
-        schedule_instructions = _schedule_related_instructions(resolved_instructions)
+        schedule_instructions = tuple(
+            instruction
+            for instruction in _schedule_related_instructions(resolved_instructions)
+            if not _mentions_excluded_primitive(plan, instruction.statement)
+        )
         if schedule_instructions:
             lines.append("  - Schedule construction:")
             lines.extend(
@@ -692,9 +761,10 @@ def _render_backend_binding_lines(plan: GenerationPlan, *, compact: bool) -> lis
             f"    - `{adapter}`"
             for adapter in plan.primitive_plan.adapters[: (6 if compact else 10)]
         )
-    if plan.primitive_plan.notes and compact:
+    construction_notes = _construction_notes(plan)
+    if construction_notes and compact:
         lines.append("  - Backend notes:")
-        lines.extend(f"    - {note}" for note in plan.primitive_plan.notes[:4])
+        lines.extend(f"    - {note}" for note in construction_notes[:4])
     return lines
 
 
@@ -774,16 +844,17 @@ def render_generation_plan(plan: GenerationPlan) -> str:
     lines.extend(f"  - `{module}`" for module in plan.inspected_modules)
     lines.append("- Approved Trellis modules for imports:")
     lines.extend(f"  - `{module}`" for module in plan.approved_modules)
-    if plan.symbols_to_reuse:
+    construction_symbols = _construction_symbols(plan)
+    if construction_symbols:
         symbol_limit = 24 if plan.lane_family else 80
         lines.append("- Public symbols available from the approved modules:")
-        lines.extend(f"  - `{symbol}`" for symbol in plan.symbols_to_reuse[:symbol_limit])
+        lines.extend(f"  - `{symbol}`" for symbol in construction_symbols[:symbol_limit])
     if plan.proposed_tests:
         lines.append("- Tests to run after generation:")
         lines.extend(f"  - `{target}`" for target in plan.proposed_tests)
-    if plan.test_map is not None and plan.symbols_to_reuse:
+    if plan.test_map is not None and construction_symbols:
         likely_test_lines = []
-        for symbol in plan.symbols_to_reuse[:8]:
+        for symbol in construction_symbols[:8]:
             likely = suggest_tests_for_symbol(symbol)
             if likely:
                 likely_test_lines.append(f"  - `{symbol}` -> {', '.join(likely[:4])}")
@@ -900,7 +971,7 @@ def _build_instruction_records(plan: GenerationPlan) -> tuple[InstructionRecord,
     route_helpers = [
         primitive
         for primitive in primitive_plan.primitives
-        if primitive.role == "route_helper"
+        if primitive.role == "route_helper" and not primitive.excluded
     ]
     if route_helpers:
         helper = route_helpers[0]
@@ -928,7 +999,11 @@ def _build_instruction_records(plan: GenerationPlan) -> tuple[InstructionRecord,
         (
             primitive
             for primitive in primitive_plan.primitives
-            if primitive.role == "schedule_builder" or primitive.symbol == "generate_schedule"
+            if not primitive.excluded
+            and (
+                primitive.role == "schedule_builder"
+                or primitive.symbol == "generate_schedule"
+            )
         ),
         None,
     )
@@ -968,8 +1043,9 @@ def _build_instruction_records(plan: GenerationPlan) -> tuple[InstructionRecord,
             )
         )
 
-    if primitive_plan.notes:
-        for index, note in enumerate(primitive_plan.notes, 1):
+    construction_notes = _construction_notes(plan)
+    if construction_notes:
+        for index, note in enumerate(construction_notes, 1):
             records.append(
                 InstructionRecord(
                     id=f"{route}:note:{index}",
@@ -1010,9 +1086,10 @@ def render_import_repair_card(plan: GenerationPlan) -> str:
         "- Approved Trellis modules:",
     ]
     lines.extend(f"  - `{module}`" for module in plan.approved_modules[:18])
-    if plan.symbols_to_reuse:
+    construction_symbols = _construction_symbols(plan)
+    if construction_symbols:
         lines.append("- Approved public symbols to reuse:")
-        lines.extend(f"  - `{symbol}`" for symbol in plan.symbols_to_reuse[:40])
+        lines.extend(f"  - `{symbol}`" for symbol in construction_symbols[:40])
     lines.append("- Use only modules and symbols listed above.")
     lines.append("- Do not invent imports, aliases, or wildcard imports.")
     return "\n".join(lines)
@@ -1035,18 +1112,20 @@ def render_semantic_repair_card(plan: GenerationPlan) -> str:
         )
         if display_route_family:
             lines.append(f"- Route family: `{display_route_family}`")
-        if plan.primitive_plan.primitives:
+        construction_primitives = _construction_primitives(plan)
+        if construction_primitives:
             lines.append("- Required primitives:")
             lines.extend(
                 f"  - `{primitive.module}.{primitive.symbol}` ({primitive.role})"
-                for primitive in plan.primitive_plan.primitives[:10]
+                for primitive in construction_primitives
             )
         if plan.primitive_plan.adapters:
             lines.append("- Required adapters:")
             lines.extend(f"  - `{adapter}`" for adapter in plan.primitive_plan.adapters[:8])
-        if plan.primitive_plan.notes:
+        construction_notes = _construction_notes(plan)
+        if construction_notes:
             lines.append("- Route notes:")
-            lines.extend(f"  - {note}" for note in plan.primitive_plan.notes[:4])
+            lines.extend(f"  - {note}" for note in construction_notes[:4])
     if plan.uncertainty_flags:
         lines.append("- Active uncertainty flags:")
         lines.extend(f"  - `{flag}`" for flag in plan.uncertainty_flags[:6])

--- a/trellis/agent/dsl_lowering.py
+++ b/trellis/agent/dsl_lowering.py
@@ -369,6 +369,7 @@ def _target_bindings_for_route(
             required=primitive.required,
         )
         for primitive in primitives
+        if not primitive.excluded
     )
 
 
@@ -1430,6 +1431,18 @@ def _build_exercise_lattice_expr_from_family_ir(
     bindings: tuple[DslTargetBinding, ...],
 ) -> tuple[ContractExpr | None, tuple[str, ...]]:
     """Build an exercise-lattice lowering from typed family IR."""
+    if (
+        family_ir.product_instrument == "swaption"
+        and family_ir.exercise_style == "bermudan"
+        and not family_ir.helper_symbol
+    ):
+        return _build_bermudan_swaption_lattice_expr_from_family_ir(
+            route_id=route_id,
+            binding_id=binding_id,
+            family_ir=family_ir,
+            bindings=bindings,
+        )
+
     route_helper = next(
         (
             binding
@@ -1493,6 +1506,249 @@ def _build_exercise_lattice_expr_from_family_ir(
         branches=(continuation, exercise),
         label=family_ir.exercise_style or route_id,
     ), ()
+
+
+def _build_bermudan_swaption_lattice_expr_from_family_ir(
+    *,
+    route_id: str,
+    binding_id: str,
+    family_ir: ExerciseLatticeIR,
+    bindings: tuple[DslTargetBinding, ...],
+) -> tuple[ContractExpr | None, tuple[str, ...]]:
+    """Build the explicit generic-lattice composition for a Bermudan swaption."""
+    symbols = (
+        "normalize_explicit_dates",
+        "year_fraction",
+        "build_payment_timeline",
+        "resolve_bermudan_swaption_tree_inputs",
+        "BINOMIAL_1F_TOPOLOGY",
+        "UNIFORM_ADDITIVE_MESH",
+        "TERM_STRUCTURE_TARGET",
+        "build_lattice",
+        "lattice_step_from_time",
+        "LatticeLinearClaimSpec",
+        "LatticeContractSpec",
+        "value_on_lattice",
+        "LatticeControlSpec",
+        "price_on_lattice",
+    )
+    required_bindings = {
+        symbol: next(
+            (binding for binding in bindings if binding.symbol == symbol),
+            None,
+        )
+        for symbol in symbols
+    }
+    missing = tuple(
+        symbol for symbol, binding in required_bindings.items() if binding is None
+    )
+    if missing:
+        return None, tuple(
+            _missing_primitive_message(
+                route_id,
+                binding_id,
+                "Bermudan lattice",
+                symbol,
+            )
+            for symbol in missing
+        )
+
+    market_signature = _market_signature_from_family_ir(family_ir)
+    timeline_roles = market_signature.timeline_roles | {
+        TimelineRole.EXERCISE,
+        TimelineRole.PAYMENT,
+    }
+    requirements = market_signature.market_data_requirements
+
+    def atom(
+        role: str,
+        symbol: str,
+        inputs: tuple[str, ...],
+        outputs: tuple[str, ...],
+        description: str,
+    ) -> ContractAtom:
+        binding = required_bindings[symbol]
+        assert binding is not None
+        return ContractAtom(
+            atom_id=_binding_atom_id(route_id, binding_id, role),
+            primitive_ref=binding.primitive_ref,
+            description=description,
+            signature=ContractSignature(
+                inputs=inputs,
+                outputs=outputs,
+                timeline_roles=timeline_roles,
+                market_data_requirements=requirements,
+            ),
+        )
+
+    ports = (
+        market_signature.inputs,
+        ("normalized_exercise_schedule:schedule",),
+        ("measured_exercise_schedule:schedule",),
+        ("exercise_payment_schedules:schedule",),
+        ("resolved_lattice_inputs:state",),
+        ("lattice_topology:state",),
+        ("lattice_mesh:state",),
+        ("calibrated_lattice_target:state",),
+        ("built_rate_lattice:state",),
+        ("mapped_lattice_schedules:state",),
+        ("fixed_leg_claim:contract",),
+        ("fixed_leg_contract:contract",),
+        ("fixed_leg_observations:state",),
+        ("signed_swap_values:state",),
+        ("exercise_decision:state",),
+        ("option_claim:contract",),
+        ("option_contract:contract",),
+        ("price:scalar",),
+    )
+    stages = (
+        atom(
+            "schedule_normalizer",
+            "normalize_explicit_dates",
+            ports[0],
+            ports[1],
+            "Normalize contractual Bermudan exercise dates before lattice mapping.",
+        ),
+        atom(
+            "timeline_mapping",
+            "year_fraction",
+            ports[1],
+            ports[2],
+            "Measure and quantize live exercise dates from settlement.",
+        ),
+        atom(
+            "payment_timeline_builder",
+            "build_payment_timeline",
+            ports[2],
+            ports[3],
+            "Build the underlying fixed-leg payment timeline from the first exercise date.",
+        ),
+        atom(
+            "market_binding",
+            "resolve_bermudan_swaption_tree_inputs",
+            ports[3],
+            ports[4],
+            "Resolve curve, volatility, Hull-White parameters, horizon, and step controls.",
+        ),
+        atom(
+            "topology",
+            "BINOMIAL_1F_TOPOLOGY",
+            ports[4],
+            ports[5],
+            "Select the admitted one-factor recombining topology.",
+        ),
+        atom(
+            "mesh",
+            "UNIFORM_ADDITIVE_MESH",
+            ports[5],
+            ports[6],
+            "Select the additive short-rate mesh.",
+        ),
+        atom(
+            "calibration_target",
+            "TERM_STRUCTURE_TARGET",
+            ports[6],
+            ports[7],
+            "Bind the discount curve as the lattice calibration target.",
+        ),
+        atom(
+            "lattice_builder",
+            "build_lattice",
+            ports[7],
+            ports[8],
+            "Build and calibrate the generic one-factor rate lattice.",
+        ),
+        atom(
+            "schedule_mapping",
+            "lattice_step_from_time",
+            ports[8],
+            ports[9],
+            "Map exercise and payment times to bounded lattice steps.",
+        ),
+        atom(
+            "fixed_leg_claim",
+            "LatticeLinearClaimSpec",
+            ports[9],
+            ports[10],
+            "Represent fixed coupons and principal as a generic linear lattice claim.",
+        ),
+        atom(
+            "fixed_leg_contract",
+            "LatticeContractSpec",
+            ports[10],
+            ports[11],
+            "Wrap the fixed leg in the generic lattice contract surface.",
+        ),
+        atom(
+            "observation_rollback",
+            "value_on_lattice",
+            ports[11],
+            ports[12],
+            "Capture fixed-leg continuation values only at Bermudan exercise steps.",
+        ),
+        ContractAtom(
+            atom_id=_binding_atom_id(route_id, binding_id, "payer_receiver_algebra"),
+            description=(
+                "Form payer or receiver swap values from par notional and fixed-leg "
+                "continuation observations in adapter-owned algebra."
+            ),
+            signature=ContractSignature(
+                inputs=ports[12],
+                outputs=ports[13],
+                timeline_roles=timeline_roles,
+                market_data_requirements=requirements,
+            ),
+        ),
+    )
+    choice_signature = ContractSignature(
+        inputs=ports[13],
+        outputs=ports[14],
+        timeline_roles=timeline_roles,
+        market_data_requirements=requirements,
+    )
+    holder_choice = ChoiceExpr(
+        style=ControlStyle.HOLDER_MAX,
+        branches=(
+            ContractAtom(
+                atom_id=f"{family_ir.route_family}:continuation",
+                description="Continue the option rollback without exercising.",
+                signature=choice_signature,
+            ),
+            ContractAtom(
+                atom_id=f"{family_ir.route_family}:exercise_now",
+                primitive_ref=required_bindings["LatticeControlSpec"].primitive_ref,
+                description=(
+                    "Exercise into the positive payer/receiver swap value under holder-max control."
+                ),
+                signature=choice_signature,
+            ),
+        ),
+        label="bermudan_swaption_holder_max",
+    )
+    suffix = (
+        atom(
+            "option_claim",
+            "LatticeLinearClaimSpec",
+            ports[14],
+            ports[15],
+            "Represent the option continuation claim with zero terminal payoff.",
+        ),
+        atom(
+            "option_contract",
+            "LatticeContractSpec",
+            ports[15],
+            ports[16],
+            "Attach the holder-max control to the generic option contract.",
+        ),
+        atom(
+            "pricing_kernel",
+            "price_on_lattice",
+            ports[16],
+            ports[17],
+            "Run the generic controlled rollback and return the root price.",
+        ),
+    )
+    return ThenExpr(terms=(*stages, holder_choice, *suffix)), ()
 
 
 def _build_correlated_basket_mc_expr_from_family_ir(

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -4067,6 +4067,7 @@ def _skeleton_exact_binding_import_lines(generation_plan) -> tuple[str, ...]:
                 getattr(primitive, "required", False)
                 or getattr(primitive, "role", "") in {"route_helper", "pricing_kernel", "schedule_builder"}
             )
+            and not getattr(primitive, "excluded", False)
             and getattr(primitive, "module", "")
             and getattr(primitive, "symbol", "")
         )
@@ -4138,6 +4139,7 @@ def _exact_binding_refs(generation_plan) -> tuple[str, ...]:
 
     for attr in (
         "lane_exact_binding_refs",
+        "lane_reusable_primitives",
         "backend_binding_id",
         "backend_exact_target_refs",
         "backend_helper_refs",
@@ -4273,24 +4275,30 @@ def _bermudan_swaption_lattice_evaluate_body(
             1,
         )
         first_exercise_step = min(valid_exercise_steps)
-        swap_end_time = float(
-            year_fraction(resolved.settlement, spec.swap_end, spec.day_count)
+        swap_tenor = float(
+            year_fraction(swap_start, spec.swap_end, spec.day_count)
         )
-        quantized_swap_end_time = (
-            round(swap_end_time * frequency_per_year) / frequency_per_year
+        quantized_tenor = (
+            round(swap_tenor * frequency_per_year) / frequency_per_year
+        )
+        swap_end_time = (
+            first_exercise_step * lattice.dt + quantized_tenor
         )
         swap_end_step = lattice_step_from_time(
-            quantized_swap_end_time,
+            swap_end_time,
             dt=lattice.dt,
             n_steps=lattice.n_steps,
             allow_terminal_step=True,
         )
         if swap_end_step is None or swap_end_step <= first_exercise_step:
             return 0.0
+        swap_start_time = float(
+            year_fraction(resolved.settlement, swap_start, spec.day_count)
+        )
         coupon = float(spec.notional) * float(spec.strike) / frequency_per_year
         coupon_by_step = {{}}
         for period in payment_timeline:
-            payment_time = (
+            absolute_payment_time = (
                 float(period.t_payment)
                 if period.t_payment is not None
                 else float(
@@ -4301,11 +4309,15 @@ def _bermudan_swaption_lattice_evaluate_body(
                     )
                 )
             )
-            quantized_payment_time = (
-                round(payment_time * frequency_per_year) / frequency_per_year
+            payment_tenor = max(absolute_payment_time - swap_start_time, 0.0)
+            quantized_payment_tenor = (
+                round(payment_tenor * frequency_per_year) / frequency_per_year
+            )
+            payment_time = (
+                first_exercise_step * lattice.dt + quantized_payment_tenor
             )
             payment_step = lattice_step_from_time(
-                quantized_payment_time,
+                payment_time,
                 dt=lattice.dt,
                 n_steps=lattice.n_steps,
                 allow_terminal_step=True,
@@ -4686,7 +4698,9 @@ def _declared_primitive_refs(generation_plan) -> set[str]:
     return {
         f"{primitive.module}.{primitive.symbol}"
         for primitive in getattr(primitive_plan, "primitives", ()) or ()
-        if getattr(primitive, "module", "") and getattr(primitive, "symbol", "")
+        if not getattr(primitive, "excluded", False)
+        and getattr(primitive, "module", "")
+        and getattr(primitive, "symbol", "")
     }
 
 

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -4204,6 +4204,191 @@ def _swaption_tree_model_name(semantic_blueprint, comparison_target: str | None)
     return "hull_white"
 
 
+def _bermudan_swaption_lattice_evaluate_body(
+    *,
+    model_name: str,
+    comparison_kwargs: str,
+) -> str:
+    """Return explicit generic-lattice construction for a Bermudan swaption."""
+    return textwrap.dedent(
+        f"""\
+        tree_steps = getattr(spec, "tree_steps", getattr(spec, "n_steps", None))
+        resolved = resolve_bermudan_swaption_tree_inputs(
+            market_state,
+            spec,
+            model="{model_name}"{comparison_kwargs},
+            n_steps=tree_steps,
+        )
+        exercise_dates = tuple(
+            exercise_date
+            for exercise_date in normalize_explicit_dates(spec.exercise_dates)
+            if resolved.settlement < exercise_date < spec.swap_end
+        )
+        if not exercise_dates:
+            return 0.0
+
+        lattice = build_lattice(
+            BINOMIAL_1F_TOPOLOGY,
+            UNIFORM_ADDITIVE_MESH,
+            "{model_name}",
+            calibration_target=TERM_STRUCTURE_TARGET(market_state.discount),
+            r0=resolved.r0,
+            sigma=resolved.sigma,
+            a=resolved.mean_reversion,
+            T=resolved.tree_horizon,
+            n_steps=resolved.n_steps,
+        )
+        exercise_steps = []
+        for exercise_date in exercise_dates:
+            exercise_time = float(
+                year_fraction(resolved.settlement, exercise_date, spec.day_count)
+            )
+            quantized_time = (
+                round(exercise_time * resolved.exercise_frequency)
+                / resolved.exercise_frequency
+            )
+            exercise_step = lattice_step_from_time(
+                quantized_time,
+                dt=lattice.dt,
+                n_steps=lattice.n_steps,
+                allow_terminal_step=False,
+            )
+            if exercise_step is not None:
+                exercise_steps.append(exercise_step)
+        valid_exercise_steps = tuple(sorted(set(exercise_steps)))
+        if not valid_exercise_steps:
+            return 0.0
+
+        swap_start = min(exercise_dates)
+        payment_timeline = build_payment_timeline(
+            swap_start,
+            spec.swap_end,
+            spec.swap_frequency,
+            day_count=spec.day_count,
+            time_origin=resolved.settlement,
+            label="bermudan_swaption_fixed_leg",
+        )
+        frequency_per_year = max(
+            int(getattr(spec.swap_frequency, "value", spec.swap_frequency)),
+            1,
+        )
+        first_exercise_step = min(valid_exercise_steps)
+        swap_end_time = float(
+            year_fraction(resolved.settlement, spec.swap_end, spec.day_count)
+        )
+        quantized_swap_end_time = (
+            round(swap_end_time * frequency_per_year) / frequency_per_year
+        )
+        swap_end_step = lattice_step_from_time(
+            quantized_swap_end_time,
+            dt=lattice.dt,
+            n_steps=lattice.n_steps,
+            allow_terminal_step=True,
+        )
+        if swap_end_step is None or swap_end_step <= first_exercise_step:
+            return 0.0
+        coupon = float(spec.notional) * float(spec.strike) / frequency_per_year
+        coupon_by_step = {{}}
+        for period in payment_timeline:
+            payment_time = (
+                float(period.t_payment)
+                if period.t_payment is not None
+                else float(
+                    year_fraction(
+                        resolved.settlement,
+                        period.payment_date,
+                        spec.day_count,
+                    )
+                )
+            )
+            quantized_payment_time = (
+                round(payment_time * frequency_per_year) / frequency_per_year
+            )
+            payment_step = lattice_step_from_time(
+                quantized_payment_time,
+                dt=lattice.dt,
+                n_steps=lattice.n_steps,
+                allow_terminal_step=True,
+            )
+            if (
+                payment_step is None
+                or payment_step <= first_exercise_step
+                or payment_step > swap_end_step
+            ):
+                continue
+            coupon_by_step[payment_step] = (
+                coupon_by_step.get(payment_step, 0.0) + coupon
+            )
+
+        notional = float(spec.notional)
+
+        def fixed_leg_terminal(step, node, lattice_, obs):
+            del node, lattice_, obs
+            if step != swap_end_step:
+                return 0.0
+            return notional + float(coupon_by_step.get(step, 0.0))
+
+        def fixed_leg_cashflow(step, node, lattice_, obs):
+            del node, obs
+            if step == lattice_.n_steps:
+                return 0.0
+            amount = float(coupon_by_step.get(step, 0.0))
+            if step == swap_end_step:
+                amount += notional
+            return amount
+
+        fixed_leg_claim = LatticeLinearClaimSpec(
+            terminal_payoff=fixed_leg_terminal,
+            node_cashflow_fn=fixed_leg_cashflow,
+            observable_requirements=("rate",),
+        )
+        fixed_leg_contract = LatticeContractSpec(claim=fixed_leg_claim)
+        fixed_leg_result = value_on_lattice(
+            lattice,
+            fixed_leg_contract,
+            observation_steps=valid_exercise_steps,
+        )
+        signed_swap_values = {{}}
+        for exercise_step in valid_exercise_steps:
+            if exercise_step >= swap_end_step:
+                continue
+            fixed_leg_values = fixed_leg_result.observation_at(
+                exercise_step
+            ).continuation_values
+            payer_values = tuple(
+                notional - fixed_leg_value
+                for fixed_leg_value in fixed_leg_values
+            )
+            signed_swap_values[exercise_step] = (
+                payer_values
+                if bool(spec.is_payer)
+                else tuple(-value for value in payer_values)
+            )
+        if not signed_swap_values:
+            return 0.0
+
+        def exercise_value(step, node, lattice_, obs):
+            del lattice_, obs
+            return max(float(signed_swap_values[step][node]), 0.0)
+
+        option_claim = LatticeLinearClaimSpec(
+            terminal_payoff=lambda step, node, lattice_, obs: 0.0,
+            observable_requirements=("rate",),
+        )
+        option_control = LatticeControlSpec(
+            objective="holder_max",
+            exercise_steps=tuple(sorted(signed_swap_values)),
+            exercise_value_fn=exercise_value,
+        )
+        option_contract = LatticeContractSpec(
+            claim=option_claim,
+            control=option_control,
+        )
+        return float(price_on_lattice(lattice, option_contract))
+        """
+    ).rstrip()
+
+
 def _vanilla_equity_monte_carlo_helper_kwargs(comparison_target: str | None) -> str:
     """Return deterministic helper kwargs for vanilla-equity Monte Carlo comparison targets."""
     target = str(comparison_target or "").strip().lower()
@@ -5384,6 +5569,20 @@ def _deterministic_exact_binding_evaluate_body(
         if variance_swap_body is not None:
             return variance_swap_body
     if (
+        instrument_type in {"swaption", "bermudan_swaption"}
+        and primitive_route == "exercise_lattice"
+        and {
+            "trellis.models.bermudan_swaption_tree.resolve_bermudan_swaption_tree_inputs",
+            "trellis.models.trees.algebra.build_lattice",
+            "trellis.models.trees.algebra.value_on_lattice",
+            "trellis.models.trees.algebra.price_on_lattice",
+        }.issubset(refs)
+    ):
+        return _bermudan_swaption_lattice_evaluate_body(
+            model_name=swaption_tree_model,
+            comparison_kwargs=swaption_comparison_kwargs,
+        )
+    if (
         instrument_type == "swaption"
         and primitive_route == "rate_tree_backward_induction"
         and "trellis.models.trees.algebra.price_on_lattice" in refs
@@ -6359,9 +6558,6 @@ def _deterministic_exact_binding_evaluate_body(
             f"{swaption_comparison_kwargs})\n"
             "return price_swaption_black76_raw(resolved)"
         ),
-        "trellis.models.bermudan_swaption_tree.price_bermudan_swaption_tree": (
-            "return price_bermudan_swaption_tree(market_state, spec)"
-        ),
         "trellis.models.monte_carlo.single_state_diffusion.price_single_state_terminal_claim_monte_carlo_result": (
             "result = price_single_state_terminal_claim_monte_carlo_result(\n"
             "    market_state,\n"
@@ -6757,7 +6953,7 @@ def _materialize_deterministic_exact_binding_module(
     request_metadata: Mapping[str, object] | None = None,
     comparison_target: str | None = None,
 ) -> GeneratedModuleResult | None:
-    """Build a thin helper-backed module without invoking the LLM when the route is exact."""
+    """Build an exact-bound adapter module without invoking the LLM."""
     body = _deterministic_exact_binding_evaluate_body(
         generation_plan,
         semantic_blueprint=semantic_blueprint,
@@ -6891,9 +7087,9 @@ def _set_generated_requirements(source: str, requirements: Sequence[str]) -> str
 def _deterministic_exact_binding_import_lines(body: str) -> tuple[str, ...]:
     """Return extra imports required by deterministic exact-binding bodies.
 
-    Exact helper bodies can reference shared support functions that are not part
-    of the exact backend-binding symbol set. Keep those imports explicit here so
-    fresh-generated proof runs exercise the same declared dependency surface as
+    Exact-bound bodies can reference shared support functions that are not part
+    of the terminal backend-binding symbol set. Keep those imports explicit so
+    isolated proof artifacts exercise the same declared dependency surface as
     ordinary generated modules.
     """
     imports: list[str] = []
@@ -6905,6 +7101,8 @@ def _deterministic_exact_binding_import_lines(body: str) -> tuple[str, ...]:
         imports.append("from trellis.core.date_utils import year_fraction")
     if "normalize_explicit_dates(" in body:
         imports.append("from trellis.core.date_utils import normalize_explicit_dates")
+    if "build_payment_timeline(" in body:
+        imports.append("from trellis.core.date_utils import build_payment_timeline")
     if "resolve_swaption_black76_inputs(" in body:
         imports.append(
             "from trellis.models.rate_style_swaption import "
@@ -6923,15 +7121,37 @@ def _deterministic_exact_binding_import_lines(body: str) -> tuple[str, ...]:
             "    resolve_bermudan_swaption_tree_inputs,\n"
             ")"
         )
+    elif "resolve_bermudan_swaption_tree_inputs(" in body:
+        imports.append(
+            "from trellis.models.bermudan_swaption_tree import "
+            "resolve_bermudan_swaption_tree_inputs"
+        )
     if "BINOMIAL_1F_TOPOLOGY" in body and "price_on_lattice(" in body:
+        algebra_symbols = [
+            "BINOMIAL_1F_TOPOLOGY",
+            "TERM_STRUCTURE_TARGET",
+            "UNIFORM_ADDITIVE_MESH",
+            "build_lattice",
+        ]
+        algebra_symbols.extend(
+            symbol
+            for symbol in (
+                "LatticeLinearClaimSpec",
+                "LatticeControlSpec",
+                "LatticeContractSpec",
+                "value_on_lattice",
+            )
+            if symbol in body
+        )
+        algebra_symbols.append("price_on_lattice")
         imports.append(
             "from trellis.models.trees.algebra import (\n"
-            "    BINOMIAL_1F_TOPOLOGY,\n"
-            "    TERM_STRUCTURE_TARGET,\n"
-            "    UNIFORM_ADDITIVE_MESH,\n"
-            "    build_lattice,\n"
-            "    price_on_lattice,\n"
-            ")"
+            + "".join(f"    {symbol},\n" for symbol in algebra_symbols)
+            + ")"
+        )
+    if "lattice_step_from_time(" in body:
+        imports.append(
+            "from trellis.models.trees.control import lattice_step_from_time"
         )
     if "price_heston_option_monte_carlo(" in body:
         imports.append(
@@ -9145,14 +9365,13 @@ def _route_specific_retry_lines(
         and stage in {"code_generation_failed", "semantic_validation_failed", "validation_failed", "actual_market_smoke_failed", "import_validation_failed"}
     ):
         return (
-            "Bermudan swaption rate-tree routes should stay on the checked-in helper surface.",
-            "Prefer `from trellis.models.bermudan_swaption_tree import price_bermudan_swaption_tree` and delegate to that helper from the adapter.",
-            "Keep `market_state.vol_surface.black_vol(...)` visible in `evaluate()` before delegating so the route makes its calibration input explicit.",
-            "Read the short-rate seed from `market_state.discount.zero_rate(...)`; do not invent `market_state.zero_rate(...)` or hide the discount curve behind a stale wrapper.",
-            "Treat `trellis.models.trees.control` as the lattice-timeline facade: use `build_exercise_timeline_from_dates(...)`, `lattice_steps_from_timeline(...)`, and `resolve_lattice_exercise_policy(\"bermudan\", exercise_steps=...)`.",
-            "Do not reuse `price_callable_bond_tree(...)` for Bermudan swaptions. Callable bonds and swaptions are separate helper routes with different exercise payoffs.",
-            "If you must build the tree directly, use `build_generic_lattice(MODEL_REGISTRY[\"hull_white\"|\"bdt\"], r0=..., sigma=..., a=..., T=..., n_steps=..., discount_curve=market_state.discount)` and keep the swaption payoff as a Bermudan option on node-wise swap values.",
-            "Keep the route thin: helper-backed lattice builder, explicit exercise schedule, explicit swaption direction (`is_payer`), and no bespoke analytical fallback inside the rate-tree build.",
+            "Bermudan swaption rate-tree routes compose the admitted generic lattice and contract surfaces directly.",
+            "Use `normalize_explicit_dates(...)`, `year_fraction(...)`, `build_payment_timeline(...)`, and `lattice_step_from_time(...)` to bind exercise and fixed-leg schedules.",
+            "Resolve market and Hull-White/BDT controls once with `resolve_bermudan_swaption_tree_inputs(...)`, then compose `BINOMIAL_1F_TOPOLOGY`, `UNIFORM_ADDITIVE_MESH`, `TERM_STRUCTURE_TARGET(...)`, and `build_lattice(...)`.",
+            "Represent coupons and principal with `LatticeLinearClaimSpec` plus `LatticeContractSpec`, and obtain fixed-leg node values with `value_on_lattice(..., observation_steps=exercise_steps)`.",
+            "Use each rollback observation's `continuation_values` for payer/receiver swap algebra so an exercise-time fixed coupon is not double counted.",
+            "Attach `LatticeControlSpec(objective=\"holder_max\", ...)` to the option contract and return `price_on_lattice(...)`.",
+            "Do not delegate to a product-level Bermudan helper, a product contract compiler, or a callable-bond route; they are compatibility/reference or different-product surfaces, not this route's construction authority.",
         )
     if (
         instrument == "bermudan_swaption"

--- a/trellis/agent/family_lowering_ir.py
+++ b/trellis/agent/family_lowering_ir.py
@@ -762,10 +762,13 @@ _EXERCISE_LATTICE_PROFILES = (
         ),
         required_observables=("forward_rate", "discount_curve"),
         required_inputs=("discount_curve", "forward_curve", "black_vol_surface"),
-        helper_symbol="price_bermudan_swaption_tree",
+        helper_symbol="",
         market_mapping="discount_curve_forward_par_rate_schedule_to_lattice",
         derived_quantities=(
             "exercise_schedule_steps",
+            "payment_schedule_steps",
+            "fixed_leg_continuation_observations",
+            "payer_receiver_swap_values",
             "schedule_bound_forward_fixings",
             "par_rate_bindings",
             "swap_accrual_fractions",
@@ -1145,9 +1148,9 @@ def _binding_supports_exercise_lattice(
     binding_spec is None`` fallback is dead code and has been retired.
     """
     del route_id
-    if _binding_has_role(binding_spec, "lattice_builder") and _binding_has_role(
-        binding_spec,
-        "backward_induction",
+    if _binding_has_role(binding_spec, "lattice_builder") and (
+        _binding_has_role(binding_spec, "backward_induction")
+        or _binding_has_symbol(binding_spec, "pricing_kernel", "price_on_lattice")
     ):
         return True
     if _binding_has_any_symbol(

--- a/trellis/agent/knowledge/api_map.py
+++ b/trellis/agent/knowledge/api_map.py
@@ -342,6 +342,21 @@ def _score_card(
     section: Mapping[str, Any],
     query: ApiMapQuery,
 ) -> int:
+    allowed_instruments = frozenset(
+        _normalize(str(value))
+        for value in (
+            section.get("instruments")
+            if isinstance(section.get("instruments"), (list, tuple))
+            else (section.get("instruments"),)
+        )
+        if str(value or "").strip()
+    )
+    if (
+        query.instrument_type.strip()
+        and allowed_instruments
+        and _normalize(query.instrument_type) not in allowed_instruments
+    ):
+        return 0
     allowed_methods = _section_methods(section)
     if (
         query.method.strip()

--- a/trellis/agent/knowledge/canonical/api_map.yaml
+++ b/trellis/agent/knowledge/canonical/api_map.yaml
@@ -252,7 +252,7 @@ rate_lattice:
   module: trellis.models.trees.lattice
   methods: [rate_tree]
   navigation:
-    aliases: [rate_tree, callable_bond, puttable_bond, bermudan_swaption]
+    aliases: [rate_tree, callable_bond, puttable_bond]
   key_imports:
     - "from trellis.models.trees.lattice import LatticeRollbackObservation, LatticeRollbackResult, build_rate_lattice, lattice_backward_induction, lattice_backward_induction_result"
     - "from trellis.models.trees.algebra import value_on_lattice"
@@ -451,9 +451,10 @@ european_swaption_monte_carlo_composition:
 
 european_swaption_rate_lattice_composition:
   module: trellis.models.trees.algebra
+  instruments: [swaption]
   methods: [rate_tree]
   navigation:
-    aliases: [swaption, european_swaption, hull_white_swaption_tree, hw_tree, bdt_tree]
+    aliases: [european_swaption, hull_white_swaption_tree, hw_tree, bdt_tree]
   modules:
     contract: trellis.models.bermudan_swaption_tree
     curve_basis: trellis.models.rate_style_swaption
@@ -468,6 +469,29 @@ european_swaption_rate_lattice_composition:
     - "Build the calibrated Hull-White or BDT lattice from the generic topology, mesh, term-structure target, and build_lattice(...) surfaces; pass resolved.mean_reversion as `a=`"
     - "Compile the lattice contract with compile_bermudan_swaption_contract_spec(...) and evaluate it with generic price_on_lattice(...)"
     - "price_swaption_tree(...) and build_swaption_tree_spec(...) remain compatibility/reference APIs and are not generated construction authority"
+
+bermudan_swaption_rate_lattice_composition:
+  module: trellis.models.trees.algebra
+  instruments: [bermudan_swaption]
+  methods: [rate_tree]
+  navigation:
+    aliases: [bermudan_swaption, hull_white_bermudan_swaption_tree, hw_tree_bermudan, bdt_tree_bermudan]
+  modules:
+    schedule: trellis.core.date_utils
+    market_binding: trellis.models.bermudan_swaption_tree
+    lattice_control: trellis.models.trees.control
+    lattice_algebra: trellis.models.trees.algebra
+  key_imports:
+    - "from trellis.core.date_utils import normalize_explicit_dates, year_fraction, build_payment_timeline"
+    - "from trellis.models.bermudan_swaption_tree import resolve_bermudan_swaption_tree_inputs"
+    - "from trellis.models.trees.control import lattice_step_from_time"
+    - "from trellis.models.trees.algebra import BINOMIAL_1F_TOPOLOGY, UNIFORM_ADDITIVE_MESH, TERM_STRUCTURE_TARGET, build_lattice"
+    - "from trellis.models.trees.algebra import LatticeLinearClaimSpec, LatticeContractSpec, value_on_lattice, LatticeControlSpec, price_on_lattice"
+  notes:
+    - "Normalize live exercise dates, build the fixed-leg payment timeline, resolve market/model controls once, and map both schedules onto the calibrated generic one-factor lattice."
+    - "Represent fixed coupons and principal with LatticeLinearClaimSpec and LatticeContractSpec, call value_on_lattice(..., observation_steps=exercise_steps), use continuation_values for adapter-owned payer/receiver algebra, then attach LatticeControlSpec(objective=\"holder_max\") and finish with price_on_lattice(...)."
+    - "Post-cashflow values can double count a coupon coincident with exercise."
+    - "Product-level Bermudan pricing and contract-compilation wrappers remain compatibility/reference APIs and are not generated construction authority."
 
 bermudan_swaption_lower_bound_composition:
   module: trellis.models.rate_style_swaption

--- a/trellis/agent/knowledge/canonical/backend_bindings.yaml
+++ b/trellis/agent/knowledge/canonical/backend_bindings.yaml
@@ -708,9 +708,53 @@ bindings:
           exercise_style: [bermudan]
           model_family: [interest_rate, short_rate]
         primitives:
+          - module: trellis.core.date_utils
+            symbol: normalize_explicit_dates
+            role: schedule_normalizer
+          - module: trellis.core.date_utils
+            symbol: year_fraction
+            role: timeline_mapping
+          - module: trellis.core.date_utils
+            symbol: build_payment_timeline
+            role: payment_timeline_builder
+          - module: trellis.models.bermudan_swaption_tree
+            symbol: resolve_bermudan_swaption_tree_inputs
+            role: market_binding
+          - module: trellis.models.trees.algebra
+            symbol: BINOMIAL_1F_TOPOLOGY
+            role: topology
+          - module: trellis.models.trees.algebra
+            symbol: UNIFORM_ADDITIVE_MESH
+            role: mesh
+          - module: trellis.models.trees.algebra
+            symbol: TERM_STRUCTURE_TARGET
+            role: calibration_target
+          - module: trellis.models.trees.algebra
+            symbol: build_lattice
+            role: lattice_builder
+          - module: trellis.models.trees.control
+            symbol: lattice_step_from_time
+            role: schedule_mapping
+          - module: trellis.models.trees.algebra
+            symbol: LatticeLinearClaimSpec
+            role: linear_claim
+          - module: trellis.models.trees.algebra
+            symbol: LatticeContractSpec
+            role: contract_spec
+          - module: trellis.models.trees.algebra
+            symbol: value_on_lattice
+            role: observation_rollback
+          - module: trellis.models.trees.algebra
+            symbol: LatticeControlSpec
+            role: exercise_control
+          - module: trellis.models.trees.algebra
+            symbol: price_on_lattice
+            role: pricing_kernel
           - module: trellis.models.bermudan_swaption_tree
             symbol: price_bermudan_swaption_tree
-            role: route_helper
+            role: compatibility_reference
+            required: false
+            excluded: true
       - when: default
         primitives:
           - module: trellis.models.trees.lattice

--- a/trellis/agent/knowledge/canonical/routes.yaml
+++ b/trellis/agent/knowledge/canonical/routes.yaml
@@ -1186,11 +1186,58 @@ routes:
           exercise_style: [bermudan]
           model_family: [interest_rate, short_rate]
         primitives:
+          - module: trellis.core.date_utils
+            symbol: normalize_explicit_dates
+            role: schedule_normalizer
+          - module: trellis.core.date_utils
+            symbol: year_fraction
+            role: timeline_mapping
+          - module: trellis.core.date_utils
+            symbol: build_payment_timeline
+            role: payment_timeline_builder
+          - module: trellis.models.bermudan_swaption_tree
+            symbol: resolve_bermudan_swaption_tree_inputs
+            role: market_binding
+          - module: trellis.models.trees.algebra
+            symbol: BINOMIAL_1F_TOPOLOGY
+            role: topology
+          - module: trellis.models.trees.algebra
+            symbol: UNIFORM_ADDITIVE_MESH
+            role: mesh
+          - module: trellis.models.trees.algebra
+            symbol: TERM_STRUCTURE_TARGET
+            role: calibration_target
+          - module: trellis.models.trees.algebra
+            symbol: build_lattice
+            role: lattice_builder
+          - module: trellis.models.trees.control
+            symbol: lattice_step_from_time
+            role: schedule_mapping
+          - module: trellis.models.trees.algebra
+            symbol: LatticeLinearClaimSpec
+            role: linear_claim
+          - module: trellis.models.trees.algebra
+            symbol: LatticeContractSpec
+            role: contract_spec
+          - module: trellis.models.trees.algebra
+            symbol: value_on_lattice
+            role: observation_rollback
+          - module: trellis.models.trees.algebra
+            symbol: LatticeControlSpec
+            role: exercise_control
+          - module: trellis.models.trees.algebra
+            symbol: price_on_lattice
+            role: pricing_kernel
           - module: trellis.models.bermudan_swaption_tree
             symbol: price_bermudan_swaption_tree
-            role: route_helper
+            role: compatibility_reference
+            required: false
+            excluded: true
         adapters: []
-        notes: []
+        notes:
+          - "Normalize the exercise/payment schedules, map them to lattice steps, and build the calibrated one-factor lattice from the admitted topology, mesh, and term-structure target."
+          - "Value the fixed leg with value_on_lattice(..., observation_steps=exercise_steps) and use each observation's continuation_values so exercise-time cashflows are not double counted; form payer/receiver swap value in the adapter."
+          - "Attach LatticeControlSpec(objective=\"holder_max\") and finish with price_on_lattice(...); retained product pricers are reference-only and excluded from generated construction."
       - when: default
         primitives:
           - module: trellis.models.trees.lattice

--- a/trellis/agent/lane_obligations.py
+++ b/trellis/agent/lane_obligations.py
@@ -634,6 +634,7 @@ def _fallback_reusable_bindings(
             binding_kind=_binding_kind_for_role(str(primitive.role)),
         )
         for primitive in (primitive_plan.primitives or ())
+        if not bool(getattr(primitive, "excluded", False))
     )
 
 

--- a/trellis/agent/lite_review.py
+++ b/trellis/agent/lite_review.py
@@ -274,6 +274,7 @@ def _capability_literal_is_subsumed_by_route_binding(
     binding_by_route = {
         "analytical_black76": "resolve_swaption_black76_inputs",
         "rate_tree_backward_induction": "resolve_bermudan_swaption_tree_inputs",
+        "exercise_lattice": "resolve_bermudan_swaption_tree_inputs",
         "monte_carlo_paths": "resolve_hull_white_monte_carlo_process_inputs",
     }
     binding_name = binding_by_route.get(primitive_plan.route)

--- a/trellis/agent/prompts.py
+++ b/trellis/agent/prompts.py
@@ -560,13 +560,13 @@ def _render_family_route_guidance(
     if instrument_type == "bermudan_swaption" and method == "rate_tree":
         lines.append("## Family Route Guidance")
         lines.extend([
-            "- Prefer the checked-in Bermudan swaption helper surface in `trellis.models.bermudan_swaption_tree`: `price_bermudan_swaption_tree(market_state, spec, model=\"hull_white\"|\"bdt\")` or the lower-level `build_bermudan_swaption_lattice(...)` + `price_bermudan_swaption_on_lattice(...)`.",
-            "- Treat `trellis.models.trees.control` as the lattice-timeline facade. Build Bermudan exercise timing with `build_exercise_timeline_from_dates(...)` and `lattice_steps_from_timeline(...)`; do not reconstruct step schedules inline from raw integers.",
-            "- Keep rate-vol access explicit in the body: bind `black_vol = float(market_state.vol_surface.black_vol(max(T_option, 1e-6), max(abs(spec.strike), 1e-6)))` before delegating to the helper.",
-            "- Read the short-rate seed from `market_state.discount.zero_rate(...)`. Do not invent `market_state.zero_rate(...)` or a separate curve accessor.",
-            "- For explicit BDT / Hull-White comparison routes, prefer `price_bermudan_swaption_tree(..., model=\"bdt\"|\"hull_white\")`. If you must build the tree directly, use `build_generic_lattice(...)` with `MODEL_REGISTRY[\"bdt\"]` or `MODEL_REGISTRY[\"hull_white\"]`.",
-            "- Resolve Bermudan exercise with `exercise_policy = resolve_lattice_exercise_policy(\"bermudan\", exercise_steps=...)`; do not drift to issuer-call semantics or `exercise_fn=min`.",
-            "- The checked-in helper already owns the fixed-leg coupon map, node-wise swap valuation, and Bermudan rollback. Keep the generated route as a thin adapter over that helper rather than rebuilding swap valuation loops inline.",
+            "- Normalize live exercise dates with `normalize_explicit_dates(...)`, build the underlying fixed-leg schedule with `build_payment_timeline(...)`, and map measured dates with `year_fraction(...)` plus `lattice_step_from_time(...)`.",
+            "- Resolve curve, volatility, Hull-White/BDT parameters, horizon, and step controls once with `resolve_bermudan_swaption_tree_inputs(...)`.",
+            "- Compose `BINOMIAL_1F_TOPOLOGY`, `UNIFORM_ADDITIVE_MESH`, `TERM_STRUCTURE_TARGET(market_state.discount)`, and generic `build_lattice(...)`; pass `resolved.mean_reversion` as `a=`.",
+            "- Represent fixed coupons and principal with `LatticeLinearClaimSpec` and `LatticeContractSpec`, then call `value_on_lattice(..., observation_steps=exercise_steps)`.",
+            "- Form payer/receiver swap values from each observation's `continuation_values`; using post-cashflow values would double count any exercise-time coupon.",
+            "- Attach `LatticeControlSpec(objective=\"holder_max\", ...)` to the option `LatticeContractSpec` and finish with `price_on_lattice(...)`.",
+            "- Product-level Bermudan pricing wrappers and contract compilers are compatibility/reference APIs, not generated construction authority.",
         ])
 
     if instrument_type == "bermudan_swaption" and method == "analytical":

--- a/trellis/agent/semantic_validation.py
+++ b/trellis/agent/semantic_validation.py
@@ -241,6 +241,23 @@ class _SemanticVisitor(ast.NodeVisitor):
                 )
                 self.lattice_exercise_functions.append(exercise_policy.exercise_objective)
 
+        if call_name.endswith("LatticeControlSpec"):
+            self.engine_families.add("lattice")
+            objective = _literal_keyword(node, "objective")
+            has_exercise_steps = any(
+                keyword.arg == "exercise_steps" for keyword in node.keywords
+            )
+            if has_exercise_steps:
+                self.lattice_has_exercise_steps = True
+                self.lattice_exercise_types.append("bermudan")
+            if isinstance(objective, str):
+                normalized_objective = objective.strip().lower()
+                self.lattice_exercise_styles.append(normalized_objective)
+                if normalized_objective == "holder_max":
+                    self.lattice_exercise_functions.append("max")
+                elif normalized_objective == "issuer_min":
+                    self.lattice_exercise_functions.append("min")
+
         if call_name.endswith("resolve_lattice_exercise_policy"):
             invalid_kwargs = sorted(
                 keyword.arg
@@ -546,7 +563,8 @@ def validate_semantics(
                     code="lattice.exercise_type_mismatch",
                     message=(
                         "Schedule-dependent lattice exercise products must use "
-                        "`exercise_type=\"bermudan\"` in lattice_backward_induction(...)."
+                        "a Bermudan exercise schedule in `LatticeControlSpec(...)` "
+                        "or `lattice_backward_induction(...)`."
                     ),
                 ))
             if product_ir.schedule_dependence and not signals.lattice_has_exercise_steps:
@@ -554,7 +572,7 @@ def validate_semantics(
                     code="lattice.exercise_schedule_missing",
                     message=(
                         "Schedule-dependent lattice exercise products must pass "
-                        "`exercise_steps=...` to lattice_backward_induction(...)."
+                        "`exercise_steps=...` to their lattice control."
                     ),
                 ))
             expected_objective = "min" if product_ir.exercise_style == "issuer_call" else "max"
@@ -563,7 +581,7 @@ def validate_semantics(
                     code="lattice.exercise_objective_mismatch",
                     message=(
                         "Lattice exercise objective does not match the product semantics. "
-                        f"Expected `exercise_fn={expected_objective}` for "
+                        f"Expected `{expected_objective}` control semantics for "
                         f"`{product_ir.exercise_style}` products."
                     ),
                 ))


### PR DESCRIPTION
## Summary

- retire `price_bermudan_swaption_tree(...)` and the product contract compiler as generated Bermudan lattice construction authority
- expose bounded composition from schedule, market binding, calibrated generic lattice, fixed-leg continuation observations, payer/receiver algebra, holder control, and `price_on_lattice(...)`
- hide excluded compatibility references from builder, review, import-repair, and semantic-repair prompts
- add instrument-scoped API navigation, semantic enforcement, generated-source execution coverage, and official documentation
- correct the distinction between fresh isolated artifacts and actual agent synthesis; track the explicit proving mode in QUA-1202

## Why

T04 was green only because generated construction could delegate to a product pricer/compiler. This change keeps the reference implementation for compatibility and numerical comparison while removing it from route authority.

## Validation

- strict fresh/offline T04 passed first attempt with zero token calls, zero LLM generation attempts, and zero recovery; bounded remediation found zero failures
- helper audit: route refs 50, binding refs 54, adapter authority calls 11, unrelated drift 4/8
- `make gate-pr`: 4,720 passed; tier-2 contracts 32 passed
- `make gate-release`: cross-validation/verification/tasks 487 passed; cassette freshness 2 passed; T13 deterministic replay passed with 0 tokens; T38 replay explicitly unsupported/skipped
- post-review focused tests: 3 passed
- `git diff --check`

## Boundaries

- no canonical cookbook change
- no product or numerical pricing helper added
- no public pricing API or `LIMITATIONS.md` support-contract change
- no live external-model execution; this PR makes no fresh-agent-synthesis claim
- QUA-1202 will add an explicit synthesis-required policy and artifact-origin evidence
