### PR TITLE
QUA-1203 Classify barrier formula as pricing kernel

### DIFF
--- a/doc/plan/active__semantic-task-synthesis-helper-retirement.md
+++ b/doc/plan/active__semantic-task-synthesis-helper-retirement.md
@@ -63,6 +63,7 @@ Status mirror last synced: `2026-07-16`
 | `QUA-1200` | Lattice rollback: observable node-value phases | Done |
 | `QUA-1201` | Bermudan swaption lattice: retire helper and compiler authority | Done |
 | `QUA-1202` | Semantic proving: distinguish fresh artifacts from agent synthesis | Done |
+| `QUA-1203` | Semantic authority: classify scalar barrier formula as pricing kernel | In Progress |
 | `QUA-1102` | Semantic target binding: typed comparison target contracts (related prerequisite) | Done |
 
 ## Current Sequence
@@ -118,6 +119,9 @@ Status mirror last synced: `2026-07-16`
 14. Run live fresh-generation evidence only with current external-model approval;
     use it to compare first-pass source selection, retrieved documentation,
     retries, and residual validator findings rather than as pricing authority.
+15. Apply QUA-1203 to classify the shared scalar barrier formula consistently
+    as a pricing kernel for F009, while requiring generated code to retain
+    market binding and settlement responsibility.
 
 ## Completion Evidence
 

--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -911,6 +911,13 @@ direction, and settlement binding. Required-primitive validation still rejects
 an analytical F009 artifact that omits the kernel; changing the role does not
 turn it into an optional hint.
 
+The equity and FX route/binding records also mark this scalar formula with
+``owns_engine_family: true``. That flag is narrower than ``pricing_kernel``:
+it means a call is itself complete evidence for the selected numerical method.
+Terminal or inner kernels used inside Monte Carlo and PDE construction leave
+the flag false, so they cannot hide a missing path engine, mesh, operator, or
+time-stepping implementation from semantic validation.
+
 The deterministic digital spec schema includes ``dividend_yield``. Benchmark
 ``dividend_rate`` aliases therefore survive spec-override filtering when an
 adapter is regenerated, rather than silently reverting the analytical forward

--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -902,6 +902,15 @@ helper-authority audit must therefore find no analytical digital helper in the
 route, binding, or checked adapter, while route and adapter tests preserve
 cash/asset and call/put basis selection.
 
+F009 uses the same boundary for the scalar Reiner-Rubinstein barrier formula.
+``barrier_option_price(...)`` is a ``pricing_kernel``, not a ``route_helper``:
+it consumes explicit scalar inputs and does not resolve a market state, choose
+the contractual barrier direction, or apply notional. The generated adapter
+therefore owns spot, rate/carry, volatility, time, monitoring, rebate, payoff
+direction, and settlement binding. Required-primitive validation still rejects
+an analytical F009 artifact that omits the kernel; changing the role does not
+turn it into an optional hint.
+
 The deterministic digital spec schema includes ``dividend_yield``. Benchmark
 ``dividend_rate`` aliases therefore survive spec-override filtering when an
 adapter is regenerated, rather than silently reverting the analytical forward

--- a/docs/quant/pricing_stack.rst
+++ b/docs/quant/pricing_stack.rst
@@ -887,6 +887,11 @@ lanes therefore classify it as a ``pricing_kernel`` and keep market binding,
 monitoring convention, rebate, payoff direction, and notional in the composed
 adapter. A market-state-taking product wrapper would remain ``route_helper``
 authority until separately retired.
+Both analytical barrier bindings set ``owns_engine_family: true`` because the
+scalar closed form is the complete numerical method once its explicit inputs
+are bound. This marker is not implied by ``pricing_kernel``: a terminal-payoff
+or inner expectation kernel inside Monte Carlo or PDE remains non-owning and
+does not replace construction of the selected numerical engine.
 The runtime plans now also carry that identity directly: ``PrimitivePlan`` and
 ``GenerationPlan`` persist ``backend_binding_id`` plus exact helper/kernel and
 schedule-builder refs, so later validation, traces, and replay do not need to

