### PR TITLE
docs mark QUA-1201 done

### DIFF
--- a/doc/plan/active__semantic-task-synthesis-helper-retirement.md
+++ b/doc/plan/active__semantic-task-synthesis-helper-retirement.md
@@ -61,7 +61,7 @@ Status mirror last synced: `2026-07-16`
 | `QUA-1198` | Swaption Monte Carlo: retire European helper and problem-resolver authority | Done |
 | `QUA-1199` | Swaption lattice: retire European tree helper authority | Done |
 | `QUA-1200` | Lattice rollback: observable node-value phases | Done |
-| `QUA-1201` | Bermudan swaption lattice: retire helper and compiler authority | In Progress |
+| `QUA-1201` | Bermudan swaption lattice: retire helper and compiler authority | Done |
 | `QUA-1202` | Semantic proving: distinguish fresh artifacts from agent synthesis | Backlog |
 | `QUA-1102` | Semantic target binding: typed comparison target contracts (related prerequisite) | Done |
 


### PR DESCRIPTION
Synchronizes the helper-retirement plan mirror after QUA-1201 was merged and marked Done in Linear.\n\nValidation: git diff --check. Documentation-only status change; TDD and runtime tests do not apply.