### PR TITLE
QUA-1202 Distinguish fresh artifacts from agent synthesis

### DIFF
--- a/.github/workflows/task-batch-report.yml
+++ b/.github/workflows/task-batch-report.yml
@@ -63,10 +63,18 @@ on:
         type: boolean
         default: true
       fresh_build:
-        description: Force fresh generation instead of reuse-backed runs.
+        description: Isolate build artifacts and bypass admitted adapter reuse.
         required: true
         type: boolean
         default: false
+      generation_policy:
+        description: Allow deterministic materialization or require observed builder-agent source synthesis.
+        required: true
+        type: choice
+        options:
+          - deterministic_allowed
+          - builder_synthesis_required
+        default: deterministic_allowed
       knowledge_light:
         description: Use the compiler-first minimal knowledge profile.
         required: true
@@ -158,6 +166,7 @@ jobs:
           CORPORA: ${{ inputs.corpora }}
           REUSE: ${{ inputs.reuse }}
           FRESH_BUILD: ${{ inputs.fresh_build }}
+          GENERATION_POLICY: ${{ inputs.generation_policy }}
           KNOWLEDGE_LIGHT: ${{ inputs.knowledge_light }}
           RESULTS_JSON: ${{ steps.paths.outputs.results_json }}
         run: |
@@ -185,6 +194,8 @@ jobs:
               os.environ["TASK_STATUS"],
               "--output",
               os.environ["RESULTS_JSON"],
+              "--generation-policy",
+              os.environ["GENERATION_POLICY"],
           ]
 
           if os.environ.get("REUSE", "").lower() == "true":
@@ -230,6 +241,7 @@ jobs:
           CORPORA: ${{ inputs.corpora }}
           REUSE: ${{ inputs.reuse }}
           FRESH_BUILD: ${{ inputs.fresh_build }}
+          GENERATION_POLICY: ${{ inputs.generation_policy }}
           KNOWLEDGE_LIGHT: ${{ inputs.knowledge_light }}
           RESULTS_JSON: ${{ steps.paths.outputs.results_json }}
           REPORT_JSON: ${{ steps.paths.outputs.report_json }}
@@ -269,6 +281,8 @@ jobs:
               os.environ["REPORT_MD"],
               "--step-summary",
               os.environ["STEP_SUMMARY_PATH"],
+              "--generation-policy",
+              os.environ["GENERATION_POLICY"],
           ]
 
           if os.environ.get("REUSE", "").lower() == "true":

--- a/doc/plan/active__semantic-task-synthesis-helper-retirement.md
+++ b/doc/plan/active__semantic-task-synthesis-helper-retirement.md
@@ -62,7 +62,7 @@ Status mirror last synced: `2026-07-16`
 | `QUA-1199` | Swaption lattice: retire European tree helper authority | Done |
 | `QUA-1200` | Lattice rollback: observable node-value phases | Done |
 | `QUA-1201` | Bermudan swaption lattice: retire helper and compiler authority | Done |
-| `QUA-1202` | Semantic proving: distinguish fresh artifacts from agent synthesis | Backlog |
+| `QUA-1202` | Semantic proving: distinguish fresh artifacts from agent synthesis | In Progress |
 | `QUA-1102` | Semantic target binding: typed comparison target contracts (related prerequisite) | Done |
 
 ## Current Sequence

--- a/docs/developer/runtime_agent_orientation.rst
+++ b/docs/developer/runtime_agent_orientation.rst
@@ -74,6 +74,15 @@ Exact symbols remain the import registry's responsibility after family
 selection. Quant and model-validator regression tests reject API-map imports
 or code templates in their resolved context.
 
+Generation proving does not change these role boundaries. A fresh artifact may
+still come from deterministic materialization, so runtime reports use the
+separate generation policy and artifact-origin evidence described in
+``task_and_eval_loops``. Only ``model_generated_source`` with observed builder
+synthesis proves that the builder returned source while its API-map and
+import-registry context was available; provenance alone does not prove which
+retrieved entries influenced the model. Quant or model-validator prompt
+activity is not source-synthesis evidence.
+
 The ``equity_tree`` and ``rate_lattice`` cards expose the product-neutral
 ``value_on_lattice(..., observation_steps=...)`` surface when generated code
 needs node-level continuation, post-cashflow, and post-control values. The

--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -306,8 +306,11 @@ three selection modes:
 - ``all`` for the full manifest surface after any status/corpus filter
 
 The workflow also accepts optional corpus filters, ``pending`` versus ``all``
-status selection, validation profile, reuse versus fresh-build controls, and
-the knowledge-light profile. The GitHub Actions default model is
+status selection, validation profile, reuse versus fresh-build controls, an
+explicit generation policy, and the knowledge-light profile. Freshness and
+generation are independent: ``fresh_build`` isolates the artifact path, while
+``builder_synthesis_required`` proves that the builder produced model-generated
+source. The GitHub Actions default model is
 ``openai/gpt-4.1`` because GitHub Models expects catalog model IDs such as
 ``openai/gpt-4.1`` rather than direct OpenAI API model names such as
 ``gpt-5.4-mini``. Each manual run emits:
@@ -542,10 +545,13 @@ gate:
 - do elapsed time and token usage fall?
 - do those improvements line up with reused knowledge signals?
 
-The runner defaults to ``fresh_build=True``. That is deliberate. Reusing
-admitted adapters would swamp the signal and turn the benchmark into a warm
-cache measurement instead of a knowledge-carry-forward measurement. Reuse mode
-still exists, but only when you explicitly want warm-path operational data.
+The runner defaults to ``fresh_build=True`` and
+``generation_policy=builder_synthesis_required``. Both controls are necessary
+for this benchmark. Reusing admitted adapters would swamp the signal, while a
+fresh deterministic materialization would prove only compiler replay, not that
+the builder navigated Trellis knowledge and composed source. Reuse mode still
+exists for warm-path operational data, but it is incompatible with the
+synthesis-required policy.
 
 Each pass writes:
 
@@ -930,8 +936,49 @@ writes the result to an isolated fresh-build path. Fresh build does not by
 itself prove agent synthesis: an admitted deterministic exact binding may still
 materialize that isolated adapter with zero model calls. A report may claim
 fresh artifact construction from this mode, but it may claim fresh agent
-synthesis only when its execution policy also bypasses deterministic
-materialization and the trace records an actual code-generation call.
+synthesis only when ``generation_policy=builder_synthesis_required`` bypasses
+semantic shims and deterministic exact materialization and the executor records
+model-generated source.
+
+Artifact freshness and generation origin
+-----------------------------------------
+
+The task runtime persists these as separate contracts:
+
+- ``fresh_build`` controls adapter reuse and output-path isolation only.
+- ``generation_policy=deterministic_allowed`` preserves production-safe reuse,
+  semantic shims, deterministic exact materialization, and model generation as
+  a final fallback.
+- ``generation_policy=builder_synthesis_required`` requires an isolated fresh
+  path and bypasses checked adapters, semantic shims, and deterministic exact
+  materializers before calling the builder.
+- ``artifact_origin`` records ``reused_adapter``, ``semantic_shim``,
+  ``deterministic_materialization``, ``model_generated_source``, or a bounded
+  deterministic proof artifact.
+- ``agent_synthesis_attempted`` and ``agent_synthesis_observed`` distinguish a
+  failed builder call from returned model source. Observed synthesis does not
+  imply that validation passed or that the artifact should be admitted.
+
+Synthesis-required execution fails closed when ``fresh_build`` is false, when
+recovery mode is ``strict``, or when execution mode is offline or cassette
+replay. Live or cassette-record execution remains an explicit assisted or
+remediation action. For example:
+
+.. code-block:: bash
+
+   /Users/steveyang/miniforge3/bin/python3 scripts/run_tasks.py \
+       --task-id T20 --status all --fresh-build \
+       --generation-policy builder_synthesis_required \
+       --recovery-mode assisted
+
+Task records, diagnosis packets, batch summaries, and platform events expose
+the policy, origin, and synthesis flags. Promotion candidates are considered
+only for validated fresh artifacts whose origin is
+``model_generated_source`` and whose synthesis was observed. A deterministic
+fresh build remains valid zero-token replay evidence but is never reported as
+model source synthesis or promoted as model-authored source. Learning reports
+separately label first-pass model synthesis, deterministic origin, and unknown
+origin instead of inferring synthesis from freshness or success.
 
 The same rule now applies to tranche-style basket-credit and typed
 loss-distribution comparison routes.

--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -961,8 +961,11 @@ The task runtime persists these as separate contracts:
 
 Synthesis-required execution fails closed when ``fresh_build`` is false, when
 recovery mode is ``strict``, or when execution mode is offline or cassette
-replay. Live or cassette-record execution remains an explicit assisted or
-remediation action. For example:
+replay. Direct builder entry points apply the same rule to active LLM
+overrides: generic/local overrides and cassette replay cannot prove model
+source, while cassette record is explicitly marked as observable because it
+wraps a live provider call. Live or cassette-record execution remains an
+explicit assisted or remediation action. For example:
 
 .. code-block:: bash
 

--- a/scripts/render_task_batch_report.py
+++ b/scripts/render_task_batch_report.py
@@ -60,6 +60,11 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     )
     parser.add_argument("--reuse", action="store_true")
     parser.add_argument("--fresh-build", action="store_true")
+    parser.add_argument(
+        "--generation-policy",
+        choices=("deterministic_allowed", "builder_synthesis_required"),
+        default="deterministic_allowed",
+    )
     parser.add_argument("--knowledge-light", action="store_true")
     parser.add_argument("--summary-json", help="Optional precomputed summary JSON path.")
     parser.add_argument("--output-json")
@@ -93,6 +98,7 @@ def main(argv: list[str]) -> int:
         validation=args.validation,
         force_rebuild=not args.reuse,
         fresh_build=args.fresh_build,