--- a/docs/quant/pricing_stack.rst
+++ b/docs/quant/pricing_stack.rst
@@ -879,6 +879,14 @@ Those exact helper/kernel facts are now materialized through
 ``trellis.agent.backend_bindings`` as a separate canonical binding catalog, and
 the route registry derives its backend-binding authority summary from that
 catalog rather than acting as the only source of exact backend identity.
+The scalar single-barrier closed form follows this kernel/helper distinction.
+``barrier_option_price(...)`` evaluates explicitly supplied
+spot/strike/barrier/rate/carry/volatility/time and barrier-payoff controls; it
+does not own market lookup or derivative settlement. Equity and FX analytical
+lanes therefore classify it as a ``pricing_kernel`` and keep market binding,
+monitoring convention, rebate, payoff direction, and notional in the composed
+adapter. A market-state-taking product wrapper would remain ``route_helper``
+authority until separately retired.
 The runtime plans now also carry that identity directly: ``PrimitivePlan`` and
 ``GenerationPlan`` persist ``backend_binding_id`` plus exact helper/kernel and
 schedule-builder refs, so later validation, traces, and replay do not need to

--- a/tests/test_agent/test_backend_bindings.py
+++ b/tests/test_agent/test_backend_bindings.py
@@ -802,8 +802,8 @@ def test_resolve_backend_binding_spec_uses_quanto_primitive_composition(
                 model_family="equity_diffusion",
             ),
             "analytical",
-            ("trellis.models.analytical.barrier.barrier_option_price",),
             (),
+            ("trellis.models.analytical.barrier.barrier_option_price",),
             id="barrier",
         ),
         pytest.param(

--- a/tests/test_agent/test_backend_bindings.py
+++ b/tests/test_agent/test_backend_bindings.py
@@ -693,6 +693,12 @@ def test_resolve_backend_binding_spec_uses_fx_barrier_primitive_composition(
     assert resolved.exact_target_refs == (expected_ref,)
     assert resolved.market_binding_refs == (expected_market_binding,)
     assert resolved.helper_refs == ()
+    target = next(
+        primitive
+        for primitive in resolved.primitives
+        if f"{primitive.module}.{primitive.symbol}" == expected_ref
+    )
+    assert target.owns_engine_family is (route_id == "analytical_fx_barrier")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_agent/test_codegen_guardrails.py
+++ b/tests/test_agent/test_codegen_guardrails.py
@@ -1207,7 +1207,7 @@ def test_barrier_option_route_card_mentions_grid_operator_and_rannacher():
     assert "rannacher_timesteps" in card
 
 
-def test_barrier_option_analytical_route_uses_absorbed_black76_helper_binding():
+def test_barrier_option_analytical_route_uses_scalar_pricing_kernel_binding():
     pricing_plan = PricingPlan(
         method="analytical",
         method_modules=["trellis.models.analytical.barrier"],
@@ -1237,7 +1237,14 @@ def test_barrier_option_analytical_route_uses_absorbed_black76_helper_binding():
         f"{primitive.module}.{primitive.symbol}" for primitive in plan.primitive_plan.primitives
     }
     assert "trellis.models.analytical.barrier.barrier_option_price" in primitive_refs
-    assert "instantiating `ResolvedBarrierInputs` in generated adapters" in card
+    barrier_kernel = next(
+        primitive
+        for primitive in plan.primitive_plan.primitives
+        if primitive.symbol == "barrier_option_price"
+    )
+    assert barrier_kernel.role == "pricing_kernel"
+    assert "scalar pricing kernel" in card
+    assert "generated adapters must bind spot" in card
     assert "barrier_option_price" in card
 
 

--- a/tests/test_agent/test_helper_authority_audit.py
+++ b/tests/test_agent/test_helper_authority_audit.py
@@ -276,6 +276,27 @@ def test_current_repository_retires_arithmetic_asian_helper_authority():
     ]
 
 
+def test_current_repository_classifies_scalar_barrier_formula_as_pricing_kernel():
+    from trellis.agent.helper_authority_audit import build_helper_authority_report
+
+    root = Path(__file__).resolve().parents[2]
+    report = build_helper_authority_report(root)
+    kernel_symbol = "barrier_option_price"
+
+    assert not [
+        item
+        for item in (*report.route_authority, *report.binding_authority)
+        if item.symbol == kernel_symbol
+    ]
+    assert not [
+        item
+        for item in report.adapter_calls
+        if item.path == "trellis/instruments/_agent/barrieroption.py"
+        and item.symbol == kernel_symbol
+        and item.matches_authority
+    ]
+
+
 def test_current_repository_retires_european_swaption_wrapper_authority():
     from trellis.agent.helper_authority_audit import build_helper_authority_report
 

--- a/tests/test_agent/test_route_registry.py
+++ b/tests/test_agent/test_route_registry.py
@@ -1898,12 +1898,12 @@ class TestAnalyticalRoutes:
         assert "Do not sum or maximize European values" in notes
         assert resolve_route_adapters(spec, self.BERMUDAN_SWAPTION_IR) == ()
 
-    def test_barrier_primitives_use_exact_helper(self, registry):
+    def test_barrier_primitives_use_scalar_pricing_kernel(self, registry):
         spec = [r for r in registry.routes if r.id == "analytical_black76"][0]
         new_prims = resolve_route_primitives(spec, self.BARRIER_IR)
         assert resolve_route_family(spec, self.BARRIER_IR) == "analytical"
         assert _prim_set(new_prims) == {
-            ("trellis.models.analytical.barrier", "barrier_option_price", "route_helper"),
+            ("trellis.models.analytical.barrier", "barrier_option_price", "pricing_kernel"),
         }
 
     def test_digital_primitives_use_black76_basis_kernels(self, registry):

--- a/tests/test_agent/test_route_registry.py
+++ b/tests/test_agent/test_route_registry.py
@@ -1905,6 +1905,7 @@ class TestAnalyticalRoutes:
         assert _prim_set(new_prims) == {
             ("trellis.models.analytical.barrier", "barrier_option_price", "pricing_kernel"),
         }
+        assert new_prims[0].owns_engine_family is True
 
     def test_digital_primitives_use_black76_basis_kernels(self, registry):
         spec = [r for r in registry.routes if r.id == "analytical_black76"][0]
@@ -2451,6 +2452,12 @@ class TestFXBarrierRoutes:
             ("trellis.models.analytical.barrier", "barrier_option_price", "pricing_kernel"),
         }
         assert _prim_set(new_prims) == expected_prims
+        barrier_kernel = next(
+            primitive
+            for primitive in new_prims
+            if primitive.symbol == "barrier_option_price"
+        )
+        assert barrier_kernel.owns_engine_family is True
 
     def test_fx_barrier_monte_carlo_candidate(self, registry):
         plan = _make_plan(

--- a/tests/test_agent/test_semantic_validators.py
+++ b/tests/test_agent/test_semantic_validators.py
@@ -267,6 +267,38 @@ def evaluate(self, market_state):
             for finding in findings
         )
 