+        generation_policy=args.generation_policy,
         knowledge_light=args.knowledge_light,
         selection={
             "selection_mode": args.selection_mode,

--- a/scripts/rerun_ids.py
+++ b/scripts/rerun_ids.py
@@ -35,7 +35,16 @@ parser.add_argument(
 parser.add_argument(
     "--fresh-build",
     action="store_true",
-    help="Bypass deterministic supported-route reuse so tasks exercise fresh build paths.",
+    help=(
+        "Bypass admitted adapter reuse and isolate the output path. This does not "
+        "by itself require model-generated source."
+    ),
+)
+parser.add_argument(
+    "--generation-policy",
+    choices=("deterministic_allowed", "builder_synthesis_required"),
+    default="deterministic_allowed",
+    help="Require observed builder-agent source synthesis or allow deterministic materialization.",
 )
 parser.add_argument(
     "--offline-local-agents",
@@ -68,6 +77,7 @@ for i, task in enumerate(tasks):
                 validation=args.validation,
                 force_rebuild=(not args.reuse) or args.fresh_build,
                 fresh_build=args.fresh_build,
+                generation_policy=args.generation_policy,
                 execution_mode_override="deterministic_replay",
             )
         result["offline_local_agents"] = True
@@ -79,6 +89,7 @@ for i, task in enumerate(tasks):
             validation=args.validation,
             force_rebuild=(not args.reuse) or args.fresh_build,
             fresh_build=args.fresh_build,
+            generation_policy=args.generation_policy,
         )
     results.append(result)
     diagnosis_headline = result.get("task_diagnosis_headline")

--- a/scripts/run_task_learning_benchmark.py
+++ b/scripts/run_task_learning_benchmark.py
@@ -71,7 +71,13 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument(
         "--reuse",
         action="store_true",
-        help="Allow adapter reuse. By default the benchmark uses fresh builds to isolate knowledge carry-forward.",
+        help="Allow adapter reuse. Incompatible with builder_synthesis_required.",
+    )
+    parser.add_argument(
+        "--generation-policy",
+        choices=("deterministic_allowed", "builder_synthesis_required"),
+        default="builder_synthesis_required",
+        help="The learning benchmark defaults to genuine builder-agent source synthesis.",
     )
     parser.add_argument("--list-tasks", action="store_true")
     parser.add_argument("--dry-run", action="store_true")
@@ -161,6 +167,7 @@ def run_learning_benchmark(
     fresh_build: bool,
     knowledge_light: bool,
     seeded_retry_fixture: bool = False,
+    generation_policy: str = "builder_synthesis_required",
 ) -> dict[str, Any]:
     """Run repeated passes for one non-canary task cohort and save the report."""
     output_root.mkdir(parents=True, exist_ok=True)
@@ -170,6 +177,9 @@ def run_learning_benchmark(
     report_root.mkdir(parents=True, exist_ok=True)
 
     git_revision = _git_revision()
+    effective_generation_policy = (
+        "deterministic_allowed" if seeded_retry_fixture else generation_policy
+    )
     pass_runs: list[dict[str, Any]] = []
 
     print(f"\n{'#' * 72}")
@@ -178,6 +188,7 @@ def run_learning_benchmark(
     print(f"# Tasks: {', '.join(task['id'] for task in tasks)}")
     print(f"# Passes: {passes}")
     print(f"# Fresh build: {fresh_build}")
+    print(f"# Generation policy: {effective_generation_policy}")
     print(f"# Knowledge light: {knowledge_light}")
     print(f"# Seeded retry fixture: {seeded_retry_fixture}")
     print(f"# Validation: {validation}")
@@ -200,6 +211,7 @@ def run_learning_benchmark(
             knowledge_light=knowledge_light,
             task_run_storage_root=output_root / "task_run_records" / label,
             seeded_retry_fixture=seeded_retry_fixture,
+            generation_policy=effective_generation_policy,
         )
         output_path.write_text(json.dumps(results, indent=2, default=str))
         summary = summarize_task_results(results)
@@ -209,6 +221,7 @@ def run_learning_benchmark(
                 "pass_number": pass_number,
                 "label": label,
                 "fresh_build": fresh_build,
+                "generation_policy": effective_generation_policy,
                 "knowledge_profile": "knowledge_light" if knowledge_light else "default",
                 "model": model,
                 "validation": validation,
@@ -234,7 +247,7 @@ def run_learning_benchmark(
         notes=[
             note
             for note in (
-                "Fresh-build passes isolate knowledge carry-forward from adapter reuse."
+                "Fresh-build passes isolate output paths and adapter reuse; only observed model-generated origin proves builder synthesis."
                 if fresh_build
                 else "Reuse mode was enabled, so adapter reuse may contribute to improvements.",
                 "This benchmark measures short-term learning evidence, not autonomous code development.",
@@ -272,6 +285,7 @@ def _run_learning_pass(
     knowledge_light: bool,
     task_run_storage_root: Path,
     seeded_retry_fixture: bool,
+    generation_policy: str = "builder_synthesis_required",
 ) -> list[dict[str, Any]]:
     market_state = object() if seeded_retry_fixture else build_market_state()
     results: list[dict[str, Any]] = []
@@ -297,12 +311,15 @@ def _run_learning_pass(
                 validation=validation,
                 task_run_storage_root=task_run_storage_root,
                 task_run_storage_layout="standalone",
+                recovery_mode="assisted",
+                generation_policy=generation_policy,
             )
         payload = dict(result)
         payload["learning_benchmark_name"] = benchmark_name
         payload["learning_benchmark_pass"] = pass_number
         payload["learning_benchmark_git_revision"] = git_revision
         payload["learning_benchmark_fresh_build"] = fresh_build
+        payload["learning_benchmark_generation_policy"] = generation_policy
         payload["learning_benchmark_knowledge_profile"] = (
             "knowledge_light" if knowledge_light else "default"
         )
@@ -452,6 +469,9 @@ def main(argv: list[str]) -> int:
     if args.passes < 1:
         print("Pass count must be at least 1.")
         return 2
+    if args.reuse and args.generation_policy == "builder_synthesis_required":
+        print("--reuse is incompatible with --generation-policy builder_synthesis_required")
+        return 2
     if args.passes < 2 and not args.seeded_retry_fixture:
         print("Pass count must be at least 2 for a learning benchmark.")
         return 2
@@ -479,6 +499,7 @@ def main(argv: list[str]) -> int:
         fresh_build=not args.reuse,
         knowledge_light=args.knowledge_light,
         seeded_retry_fixture=args.seeded_retry_fixture,
+        generation_policy=args.generation_policy,
     )
     return 0
 

--- a/scripts/run_tasks.py
+++ b/scripts/run_tasks.py
@@ -56,7 +56,16 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument(
         "--fresh-build",
         action="store_true",
-        help="Bypass deterministic supported-route reuse so tasks exercise live code generation.",
+        help=(
+            "Bypass admitted adapter reuse and isolate the output path. This does not "
+            "by itself require model-generated source."
+        ),
+    )
+    parser.add_argument(
+        "--generation-policy",
+        choices=("deterministic_allowed", "builder_synthesis_required"),
+        default="deterministic_allowed",
+        help="Require observed builder-agent source synthesis or allow deterministic materialization.",
     )
     parser.add_argument(
         "--knowledge-light",
@@ -131,6 +140,7 @@ def run_block(
     model: str = "gpt-5.4-mini",
     force_rebuild: bool = True,
     fresh_build: bool = False,
+    generation_policy: str = "deterministic_allowed",
     knowledge_light: bool = False,
     validation: str = "standard",
     recovery_mode: str = "assisted",
@@ -149,6 +159,7 @@ def run_block(
     print(f"# Model: {model}")
     print(f"# Force rebuild: {force_rebuild}")
     print(f"# Fresh build: {fresh_build}")
+    print(f"# Generation policy: {generation_policy}")
     print(f"# Knowledge light: {knowledge_light}")
     print(f"# Validation: {validation}")
     print(f"# Recovery mode: {recovery_mode}")
@@ -168,6 +179,7 @@ def run_block(
                     model=model,
                     force_rebuild=(force_rebuild or fresh_build),
                     fresh_build=fresh_build,
+                    generation_policy=generation_policy,
                     knowledge_profile="knowledge_light" if knowledge_light else None,
                     validation=validation,
                     recovery_mode=recovery_mode,
@@ -181,6 +193,7 @@ def run_block(
                 model=model,
                 force_rebuild=(force_rebuild or fresh_build),
                 fresh_build=fresh_build,
+                generation_policy=generation_policy,
                 knowledge_profile="knowledge_light" if knowledge_light else None,
                 validation=validation,
                 recovery_mode=recovery_mode,
@@ -226,6 +239,7 @@ def run_block(
     print(f"  Retry recovery: {summary['retry_recovery']}")
     print(f"  Reviewer signals: {summary['reviewer_signals']}")
     print(f"  Shared knowledge: {summary['shared_knowledge']}")
+    print(f"  Generation proving: {summary['generation_proving']}")
     print(f"  Promotion discipline: {summary['promotion_discipline']}")
     print(f"  Token usage: {summary['token_usage']}")
     if batch_token_budget:
@@ -311,6 +325,7 @@ if __name__ == "__main__":
         model=args.model,
         force_rebuild=not args.reuse,
         fresh_build=args.fresh_build,
+        generation_policy=args.generation_policy,
         knowledge_light=args.knowledge_light,
         validation=args.validation,
         recovery_mode=args.recovery_mode,

--- a/tests/test_agent/test_autonomous.py
+++ b/tests/test_agent/test_autonomous.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from importlib import import_module
 from types import SimpleNamespace
 
+import pytest
+
 
 def test_generated_module_code_text_handles_structured_results():
     from trellis.agent.knowledge.autonomous import _generated_module_code_text
@@ -828,6 +830,12 @@ def test_build_with_knowledge_skips_post_build_stages_from_task_policy(monkeypat
                 "code": "pass",
                 "platform_trace_path": None,
                 "platform_request_id": "executor_build_cached",
+                "generation_evidence": {
+                    "policy": "deterministic_allowed",
+                    "artifact_origin": "deterministic_materialization",
+                    "agent_synthesis_attempted": False,
+                    "agent_synthesis_observed": False,
+                },
             },
         ),
     )
@@ -857,6 +865,12 @@ def test_build_with_knowledge_skips_post_build_stages_from_task_policy(monkeypat
     assert result.success is True
     assert result.token_usage_summary["call_count"] == 0
     assert result.token_usage_summary["total_tokens"] == 0
+    assert result.generation_evidence == {
+        "policy": "deterministic_allowed",
+        "artifact_origin": "deterministic_materialization",
+        "agent_synthesis_attempted": False,
+        "agent_synthesis_observed": False,
+    }
     assert result.reflection == {
         "skipped": True,
         "reason": "execution_mode_deterministic_replay",
@@ -888,6 +902,26 @@ def test_build_with_knowledge_skips_post_build_stages_from_task_policy(monkeypat
     assert events["consolidation_dispatched"]["details"]["reason"] == (
         "execution_mode_deterministic_replay"
     )
+
+
+def test_build_with_knowledge_requires_isolated_path_before_synthesis(monkeypatch):
+    from trellis.agent.generation_policy import GenerationPolicyError
+    from trellis.agent.knowledge.autonomous import build_with_knowledge
+
+    decompose_mod = import_module("trellis.agent.knowledge.decompose")
+    monkeypatch.setattr(
+        decompose_mod,
+        "decompose",
+        lambda *args, **kwargs: pytest.fail("decomposition must not run"),
+    )
+
+    with pytest.raises(GenerationPolicyError, match="fresh_build=True"):
+        build_with_knowledge(
+            "European option",
+            instrument_type="european_option",
+            fresh_build=False,
+            generation_policy="builder_synthesis_required",
+        )
 
 
 def test_environment_skip_remains_distinct_from_policy_skip(monkeypatch):

--- a/tests/test_agent/test_autonomous.py
+++ b/tests/test_agent/test_autonomous.py
@@ -924,6 +924,35 @@ def test_build_with_knowledge_requires_isolated_path_before_synthesis(monkeypatc
         )
 
 
+def test_build_with_knowledge_rejects_untrusted_llm_override_before_decomposition(
+    monkeypatch,
+):
+    from trellis.agent.config import llm_override_scope
+    from trellis.agent.generation_policy import GenerationPolicyError
+    from trellis.agent.knowledge.autonomous import build_with_knowledge
+
+    decompose_mod = import_module("trellis.agent.knowledge.decompose")
+    monkeypatch.setattr(
+        decompose_mod,
+        "decompose",
+        lambda *args, **kwargs: pytest.fail("decomposition must not run"),
+    )
+
+    with llm_override_scope(
+        generate=lambda *_args, **_kwargs: "replayed source",
+        generate_json=lambda *_args, **_kwargs: {},
+    ):
+        with pytest.raises(GenerationPolicyError) as exc_info:
+            build_with_knowledge(
+                "European option",
+                instrument_type="european_option",
+                fresh_build=True,
+                generation_policy="builder_synthesis_required",
+            )
+
+    assert exc_info.value.reason == "llm_override_untrusted"
+
+
 def test_environment_skip_remains_distinct_from_policy_skip(monkeypatch):
     from trellis.agent.knowledge.autonomous import _post_build_control_flags
     from trellis.agent.post_build_policy import determine_post_build_learning_policy

--- a/tests/test_agent/test_build_loop.py
+++ b/tests/test_agent/test_build_loop.py
@@ -1622,9 +1622,16 @@ class QuantoOptionAnalyticalPayoff:
         mod = ModuleType("trellis.instruments._agent._fresh.quantooptionanalytical")
         setattr(mod, "QuantoOptionAnalyticalPayoff", type("QuantoOptionAnalyticalPayoff", (), {}))
         mock_dynamic_import.return_value = mod
+        build_meta = {}
         with patch(
             "trellis.agent.executor.validate_semantics",
             return_value=SimpleNamespace(ok=True, errors=()),
+        ), patch(
+            "trellis.agent.executor.validate_generated_imports",
+            return_value=SimpleNamespace(ok=True, errors=()),
+        ), patch(
+            "trellis.agent.semantic_validators.validate_generated_semantics",
+            return_value=SimpleNamespace(ok=True, errors=(), findings=[]),
         ), patch(
             "trellis.agent.lite_review.review_generated_code",
             return_value=SimpleNamespace(ok=True, errors=(), issues=[]),
@@ -1636,10 +1643,18 @@ class QuantoOptionAnalyticalPayoff:
                 validation="fast",
                 instrument_type="quanto_option",
                 preferred_method="analytical",
+                generation_policy="builder_synthesis_required",
+                build_meta=build_meta,
             )
 
         write_path = mock_write_module.call_args.args[0]
         assert write_path == "instruments/_agent/_fresh/quantooptionanalytical.py"
+        assert build_meta["generation_evidence"] == {
+            "policy": "builder_synthesis_required",
+            "artifact_origin": "model_generated_source",
+            "agent_synthesis_attempted": True,
+            "agent_synthesis_observed": True,
+        }
 
     @patch("trellis.agent.executor._generate_module")
     def test_build_reuses_existing_quanto_monte_carlo_module(self, mock_gen_mod):

--- a/tests/test_agent/test_cassette.py
+++ b/tests/test_agent/test_cassette.py
@@ -45,6 +45,28 @@ def _make_cassette_yaml(calls: list[dict], meta: dict | None = None) -> str:
     return yaml.dump({"meta": meta, "calls": calls}, default_flow_style=False)
 
 
+def test_cassette_session_marks_only_record_override_as_model_source_observable(
+    tmp_path,
+):
+    from trellis.agent.cassette import llm_cassette_session
+    from trellis.agent.config import current_llm_override_context
+
+    path = tmp_path / "provenance.yaml"
+    with llm_cassette_session(path, mode="record"):
+        assert current_llm_override_context() == {
+            "source": "cassette_record",
+            "model_source_observable": True,
+        }
+
+    assert current_llm_override_context() is None
+
+    with llm_cassette_session(path, mode="replay"):
+        assert current_llm_override_context() == {
+            "source": "cassette_replay",
+            "model_source_observable": False,
+        }
+
+
 # ---------------------------------------------------------------------------
 # _prompt_hash
 # ---------------------------------------------------------------------------

--- a/tests/test_agent/test_executor.py
+++ b/tests/test_agent/test_executor.py
@@ -6913,6 +6913,51 @@ def test_build_payoff_fresh_build_still_uses_deterministic_exact_binding(monkeyp
             fresh_build=True,
         )
 
+    def fail_semantic_shim(*args, **kwargs):
+        pytest.fail("semantic shims must be bypassed when builder synthesis is required")
+
+    def fail_deterministic_materializer(*args, **kwargs):
+        pytest.fail(
+            "deterministic exact bindings must be bypassed when builder synthesis is required"
+        )
+
+    def fail_builder(*args, **kwargs):
+        raise RuntimeError("builder synthesis path used")
+
+    monkeypatch.setattr(
+        "trellis.agent.executor._materialize_semantic_execution_shim_module",
+        fail_semantic_shim,
+    )
+    monkeypatch.setattr(
+        "trellis.agent.executor._materialize_deterministic_exact_binding_module",
+        fail_deterministic_materializer,
+    )
+    monkeypatch.setattr("trellis.agent.executor._generate_module", fail_builder)
+    build_meta = {}
+
+    with pytest.raises(RuntimeError, match="builder synthesis path used"):
+        build_payoff(
+            "CDO tranche exact binding synthesis proof",
+            compiled_request=compiled_request,
+            instrument_type="cdo",
+            market_state=SimpleNamespace(
+                selected_curve_names={},
+                available_capabilities={"credit_curve"},
+            ),
+            max_retries=1,
+            model="gpt-5-mini",
+            fresh_build=True,
+            generation_policy="builder_synthesis_required",
+            build_meta=build_meta,
+        )
+
+    assert build_meta["generation_evidence"] == {
+        "policy": "builder_synthesis_required",
+        "artifact_origin": "none",
+        "agent_synthesis_attempted": True,
+        "agent_synthesis_observed": False,
+    }
+
 
 def test_p001_semantic_execution_shim_source_is_thin_adapter():
     from trellis.agent.codegen_guardrails import validate_generated_imports

--- a/tests/test_agent/test_generation_policy.py
+++ b/tests/test_agent/test_generation_policy.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import pytest
+
+
+def test_generation_policy_and_artifact_origin_payload_are_typed():
+    from trellis.agent.generation_policy import generation_evidence_payload
+
+    assert generation_evidence_payload(
+        policy="builder_synthesis_required",
+        artifact_origin="model_generated_source",
+        agent_synthesis_attempted=True,
+        agent_synthesis_observed=True,
+    ) == {
+        "policy": "builder_synthesis_required",
+        "artifact_origin": "model_generated_source",
+        "agent_synthesis_attempted": True,
+        "agent_synthesis_observed": True,
+    }
+
+
+@pytest.mark.parametrize(
+    ("fresh_build", "recovery_mode", "execution_mode", "reason"),
+    [
+        (False, "assisted", "live", "fresh_build_required"),
+        (True, "strict", "live", "recovery_mode_strict"),
+        (
+            True,
+            "assisted",
+            "deterministic_replay",
+            "execution_mode_deterministic_replay",
+        ),
+    ],
+)
+def test_builder_synthesis_policy_fails_closed_when_controls_cannot_prove_it(
+    fresh_build,
+    recovery_mode,
+    execution_mode,
+    reason,
+):
+    from trellis.agent.generation_policy import (
+        GenerationPolicyError,
+        validate_generation_policy_request,
+    )
+
+    with pytest.raises(GenerationPolicyError) as exc_info:
+        validate_generation_policy_request(
+            policy="builder_synthesis_required",
+            fresh_build=fresh_build,
+            recovery_mode=recovery_mode,
+            execution_mode=execution_mode,
+        )
+
+    assert exc_info.value.reason == reason
+
+
+def test_builder_synthesis_policy_allows_assisted_live_execution():
+    from trellis.agent.generation_policy import validate_generation_policy_request
+
+    validate_generation_policy_request(
+        policy="builder_synthesis_required",
+        fresh_build=True,
+        recovery_mode="assisted",
+        execution_mode="live",
+    )

--- a/tests/test_agent/test_generation_policy.py
+++ b/tests/test_agent/test_generation_policy.py
@@ -63,3 +63,78 @@ def test_builder_synthesis_policy_allows_assisted_live_execution():
         recovery_mode="assisted",
         execution_mode="live",
     )
+
+
+def test_builder_synthesis_context_rejects_untrusted_llm_override():
+    from trellis.agent.config import llm_override_scope
+    from trellis.agent.generation_policy import (
+        GenerationPolicyError,
+        validate_builder_synthesis_context,
+    )
+
+    with llm_override_scope(
+        generate=lambda *_args, **_kwargs: "replayed source",
+        generate_json=lambda *_args, **_kwargs: {},
+    ):
+        with pytest.raises(GenerationPolicyError) as exc_info:
+            validate_builder_synthesis_context(
+                policy="builder_synthesis_required",
+            )
+
+    assert exc_info.value.reason == "llm_override_untrusted"
+
+
+def test_build_payoff_rejects_untrusted_llm_override_before_planning():
+    from trellis.agent.config import llm_override_scope
+    from trellis.agent.executor import build_payoff
+    from trellis.agent.generation_policy import GenerationPolicyError
+
+    with llm_override_scope(
+        generate=lambda *_args, **_kwargs: "replayed source",
+        generate_json=lambda *_args, **_kwargs: {},
+    ):
+        with pytest.raises(GenerationPolicyError) as exc_info:
+            build_payoff(
+                "European option",
+                fresh_build=True,
+                generation_policy="builder_synthesis_required",
+            )
+
+    assert exc_info.value.reason == "llm_override_untrusted"
+
+
+@pytest.mark.parametrize(
+    ("cassette_mode", "expected_reason"),
+    [
+        ("replay", "execution_mode_cassette_replay"),
+        ("record", None),
+    ],
+)
+def test_builder_synthesis_context_distinguishes_cassette_record_from_replay(
+    monkeypatch,
+    cassette_mode,
+    expected_reason,
+):
+    from trellis.agent.generation_policy import (
+        GenerationPolicyError,
+        validate_builder_synthesis_context,
+    )
+
+    monkeypatch.setattr(
+        "trellis.agent.cassette.current_llm_cassette_context",
+        lambda: {"mode": cassette_mode},
+    )
+    monkeypatch.setattr(
+        "trellis.agent.config.current_llm_override_context",
+        lambda: {
+            "source": f"cassette_{cassette_mode}",
+            "model_source_observable": cassette_mode == "record",
+        },
+    )
+
+    if expected_reason is None:
+        validate_builder_synthesis_context(policy="builder_synthesis_required")
+    else:
+        with pytest.raises(GenerationPolicyError) as exc_info:
+            validate_builder_synthesis_context(policy="builder_synthesis_required")
+        assert exc_info.value.reason == expected_reason

--- a/tests/test_agent/test_task_batch_reports.py
+++ b/tests/test_agent/test_task_batch_reports.py
@@ -17,6 +17,12 @@ def test_build_task_batch_report_normalizes_paths_and_failed_rows():
             "elapsed_seconds": 12.3,
             "token_usage_summary": {"total_tokens": 42},
             "task_run_history_path": str(root / "task_runs" / "history" / "F001" / "run.json"),
+            "generation_evidence": {
+                "policy": "builder_synthesis_required",
+                "artifact_origins": ["model_generated_source"],
+                "agent_synthesis_attempted": True,
+                "agent_synthesis_observed": True,
+            },
         },
         {
             "task_id": "P004",
@@ -42,6 +48,7 @@ def test_build_task_batch_report_normalizes_paths_and_failed_rows():
         validation="standard",
         force_rebuild=False,
         fresh_build=False,
+        generation_policy="builder_synthesis_required",
         knowledge_light=False,
         selection={"selection_mode": "ids", "status": "all", "requested_task_ids": ("F001", "P004")},
         raw_results_path=root / "task_results_manual.json",
@@ -52,6 +59,10 @@ def test_build_task_batch_report_normalizes_paths_and_failed_rows():
     assert report["summary"]["totals"]["tasks"] == 2
     assert report["artifacts"]["raw_results_path"] == "task_results_manual.json"
     assert report["tasks"][0]["history_path"] == "task_runs/history/F001/run.json"
+    assert report["config"]["generation_policy"] == "builder_synthesis_required"
+    assert report["summary"]["generation_proving"]["synthesis_observed_tasks"] == 1
+    assert report["tasks"][0]["artifact_origins"] == ["model_generated_source"]
+    assert report["tasks"][0]["agent_synthesis_observed"] is True
     assert report["failed_tasks"][0]["diagnosis_packet_path"] == "task_runs/diagnostics/history/P004/run.json"
     assert report["failed_tasks"][0]["status_bucket"] == "blocked"
 
@@ -79,6 +90,7 @@ def test_render_task_batch_markdown_includes_selection_and_gap_signals():
         validation="standard",
         force_rebuild=False,
         fresh_build=False,
+        generation_policy="deterministic_allowed",
         knowledge_light=False,
         selection={
             "selection_mode": "ids",
@@ -93,6 +105,8 @@ def test_render_task_batch_markdown_includes_selection_and_gap_signals():
     assert "# Manual batch" in markdown
     assert "- Mode: `ids`" in markdown
     assert "- Corpora: `extension`" in markdown
+    assert "- Generation policy: `deterministic_allowed`" in markdown
+    assert "Observed model synthesis" in markdown
     assert "## Gap Signals" in markdown
     assert "`P004` `blocked`" in markdown
     assert "| `P004` | `extension` | `blocked` |" in markdown

--- a/tests/test_agent/test_task_diagnostics.py
+++ b/tests/test_agent/test_task_diagnostics.py
@@ -50,6 +50,13 @@ def _sample_record(root: Path) -> dict[str, object]:
         },
         "execution": {
             "mode": "deterministic_replay",
+            "generation_policy": "deterministic_allowed",
+            "generation_evidence": {
+                "policy": "deterministic_allowed",
+                "artifact_origins": ["deterministic_materialization"],
+                "agent_synthesis_attempted": False,
+                "agent_synthesis_observed": False,
+            },
             "llm_cassette": {
                 "mode": "deterministic_replay",
                 "name": "T999",
@@ -347,6 +354,9 @@ def test_build_task_diagnosis_packet_summarizes_failure(tmp_path):
     assert "## Storage" in rendered
     assert "comparison_insufficient_results" in rendered
     assert "Execution mode: `deterministic_replay`" in rendered
+    assert "Generation policy: `deterministic_allowed`" in rendered
+    assert "Artifact origins: `deterministic_materialization`" in rendered
+    assert "Agent synthesis observed: `no`" in rendered
     assert "semantic_validation_failed" in rendered
     assert "route_hint:callable_bond_tree" in rendered
     assert "EventAwarePDEIR" in rendered

--- a/tests/test_agent/test_task_learning_benchmark.py
+++ b/tests/test_agent/test_task_learning_benchmark.py
@@ -18,6 +18,7 @@ def _result(
     promotion_candidate_saved: str | None = None,
     total_tokens: int = 0,
     intra_run_learning: dict | None = None,
+    generation_evidence: dict | None = None,
 ) -> dict:
     return {
         "task_id": task_id,
@@ -53,6 +54,7 @@ def _result(
             "by_provider": {},
         },
         "intra_run_learning": intra_run_learning or {},
+        "generation_evidence": generation_evidence or {},
     }
 
 
@@ -170,12 +172,14 @@ def test_build_task_learning_benchmark_report_tracks_pass_deltas_and_attribution
             {
                 "pass_number": 1,
                 "label": "pass_1",
+                "generation_policy": "builder_synthesis_required",
                 "results": pass_one,
                 "results_path": "/tmp/pass_1.json",
             },
             {
                 "pass_number": 2,
                 "label": "pass_2",
+                "generation_policy": "builder_synthesis_required",
                 "results": pass_two,
                 "results_path": "/tmp/pass_2.json",
             },
@@ -184,6 +188,7 @@ def test_build_task_learning_benchmark_report_tracks_pass_deltas_and_attribution
     )
 
     assert report["passes"][0]["summary"]["totals"]["successes"] == 0
+    assert report["passes"][0]["generation_policy"] == "builder_synthesis_required"
     assert report["passes"][1]["summary"]["totals"]["successes"] == 1
     assert report["pairwise_comparisons"][0]["comparison"]["task_transitions"]["improved"] == 1
     assert report["pairwise_comparisons"][0]["deltas"]["elapsed_seconds_total"] == -11.0
@@ -195,6 +200,7 @@ def test_build_task_learning_benchmark_report_tracks_pass_deltas_and_attribution
     rendered = render_task_learning_benchmark_report(report)
     assert "Task Learning Benchmark" in rendered
     assert "Knowledge-assisted improvements" in rendered
+    assert "Generation policy: `builder_synthesis_required`" in rendered
     assert "Residual implementation gaps" in rendered
 
     artifacts = save_task_learning_benchmark_report(
@@ -284,6 +290,8 @@ def test_build_task_learning_benchmark_report_labels_retry_learned_recovery():
         tasks=[
             _task("L001", "Seeded retry fixture"),
             _task("T13", "First-pass deterministic route"),
+            _task("T16", "First-pass model synthesis"),
+            _task("T17", "First-pass origin unknown"),
             _task("T22", "Failed retry evidence"),
         ],
         pass_runs=[
@@ -297,7 +305,29 @@ def test_build_task_learning_benchmark_report_labels_retry_learned_recovery():
                         attempts=2,
                         intra_run_learning=retry_learning,
                     ),
-                    _result(task_id="T13", success=True, attempts=1),
+                    _result(
+                        task_id="T13",
+                        success=True,
+                        attempts=1,
+                        generation_evidence={
+                            "policy": "deterministic_allowed",
+                            "artifact_origin": "reused_adapter",
+                            "agent_synthesis_attempted": False,
+                            "agent_synthesis_observed": False,
+                        },
+                    ),
+                    _result(
+                        task_id="T16",
+                        success=True,
+                        attempts=1,
+                        generation_evidence={
+                            "policy": "builder_synthesis_required",
+                            "artifact_origin": "model_generated_source",
+                            "agent_synthesis_attempted": True,
+                            "agent_synthesis_observed": True,
+                        },
+                    ),
+                    _result(task_id="T17", success=True, attempts=1),
                     _result(
                         task_id="T22",
                         success=False,
@@ -315,6 +345,8 @@ def test_build_task_learning_benchmark_report_labels_retry_learned_recovery():
     retry_learning_report = report["attribution"]["retry_learning"]
     assert retry_learning_report["retry_learned_recoveries"]["task_ids"] == ["L001"]
     assert retry_learning_report["first_pass_deterministic_reuse"]["task_ids"] == ["T13"]
+    assert retry_learning_report["first_pass_model_synthesis"]["task_ids"] == ["T16"]
+    assert retry_learning_report["first_pass_origin_unknown"]["task_ids"] == ["T17"]
     assert retry_learning_report["failed_or_unvalidated_retry_evidence"]["task_ids"] == [
         "T22"
     ]
@@ -322,4 +354,6 @@ def test_build_task_learning_benchmark_report_labels_retry_learned_recovery():
     rendered = render_task_learning_benchmark_report(report)
     assert "Retry-learned recoveries" in rendered
     assert "First-pass deterministic reuse" in rendered
+    assert "First-pass model synthesis" in rendered
+    assert "First-pass origin unknown" in rendered
     assert "Failed or unvalidated retry evidence" in rendered

--- a/tests/test_agent/test_task_learning_benchmark_runner.py
+++ b/tests/test_agent/test_task_learning_benchmark_runner.py
@@ -151,4 +151,5 @@ def test_run_learning_benchmark_seeded_retry_fixture_recovers_without_llm(
     assert report["attribution"]["retry_learning"]["retry_learned_recoveries"][
         "task_ids"
     ] == ["L001"]
+    assert report["passes"][0]["generation_policy"] == "deterministic_allowed"
     assert "Saved learning benchmark report" in stdout

--- a/tests/test_agent/test_task_run_store.py
+++ b/tests/test_agent/test_task_run_store.py
@@ -178,6 +178,13 @@ def test_persist_task_run_record_writes_latest_and_enriches_traces(tmp_path):
         "start_time": "2026-03-25T14:05:00",
         "comparison_task": True,
         "comparison_targets": ["fft", "cos", "black_scholes"],
+        "generation_policy": "builder_synthesis_required",
+        "generation_evidence": {
+            "policy": "builder_synthesis_required",
+            "artifact_origins": ["model_generated_source"],
+            "agent_synthesis_attempted": True,
+            "agent_synthesis_observed": True,
+        },
         "token_usage_summary": {
             "call_count": 3,
             "calls_with_usage": 3,
@@ -290,6 +297,11 @@ def test_persist_task_run_record_writes_latest_and_enriches_traces(tmp_path):
     assert Path(persisted["latest_diagnosis_dossier_path"]).exists()
     assert latest["task_id"] == "T104"
     assert latest["summary"]["comparison_status"] == "failed"
+    assert latest["execution"]["generation_policy"] == "builder_synthesis_required"
+    assert latest["execution"]["generation_evidence"]["artifact_origins"] == [
+        "model_generated_source"
+    ]
+    assert latest["summary"]["generation_evidence"]["agent_synthesis_observed"] is True
     assert latest["summary"]["prices"]["fft"] == 10.12
     assert latest["method_runs"]["fft"]["trace_summary"]["linear_issue"]["identifier"] == "QUA-99"
     assert latest["method_runs"]["fft"]["trace_summary"]["semantic_role_ownership"]["selected_role"] == "quant"

--- a/tests/test_agent/test_task_runtime.py
+++ b/tests/test_agent/test_task_runtime.py
@@ -82,6 +82,8 @@ def test_run_task_passes_force_rebuild_and_validation():
     assert calls[0]["validation"] == "fast"
     assert calls[0]["force_rebuild"] is False
     assert calls[0]["fresh_build"] is True
+    assert calls[0]["generation_policy"] == "deterministic_allowed"
+    assert calls[0]["request_metadata"]["generation_policy"] == "deterministic_allowed"
     assert calls[0]["request_metadata"]["post_build_learning_policy"] == {
         "execution_mode": "live",
         "artifact_policy": "fresh_generated",
@@ -97,11 +99,128 @@ def test_run_task_passes_force_rebuild_and_validation():
         "post_build_learning_policy"
     ]
     assert result["execution_mode"] == "live"
+    assert result["generation_policy"] == "deterministic_allowed"
+    assert result["generation_evidence"] == {
+        "policy": "deterministic_allowed",
+        "artifact_origins": [],
+        "agent_synthesis_attempted": False,
+        "agent_synthesis_observed": False,
+    }
     assert result["runtime_controls"]["llm_wait_log_path"] == wait_log_path
     assert result["success"] is True
     assert result["elapsed_seconds"] == 4.5
     assert result["payoff_class"] == "FakePayoffClass"
     monkeypatch.undo()
+
+
+@pytest.mark.parametrize(
+    ("recovery_mode", "execution_mode", "expected_reason"),
+    [
+        ("strict", "live", "recovery_mode_strict"),
+        ("assisted", "offline_local_agents", "execution_mode_offline_local_agents"),
+        ("assisted", "cassette_replay", "execution_mode_cassette_replay"),
+    ],
+)
+def test_run_task_fails_closed_when_builder_synthesis_is_unavailable(
+    recovery_mode,
+    execution_mode,
+    expected_reason,
+):
+    from trellis.agent.task_runtime import run_task
+
+    calls = []
+
+    result = run_task(
+        {"id": "T20", "title": "Heston ADI PDE"},
+        market_state=object(),
+        fresh_build=True,
+        generation_policy="builder_synthesis_required",
+        recovery_mode=recovery_mode,
+        execution_mode_override=execution_mode,
+        build_fn=lambda **kwargs: calls.append(kwargs),
+    )
+
+    assert calls == []
+    assert result["success"] is False
+    assert result["attempts"] == 0
+    assert result["generation_policy_error"]["reason"] == expected_reason
+    assert result["task_diagnosis_failure_bucket"] == "generation_policy"
+    assert result["generation_evidence"] == {
+        "policy": "builder_synthesis_required",
+        "artifact_origins": [],
+        "agent_synthesis_attempted": False,
+        "agent_synthesis_observed": False,
+    }
+
+
+def test_run_task_records_observed_builder_synthesis_without_trace_inspection():
+    from trellis.agent.task_runtime import run_task
+
+    calls = []
+
+    class FakeResult:
+        success = True
+        attempts = 1
+        gap_confidence = 1.0
+        knowledge_gaps = []
+        payoff_cls = type("ModelGeneratedPayoff", (), {})
+        failures = []
+        reflection = {}
+        generation_evidence = {
+            "policy": "builder_synthesis_required",
+            "artifact_origin": "model_generated_source",
+            "agent_synthesis_attempted": True,
+            "agent_synthesis_observed": True,
+        }
+
+    def fake_build(**kwargs):
+        calls.append(kwargs)
+        return FakeResult()
+
+    result = run_task(
+        {"id": "T20", "title": "Heston ADI PDE"},
+        market_state=object(),
+        fresh_build=True,
+        generation_policy="builder_synthesis_required",
+        recovery_mode="assisted",
+        execution_mode_override="live",
+        build_fn=fake_build,
+    )
+
+    assert calls[0]["generation_policy"] == "builder_synthesis_required"
+    assert result["generation_evidence"] == {
+        "policy": "builder_synthesis_required",
+        "artifact_origins": ["model_generated_source"],
+        "agent_synthesis_attempted": True,
+        "agent_synthesis_observed": True,
+    }
+
+
+def test_run_task_rejects_unproven_success_when_builder_synthesis_is_required():
+    from trellis.agent.task_runtime import run_task
+
+    class UnprovenResult:
+        success = True
+        attempts = 0
+        gap_confidence = 1.0
+        knowledge_gaps = []
+        payoff_cls = type("DeterministicPayoff", (), {})
+        failures = []
+        reflection = {}
+
+    result = run_task(
+        {"id": "T20", "title": "Heston ADI PDE"},
+        market_state=object(),
+        fresh_build=True,
+        generation_policy="builder_synthesis_required",
+        recovery_mode="assisted",
+        execution_mode_override="live",
+        build_fn=lambda **kwargs: UnprovenResult(),
+    )
+
+    assert result["success"] is False
+    assert result["generation_policy_error"]["reason"] == "synthesis_evidence_missing"
+    assert result["generation_evidence"]["agent_synthesis_observed"] is False
 
 
 def test_run_task_strict_mode_does_not_retry_failed_target():
@@ -3156,6 +3275,12 @@ def test_run_task_records_promotion_candidates_for_fresh_build_comparison_succes
             self.reflection = {}
             self.selected_method = method
             self.comparison_target_contract = dict(target_contract)
+            self.generation_evidence = {
+                "policy": "builder_synthesis_required",
+                "artifact_origin": "model_generated_source",
+                "agent_synthesis_attempted": True,
+                "agent_synthesis_observed": True,
+            }
 
     def fake_build(**kwargs):
         return FakeResult(
@@ -3213,6 +3338,46 @@ def test_run_task_records_promotion_candidates_for_fresh_build_comparison_succes
         result["method_results"]["mc_exact"]["artifacts"]["promotion_candidate_paths"]
         == ["/tmp/mc_exact_candidate.yaml"]
     )
+
+
+def test_record_promotion_candidates_ignores_fresh_deterministic_materialization(
+    monkeypatch,
+):
+    from trellis.agent.task_runtime import _record_promotion_candidates
+
+    calls = []
+    monkeypatch.setattr(
+        "trellis.agent.knowledge.promotion.record_promotion_candidate",
+        lambda **kwargs: calls.append(kwargs) or "/tmp/candidate.yaml",
+    )
+    live_result = SimpleNamespace(
+        success=True,
+        attempts=0,
+        code="class DeterministicPayoff: pass\n",
+        payoff_cls=type("DeterministicPayoff", (), {}),
+    )
+
+    candidates = _record_promotion_candidates(
+        task={"id": "T105", "title": "Quanto proof"},
+        instrument_type="quanto_option",
+        market_context={},
+        live_results={"analytical": live_result},
+        method_results={
+            "analytical": {
+                "success": True,
+                "generation_evidence": {
+                    "policy": "deterministic_allowed",
+                    "artifact_origin": "deterministic_materialization",
+                    "agent_synthesis_attempted": False,
+                    "agent_synthesis_observed": False,
+                },
+            }
+        },
+        cross_validation={"status": "passed"},
+    )
+
+    assert candidates == {}
+    assert calls == []
 
 
 def test_run_task_skips_promotion_candidates_without_fresh_build(monkeypatch):

--- a/trellis/agent/cassette.py
+++ b/trellis/agent/cassette.py
@@ -461,6 +461,8 @@ def llm_cassette_session(
         with llm_override_scope(
             generate=generate,
             generate_json=generate_json,
+            source=f"cassette_{mode}",
+            model_source_observable=mode == "record",
         ):
             yield handler
     finally:

--- a/trellis/agent/config.py
+++ b/trellis/agent/config.py
@@ -83,6 +83,8 @@ class LLMOverrideHandlers:
 
     generate: Callable[..., str]
     generate_json: Callable[..., dict]
+    source: str = "custom"
+    model_source_observable: bool = False
 
 
 class TokenBudgetExceeded(RuntimeError):
@@ -377,18 +379,33 @@ def llm_override_scope(
     *,
     generate: Callable[..., str],
     generate_json: Callable[..., dict],
+    source: str = "custom",
+    model_source_observable: bool = False,
 ):
     """Temporarily override LLM text/JSON calls in the current context."""
     token = _LLM_OVERRIDE_HANDLERS.set(
         LLMOverrideHandlers(
             generate=generate,
             generate_json=generate_json,
+            source=str(source).strip() or "custom",
+            model_source_observable=bool(model_source_observable),
         )
     )
     try:
         yield
     finally:
         _LLM_OVERRIDE_HANDLERS.reset(token)
+
+
+def current_llm_override_context() -> dict[str, Any] | None:
+    """Describe the active LLM override and whether it can prove model source."""
+    override = _LLM_OVERRIDE_HANDLERS.get()
+    if override is None:
+        return None
+    return {
+        "source": override.source,
+        "model_source_observable": override.model_source_observable,
+    }
 
 
 def _validate_llm_text_response(text: str | None, *, provider: str, model: str) -> str:

--- a/trellis/agent/evals.py
+++ b/trellis/agent/evals.py
@@ -1157,6 +1157,9 @@ def classify_task_result(result: Mapping[str, Any]) -> str:
     if blocker_details:
         return "blocked"
 
+    if result.get("generation_policy_error"):
+        return "generation_policy"
+
     cross_validation = result.get("cross_validation") or {}
     cross_status = str(cross_validation.get("status") or "").strip().lower()
     if cross_status and cross_status != "passed":
@@ -1254,6 +1257,10 @@ def summarize_task_results(results: list[Mapping[str, Any]]) -> dict[str, Any]:
     retry_taxonomy_by_stage: dict[str, dict[str, Any]] = {}
     retry_taxonomy_by_task: dict[str, list[str]] = {}
     unattributed_recoveries = 0
+    generation_policy_counts: dict[str, int] = {}
+    artifact_origin_counts: dict[str, int] = {}
+    synthesis_attempted_tasks = 0
+    synthesis_observed_tasks = 0
 
     successes = 0
     expectation_passes = 0
@@ -1327,6 +1334,26 @@ def summarize_task_results(results: list[Mapping[str, Any]]) -> dict[str, Any]:
 
         _merge_token_usage_summary(token_usage, result.get("token_usage_summary") or {})
 
+        generation_evidence = result.get("generation_evidence")
+        if isinstance(generation_evidence, Mapping):
+            policy = str(generation_evidence.get("policy") or "").strip()
+            if policy:
+                generation_policy_counts[policy] = generation_policy_counts.get(policy, 0) + 1
+            raw_origins = generation_evidence.get("artifact_origins")
+            if raw_origins is None:
+                raw_origins = [generation_evidence.get("artifact_origin")]
+            elif isinstance(raw_origins, str):
+                raw_origins = [raw_origins]
+            for raw_origin in raw_origins or ():
+                origin = str(raw_origin or "").strip()
+                if not origin or origin == "none":
+                    continue
+                artifact_origin_counts[origin] = artifact_origin_counts.get(origin, 0) + 1
+            if bool(generation_evidence.get("agent_synthesis_attempted")):
+                synthesis_attempted_tasks += 1
+            if bool(generation_evidence.get("agent_synthesis_observed")):
+                synthesis_observed_tasks += 1
+
     return {
         "totals": {
             "tasks": len(results),
@@ -1381,6 +1408,12 @@ def summarize_task_results(results: list[Mapping[str, Any]]) -> dict[str, Any]:
         "shared_knowledge": {
             "tasks_with_shared_context": shared_knowledge_tasks,
             "tasks_with_lessons": shared_knowledge_lessons,
+        },
+        "generation_proving": {
+            "policies": dict(sorted(generation_policy_counts.items())),
+            "artifact_origins": dict(sorted(artifact_origin_counts.items())),
+            "synthesis_attempted_tasks": synthesis_attempted_tasks,
+            "synthesis_observed_tasks": synthesis_observed_tasks,
         },
         "promotion_discipline": summarize_promotion_discipline(results),
         "token_usage": token_usage,

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -35,6 +35,13 @@ from trellis.agent.introspection import (
     search_tests,
 )
 from trellis.agent.analytical_traces import emit_analytical_trace_from_generation_plan
+from trellis.agent.generation_policy import (
+    ArtifactOrigin,
+    GenerationPolicy,
+    GenerationPolicyError,
+    normalize_generation_policy,
+    record_generation_evidence,
+)
 from trellis.agent.semantic_validation import validate_semantics
 from trellis.agent.builder import write_module, run_tests
 from trellis.agent.knowledge.import_registry import resolve_import_candidates
@@ -1231,6 +1238,7 @@ def build_payoff(
     gap_report=None,
     knowledge_retriever: Callable[[KnowledgeRetrievalRequest], str | None] | None = None,
     knowledge_overlays: Sequence[Mapping[str, object]] | None = None,
+    generation_policy: str | GenerationPolicy = GenerationPolicy.DETERMINISTIC_ALLOWED,
 ) -> type:
     """Build a Payoff class via the multi-agent pipeline.
 
@@ -1241,6 +1249,9 @@ def build_payoff(
     4. **Builder agent** generates the code using the prescribed method
     5. **Critic agent** reviews the code
     6. **Arbiter** validates with invariants
+
+    ``fresh_build`` controls path isolation; ``generation_policy`` separately
+    controls whether deterministic source construction may satisfy the build.
     """
     from trellis.agent.planner import plan_build
     from trellis.agent.quant import (
@@ -1263,6 +1274,19 @@ def build_payoff(
     from trellis.core.market_state import MissingCapabilityError
 
     model = model or get_default_model()
+    generation_policy_value = normalize_generation_policy(generation_policy)
+    record_generation_evidence(
+        build_meta,
+        policy=generation_policy_value,
+    )
+    if (
+        generation_policy_value is GenerationPolicy.BUILDER_SYNTHESIS_REQUIRED
+        and not fresh_build
+    ):
+        raise GenerationPolicyError(
+            "Builder synthesis requires fresh_build=True so model source is isolated from admitted adapters.",
+            reason="fresh_build_required",
+        )
     product_ir = None
     if compiled_request is None:
         try:
@@ -1486,6 +1510,11 @@ def build_payoff(
         elif not force_rebuild:
             reuse_reason = "cached_generated_module"
     if existing is not None and reuse_reason is not None:
+        record_generation_evidence(
+            build_meta,
+            policy=generation_policy_value,
+            artifact_origin=ArtifactOrigin.REUSED_ADAPTER,
+        )
         _record_platform_event(
             compiled_request,
             "existing_generated_module_reused",
@@ -1494,6 +1523,9 @@ def build_payoff(
                 "module_path": plan.steps[0].module_path if plan.steps else "",
                 "class_name": getattr(existing, "__name__", type(existing).__name__),
                 "reason": reuse_reason,
+                "generation_evidence": dict(
+                    (build_meta or {}).get("generation_evidence") or {}
+                ),
             },
         )
         generation_plan = (
@@ -1830,6 +1862,7 @@ def build_payoff(
             "module_name": module_name,
             "validation": validation,
             "max_retries": max_retries,
+            "generation_policy": generation_policy_value.value,
         },
     )
     if validation != "thorough":
@@ -1883,6 +1916,9 @@ def build_payoff(
                 "retrieval_source": knowledge_context.retrieval_source,
                 "retry_reason": retry_reason,
                 "knowledge_context_chars": len(knowledge_text),
+                "generation_evidence": dict(
+                    (build_meta or {}).get("generation_evidence") or {}
+                ),
             },
         )
         stage_model = get_model_for_stage("code_generation", model)
@@ -1893,25 +1929,43 @@ def build_payoff(
             request_metadata,
         )
         try:
-            generated_module = _materialize_semantic_execution_shim_module(
-                skeleton,
-                generation_plan,
-                request_metadata=request_metadata,
-                comparison_target=comparison_target,
-            )
-            if generated_module is None:
-                generated_module = _materialize_deterministic_exact_binding_module(
+            if generation_policy_value is GenerationPolicy.DETERMINISTIC_ALLOWED:
+                generated_module = _materialize_semantic_execution_shim_module(
                     skeleton,
                     generation_plan,
-                    semantic_blueprint=(
-                        getattr(compiled_request, "semantic_blueprint", None)
-                        if compiled_request is not None
-                        else None
-                    ),
                     request_metadata=request_metadata,
                     comparison_target=comparison_target,
                 )
+                if generated_module is not None:
+                    record_generation_evidence(
+                        build_meta,
+                        policy=generation_policy_value,
+                        artifact_origin=ArtifactOrigin.SEMANTIC_SHIM,
+                    )
+                if generated_module is None:
+                    generated_module = _materialize_deterministic_exact_binding_module(
+                        skeleton,
+                        generation_plan,
+                        semantic_blueprint=(
+                            getattr(compiled_request, "semantic_blueprint", None)
+                            if compiled_request is not None
+                            else None
+                        ),
+                        request_metadata=request_metadata,
+                        comparison_target=comparison_target,
+                    )
+                    if generated_module is not None:
+                        record_generation_evidence(
+                            build_meta,
+                            policy=generation_policy_value,
+                            artifact_origin=ArtifactOrigin.DETERMINISTIC_MATERIALIZATION,
+                        )
             if generated_module is None:
+                record_generation_evidence(
+                    build_meta,
+                    policy=generation_policy_value,
+                    agent_synthesis_attempted=True,
+                )
                 with llm_usage_stage(
                     "code_generation",
                     metadata=_llm_stage_metadata(
@@ -1937,6 +1991,13 @@ def build_payoff(
                             code=source_report.sanitized_source.expandtabs(4),
                             source_report=source_report,
                         )
+                record_generation_evidence(
+                    build_meta,
+                    policy=generation_policy_value,
+                    artifact_origin=ArtifactOrigin.MODEL_GENERATED_SOURCE,
+                    agent_synthesis_attempted=True,
+                    agent_synthesis_observed=True,
+                )
                 generation_token_usage = summarize_llm_usage(usage_records)
                 enforce_llm_token_budget(stage="code_generation")
             code = generated_module.code
@@ -1966,6 +2027,9 @@ def build_payoff(
                     if source_report is not None
                     else None,
                     "token_usage": generation_token_usage,
+                    "generation_evidence": dict(
+                        (build_meta or {}).get("generation_evidence") or {}
+                    ),
                 },
             )
             validation_feedback = (
@@ -1993,6 +2057,9 @@ def build_payoff(
                 if generated_module is not None
                 else None,
                 "token_usage": generation_token_usage,
+                "generation_evidence": dict(
+                    (build_meta or {}).get("generation_evidence") or {}
+                ),
             },
         )
 
@@ -2191,7 +2258,12 @@ def build_payoff(
                 status="ok",
                 success=True if _finalizes_in_executor(compiled_request) else None,
                 outcome="build_completed" if _finalizes_in_executor(compiled_request) else None,
-                details={"attempts": attempt_number},
+                details={
+                    "attempts": attempt_number,
+                    "generation_evidence": dict(
+                        (build_meta or {}).get("generation_evidence") or {}
+                    ),
+                },
             )
             _audit_path = _write_build_audit_record(
                 compiled_request=compiled_request,
@@ -2242,7 +2314,12 @@ def build_payoff(
                 status="ok",
                 success=True if _finalizes_in_executor(compiled_request) else None,
                 outcome="build_completed" if _finalizes_in_executor(compiled_request) else None,
-                details={"attempts": attempt_number},
+                details={
+                    "attempts": attempt_number,
+                    "generation_evidence": dict(
+                        (build_meta or {}).get("generation_evidence") or {}
+                    ),
+                },
             )
             _audit_path = _write_build_audit_record(
                 compiled_request=compiled_request,

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -41,6 +41,7 @@ from trellis.agent.generation_policy import (
     GenerationPolicyError,
     normalize_generation_policy,
     record_generation_evidence,
+    validate_builder_synthesis_context,
 )
 from trellis.agent.semantic_validation import validate_semantics
 from trellis.agent.builder import write_module, run_tests
@@ -1287,6 +1288,10 @@ def build_payoff(
             "Builder synthesis requires fresh_build=True so model source is isolated from admitted adapters.",
             reason="fresh_build_required",
         )
+    validate_builder_synthesis_context(
+        policy=generation_policy_value,
+        request_metadata=request_metadata,
+    )
     product_ir = None
     if compiled_request is None:
         try:

--- a/trellis/agent/generation_policy.py
+++ b/trellis/agent/generation_policy.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Mapping
@@ -167,3 +168,68 @@ def validate_generation_policy_request(
             f"{normalized_execution or '<empty>'!r}.",
             reason=f"execution_mode_{normalized_execution or 'unknown'}",
         )
+
+
+def validate_builder_synthesis_context(
+    *,
+    policy: str | GenerationPolicy,
+    request_metadata: Mapping[str, object] | None = None,
+) -> None:
+    """Reject replayed or untrusted override source before proving synthesis."""
+    normalized = normalize_generation_policy(policy)
+    if normalized is GenerationPolicy.DETERMINISTIC_ALLOWED:
+        return
+
+    metadata_mode = _metadata_execution_mode(request_metadata)
+    if metadata_mode and metadata_mode not in {"live", "cassette_record"}:
+        raise GenerationPolicyError(
+            f"Builder synthesis is unavailable in execution mode {metadata_mode!r}.",
+            reason=f"execution_mode_{metadata_mode}",
+        )
+    if os.environ.get("TRELLIS_OFFLINE_LOCAL_AGENTS", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }:
+        raise GenerationPolicyError(
+            "Builder synthesis is unavailable in offline_local_agents mode.",
+            reason="execution_mode_offline_local_agents",
+        )
+
+    from trellis.agent.cassette import current_llm_cassette_context
+    from trellis.agent.config import current_llm_override_context
+
+    cassette_context = current_llm_cassette_context()
+    cassette_mode = str((cassette_context or {}).get("mode") or "").strip().lower()
+    if cassette_mode and cassette_mode != "record":
+        execution_mode = f"cassette_{cassette_mode}"
+        raise GenerationPolicyError(
+            f"Builder synthesis is unavailable in execution mode {execution_mode!r}.",
+            reason=f"execution_mode_{execution_mode}",
+        )
+
+    override_context = current_llm_override_context()
+    if override_context and not bool(
+        override_context.get("model_source_observable")
+    ):
+        source = str(override_context.get("source") or "custom").strip()
+        raise GenerationPolicyError(
+            "Builder synthesis cannot be proved through untrusted LLM override "
+            f"{source!r}.",
+            reason="llm_override_untrusted",
+        )
+
+
+def _metadata_execution_mode(
+    request_metadata: Mapping[str, object] | None,
+) -> str:
+    if not isinstance(request_metadata, Mapping):
+        return ""
+    direct = str(request_metadata.get("execution_mode") or "").strip().lower()
+    if direct:
+        return direct
+    policy = request_metadata.get("post_build_learning_policy")
+    if isinstance(policy, Mapping):
+        return str(policy.get("execution_mode") or "").strip().lower()
+    return ""

--- a/trellis/agent/generation_policy.py
+++ b/trellis/agent/generation_policy.py
@@ -1,0 +1,169 @@
+"""Typed policy and evidence for task artifact generation provenance."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Mapping
+
+
+class GenerationPolicy(str, Enum):
+    """Controls whether deterministic source construction may satisfy a build."""
+
+    DETERMINISTIC_ALLOWED = "deterministic_allowed"
+    BUILDER_SYNTHESIS_REQUIRED = "builder_synthesis_required"
+
+
+class ArtifactOrigin(str, Enum):
+    """Identifies how the executed pricing artifact was produced."""
+
+    NONE = "none"
+    REUSED_ADAPTER = "reused_adapter"
+    SEMANTIC_SHIM = "semantic_shim"
+    DETERMINISTIC_MATERIALIZATION = "deterministic_materialization"
+    MODEL_GENERATED_SOURCE = "model_generated_source"
+    DETERMINISTIC_PROOF_ARTIFACT = "deterministic_proof_artifact"
+
+
+class GenerationPolicyError(RuntimeError):
+    """Raised when the requested proving policy cannot be satisfied safely."""
+
+    def __init__(self, message: str, *, reason: str) -> None:
+        super().__init__(message)
+        self.reason = reason
+
+
+@dataclass(frozen=True)
+class GenerationEvidence:
+    """Stable evidence separating artifact origin from path freshness."""
+
+    policy: GenerationPolicy
+    artifact_origin: ArtifactOrigin = ArtifactOrigin.NONE
+    agent_synthesis_attempted: bool = False
+    agent_synthesis_observed: bool = False
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return the machine-readable evidence shape persisted by task runs."""
+        return {
+            "policy": self.policy.value,
+            "artifact_origin": self.artifact_origin.value,
+            "agent_synthesis_attempted": self.agent_synthesis_attempted,
+            "agent_synthesis_observed": self.agent_synthesis_observed,
+        }
+
+
+def normalize_generation_policy(
+    value: str | GenerationPolicy,
+) -> GenerationPolicy:
+    """Normalize a public policy value and reject unknown policy names."""
+    if isinstance(value, GenerationPolicy):
+        return value
+    try:
+        return GenerationPolicy(str(value).strip().lower())
+    except ValueError as exc:
+        allowed = ", ".join(policy.value for policy in GenerationPolicy)
+        raise ValueError(
+            f"Unknown generation policy {value!r}; expected one of: {allowed}"
+        ) from exc
+
+
+def generation_evidence_payload(
+    *,
+    policy: str | GenerationPolicy,
+    artifact_origin: str | ArtifactOrigin = ArtifactOrigin.NONE,
+    agent_synthesis_attempted: bool = False,
+    agent_synthesis_observed: bool = False,
+) -> dict[str, Any]:
+    """Build one normalized evidence payload."""
+    normalized_origin = (
+        artifact_origin
+        if isinstance(artifact_origin, ArtifactOrigin)
+        else ArtifactOrigin(str(artifact_origin).strip().lower())
+    )
+    return GenerationEvidence(
+        policy=normalize_generation_policy(policy),
+        artifact_origin=normalized_origin,
+        agent_synthesis_attempted=bool(agent_synthesis_attempted),
+        agent_synthesis_observed=bool(agent_synthesis_observed),
+    ).to_payload()
+
+
+def record_generation_evidence(
+    build_meta: dict[str, Any] | None,
+    *,
+    policy: str | GenerationPolicy,
+    artifact_origin: str | ArtifactOrigin | None = None,
+    agent_synthesis_attempted: bool | None = None,
+    agent_synthesis_observed: bool | None = None,
+) -> dict[str, Any]:
+    """Update build metadata while preserving evidence not changed by this stage."""
+    current = dict((build_meta or {}).get("generation_evidence") or {})
+    payload = generation_evidence_payload(
+        policy=policy,
+        artifact_origin=(
+            artifact_origin
+            if artifact_origin is not None
+            else current.get("artifact_origin", ArtifactOrigin.NONE.value)
+        ),
+        agent_synthesis_attempted=(
+            bool(agent_synthesis_attempted)
+            if agent_synthesis_attempted is not None
+            else bool(current.get("agent_synthesis_attempted"))
+        ),
+        agent_synthesis_observed=(
+            bool(agent_synthesis_observed)
+            if agent_synthesis_observed is not None
+            else bool(current.get("agent_synthesis_observed"))
+        ),
+    )
+    if build_meta is not None:
+        build_meta["generation_evidence"] = payload
+    return payload
+
+
+def generation_evidence_from_result(
+    result: object,
+    *,
+    default_policy: str | GenerationPolicy = GenerationPolicy.DETERMINISTIC_ALLOWED,
+) -> dict[str, Any]:
+    """Read normalized generation evidence from a BuildResult-like object."""
+    raw = getattr(result, "generation_evidence", None)
+    if not isinstance(raw, Mapping):
+        return generation_evidence_payload(policy=default_policy)
+    return generation_evidence_payload(
+        policy=raw.get("policy", default_policy),
+        artifact_origin=raw.get("artifact_origin", ArtifactOrigin.NONE.value),
+        agent_synthesis_attempted=bool(raw.get("agent_synthesis_attempted")),
+        agent_synthesis_observed=bool(raw.get("agent_synthesis_observed")),
+    )
+
+
+def validate_generation_policy_request(
+    *,
+    policy: str | GenerationPolicy,
+    fresh_build: bool,
+    recovery_mode: str,
+    execution_mode: str,
+) -> None:
+    """Fail closed when task controls cannot prove required builder synthesis."""
+    normalized = normalize_generation_policy(policy)
+    if normalized is GenerationPolicy.DETERMINISTIC_ALLOWED:
+        return
+    if not fresh_build:
+        raise GenerationPolicyError(
+            "Builder synthesis requires fresh_build=True so model source is isolated from admitted adapters.",
+            reason="fresh_build_required",
+        )
+    normalized_recovery = str(recovery_mode).strip().lower()
+    if normalized_recovery == "strict":
+        raise GenerationPolicyError(
+            "Builder synthesis is disabled in strict recovery mode.",
+            reason="recovery_mode_strict",
+        )
+    normalized_execution = str(execution_mode).strip().lower()
+    if normalized_execution not in {"live", "cassette_record"}:
+        raise GenerationPolicyError(
+            "Builder synthesis is unavailable in execution mode "
+            f"{normalized_execution or '<empty>'!r}.",
+            reason=f"execution_mode_{normalized_execution or 'unknown'}",
+        )

--- a/trellis/agent/knowledge/autonomous.py
+++ b/trellis/agent/knowledge/autonomous.py
@@ -29,6 +29,12 @@ from trellis.agent.post_build_policy import (
     PostBuildLearningPolicy,
     post_build_policy_from_request_metadata,
 )
+from trellis.agent.generation_policy import (
+    GenerationPolicy,
+    GenerationPolicyError,
+    generation_evidence_payload,
+    normalize_generation_policy,
+)
 
 
 class BuildTrackingFailure(RuntimeError):
@@ -81,6 +87,7 @@ class BuildResult:
     intra_run_learning: dict[str, Any] = field(default_factory=dict)
     gate_decision: object | None = None  # BuildGateDecision when gate evaluated
     post_build_tracking: dict[str, Any] = field(default_factory=dict)
+    generation_evidence: dict[str, Any] = field(default_factory=dict)
 
 
 _PROVIDER_FAILURE_MARKERS = (
@@ -204,6 +211,7 @@ def build_with_knowledge(
     request_metadata: Mapping[str, object] | None = None,
     semantic_contract=None,
     knowledge_overlays: Sequence[Mapping[str, object]] | None = None,
+    generation_policy: str | GenerationPolicy = GenerationPolicy.DETERMINISTIC_ALLOWED,
 ) -> BuildResult:
     """Build a payoff class while autonomously managing the knowledge lifecycle.
 
@@ -241,6 +249,18 @@ def build_with_knowledge(
             f"Implementation target: {comparison_target}"
         )
 
+    generation_policy_value = normalize_generation_policy(generation_policy)
+    if (
+        generation_policy_value is GenerationPolicy.BUILDER_SYNTHESIS_REQUIRED
+        and not fresh_build
+    ):
+        raise GenerationPolicyError(
+            "Builder synthesis requires fresh_build=True so model source is isolated from admitted adapters.",
+            reason="fresh_build_required",
+        )
+    initial_generation_evidence = generation_evidence_payload(
+        policy=generation_policy_value
+    )
     post_build_policy = post_build_policy_from_request_metadata(request_metadata)
     post_build_controls = _post_build_control_flags(post_build_policy)
 
@@ -284,6 +304,7 @@ def build_with_knowledge(
                     "active_flags": post_build_controls,
                     "events": [],
                 },
+                generation_evidence=initial_generation_evidence,
             )
 
         # Increase retries if knowledge is thin
@@ -303,6 +324,7 @@ def build_with_knowledge(
                 "active_flags": post_build_controls,
                 "events": [],
             },
+            generation_evidence=initial_generation_evidence,
         )
 
         try:
@@ -319,6 +341,7 @@ def build_with_knowledge(
                 validation=validation,
                 force_rebuild=force_rebuild,
                 fresh_build=fresh_build,
+                generation_policy=generation_policy_value,
                 preferred_method=preferred_method,
                 request_metadata=request_metadata,
                 semantic_contract=semantic_contract,
@@ -366,6 +389,9 @@ def build_with_knowledge(
             )
             result.blocker_details = build_meta.get("blocker_details")
             result.intra_run_learning = dict(build_meta.get("intra_run_learning") or {})
+            result.generation_evidence = dict(
+                build_meta.get("generation_evidence") or initial_generation_evidence
+            )
         except BuildTrackingFailure as exc:
             result.failures = [str(exc.cause)]
             result.attempts = exc.meta.get("attempts", 0)
@@ -407,6 +433,9 @@ def build_with_knowledge(
             )
             result.blocker_details = exc.meta.get("blocker_details")
             result.intra_run_learning = dict(exc.meta.get("intra_run_learning") or {})
+            result.generation_evidence = dict(
+                exc.meta.get("generation_evidence") or initial_generation_evidence
+            )
         except Exception as e:
             result.failures = [str(e)]
         _record_post_build_phase(
@@ -611,6 +640,7 @@ def _build_with_tracking(
     validation: str,
     force_rebuild: bool,
     fresh_build: bool = False,
+    generation_policy: str | GenerationPolicy = GenerationPolicy.DETERMINISTIC_ALLOWED,
     build_description: str | None = None,
     preferred_method: str | None = None,
     request_metadata: Mapping[str, object] | None = None,
@@ -651,6 +681,9 @@ def _build_with_tracking(
     knowledge_payload = build_shared_knowledge_payload(knowledge)
     meta: dict = {
         "knowledge_summary": dict(knowledge_payload.get("summary") or {}),
+        "generation_evidence": generation_evidence_payload(
+            policy=generation_policy
+        ),
     }
     overlay_text = ""
     overlay_payloads = [
@@ -797,6 +830,7 @@ def _build_with_tracking(
             instrument_type=instrument_type,
             force_rebuild=force_rebuild,
             fresh_build=fresh_build,
+            generation_policy=generation_policy,
             validation=validation,
             max_retries=max_retries,
             preferred_method=preferred_method,

--- a/trellis/agent/knowledge/autonomous.py
+++ b/trellis/agent/knowledge/autonomous.py
@@ -34,6 +34,7 @@ from trellis.agent.generation_policy import (
     GenerationPolicyError,
     generation_evidence_payload,
     normalize_generation_policy,
+    validate_builder_synthesis_context,
 )
 
 
@@ -258,6 +259,10 @@ def build_with_knowledge(
             "Builder synthesis requires fresh_build=True so model source is isolated from admitted adapters.",
             reason="fresh_build_required",
         )
+    validate_builder_synthesis_context(
+        policy=generation_policy_value,
+        request_metadata=request_metadata,
+    )
     initial_generation_evidence = generation_evidence_payload(
         policy=generation_policy_value
     )

--- a/trellis/agent/offline_agents.py
+++ b/trellis/agent/offline_agents.py
@@ -26,6 +26,7 @@ def offline_local_agent_llm_guard():
     with llm_override_scope(
         generate=_blocked_llm_text,
         generate_json=_blocked_llm_json,
+        source="offline_local_agents",
     ):
         yield
 

--- a/trellis/agent/task_batch_reports.py
+++ b/trellis/agent/task_batch_reports.py
@@ -28,6 +28,7 @@ def build_task_batch_report(
     force_rebuild: bool,
     fresh_build: bool,
     knowledge_light: bool,
+    generation_policy: str = "deterministic_allowed",
     selection: Mapping[str, Any] | None = None,
     raw_results_path: str | Path | None = None,
     summary_path: str | Path | None = None,
@@ -76,6 +77,7 @@ def build_task_batch_report(
             "validation": str(validation).strip(),
             "force_rebuild": bool(force_rebuild),
             "fresh_build": bool(fresh_build),
+            "generation_policy": str(generation_policy).strip(),
             "knowledge_light": bool(knowledge_light),
         },
         "selection": _normalize_selection(selection or {}),
@@ -118,6 +120,7 @@ def render_task_batch_markdown(
     shared_knowledge = dict(summary.get("shared_knowledge") or {})
     retry_recovery = dict(summary.get("retry_recovery") or {})
     token_usage = dict(summary.get("token_usage") or {})
+    generation_proving = dict(summary.get("generation_proving") or {})
     tasks = list(report.get("tasks") or [])
     failed_tasks = list(report.get("failed_tasks") or [])
     displayed_tasks = tasks[:max_task_rows] if max_task_rows is not None else tasks
@@ -130,6 +133,7 @@ def render_task_batch_markdown(
         f"- Validation: `{config.get('validation') or ''}`",
         f"- Force rebuild: `{bool(config.get('force_rebuild'))}`",
         f"- Fresh build: `{bool(config.get('fresh_build'))}`",
+        f"- Generation policy: `{config.get('generation_policy') or 'deterministic_allowed'}`",
         f"- Knowledge light: `{bool(config.get('knowledge_light'))}`",
         "",
         "## Selection",
@@ -178,6 +182,8 @@ def render_task_batch_markdown(
             f"| Tasks with reviewer issues | {reviewer_signals.get('tasks_with_reviewer_issues', 0)} |",
             f"| Tasks with shared context | {shared_knowledge.get('tasks_with_shared_context', 0)} |",
             f"| Total tokens | {token_usage.get('total_tokens', 0)} |",
+            f"| Builder synthesis attempted | {generation_proving.get('synthesis_attempted_tasks', 0)} |",
+            f"| Observed model synthesis | {generation_proving.get('synthesis_observed_tasks', 0)} |",
         ]
     )
 
@@ -221,8 +227,8 @@ def render_task_batch_markdown(
     if displayed_tasks:
         lines.extend(
             [
-                "| Task | Corpus | Outcome | Attempts | Elapsed (s) | Tokens | Diagnosis |",
-                "| --- | --- | --- | ---: | ---: | ---: | --- |",
+                "| Task | Corpus | Outcome | Attempts | Elapsed (s) | Tokens | Diagnosis | Generation origin |",
+                "| --- | --- | --- | ---: | ---: | ---: | --- | --- |",
             ]
         )
         for row in displayed_tasks:
@@ -242,6 +248,9 @@ def render_task_batch_markdown(
                                 str(row.get("diagnosis_headline") or row.get("title") or ""),
                                 limit=120,
                             )
+                        ),
+                        _md_table_cell(
+                            ", ".join(row.get("artifact_origins") or ()) or "none"
                         ),
                     ]
                 )
@@ -267,6 +276,17 @@ def _build_task_row(result: Mapping[str, Any], *, root: Path) -> dict[str, Any]:
     bucket = classify_task_result(result)
     outcome_class = task_result_outcome_class(result)
     passed_expectation = task_result_passed_expectation(result)
+    generation_evidence = dict(result.get("generation_evidence") or {})
+    raw_origins = generation_evidence.get("artifact_origins")
+    if raw_origins is None:
+        raw_origins = [generation_evidence.get("artifact_origin")]
+    elif isinstance(raw_origins, str):
+        raw_origins = [raw_origins]
+    artifact_origins = [
+        str(origin).strip()
+        for origin in (raw_origins or ())
+        if str(origin or "").strip() not in {"", "none"}
+    ]
     return {
         "task_id": str(result.get("task_id") or "").strip(),
         "title": str(result.get("title") or "").strip(),
@@ -281,6 +301,14 @@ def _build_task_row(result: Mapping[str, Any], *, root: Path) -> dict[str, Any]:
         "elapsed_seconds": round(float(result.get("elapsed_seconds") or 0.0), 2),
         "token_usage_total": int(
             dict(result.get("token_usage_summary") or {}).get("total_tokens") or 0
+        ),
+        "generation_policy": str(generation_evidence.get("policy") or "").strip(),
+        "artifact_origins": artifact_origins,
+        "agent_synthesis_attempted": bool(
+            generation_evidence.get("agent_synthesis_attempted")
+        ),
+        "agent_synthesis_observed": bool(
+            generation_evidence.get("agent_synthesis_observed")
         ),
         "diagnosis_failure_bucket": str(
             result.get("task_diagnosis_failure_bucket") or ""

--- a/trellis/agent/task_diagnostics.py
+++ b/trellis/agent/task_diagnostics.py
@@ -199,6 +199,10 @@ def render_task_diagnosis_dossier(packet: Mapping[str, Any]) -> str:
         f"- Run id: `{run.get('run_id', '')}`",
         f"- Persisted at: `{run.get('persisted_at', '')}`",
         f"- Execution mode: `{execution.get('mode', '')}`",
+        f"- Generation policy: `{execution.get('generation_policy', '')}`",
+        f"- Artifact origins: `{_join_or_none(dict(execution.get('generation_evidence') or {}).get('artifact_origins'))}`",
+        f"- Agent synthesis attempted: `{_yes_no(dict(execution.get('generation_evidence') or {}).get('agent_synthesis_attempted'))}`",
+        f"- Agent synthesis observed: `{_yes_no(dict(execution.get('generation_evidence') or {}).get('agent_synthesis_observed'))}`",
         f"- Outcome: `{outcome.get('status', '')}`",
         f"- Failure bucket: `{outcome.get('failure_bucket', '')}`",
         f"- Decision stage: `{outcome.get('decision_stage', '')}`",
@@ -1073,6 +1077,8 @@ def _decision_stage(
         return "task_contract"
     if result.get("blocker_details"):
         return "blocked"
+    if failure_bucket == "generation_policy":
+        return "generation_policy"
     comparison_status = str(summary.get("comparison_status") or "").strip().lower()
     if comparison_status and comparison_status != "passed":
         return "comparison"
@@ -1115,6 +1121,7 @@ def _method_outcomes(method_runs: Mapping[str, Any]) -> list[dict[str, Any]]:
             "failures": list(payload.get("failures") or []),
             "post_build_latest_phase": dict(payload.get("post_build_tracking") or {}).get("last_phase"),
             "post_build_latest_status": dict(payload.get("post_build_tracking") or {}).get("last_status"),
+            "generation_evidence": dict(payload.get("generation_evidence") or {}),
         }
         outcomes.append(outcome)
     return outcomes
@@ -1252,6 +1259,11 @@ def _likely_cause(
         return "The task contract itself is invalid, so the run failed before a usable pricing path could be assembled."
     if result.get("blocker_details"):
         return "The run was intentionally blocked by explicit blocker details."
+    if failure_bucket == "generation_policy":
+        return (
+            "The requested builder-synthesis proof could not be established under "
+            "the configured freshness, recovery, execution, or artifact-origin evidence."
+        )
     if failure_bucket == "comparator_build_failure":
         failed_methods = [item.get("method") for item in method_outcomes if not item.get("success")]
         if failed_methods:
@@ -1299,7 +1311,7 @@ def _likely_cause(
 
 
 def _confidence_for(*, failure_bucket: str, signals: list[str]) -> str:
-    if failure_bucket in {"import_hallucination", "missing_market_data", "llm_response", "timeout", "rate_limit"}:
+    if failure_bucket in {"generation_policy", "import_hallucination", "missing_market_data", "llm_response", "timeout", "rate_limit"}:
         return "high"
     if failure_bucket == "comparator_build_failure":
         return "high"
@@ -1344,6 +1356,8 @@ def _headline_from_bucket(
         if failing_methods:
             return f"Comparison failed after {len(failing_methods)} method failure(s)."
         return "Comparison failed before enough methods returned valid results."
+    if failure_bucket == "generation_policy":
+        return "Builder-synthesis proof failed closed before an unproven success could be reported."
     if failure_bucket == "implementation_gap":
         return f"Implementation gap surfaced during {decision_stage}."
     if failure_bucket == "missing_market_data":
@@ -1369,6 +1383,11 @@ def _default_next_action(*, failure_bucket: str, decision_stage: str) -> str:
         )
     if failure_bucket == "implementation_gap":
         return "Fix the missing primitive or symbol in the implementation path and rerun the task."
+    if failure_bucket == "generation_policy":
+        return (
+            "Use an isolated fresh build with assisted or remediation recovery in "
+            "live or cassette-record mode, then require observed model-generated source."
+        )
     if failure_bucket == "missing_market_data":
         return "Fill in the missing market capability or mock data before rerunning."
     if failure_bucket in {"import_hallucination", "missing_cookbook", "missing_decomposition"}:

--- a/trellis/agent/task_learning_benchmark.py
+++ b/trellis/agent/task_learning_benchmark.py
@@ -99,6 +99,9 @@ def build_task_learning_benchmark_report(
                 "pass_number": int(raw_pass.get("pass_number") or 0),
                 "label": str(raw_pass.get("label") or f"pass_{len(normalized_passes) + 1}"),
                 "fresh_build": bool(raw_pass.get("fresh_build")),
+                "generation_policy": str(
+                    raw_pass.get("generation_policy") or "deterministic_allowed"
+                ),
                 "knowledge_profile": str(raw_pass.get("knowledge_profile") or "default"),
                 "model": str(raw_pass.get("model") or ""),
                 "validation": str(raw_pass.get("validation") or ""),
@@ -186,6 +189,7 @@ def render_task_learning_benchmark_report(report: Mapping[str, Any]) -> str:
     lines.extend(["", "## Pass Summaries"])
     for learning_pass in report.get("passes") or []:
         summary = learning_pass["summary"]
+        generation_proving = dict(summary.get("generation_proving") or {})
         lines.extend(
             [
                 "",
@@ -197,6 +201,9 @@ def render_task_learning_benchmark_report(report: Mapping[str, Any]) -> str:
                 f"- Elapsed seconds: `{learning_pass['elapsed_seconds_total']}`",
                 f"- Token usage: `{summary['token_usage']['total_tokens']}`",
                 f"- Shared-knowledge tasks: `{summary['shared_knowledge']['tasks_with_shared_context']}`",
+                f"- Generation policy: `{learning_pass.get('generation_policy', 'deterministic_allowed')}`",
+                f"- Builder synthesis attempted: `{generation_proving.get('synthesis_attempted_tasks', 0)}`",
+                f"- Builder synthesis observed: `{generation_proving.get('synthesis_observed_tasks', 0)}`",
                 f"- Results path: `{learning_pass.get('results_path', '')}`",
             ]
         )
@@ -230,6 +237,8 @@ def render_task_learning_benchmark_report(report: Mapping[str, Any]) -> str:
             f"- Knowledge-assisted improvements: {', '.join(_format_task_ids(attribution.get('knowledge_assisted_improvements', {}).get('task_ids') or [])) or 'none'}",
             f"- Retry-learned recoveries: {', '.join(_format_task_ids(retry_learning.get('retry_learned_recoveries', {}).get('task_ids') or [])) or 'none'}",
             f"- First-pass deterministic reuse: {', '.join(_format_task_ids(retry_learning.get('first_pass_deterministic_reuse', {}).get('task_ids') or [])) or 'none'}",
+            f"- First-pass model synthesis: {', '.join(_format_task_ids(retry_learning.get('first_pass_model_synthesis', {}).get('task_ids') or [])) or 'none'}",
+            f"- First-pass origin unknown: {', '.join(_format_task_ids(retry_learning.get('first_pass_origin_unknown', {}).get('task_ids') or [])) or 'none'}",
             f"- Failed or unvalidated retry evidence: {', '.join(_format_task_ids(retry_learning.get('failed_or_unvalidated_retry_evidence', {}).get('task_ids') or [])) or 'none'}",
             f"- Residual knowledge gaps: {', '.join(_format_task_ids(attribution.get('residual_knowledge_gaps', {}).get('task_ids') or [])) or 'none'}",
             f"- Residual implementation gaps: {', '.join(_format_task_ids(attribution.get('residual_implementation_gaps', {}).get('task_ids') or [])) or 'none'}",
@@ -377,6 +386,8 @@ def _empty_retry_learning_attribution() -> dict[str, Any]:
     return {
         "retry_learned_recoveries": {"count": 0, "task_ids": []},
         "first_pass_deterministic_reuse": {"count": 0, "task_ids": []},
+        "first_pass_model_synthesis": {"count": 0, "task_ids": []},
+        "first_pass_origin_unknown": {"count": 0, "task_ids": []},
         "failed_or_unvalidated_retry_evidence": {"count": 0, "task_ids": []},
     }
 
@@ -386,6 +397,8 @@ def _build_retry_learning_attribution(
 ) -> dict[str, Any]:
     retry_learned: list[str] = []
     first_pass_reuse: list[str] = []
+    first_pass_model_synthesis: list[str] = []
+    first_pass_origin_unknown: list[str] = []
     unvalidated_retry: list[str] = []
 
     for result in results:
@@ -398,7 +411,13 @@ def _build_retry_learning_attribution(
         elif has_retry_evidence:
             unvalidated_retry.append(task_id)
         elif bool(result.get("success")) and _result_attempts_to_success(result) <= 1:
-            first_pass_reuse.append(task_id)
+            origin_kind = _result_first_pass_origin_kind(result)
+            if origin_kind == "model_synthesis":
+                first_pass_model_synthesis.append(task_id)
+            elif origin_kind == "deterministic":
+                first_pass_reuse.append(task_id)
+            else:
+                first_pass_origin_unknown.append(task_id)
 
     return {
         "retry_learned_recoveries": {
@@ -409,11 +428,56 @@ def _build_retry_learning_attribution(
             "count": len(first_pass_reuse),
             "task_ids": sorted(first_pass_reuse),
         },
+        "first_pass_model_synthesis": {
+            "count": len(first_pass_model_synthesis),
+            "task_ids": sorted(first_pass_model_synthesis),
+        },
+        "first_pass_origin_unknown": {
+            "count": len(first_pass_origin_unknown),
+            "task_ids": sorted(first_pass_origin_unknown),
+        },
         "failed_or_unvalidated_retry_evidence": {
             "count": len(unvalidated_retry),
             "task_ids": sorted(unvalidated_retry),
         },
     }
+
+
+_DETERMINISTIC_ARTIFACT_ORIGINS = frozenset(
+    {
+        "reused_adapter",
+        "semantic_shim",
+        "deterministic_materialization",
+        "deterministic_proof_artifact",
+    }
+)
+
+
+def _result_first_pass_origin_kind(result: Mapping[str, Any]) -> str:
+    origins: set[str] = set()
+    synthesis_observed = False
+    for payload in _iter_result_payloads(result):
+        evidence = payload.get("generation_evidence")
+        if not isinstance(evidence, Mapping):
+            continue
+        synthesis_observed = synthesis_observed or bool(
+            evidence.get("agent_synthesis_observed")
+        )
+        raw_origins = evidence.get("artifact_origins")
+        if raw_origins is None:
+            raw_origins = [evidence.get("artifact_origin")]
+        elif isinstance(raw_origins, str):
+            raw_origins = [raw_origins]
+        for raw_origin in raw_origins or ():
+            origin = str(raw_origin or "").strip()
+            if origin and origin != "none":
+                origins.add(origin)
+
+    if synthesis_observed or "model_generated_source" in origins:
+        return "model_synthesis"
+    if origins and origins.issubset(_DETERMINISTIC_ARTIFACT_ORIGINS):
+        return "deterministic"
+    return "unknown"
 
 
 def _result_has_retry_learned_recovery(result: Mapping[str, Any]) -> bool:

--- a/trellis/agent/task_run_store.py
+++ b/trellis/agent/task_run_store.py
@@ -512,6 +512,10 @@ def build_task_run_record(
         "execution": {
             "mode": str(result.get("execution_mode") or "live"),
             "llm_cassette": dict(result.get("llm_cassette") or {}),
+            "generation_policy": str(
+                result.get("generation_policy") or "deterministic_allowed"
+            ),
+            "generation_evidence": dict(result.get("generation_evidence") or {}),
         },
         "market": dict(result.get("market_context") or {}),
         "framework": framework,
@@ -556,6 +560,10 @@ def build_task_run_record(
             "knowledge_revision": revisions["knowledge_revision"],
             "framework_outcome": framework.get("outcome_type"),
             "execution_mode": str(result.get("execution_mode") or "live"),
+            "generation_policy": str(
+                result.get("generation_policy") or "deterministic_allowed"
+            ),
+            "generation_evidence": dict(result.get("generation_evidence") or {}),
             "learning": learning,
         },
     }

--- a/trellis/agent/task_runtime.py
+++ b/trellis/agent/task_runtime.py
@@ -44,6 +44,14 @@ from trellis.agent.comparison_target_contracts import (
     declared_comparison_target_contract,
 )
 from trellis.agent.financepy_parity import align_market_state_for_financepy_parity
+from trellis.agent.generation_policy import (
+    ArtifactOrigin,
+    GenerationPolicy,
+    GenerationPolicyError,
+    generation_evidence_from_result,
+    normalize_generation_policy,
+    validate_generation_policy_request,
+)
 from trellis.agent.instrument_identity import (
     InstrumentIdentityResolution,
     normalize_instrument_type,
@@ -1652,6 +1660,12 @@ def _proof_legacy_comparison_build_result(
         selected_validation_bundle_id=artifact_contract.validation_bundle_id,
         selected_semantic_axes=selected_semantic_axes,
         blocker_details=None,
+        generation_evidence={
+            "policy": GenerationPolicy.DETERMINISTIC_ALLOWED.value,
+            "artifact_origin": ArtifactOrigin.DETERMINISTIC_PROOF_ARTIFACT.value,
+            "agent_synthesis_attempted": False,
+            "agent_synthesis_observed": False,
+        },
         post_build_tracking={
             "active_flags": [],
             "events": [],
@@ -1944,6 +1958,7 @@ def run_task(
     model: str = "gpt-5.4-mini",
     force_rebuild: bool = True,
     fresh_build: bool = False,
+    generation_policy: str | GenerationPolicy = GenerationPolicy.DETERMINISTIC_ALLOWED,
     validation: str = "standard",
     max_retries: int = 3,
     knowledge_profile: str | None = None,
@@ -1958,7 +1973,7 @@ def run_task(
     execution_mode_override: str | None = None,
     llm_cassette_metadata: Mapping[str, Any] | None = None,
 ) -> dict:
-    """Execute one task through the knowledge-aware build pipeline."""
+    """Execute one task with separate artifact-freshness and source-origin policy."""
     from trellis.agent.cassette import current_llm_cassette_context
     from trellis.agent.evals import (
         task_result_outcome_class,
@@ -1972,6 +1987,7 @@ def run_task(
         build_fn = build_with_knowledge
 
     recovery_mode_value = normalize_recovery_mode(recovery_mode)
+    generation_policy_value = normalize_generation_policy(generation_policy)
     task_id = task["id"]
     description = _effective_task_description(task)
     instrument_identity = task_to_instrument_identity(task)
@@ -2065,6 +2081,13 @@ def run_task(
         "task_definition_manifest": str(task.get("task_definition_manifest") or ""),
         "market_scenario_id": str(task.get("market_scenario_id") or ""),
         "recovery_mode": recovery_mode_value.value,
+        "generation_policy": generation_policy_value.value,
+        "generation_evidence": {
+            "policy": generation_policy_value.value,
+            "artifact_origins": [],
+            "agent_synthesis_attempted": False,
+            "agent_synthesis_observed": False,
+        },
         "post_build_learning_policy": post_build_learning_policy,
         "recovery_attempts": [],
     }
@@ -2078,6 +2101,12 @@ def run_task(
         if expected_honest_block is not None:
             raise ExpectedTaskHonestBlock(expected_honest_block)
         _validate_task_contract(task, instrument_type, construct_methods)
+        validate_generation_policy_request(
+            policy=generation_policy_value,
+            fresh_build=fresh_build,
+            recovery_mode=recovery_mode_value.value,
+            execution_mode=execution_mode,
+        )
         market_state, market_context = build_market_state_for_task(task, market_state)
         runtime_contract = _runtime_contract_metadata(
             task,
@@ -2098,6 +2127,7 @@ def run_task(
             "instrument_identity_source": instrument_identity.source,
             "runtime_contract": runtime_contract,
             "post_build_learning_policy": post_build_learning_policy,
+            "generation_policy": generation_policy_value.value,
         }
         if task_benchmark_spec_overrides:
             base_request_metadata["benchmark_spec_overrides"] = dict(task_benchmark_spec_overrides)
@@ -2132,6 +2162,7 @@ def run_task(
                     "validation": validation,
                     "force_rebuild": force_rebuild,
                     "fresh_build": fresh_build,
+                    "generation_policy": generation_policy_value.value,
                 }
                 if semantic_contract is not None:
                     build_kwargs["semantic_contract"] = semantic_contract
@@ -2144,7 +2175,11 @@ def run_task(
                         repair_packet = None
                 else:
                     repair_packet = None
-                deterministic_result = _proof_legacy_comparison_build_result(task, target)
+                deterministic_result = (
+                    _proof_legacy_comparison_build_result(task, target)
+                    if generation_policy_value is GenerationPolicy.DETERMINISTIC_ALLOWED
+                    else None
+                )
                 if deterministic_result is not None:
                     result = deterministic_result
                 elif repair_packet:
@@ -2152,6 +2187,7 @@ def run_task(
                         target.target_id,
                         repair_packet,
                         preferred_method=target.preferred_method,
+                        generation_policy=generation_policy_value,
                     )
                 else:
                     result = build_fn(**build_kwargs)
@@ -2161,6 +2197,7 @@ def run_task(
                     reference_target=target.is_reference,
                     task_kind="pricing",
                     comparison_target_contract=target.contract,
+                    generation_policy=generation_policy_value,
                 )
                 result, payload, recovery_record = _maybe_retry_with_intra_run_learning(
                     build_fn=build_fn,
@@ -2244,6 +2281,10 @@ def run_task(
                 fresh_build
                 and all(payload["success"] for payload in method_results.values())
                 and cross_validation["status"] == "passed"
+                and any(
+                    _payload_has_observed_model_synthesis(payload)
+                    for payload in method_results.values()
+                )
             ):
                 promotion_candidates = _record_promotion_candidates(
                     task=task,
@@ -2291,6 +2332,10 @@ def run_task(
                 "method_results": method_results,
                 "artifacts": _aggregate_artifacts(method_results),
                 "generated_artifact": _select_generated_artifact(method_results),
+                "generation_evidence": _aggregate_generation_evidence(
+                    method_results,
+                    policy=generation_policy_value,
+                ),
                 "knowledge_summary": _aggregate_knowledge_summaries(method_results),
                 "token_usage_summary": _aggregate_token_usage(method_results),
                 "agent_observation_count": sum(
@@ -2301,6 +2346,16 @@ def run_task(
                 "reflection": reflection_payload,
                 "cross_validation": cross_validation,
             })
+            generation_policy_errors = {
+                target_id: dict(payload.get("generation_policy_error") or {})
+                for target_id, payload in method_results.items()
+                if payload.get("generation_policy_error")
+            }
+            if generation_policy_errors:
+                result_data["generation_policy_error"] = {
+                    "reason": "synthesis_evidence_missing",
+                    "targets": generation_policy_errors,
+                }
             if result_data.get("recovery_attempts"):
                 result_data["intra_run_learning"] = _aggregate_intra_run_learning(
                     method_results
@@ -2334,6 +2389,7 @@ def run_task(
                 "validation": validation,
                 "force_rebuild": force_rebuild,
                 "fresh_build": fresh_build,
+                "generation_policy": generation_policy_value.value,
             }
             if semantic_contract is not None:
                 build_kwargs["semantic_contract"] = semantic_contract
@@ -2348,7 +2404,11 @@ def run_task(
             if task.get("cross_validate") and comparison_targets:
                 build_kwargs["comparison_target"] = comparison_targets[0].target_id
             result = build_fn(**build_kwargs)
-            payload = _build_result_payload(result, preferred_method=preferred_method)
+            payload = _build_result_payload(
+                result,
+                preferred_method=preferred_method,
+                generation_policy=generation_policy_value,
+            )
             target_id = (
                 comparison_targets[0].target_id
                 if comparison_targets
@@ -2376,6 +2436,10 @@ def run_task(
             runtime_contract_result["analytical_trace_text_path"] = getattr(result, "analytical_trace_text_path", None)
             result_data.update({
                 **payload,
+                "generation_evidence": _aggregate_generation_evidence(
+                    {target_id: payload},
+                    policy=generation_policy_value,
+                ),
                 "elapsed_seconds": round(elapsed, 1),
                 "preferred_method": preferred_method,
                 "runtime_contract": runtime_contract_result,
@@ -2452,6 +2516,21 @@ def run_task(
             f"  [{status}] {elapsed:.1f}s, llm_generation_attempts=0, "
             f"confidence={result_data.get('gap_confidence', 0):.0%}"
         )
+    except GenerationPolicyError as exc:
+        elapsed = timer() - t0
+        result_data.update({
+            "success": False,
+            "elapsed_seconds": round(elapsed, 1),
+            "attempts": 0,
+            "gap_confidence": 1.0,
+            "error": str(exc),
+            "failures": [str(exc)],
+            "generation_policy_error": {
+                "reason": exc.reason,
+                "message": str(exc),
+            },
+        })
+        print(f"  [GENERATION POLICY] {elapsed:.1f}s: {exc}")
     except TaskContractError as exc:
         elapsed = timer() - t0
         result_data.update({
@@ -2700,6 +2779,7 @@ def _blocked_result_for_repair_packet(
     repair_packet: Mapping[str, Any],
     *,
     preferred_method: str | None = None,
+    generation_policy: str | GenerationPolicy = GenerationPolicy.DETERMINISTIC_ALLOWED,
 ):
     """Return a BuildResult-like blocked result for unsupported target primitives."""
     summary = str(repair_packet.get("summary") or "Unsupported comparison target").strip()
@@ -2738,6 +2818,12 @@ def _blocked_result_for_repair_packet(
         analytical_trace_text_path=None,
         audit_record_path=None,
         generated_artifact=None,
+        generation_evidence={
+            "policy": normalize_generation_policy(generation_policy).value,
+            "artifact_origin": ArtifactOrigin.NONE.value,
+            "agent_synthesis_attempted": False,
+            "agent_synthesis_observed": False,
+        },
         blocker_details={
             "target_id": target_id,
             "preferred_method": preferred_method,
@@ -2882,6 +2968,10 @@ def _maybe_retry_with_intra_run_learning(
         reference_target=reference_target,
         task_kind=task_kind,
         comparison_target_contract=comparison_target_contract,
+        generation_policy=build_kwargs.get(
+            "generation_policy",
+            GenerationPolicy.DETERMINISTIC_ALLOWED.value,
+        ),
     )
     retry_payload["attempts"] = int(initial_payload.get("attempts") or 0) + int(
         retry_payload.get("attempts") or 0
@@ -3109,6 +3199,7 @@ def _build_result_payload(
     reference_target: bool = False,
     task_kind: str = "pricing",
     comparison_target_contract: ComparisonTargetContract | None = None,
+    generation_policy: str | GenerationPolicy = GenerationPolicy.DETERMINISTIC_ALLOWED,
 ) -> dict[str, Any]:
     """Project a BuildResult-like object into a stable task result payload."""
     from trellis.agent.task_run_store import summarize_task_learning
@@ -3116,8 +3207,25 @@ def _build_result_payload(
     build_observability = _trace_observability(
         getattr(result, "platform_trace_path", None)
     )
+    generation_evidence = generation_evidence_from_result(
+        result,
+        default_policy=generation_policy,
+    )
+    normalized_generation_policy = normalize_generation_policy(generation_policy)
+    synthesis_proof_missing = bool(
+        result.success
+        and normalized_generation_policy
+        is GenerationPolicy.BUILDER_SYNTHESIS_REQUIRED
+        and not generation_evidence.get("agent_synthesis_observed")
+    )
+    result_failures = list(result.failures[:3])
+    if synthesis_proof_missing:
+        result_failures.insert(
+            0,
+            "Builder synthesis was required, but the build returned no observed model-generated source evidence.",
+        )
     payload = {
-        "success": result.success,
+        "success": bool(result.success) and not synthesis_proof_missing,
         "attempts": result.attempts,
         "gap_confidence": result.gap_confidence,
         "knowledge_gaps": result.knowledge_gaps,
@@ -3151,7 +3259,7 @@ def _build_result_payload(
         "selected_semantic_axes": dict(
             getattr(result, "selected_semantic_axes", {}) or {}
         ),
-        "failures": result.failures[:3],
+        "failures": result_failures[:3],
         "agent_observation_count": len(getattr(result, "agent_observations", []) or []),
         "agent_observations": list(getattr(result, "agent_observations", []) or []),
         "knowledge_summary": dict(getattr(result, "knowledge_summary", {}) or {}),
@@ -3163,6 +3271,7 @@ def _build_result_payload(
         "analytical_trace_text_path": getattr(result, "analytical_trace_text_path", None),
         "audit_record_path": getattr(result, "audit_record_path", None),
         "generated_artifact": _generated_artifact_from_result(result),
+        "generation_evidence": generation_evidence,
         "build_observability": build_observability,
         "agent_cycle": dict(build_observability.get("agent_cycle") or {}),
         "blocker_details": getattr(result, "blocker_details", None),
@@ -3191,6 +3300,11 @@ def _build_result_payload(
             )
         },
     }
+    if synthesis_proof_missing:
+        payload["generation_policy_error"] = {
+            "reason": "synthesis_evidence_missing",
+            "message": result_failures[0],
+        }
     payload["artifacts"] = _artifacts_from_payload(payload)
     payload["learning"] = summarize_task_learning(payload, task_kind=task_kind)
     return payload
@@ -3372,6 +3486,34 @@ def _aggregate_intra_run_learning(
     }
 
 
+def _aggregate_generation_evidence(
+    method_payloads: Mapping[str, Mapping[str, Any]],
+    *,
+    policy: str | GenerationPolicy,
+) -> dict[str, Any]:
+    """Merge artifact origins and synthesis evidence across comparison targets."""
+    origins: list[str] = []
+    attempted = False
+    observed = False
+    for payload in method_payloads.values():
+        if not isinstance(payload, Mapping):
+            continue
+        evidence = payload.get("generation_evidence")
+        if not isinstance(evidence, Mapping):
+            continue
+        origin = str(evidence.get("artifact_origin") or "").strip()
+        if origin and origin != ArtifactOrigin.NONE.value and origin not in origins:
+            origins.append(origin)
+        attempted = attempted or bool(evidence.get("agent_synthesis_attempted"))
+        observed = observed or bool(evidence.get("agent_synthesis_observed"))
+    return {
+        "policy": normalize_generation_policy(policy).value,
+        "artifact_origins": origins,
+        "agent_synthesis_attempted": attempted,
+        "agent_synthesis_observed": observed,
+    }
+
+
 def _select_generated_artifact(
     method_payloads: Mapping[str, Mapping[str, Any]],
     *,
@@ -3461,6 +3603,7 @@ def _generated_artifact_from_result(result: Any) -> dict[str, Any]:
         or "/financepy_benchmarks/generated/" in normalized_module_path
         or "/financepy_benchmarks/generated/" in normalized_file_path
     )
+    generation_evidence = generation_evidence_from_result(result)
     return {
         "module_name": module_name,
         "class_name": payoff_cls.__name__,
@@ -3468,6 +3611,14 @@ def _generated_artifact_from_result(result: Any) -> dict[str, Any]:
         "module_path": module_path,
         "code_hash": code_hash,
         "is_fresh_build": is_fresh_build,
+        "origin": generation_evidence["artifact_origin"],
+        "generation_policy": generation_evidence["policy"],
+        "agent_synthesis_attempted": generation_evidence[
+            "agent_synthesis_attempted"
+        ],
+        "agent_synthesis_observed": generation_evidence[
+            "agent_synthesis_observed"
+        ],
         "execution_module_name": str(getattr(result, "execution_module_name", "") or ""),
         "execution_module_path": str(getattr(result, "execution_module_path", "") or ""),
         "execution_file_path": str(getattr(result, "execution_file_path", "") or ""),
@@ -3700,6 +3851,15 @@ def _record_promotion_candidates(
         live_result = live_results.get(target_id)
         if live_result is None or not payload.get("success"):
             continue
+        generation_evidence = payload.get("generation_evidence")
+        if not isinstance(generation_evidence, Mapping):
+            continue
+        if (
+            generation_evidence.get("artifact_origin")
+            != ArtifactOrigin.MODEL_GENERATED_SOURCE.value
+            or not bool(generation_evidence.get("agent_synthesis_observed"))
+        ):
+            continue
         code = str(getattr(live_result, "code", "") or "").strip()
         if not code:
             continue
@@ -3726,6 +3886,17 @@ def _record_promotion_candidates(
         if path:
             candidate_paths[target_id] = path
     return candidate_paths
+
+
+def _payload_has_observed_model_synthesis(payload: Mapping[str, Any]) -> bool:
+    """Return whether one build payload proves model-generated source."""
+    evidence = payload.get("generation_evidence")
+    return bool(
+        isinstance(evidence, Mapping)
+        and evidence.get("artifact_origin")
+        == ArtifactOrigin.MODEL_GENERATED_SOURCE.value
+        and evidence.get("agent_synthesis_observed")
+    )
 
 
 def _aggregate_knowledge_summaries(method_payloads: dict[str, dict[str, Any]]) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- add typed generation policy and artifact-origin evidence
- require observed builder source for synthesis-proving runs and promotions
- persist provenance through task records, diagnostics, batch reports, and learning benchmarks
- document freshness versus source synthesis

## Validation
- focused agent suite: 459 passed
- final compatibility subset: 11 passed
- make gate-pr: passed
- make gate-release: passed
- offline synthesis-required T20: generation_policy failure, 0 attempts, 0 tokens

## Notes
- no live external-model proving run was performed
- LIMITATIONS.md unchanged because pricing support did not change