+    def test_non_owning_pricing_kernel_does_not_hide_missing_engine(self, registry):
+        spec = [r for r in registry.routes if r.id == "local_vol_monte_carlo"][0]
+        local_vol_ir = ProductIR(
+            instrument="european_option",
+            payoff_family="vanilla_option",
+            payoff_traits=("terminal_markov",),
+            exercise_style="european",
+            state_dependence="terminal_markov",
+            model_family="local_volatility",
+        )
+        primitives = resolve_route_primitives(spec, local_vol_ir)
+        source = '''
+def evaluate(self, market_state):
+    return local_vol_european_vanilla_price(spot, strike, rate, vol, time)
+'''
+
+        findings = AlgorithmContractValidator().validate(
+            source,
+            _make_plan(
+                "local_vol_monte_carlo",
+                engine_family="monte_carlo",
+                instrument_type="european_option",
+                primitives=primitives,
+            ),
+            spec,
+        )
+
+        assert any(
+            finding.category == "engine_family_mismatch"
+            for finding in findings
+        )
+
     def test_analytical_black76_helper_owned_rate_strip_does_not_require_internal_kernels(
         self,
         registry,

--- a/tests/test_agent/test_semantic_validators.py
+++ b/tests/test_agent/test_semantic_validators.py
@@ -249,7 +249,7 @@ def evaluate(self, market_state):
         primitives = resolve_route_primitives(spec, barrier_ir)
         source = '''
 def evaluate(self, market_state):
-    return barrier_option_price(spot, strike, barrier, rate, carry, vol, time)
+    return barrier_option_price(spot, strike, barrier, rate, vol, time, q=carry)
 '''
 
         findings = AlgorithmContractValidator().validate(

--- a/tests/test_agent/test_semantic_validators.py
+++ b/tests/test_agent/test_semantic_validators.py
@@ -267,6 +267,37 @@ def evaluate(self, market_state):
             for finding in findings
         )
 
+    def test_fx_barrier_pricing_kernel_satisfies_analytical_engine_family(self, registry):
+        spec = [r for r in registry.routes if r.id == "analytical_fx_barrier"][0]
+        barrier_ir = ProductIR(
+            instrument="barrier_option",
+            payoff_family="barrier_option",
+            payoff_traits=("barrier", "single_barrier", "terminal_markov"),
+            exercise_style="european",
+            state_dependence="terminal_markov",
+            model_family="fx",
+        )
+        primitives = resolve_route_primitives(spec, barrier_ir)
+        source = '''
+def evaluate(self, market_state):
+    return barrier_option_price(spot, strike, barrier, rate, vol, time, q=carry)
+'''
+
+        findings = AlgorithmContractValidator().validate(
+            source,
+            _make_plan(
+                "analytical_fx_barrier",
+                instrument_type="barrier_option",
+                primitives=primitives,
+            ),
+            spec,
+        )
+
+        assert not any(
+            finding.category == "engine_family_mismatch"
+            for finding in findings
+        )
+
     def test_non_owning_pricing_kernel_does_not_hide_missing_engine(self, registry):
         spec = [r for r in registry.routes if r.id == "local_vol_monte_carlo"][0]
         local_vol_ir = ProductIR(

--- a/tests/test_agent/test_semantic_validators.py
+++ b/tests/test_agent/test_semantic_validators.py
@@ -298,6 +298,38 @@ def evaluate(self, market_state):
             for finding in findings
         )
 
+    def test_fx_barrier_rejects_substituted_analytical_kernel(self, registry):
+        spec = [r for r in registry.routes if r.id == "analytical_fx_barrier"][0]
+        barrier_ir = ProductIR(
+            instrument="barrier_option",
+            payoff_family="barrier_option",
+            payoff_traits=("barrier", "single_barrier", "terminal_markov"),
+            exercise_style="european",
+            state_dependence="terminal_markov",
+            model_family="fx",
+        )
+        primitives = resolve_route_primitives(spec, barrier_ir)
+        source = '''
+def evaluate(self, market_state):
+    return garman_kohlhagen_price_raw(resolved)
+'''
+
+        findings = AlgorithmContractValidator().validate(
+            source,
+            _make_plan(
+                "analytical_fx_barrier",
+                instrument_type="barrier_option",
+                primitives=primitives,
+            ),
+            spec,
+        )
+
+        assert any(
+            finding.category == "required_primitive_not_called"
+            and "barrier_option_price" in finding.message
+            for finding in findings
+        )
+
     def test_non_owning_pricing_kernel_does_not_hide_missing_engine(self, registry):
         spec = [r for r in registry.routes if r.id == "local_vol_monte_carlo"][0]
         local_vol_ir = ProductIR(

--- a/tests/test_agent/test_semantic_validators.py
+++ b/tests/test_agent/test_semantic_validators.py
@@ -236,6 +236,37 @@ def evaluate(self, market_state):
             for finding in findings
         )
 
+    def test_barrier_pricing_kernel_satisfies_analytical_engine_family(self, registry):
+        spec = [r for r in registry.routes if r.id == "analytical_black76"][0]
+        barrier_ir = ProductIR(
+            instrument="barrier_option",
+            payoff_family="barrier_option",
+            payoff_traits=("barrier", "single_barrier", "terminal_markov"),
+            exercise_style="european",
+            state_dependence="terminal_markov",
+            model_family="equity_diffusion",
+        )
+        primitives = resolve_route_primitives(spec, barrier_ir)
+        source = '''
+def evaluate(self, market_state):
+    return barrier_option_price(spot, strike, barrier, rate, carry, vol, time)
+'''
+
+        findings = AlgorithmContractValidator().validate(
+            source,
+            _make_plan(
+                "analytical_black76",
+                instrument_type="barrier_option",
+                primitives=primitives,
+            ),
+            spec,
+        )
+
+        assert not any(
+            finding.category == "engine_family_mismatch"
+            for finding in findings
+        )
+
     def test_analytical_black76_helper_owned_rate_strip_does_not_require_internal_kernels(
         self,
         registry,

--- a/tests/test_agent/test_semantic_validators.py
+++ b/tests/test_agent/test_semantic_validators.py
@@ -236,6 +236,40 @@ def evaluate(self, market_state):
             for finding in findings
         )
 
+    def test_analytical_black76_helper_owned_rate_strip_does_not_require_internal_kernels(
+        self,
+        registry,
+    ):
+        spec = [r for r in registry.routes if r.id == "analytical_black76"][0]
+        rate_strip_ir = ProductIR(
+            instrument="cap",
+            payoff_family="period_rate_option_strip",
+            exercise_style="none",
+            schedule_dependence=True,
+            state_dependence="schedule_dependent",
+            model_family="interest_rate",
+        )
+        primitives = resolve_route_primitives(spec, rate_strip_ir)
+        source = '''
+def evaluate(self, market_state):
+    return price_rate_cap_floor_strip_analytical(market_state, self._spec)
+'''
+
+        findings = AlgorithmContractValidator().validate(
+            source,
+            _make_plan(
+                "analytical_black76",
+                instrument_type="cap",
+                primitives=primitives,
+            ),
+            spec,
+        )
+
+        assert not any(
+            finding.category == "required_primitive_not_called"
+            for finding in findings
+        )
+
     def test_rejects_autocallable_shortcut_for_monte_carlo_paths(self, registry):
         spec = [r for r in registry.routes if r.id == "monte_carlo_paths"][0]
         source = '''

--- a/tests/test_agent/test_semantic_validators.py
+++ b/tests/test_agent/test_semantic_validators.py
@@ -204,6 +204,38 @@ def evaluate(self, market_state):
         findings = validator.validate(source, _make_plan("equity_quanto"), spec)
         assert any(f.category == "required_primitive_not_called" for f in findings)
 
+    def test_flags_missing_equity_barrier_pricing_kernel(self, registry):
+        spec = [r for r in registry.routes if r.id == "analytical_black76"][0]
+        barrier_ir = ProductIR(
+            instrument="barrier_option",
+            payoff_family="barrier_option",
+            payoff_traits=("barrier", "single_barrier", "terminal_markov"),
+            exercise_style="european",
+            state_dependence="terminal_markov",
+            model_family="equity_diffusion",
+        )
+        primitives = resolve_route_primitives(spec, barrier_ir)
+        source = '''
+def evaluate(self, market_state):
+    return 0.0
+'''
+
+        findings = AlgorithmContractValidator().validate(
+            source,
+            _make_plan(
+                "analytical_black76",
+                instrument_type="barrier_option",
+                primitives=primitives,
+            ),
+            spec,
+        )
+
+        assert any(
+            finding.category == "required_primitive_not_called"
+            and "barrier_option_price" in finding.message
+            for finding in findings
+        )
+
     def test_rejects_autocallable_shortcut_for_monte_carlo_paths(self, registry):
         spec = [r for r in registry.routes if r.id == "monte_carlo_paths"][0]
         source = '''

--- a/trellis/agent/backend_bindings.py
+++ b/trellis/agent/backend_bindings.py
@@ -377,6 +377,7 @@ def _parse_primitive(raw: dict[str, Any]) -> PrimitiveRef:
         role=str(raw["role"]),
         required=raw.get("required", True),
         excluded=raw.get("excluded", False),
+        owns_engine_family=raw.get("owns_engine_family", False),
     )
 
 

--- a/trellis/agent/codegen_guardrails.py
+++ b/trellis/agent/codegen_guardrails.py
@@ -204,6 +204,7 @@ class PrimitiveRef:
     role: str
     required: bool = True
     excluded: bool = False  # if True, generated code must NOT call this symbol
+    owns_engine_family: bool = False
 
 
 @dataclass(frozen=True)

--- a/trellis/agent/knowledge/canonical/backend_bindings.yaml
+++ b/trellis/agent/knowledge/canonical/backend_bindings.yaml
@@ -1076,6 +1076,7 @@ bindings:
           - module: trellis.models.analytical.barrier
             symbol: barrier_option_price
             role: pricing_kernel
+            owns_engine_family: true
       - when:
           contract_pattern:
             payoff:
@@ -1307,6 +1308,7 @@ bindings:
       - module: trellis.models.analytical.barrier
         symbol: barrier_option_price
         role: pricing_kernel
+        owns_engine_family: true
 
   - route_id: analytical_garman_kohlhagen
     engine_family: analytical

--- a/trellis/agent/knowledge/canonical/backend_bindings.yaml
+++ b/trellis/agent/knowledge/canonical/backend_bindings.yaml
@@ -1075,7 +1075,7 @@ bindings:
         primitives:
           - module: trellis.models.analytical.barrier
             symbol: barrier_option_price
-            role: route_helper
+            role: pricing_kernel
       - when:
           contract_pattern:
             payoff:

--- a/trellis/agent/knowledge/canonical/routes.yaml
+++ b/trellis/agent/knowledge/canonical/routes.yaml
@@ -1699,7 +1699,7 @@ routes:
         primitives:
           - module: trellis.models.analytical.barrier
             symbol: barrier_option_price
-            role: route_helper
+            role: pricing_kernel
           - module: trellis.models.analytical.support.barriers
             symbol: terminal_double_barrier_payoff
             role: terminal_payoff
@@ -1708,7 +1708,7 @@ routes:
             role: payoff_primitive
         adapters: []
         notes:
-          - "Use `barrier_option_price` directly with scalar spot/strike/barrier/rate/sigma/T inputs instead of instantiating `ResolvedBarrierInputs` in generated adapters."
+          - "Treat `barrier_option_price` as a scalar pricing kernel: generated adapters must bind spot, strike, barrier, rate/carry, volatility, time, monitoring, rebate, payoff direction, and notional explicitly."
           - "For double-barrier targets with lower and upper barriers, compose the PDE grid or MC path estimator using the shared payoff primitives instead of adapting the single-barrier formula."
           - "When the contract carries discrete monitoring or non-zero dividend carry, pass `observations_per_year` and `q` through explicitly."
       - when:

--- a/trellis/agent/knowledge/canonical/routes.yaml
+++ b/trellis/agent/knowledge/canonical/routes.yaml
@@ -1700,6 +1700,7 @@ routes:
           - module: trellis.models.analytical.barrier
             symbol: barrier_option_price
             role: pricing_kernel
+            owns_engine_family: true
           - module: trellis.models.analytical.support.barriers
             symbol: terminal_double_barrier_payoff
             role: terminal_payoff
@@ -2138,6 +2139,7 @@ routes:
       - module: trellis.models.analytical.barrier
         symbol: barrier_option_price
         role: pricing_kernel
+        owns_engine_family: true
     adapters: []
     notes:
       - "Resolve FX spot, domestic/foreign rates, volatility, monitoring, and payoff terms, then call `barrier_option_price(...)` with foreign rate as `q` and apply notional."

--- a/trellis/agent/route_registry.py
+++ b/trellis/agent/route_registry.py
@@ -289,6 +289,7 @@ def _parse_primitive(raw: dict) -> PrimitiveRef:
         role=raw["role"],
         required=raw.get("required", True),
         excluded=raw.get("excluded", False),
+        owns_engine_family=raw.get("owns_engine_family", False),
     )
 
 

--- a/trellis/agent/semantic_validators/algorithm_contract.py
+++ b/trellis/agent/semantic_validators/algorithm_contract.py
@@ -657,12 +657,14 @@ class AlgorithmContractValidator:
         if not signatures:
             return []
 
-        helper_symbols = tuple(
+        admitted_pricing_symbols = tuple(
             prim.symbol
             for prim in exact_surface_primitives
-            if prim.role == "route_helper" and prim.required
+            if prim.role in {"route_helper", "pricing_kernel"} and prim.required
         )
-        if helper_symbols and any(_calls_symbol(source, symbol) for symbol in helper_symbols):
+        if admitted_pricing_symbols and any(
+            _calls_symbol(source, symbol) for symbol in admitted_pricing_symbols
+        ):
             return []
 
         found = any(sig in source for sig in signatures)

--- a/trellis/agent/semantic_validators/algorithm_contract.py
+++ b/trellis/agent/semantic_validators/algorithm_contract.py
@@ -706,7 +706,11 @@ class AlgorithmContractValidator:
         exact_surface_primitives,
     ) -> list[SemanticFinding]:
         """Require explicit primitive composition for helper-retired routes."""
-        if route_spec.id not in {"equity_quanto", "rate_tree_backward_induction"}:
+        if route_spec.id not in {
+            "analytical_black76",
+            "equity_quanto",
+            "rate_tree_backward_induction",
+        }:
             return []
 
         findings: list[SemanticFinding] = []

--- a/trellis/agent/semantic_validators/algorithm_contract.py
+++ b/trellis/agent/semantic_validators/algorithm_contract.py
@@ -68,9 +68,6 @@ _EXPLICIT_COMPOSITION_ROUTE_IDS = frozenset({
     "equity_quanto",
     "rate_tree_backward_induction",
 })
-_EXPLICIT_COMPOSITION_PRIMITIVES = frozenset({
-    ("analytical_black76", "barrier_option_price"),
-})
 _EXACT_HELPER_SIGNATURES = {
     "price_double_barrier_option_pde_result": {
         "min_positional_args": 2,
@@ -723,7 +720,7 @@ class AlgorithmContractValidator:
             primitive
             for primitive in exact_surface_primitives
             if enforce_whole_route
-            or (route_spec.id, primitive.symbol) in _EXPLICIT_COMPOSITION_PRIMITIVES
+            or primitive.owns_engine_family
         )
         if not required_primitives:
             return []

--- a/trellis/agent/semantic_validators/algorithm_contract.py
+++ b/trellis/agent/semantic_validators/algorithm_contract.py
@@ -64,6 +64,13 @@ _HELPER_OWNED_ROUTE_SYMBOLS = _CHECKED_ROUTE_HELPER_SYMBOLS | frozenset({
     "price_double_barrier_option_monte_carlo_result",
 })
 _DECLARATIVE_PRIMITIVE_ROLES = frozenset({"mesh", "topology"})
+_EXPLICIT_COMPOSITION_ROUTE_IDS = frozenset({
+    "equity_quanto",
+    "rate_tree_backward_induction",
+})
+_EXPLICIT_COMPOSITION_PRIMITIVES = frozenset({
+    ("analytical_black76", "barrier_option_price"),
+})
 
 _EXACT_HELPER_SIGNATURES = {
     "price_double_barrier_option_pde_result": {
@@ -706,15 +713,18 @@ class AlgorithmContractValidator:
         exact_surface_primitives,
     ) -> list[SemanticFinding]:
         """Require explicit primitive composition for helper-retired routes."""
-        if route_spec.id not in {
-            "analytical_black76",
-            "equity_quanto",
-            "rate_tree_backward_induction",
-        }:
+        enforce_whole_route = route_spec.id in _EXPLICIT_COMPOSITION_ROUTE_IDS
+        required_primitives = tuple(
+            primitive
+            for primitive in exact_surface_primitives
+            if enforce_whole_route
+            or (route_spec.id, primitive.symbol) in _EXPLICIT_COMPOSITION_PRIMITIVES
+        )
+        if not required_primitives:
             return []
 
         findings: list[SemanticFinding] = []
-        for primitive in exact_surface_primitives:
+        for primitive in required_primitives:
             if not primitive.required or primitive.excluded:
                 continue
             if _calls_symbol(source, primitive.symbol) or (

--- a/trellis/agent/semantic_validators/algorithm_contract.py
+++ b/trellis/agent/semantic_validators/algorithm_contract.py
@@ -71,10 +71,6 @@ _EXPLICIT_COMPOSITION_ROUTE_IDS = frozenset({
 _EXPLICIT_COMPOSITION_PRIMITIVES = frozenset({
     ("analytical_black76", "barrier_option_price"),
 })
-_ENGINE_OWNING_PRICING_KERNELS = frozenset({
-    ("analytical_black76", "barrier_option_price"),
-})
-
 _EXACT_HELPER_SIGNATURES = {
     "price_double_barrier_option_pde_result": {
         "min_positional_args": 2,
@@ -666,7 +662,7 @@ class AlgorithmContractValidator:
             if prim.required
             and (
                 prim.role == "route_helper"
-                or (route_spec.id, prim.symbol) in _ENGINE_OWNING_PRICING_KERNELS
+                or prim.owns_engine_family
             )
         )
         if engine_owning_symbols and any(

--- a/trellis/agent/semantic_validators/algorithm_contract.py
+++ b/trellis/agent/semantic_validators/algorithm_contract.py
@@ -71,6 +71,9 @@ _EXPLICIT_COMPOSITION_ROUTE_IDS = frozenset({
 _EXPLICIT_COMPOSITION_PRIMITIVES = frozenset({
     ("analytical_black76", "barrier_option_price"),
 })
+_ENGINE_OWNING_PRICING_KERNELS = frozenset({
+    ("analytical_black76", "barrier_option_price"),
+})
 
 _EXACT_HELPER_SIGNATURES = {
     "price_double_barrier_option_pde_result": {
@@ -657,13 +660,17 @@ class AlgorithmContractValidator:
         if not signatures:
             return []
 
-        admitted_pricing_symbols = tuple(
+        engine_owning_symbols = tuple(
             prim.symbol
             for prim in exact_surface_primitives
-            if prim.role in {"route_helper", "pricing_kernel"} and prim.required
+            if prim.required
+            and (
+                prim.role == "route_helper"
+                or (route_spec.id, prim.symbol) in _ENGINE_OWNING_PRICING_KERNELS
+            )
         )
-        if admitted_pricing_symbols and any(
-            _calls_symbol(source, symbol) for symbol in admitted_pricing_symbols
+        if engine_owning_symbols and any(
+            _calls_symbol(source, symbol) for symbol in engine_owning_symbols
         ):
             return []
 


### PR DESCRIPTION
## Summary
- classify the scalar single-barrier formula as a pricing kernel for F009 route and exact binding contracts
- retain explicit composition enforcement so generated source must call the kernel and own market binding and settlement
- reduce the helper-authority audit without changing numerical support or canonical cookbooks

## Validation
- 466 affected agent and knowledge tests passed
- strict isolated offline F009 replay passed with zero LLM calls or recovery
- helper audit: route refs 50 to 49, binding refs 54 to 53, adapter authority calls 11 to 10; drift unchanged
- NUMBA_CACHE_DIR=/tmp/trellis-numba-cache make gate-pr: 4,742 main-suite tests and 32 tier-2 contract tests passed