### PR TITLE
Short-rate lattice: add reusable market calibration binding

### DIFF
--- a/doc/plan/active__semantic-task-synthesis-helper-retirement.md
+++ b/doc/plan/active__semantic-task-synthesis-helper-retirement.md
@@ -64,6 +64,9 @@ Status mirror last synced: `2026-07-16`
 | `QUA-1201` | Bermudan swaption lattice: retire helper and compiler authority | Done |
 | `QUA-1202` | Semantic proving: distinguish fresh artifacts from agent synthesis | Done |
 | `QUA-1203` | Semantic authority: classify scalar barrier formula as pricing kernel | Done |
+| `QUA-1204` | Short-rate lattice: reusable market calibration inputs | In Progress |
+| `QUA-1206` | Semantic comparison: bind callable fixed-income target variants | Backlog |
+| `QUA-1205` | Callable fixed income: raw lattice primitive assembly | Blocked by QUA-1204, QUA-1206 |
 | `QUA-1102` | Semantic target binding: typed comparison target contracts (related prerequisite) | Done |
 
 ## Current Sequence
@@ -122,6 +125,14 @@ Status mirror last synced: `2026-07-16`
 15. Apply QUA-1203 to classify the shared scalar barrier formula consistently
     as a pricing kernel for F009, while requiring generated code to retain
     market binding and settlement responsibility.
+16. Apply QUA-1204 to expose product-neutral short-rate lattice calibration
+    inputs, including model-specific volatility units and bounded step policy.
+17. Apply QUA-1206 to bind T02, T05, and T17 comparison targets explicitly
+    and require target-specific artifact evidence instead of legacy label
+    inference.
+18. After QUA-1204 and QUA-1206 land, apply QUA-1205 to retire
+    callable/puttable tree wrapper authority through explicit event, contract,
+    lattice, and bound composition.
 
 ## Completion Evidence
 

--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -1019,6 +1019,16 @@ contract, and calls ``price_on_lattice(...)``. The semantic gate requires
 ``price_swaption_tree(...)`` surface remains independent comparison evidence,
 not the generated artifact identity.
 
+The underlying market binding is now product-neutral. The ``rate_lattice`` API
+card exposes ``resolve_short_rate_lattice_inputs(...)`` together with
+``MODEL_REGISTRY``, ``TERM_STRUCTURE_TARGET(...)``, and ``build_lattice(...)``.
+The resolver records canonical model and volatility units, gives explicit or
+calibrated parameters precedence over surface-derived defaults, and fails
+closed when discount or volatility evidence is absent. Callable-bond and
+Bermudan-swaption builders share this binding, so a later route migration can
+remove product-wrapper authority without asking generated code to recreate
+normal-versus-lognormal volatility conversion.
+
 Helper-authority inventory
 --------------------------
 

--- a/docs/quant/lattice_algebra.rst
+++ b/docs/quant/lattice_algebra.rst
@@ -338,7 +338,9 @@ bounded discretization policy, it returns the frozen
 - mean reversion and lattice volatility :math:`\sigma`;
 - the resolved lattice step count.
 
-Explicit parameters and calibrated model-parameter payloads take precedence.
+Explicit parameters and calibrated model-parameter payloads associated with
+the selected lattice model take precedence. A payload for another model family
+is not reused as short-rate calibration evidence.
 If neither supplies :math:`\sigma`, the resolver may bind a Black-style
 volatility surface quote. For a normal model it converts that quote to absolute
 rate volatility using

--- a/docs/quant/lattice_algebra.rst
+++ b/docs/quant/lattice_algebra.rst
@@ -324,6 +324,40 @@ should use this bounded result when they need schedule or exercise-state
 composition instead of open-coding backward induction or adding a
 product-specific helper.
 
+Short-Rate Lattice Market Binding
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``resolve_short_rate_lattice_inputs(...)`` is the product-neutral boundary
+between market evidence and one-factor rate-lattice construction. Given a
+positive horizon, a model name, optional volatility quote coordinates, and a
+bounded discretization policy, it returns the frozen
+``ResolvedShortRateLatticeInputs`` value:
+
+- canonical ``model_name`` and ``volatility_type``;
+- horizon and initial short rate :math:`r_0`;
+- mean reversion and lattice volatility :math:`\sigma`;
+- the resolved lattice step count.
+
+Explicit parameters and calibrated model-parameter payloads take precedence.
+If neither supplies :math:`\sigma`, the resolver may bind a Black-style
+volatility surface quote. For a normal model it converts that quote to absolute
+rate volatility using
+
+.. math::
+
+   \sigma_{\mathrm{rate}}
+   = \sigma_{\mathrm{Black}}\max\!\left(\lvert r_0\rvert, 10^{-6}\right),
+
+whereas a lognormal model retains :math:`\sigma_{\mathrm{Black}}`. Missing
+discount or volatility evidence, unsupported model names, non-positive
+horizons, and invalid step policies fail closed.
+
+The callable-bond and Bermudan-swaption lattice builders consume this same
+binding while retaining their own schedule and payoff semantics. Generated
+construction can therefore use the resolver with ``MODEL_REGISTRY``,
+``TERM_STRUCTURE_TARGET(...)``, and ``build_lattice(...)`` without copying
+market-default conventions or invoking a product pricer.
+
 Bermudan Swaption Composition
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/test_agent/test_api_map.py
+++ b/tests/test_agent/test_api_map.py
@@ -889,6 +889,23 @@ def test_rate_lattice_api_map_exposes_bounded_rollback_observations():
     assert "price_bermudan_swaption_tree" not in text
 
 
+def test_rate_lattice_api_map_exposes_product_neutral_market_binding():
+    section = get_api_map()["rate_lattice"]
+    text = "\n".join((*section["key_imports"], *section["notes"]))
+
+    for symbol in (
+        "ResolvedShortRateLatticeInputs",
+        "resolve_short_rate_lattice_inputs",
+        "MODEL_REGISTRY",
+        "TERM_STRUCTURE_TARGET",
+        "build_lattice",
+    ):
+        assert symbol in text
+    assert "absolute rate volatility" in text
+    assert "lognormal" in text.lower()
+    assert "build_rate_lattice" not in "\n".join(section["key_imports"])
+
+
 def _assert_import_statements_valid(import_statements: list[str]) -> None:
     for statement in import_statements:
         cleaned = statement.split("#", 1)[0].strip()

--- a/tests/test_agent/test_import_registry.py
+++ b/tests/test_agent/test_import_registry.py
@@ -530,6 +530,24 @@ def test_short_rate_bond_helpers_are_visible_to_import_registry():
         assert symbol in registry_text
 
 
+def test_short_rate_lattice_binding_is_visible_to_import_registry():
+    module = "trellis.models.short_rate_lattice"
+    symbols = {
+        "ResolvedShortRateLatticeInputs",
+        "resolve_short_rate_lattice_inputs",
+    }
+
+    assert module_exists(module)
+    assert symbols <= set(list_module_exports(module))
+    registry_text = get_import_registry()
+    assert f"from {module} import" in registry_text
+
+    static_registry = import_registry._parse_static_registry(
+        import_registry._STATIC_REGISTRY
+    )
+    assert symbols <= set(static_registry[module])
+
+
 def test_cev_helpers_are_visible_to_import_registry():
     pde_module = "trellis.models.equity_option_pde"
     tree_module = "trellis.models.equity_option_tree"

--- a/tests/test_models/test_resolution_short_rate_lattice.py
+++ b/tests/test_models/test_resolution_short_rate_lattice.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from trellis.models.short_rate_lattice import (
+    ResolvedShortRateLatticeInputs,
+    resolve_short_rate_lattice_inputs,
+)
+
+
+class _DiscountCurve:
+    def __init__(self, rate: float = 0.04):
+        self.rate = float(rate)
+        self.requested_times: list[float] = []
+
+    def zero_rate(self, time: float) -> float:
+        self.requested_times.append(float(time))
+        return self.rate
+
+
+class _VolSurface:
+    def __init__(self, volatility: float = 0.20):
+        self.volatility = float(volatility)
+        self.requests: list[tuple[float, float]] = []
+
+    def black_vol(self, time: float, strike: float) -> float:
+        self.requests.append((float(time), float(strike)))
+        return self.volatility
+
+
+def _market_state(
+    *,
+    rate: float = 0.04,
+    volatility: float | None = 0.20,
+    model_parameters: dict[str, object] | None = None,
+):
+    surface = None if volatility is None else _VolSurface(volatility)
+    return SimpleNamespace(
+        discount=_DiscountCurve(rate),
+        vol_surface=surface,
+        model_parameters=model_parameters,
+        model_parameter_sets={},
+    )
+
+
+def test_resolve_normal_short_rate_lattice_inputs_converts_black_volatility() -> None:
+    market_state = _market_state(rate=0.04, volatility=0.20)
+
+    resolved = resolve_short_rate_lattice_inputs(
+        market_state,
+        horizon=5.0,
+        model="hull_white",
+        volatility_time=2.0,
+        volatility_strike=0.03,
+    )
+
+    assert isinstance(resolved, ResolvedShortRateLatticeInputs)
+    assert resolved.model_name == "hull_white"
+    assert resolved.horizon == pytest.approx(5.0)
+    assert resolved.r0 == pytest.approx(0.04)
+    assert resolved.mean_reversion == pytest.approx(0.1)
+    assert resolved.sigma == pytest.approx(0.20 * 0.04)
+    assert resolved.n_steps == 200
+    assert market_state.discount.requested_times == [pytest.approx(2.5)]
+    assert market_state.vol_surface.requests == [
+        (pytest.approx(2.0), pytest.approx(0.03))
+    ]
+
+
+def test_resolve_lognormal_short_rate_lattice_inputs_retains_black_volatility() -> None:
+    market_state = _market_state(rate=0.04, volatility=0.20)
+
+    resolved = resolve_short_rate_lattice_inputs(
+        market_state,
+        horizon=3.0,
+        model="bdt",
+        n_steps=80,
+    )
+
+    assert resolved.model_name == "bdt"
+    assert resolved.sigma == pytest.approx(0.20)
+    assert resolved.n_steps == 80
+    assert market_state.vol_surface.requests == [
+        (pytest.approx(1.5), pytest.approx(0.04))
+    ]
+
+
+def test_resolve_short_rate_lattice_inputs_prefers_model_parameter_payload() -> None:
+    market_state = _market_state(
+        volatility=None,
+        model_parameters={
+            "model_family": "hull_white",
+            "mean_reversion": 0.03,
+            "sigma": 0.012,
+        },
+    )
+
+    resolved = resolve_short_rate_lattice_inputs(
+        market_state,
+        horizon=2.0,
+        sigma=None,
+        mean_reversion=None,
+    )
+
+    assert resolved.mean_reversion == pytest.approx(0.03)
+    assert resolved.sigma == pytest.approx(0.012)
+
+
+def test_resolve_short_rate_lattice_inputs_accepts_explicit_sigma_without_surface() -> None:
+    resolved = resolve_short_rate_lattice_inputs(
+        _market_state(volatility=None),
+        horizon=2.0,
+        mean_reversion=0.07,
+        sigma=0.009,
+    )
+
+    assert resolved.mean_reversion == pytest.approx(0.07)
+    assert resolved.sigma == pytest.approx(0.009)
+
+
+def test_resolve_short_rate_lattice_inputs_applies_route_discretization_policy() -> None:
+    resolved = resolve_short_rate_lattice_inputs(
+        _market_state(),
+        horizon=6.0,
+        minimum_steps=100,
+        maximum_steps=400,
+        steps_per_year=20.0,
+    )
+
+    assert resolved.n_steps == 120
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"horizon": 0.0}, "horizon must be positive"),
+        ({"horizon": 1.0, "model": "not_a_model"}, "Unsupported short-rate lattice model"),
+        ({"horizon": 1.0, "n_steps": 0}, "n_steps must be positive"),
+        ({"horizon": 1.0, "n_steps": 1.5}, "n_steps must be a positive integer"),
+        (
+            {"horizon": 1.0, "minimum_steps": 20, "maximum_steps": 10},
+            "maximum_steps must be at least minimum_steps",
+        ),
+    ],
+)
+def test_resolve_short_rate_lattice_inputs_rejects_invalid_contracts(
+    kwargs: dict[str, object],
+    match: str,
+) -> None:
+    with pytest.raises(ValueError, match=match):
+        resolve_short_rate_lattice_inputs(_market_state(), **kwargs)
+
+
+def test_resolve_short_rate_lattice_inputs_requires_discount_curve() -> None:
+    with pytest.raises(ValueError, match="requires market_state.discount"):
+        resolve_short_rate_lattice_inputs(
+            SimpleNamespace(discount=None, vol_surface=_VolSurface()),
+            horizon=1.0,
+        )
+
+
+def test_resolve_short_rate_lattice_inputs_requires_volatility_evidence() -> None:
+    with pytest.raises(ValueError, match="sigma must be provided"):
+        resolve_short_rate_lattice_inputs(
+            _market_state(volatility=None),
+            horizon=1.0,
+        )

--- a/tests/test_models/test_resolution_short_rate_lattice.py
+++ b/tests/test_models/test_resolution_short_rate_lattice.py
@@ -108,9 +108,69 @@ def test_resolve_short_rate_lattice_inputs_prefers_model_parameter_payload() -> 
     assert resolved.sigma == pytest.approx(0.012)
 
 
+@pytest.mark.parametrize(
+    ("model", "model_family", "calibrated_mean_reversion", "calibrated_sigma"),
+    [
+        ("bdt", "black_derman_toy", 0.0, 0.17),
+        ("black_karasinski", "black-karasinski", 0.06, 0.11),
+    ],
+)
+def test_resolve_short_rate_lattice_inputs_selects_calibration_for_requested_model(
+    model: str,
+    model_family: str,
+    calibrated_mean_reversion: float,
+    calibrated_sigma: float,
+) -> None:
+    market_state = _market_state(
+        volatility=None,
+        model_parameters={
+            "model_family": "hull_white",
+            "mean_reversion": 0.03,
+            "sigma": 0.012,
+        },
+    )
+    market_state.model_parameter_sets = {
+        "hull_white": market_state.model_parameters,
+        f"{model}_short_rate": {
+            "model_family": model_family,
+            "mean_reversion": calibrated_mean_reversion,
+            "sigma": calibrated_sigma,
+        },
+    }
+
+    resolved = resolve_short_rate_lattice_inputs(
+        market_state,
+        horizon=2.0,
+        model=model,
+    )
+
+    assert resolved.model_name == model
+    assert resolved.mean_reversion == pytest.approx(calibrated_mean_reversion)
+    assert resolved.sigma == pytest.approx(calibrated_sigma)
+
+
 def test_resolve_short_rate_lattice_inputs_accepts_explicit_sigma_without_surface() -> None:
     resolved = resolve_short_rate_lattice_inputs(
         _market_state(volatility=None),
+        horizon=2.0,
+        mean_reversion=0.07,
+        sigma=0.009,
+    )
+
+    assert resolved.mean_reversion == pytest.approx(0.07)
+    assert resolved.sigma == pytest.approx(0.009)
+
+
+def test_resolve_short_rate_lattice_inputs_explicit_values_override_invalid_payload() -> None:
+    resolved = resolve_short_rate_lattice_inputs(
+        _market_state(
+            volatility=None,
+            model_parameters={
+                "model_family": "hull_white",
+                "mean_reversion": "invalid",
+                "sigma": "invalid",
+            },
+        ),
         horizon=2.0,
         mean_reversion=0.07,
         sigma=0.009,

--- a/trellis/agent/knowledge/canonical/api_map.yaml
+++ b/trellis/agent/knowledge/canonical/api_map.yaml
@@ -254,11 +254,16 @@ rate_lattice:
   navigation:
     aliases: [rate_tree, callable_bond, puttable_bond]
   key_imports:
-    - "from trellis.models.trees.lattice import LatticeRollbackObservation, LatticeRollbackResult, build_rate_lattice, lattice_backward_induction, lattice_backward_induction_result"
-    - "from trellis.models.trees.algebra import value_on_lattice"
+    - "from trellis.models.short_rate_lattice import ResolvedShortRateLatticeInputs, resolve_short_rate_lattice_inputs"
+    - "from trellis.models.trees.models import MODEL_REGISTRY"
+    - "from trellis.models.trees.algebra import BINOMIAL_1F_TOPOLOGY, UNIFORM_ADDITIVE_MESH, TERM_STRUCTURE_TARGET, build_lattice, value_on_lattice"
+    - "from trellis.models.trees.lattice import LatticeRollbackObservation, LatticeRollbackResult, lattice_backward_induction, lattice_backward_induction_result"
     - "from trellis.models.zcb_option_tree import price_zcb_option_tree"
   notes:
     - "Callable bonds, puttable bonds, and Bermudan swaptions use a calibrated rate lattice from a TreeModel specification such as Hull-White or Black-Derman-Toy"
+    - "Resolve product-neutral market inputs with resolve_short_rate_lattice_inputs(...), then select the returned model_name from MODEL_REGISTRY and build against TERM_STRUCTURE_TARGET(discount_curve)"
+    - "Normal models receive absolute rate volatility; when only a Black-style surface quote exists the resolver multiplies it by abs(r0). Lognormal models retain the Black-style quote"
+    - "Explicit sigma or a calibrated model-parameter payload takes precedence; missing discount or volatility evidence fails closed"
     - "lattice_backward_induction handles cashflow_at_node and exercise_fn"
     - "lattice_backward_induction_result(..., observation_steps=...) and value_on_lattice(..., observation_steps=...) capture only requested steps as immutable LatticeRollbackObservation values"
     - "Each nonterminal observation separates discounted continuation, post-cashflow, and post-control node vectors; terminal observations use the terminal payoff vector for all three phases"

--- a/trellis/agent/knowledge/canonical/api_map.yaml
+++ b/trellis/agent/knowledge/canonical/api_map.yaml
@@ -263,7 +263,7 @@ rate_lattice:
     - "Callable bonds, puttable bonds, and Bermudan swaptions use a calibrated rate lattice from a TreeModel specification such as Hull-White or Black-Derman-Toy"
     - "Resolve product-neutral market inputs with resolve_short_rate_lattice_inputs(...), then select the returned model_name from MODEL_REGISTRY and build against TERM_STRUCTURE_TARGET(discount_curve)"
     - "Normal models receive absolute rate volatility; when only a Black-style surface quote exists the resolver multiplies it by abs(r0). Lognormal models retain the Black-style quote"
-    - "Explicit sigma or a calibrated model-parameter payload takes precedence; missing discount or volatility evidence fails closed"
+    - "Explicit sigma or a calibrated model-parameter payload matched to the selected lattice model takes precedence; missing discount or volatility evidence fails closed"
     - "lattice_backward_induction handles cashflow_at_node and exercise_fn"
     - "lattice_backward_induction_result(..., observation_steps=...) and value_on_lattice(..., observation_steps=...) capture only requested steps as immutable LatticeRollbackObservation values"
     - "Each nonterminal observation separates discounted continuation, post-cashflow, and post-control node vectors; terminal observations use the terminal payoff vector for all three phases"

--- a/trellis/agent/knowledge/import_registry.py
+++ b/trellis/agent/knowledge/import_registry.py
@@ -485,6 +485,8 @@ def _format_registry(registry: dict[str, tuple[str, ...]]) -> str:
             groups["Models — Analytical"].append(line)
         elif mod == "trellis.models.fx_barrier_option":
             groups["Models — Analytical"].append(line)
+        elif mod == "trellis.models.short_rate_lattice":
+            groups["Models — Trees"].append(line)
         elif mod == "trellis.models.equity_option_tree":
             groups["Models — Trees"].append(line)
         elif mod == "trellis.models.equity_option_monte_carlo":
@@ -589,6 +591,7 @@ from trellis.models.sabr_option import ResolvedSabrForwardOptionInputs, SabrForw
 ### Models — Trees
 from trellis.models.bermudan_swaption_tree import BermudanSwaptionTreeSpec, compile_bermudan_swaption_contract_spec, resolve_bermudan_swaption_tree_inputs
 from trellis.models.rate_style_swaption import resolve_swaption_curve_basis_spread
+from trellis.models.short_rate_lattice import ResolvedShortRateLatticeInputs, resolve_short_rate_lattice_inputs
 from trellis.models.trees.algebra import BINOMIAL_1F_TOPOLOGY, TERM_STRUCTURE_TARGET, UNIFORM_ADDITIVE_MESH, build_lattice, price_on_lattice, value_on_lattice
 from trellis.models.equity_option_tree import build_vanilla_equity_lattice, compile_vanilla_equity_contract_spec, price_cev_option_tree, price_vanilla_equity_option_on_lattice, price_vanilla_equity_option_tree, resolve_vanilla_equity_tree_inputs
 from trellis.models.trees.lattice import LatticeRollbackObservation, LatticeRollbackResult, build_rate_lattice, build_spot_lattice, lattice_backward_induction, lattice_backward_induction_result, build_generic_lattice, calibrate_lattice

--- a/trellis/models/bermudan_swaption_tree.py
+++ b/trellis/models/bermudan_swaption_tree.py
@@ -15,6 +15,7 @@ from trellis.core.differentiable import get_numpy
 from trellis.core.types import ContractTimeline, DayCountConvention, Frequency
 import trellis.models.trees.algebra as lattice_algebra
 import trellis.models.trees.models as tree_models
+from trellis.models.short_rate_lattice import resolve_short_rate_lattice_inputs
 from trellis.models.trees.control import (
     lattice_step_from_time,
     lattice_steps_from_timeline,
@@ -25,7 +26,6 @@ from trellis.models.trees.lattice import (
     build_lattice,
     price_on_lattice,
 )
-from trellis.models.hull_white_parameters import resolve_hull_white_parameters
 
 
 class DiscountCurveLike(Protocol):
@@ -135,22 +135,19 @@ def resolve_bermudan_swaption_tree_inputs(
     if tenor <= 0.0:
         raise ValueError("swap_end must be after the first Bermudan exercise date")
 
-    r0 = float(discount_curve.zero_rate(max(tree_horizon / 2.0, 1e-6)))
-    tree_model = tree_models.MODEL_REGISTRY[str(model).strip().lower()]
-    default_sigma = None
-    if market_state.vol_surface is not None:
-        black_vol = float(
-            market_state.vol_surface.black_vol(max(option_horizon, 1e-6), max(abs(float(spec.strike)), 1e-6))
-        )
-        default_sigma = black_vol if tree_model.vol_type == "lognormal" else black_vol * max(abs(r0), 1e-6)
-    resolved_mean_reversion, resolved_sigma = resolve_hull_white_parameters(
+    lattice_inputs = resolve_short_rate_lattice_inputs(
         market_state,
+        horizon=tree_horizon,
+        model=model,
+        volatility_time=max(option_horizon, 1e-6),
+        volatility_strike=max(abs(float(spec.strike)), 1e-6),
         mean_reversion=mean_reversion,
         sigma=sigma,
-        default_mean_reversion=0.1,
-        default_sigma=default_sigma,
+        n_steps=n_steps,
+        minimum_steps=100,
+        maximum_steps=400,
+        steps_per_year=20.0,
     )
-    step_count = int(n_steps or min(400, max(100, int(tree_horizon * 20.0))))
     return ResolvedBermudanSwaptionTreeInputs(
         settlement=settlement,
         swap_start=swap_start,
@@ -158,10 +155,10 @@ def resolve_bermudan_swaption_tree_inputs(
         exercise_frequency=exercise_frequency,
         tree_horizon=tree_horizon,
         option_horizon=option_horizon,
-        r0=r0,
-        mean_reversion=float(resolved_mean_reversion),
-        sigma=float(resolved_sigma),
-        n_steps=step_count,
+        r0=lattice_inputs.r0,
+        mean_reversion=lattice_inputs.mean_reversion,
+        sigma=lattice_inputs.sigma,
+        n_steps=lattice_inputs.n_steps,
     )
 
 

--- a/trellis/models/callable_bond_tree.py
+++ b/trellis/models/callable_bond_tree.py
@@ -14,12 +14,12 @@ from trellis.core.date_utils import (
 )
 import trellis.models.trees.algebra as lattice_algebra
 import trellis.models.trees.models as tree_models
+from trellis.models.short_rate_lattice import resolve_short_rate_lattice_inputs
 from trellis.models.trees.lattice import (
     RecombiningLattice,
     build_lattice,
     price_on_lattice,
 )
-from trellis.models.hull_white_parameters import resolve_hull_white_parameters
 from trellis.models.short_rate_fixed_income import (
     build_embedded_fixed_income_coupon_step_map,
     build_embedded_fixed_income_event_timeline,
@@ -45,32 +45,28 @@ def build_callable_bond_lattice(
     if maturity <= 0.0:
         raise ValueError("Callable bond maturity must be after settlement")
 
-    r0 = float(market_state.discount.zero_rate(max(maturity / 2.0, 1e-6)))
-    default_sigma = None
-    if market_state.vol_surface is not None:
-        black_vol = float(market_state.vol_surface.black_vol(max(maturity / 2.0, 1e-6), max(r0, 1e-6)))
-        default_sigma = black_vol * max(abs(r0), 1e-6)
-    step_count = int(n_steps or min(200, max(50, int(maturity * 50))))
-    model_key = str(model).strip().lower()
-
-    tree_model = tree_models.MODEL_REGISTRY[model_key]
-    resolved_mean_reversion, resolved_sigma = resolve_hull_white_parameters(
+    resolved = resolve_short_rate_lattice_inputs(
         market_state,
+        horizon=maturity,
+        model=model,
         mean_reversion=mean_reversion,
         sigma=sigma,
-        default_mean_reversion=0.1,
-        default_sigma=default_sigma if tree_model.vol_type != "lognormal" else black_vol if market_state.vol_surface is not None else None,
+        n_steps=n_steps,
+        minimum_steps=50,
+        maximum_steps=200,
+        steps_per_year=50.0,
     )
+    tree_model = tree_models.MODEL_REGISTRY[resolved.model_name]
     return build_lattice(
         lattice_algebra.BINOMIAL_1F_TOPOLOGY,
         lattice_algebra.UNIFORM_ADDITIVE_MESH,
         tree_model.as_lattice_model_spec(),
         calibration_target=lattice_algebra.TERM_STRUCTURE_TARGET(market_state.discount),
-        r0=r0,
-        sigma=resolved_sigma,
-        a=resolved_mean_reversion,
-        T=maturity,
-        n_steps=step_count,
+        r0=resolved.r0,
+        sigma=resolved.sigma,
+        a=resolved.mean_reversion,
+        T=resolved.horizon,
+        n_steps=resolved.n_steps,
     )
 
 

--- a/trellis/models/short_rate_lattice.py
+++ b/trellis/models/short_rate_lattice.py
@@ -1,0 +1,196 @@
+"""Product-neutral market binding for one-factor short-rate lattices."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import isfinite
+from operator import index as integer_index
+from typing import Protocol, SupportsIndex, cast
+
+from trellis.models.hull_white_parameters import (
+    extract_hull_white_parameter_payload,
+    resolve_hull_white_parameters,
+)
+from trellis.models.trees.models import MODEL_REGISTRY
+
+
+class DiscountCurveLike(Protocol):
+    """Discount-curve surface required by short-rate lattice resolution."""
+
+    def zero_rate(self, time: float) -> float:
+        """Return the continuously compounded zero rate at ``time``."""
+        ...
+
+
+class VolSurfaceLike(Protocol):
+    """Black-volatility surface used as a bounded lattice fallback."""
+
+    def black_vol(self, time: float, strike: float) -> float:
+        """Return the Black-style volatility quote at ``time`` and ``strike``."""
+        ...
+
+
+class ShortRateLatticeMarketStateLike(Protocol):
+    """Market-state fields consumed by the short-rate lattice resolver."""
+
+    @property
+    def discount(self) -> DiscountCurveLike | None:
+        """Return the discount curve used for calibration."""
+        ...
+
+    @property
+    def vol_surface(self) -> VolSurfaceLike | None:
+        """Return optional Black-style volatility evidence."""
+        ...
+
+
+@dataclass(frozen=True)
+class ResolvedShortRateLatticeInputs:
+    """Canonical inputs for a calibrated one-factor short-rate lattice."""
+
+    model_name: str
+    volatility_type: str
+    horizon: float
+    r0: float
+    mean_reversion: float
+    sigma: float
+    n_steps: int
+
+
+def _positive_integer(value: object, *, name: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be a positive integer")
+    try:
+        resolved = int(integer_index(cast(SupportsIndex, value)))
+    except TypeError as exc:
+        raise ValueError(f"{name} must be a positive integer") from exc
+    if resolved <= 0:
+        raise ValueError(f"{name} must be positive")
+    return resolved
+
+
+def resolve_short_rate_lattice_inputs(
+    market_state: ShortRateLatticeMarketStateLike,
+    *,
+    horizon: float,
+    model: str = "hull_white",
+    volatility_time: float | None = None,
+    volatility_strike: float | None = None,
+    mean_reversion: float | None = None,
+    sigma: float | None = None,
+    n_steps: int | None = None,
+    default_mean_reversion: float = 0.1,
+    minimum_steps: int = 50,
+    maximum_steps: int = 200,
+    steps_per_year: float = 50.0,
+) -> ResolvedShortRateLatticeInputs:
+    """Resolve market and discretization inputs for a short-rate lattice.
+
+    Explicit or calibrated model parameters take precedence. When sigma is not
+    available from either source, a Black-style surface quote is retained for
+    lognormal models and converted to absolute rate volatility for normal
+    models.
+    """
+    resolved_horizon = float(horizon)
+    if not isfinite(resolved_horizon) or resolved_horizon <= 0.0:
+        raise ValueError("short-rate lattice horizon must be positive")
+
+    discount_curve = market_state.discount
+    if discount_curve is None:
+        raise ValueError("short-rate lattice resolution requires market_state.discount")
+
+    model_key = str(model).strip().lower()
+    try:
+        tree_model = MODEL_REGISTRY[model_key]
+    except KeyError as exc:
+        supported = ", ".join(sorted(MODEL_REGISTRY))
+        raise ValueError(
+            f"Unsupported short-rate lattice model {model!r}; expected one of: {supported}"
+        ) from exc
+
+    resolved_r0 = float(discount_curve.zero_rate(max(resolved_horizon / 2.0, 1e-6)))
+    if not isfinite(resolved_r0):
+        raise ValueError("short-rate lattice initial rate must be finite")
+    parameter_payload = extract_hull_white_parameter_payload(market_state)
+    has_parameter_sigma = (
+        parameter_payload is not None and parameter_payload.get("sigma") is not None
+    )
+    fallback_sigma: float | None = None
+    if sigma is None and not has_parameter_sigma:
+        vol_surface = market_state.vol_surface
+        if vol_surface is None:
+            raise ValueError(
+                "short-rate lattice sigma must be provided explicitly, through model parameters, "
+                "or through market_state.vol_surface"
+            )
+        quote_time = (
+            resolved_horizon / 2.0
+            if volatility_time is None
+            else float(volatility_time)
+        )
+        if not isfinite(quote_time) or quote_time <= 0.0:
+            raise ValueError("short-rate lattice volatility_time must be positive")
+        quote_strike = (
+            max(resolved_r0, 1e-6)
+            if volatility_strike is None
+            else float(volatility_strike)
+        )
+        if not isfinite(quote_strike):
+            raise ValueError("short-rate lattice volatility_strike must be finite")
+        black_vol = float(vol_surface.black_vol(quote_time, quote_strike))
+        if not isfinite(black_vol) or black_vol < 0.0:
+            raise ValueError(
+                "short-rate lattice Black volatility must be finite and non-negative"
+            )
+        fallback_sigma = (
+            black_vol
+            if tree_model.vol_type == "lognormal"
+            else black_vol * max(abs(resolved_r0), 1e-6)
+        )
+
+    resolved_mean_reversion, resolved_sigma = resolve_hull_white_parameters(
+        market_state,
+        mean_reversion=mean_reversion,
+        sigma=sigma,
+        default_mean_reversion=default_mean_reversion,
+        default_sigma=fallback_sigma,
+    )
+
+    if not isfinite(float(resolved_mean_reversion)):
+        raise ValueError("short-rate lattice mean reversion must be finite")
+    if not isfinite(float(resolved_sigma)) or float(resolved_sigma) < 0.0:
+        raise ValueError("short-rate lattice sigma must be finite and non-negative")
+
+    lower_steps = _positive_integer(minimum_steps, name="minimum_steps")
+    upper_steps = _positive_integer(maximum_steps, name="maximum_steps")
+    if upper_steps < lower_steps:
+        raise ValueError("maximum_steps must be at least minimum_steps")
+    resolved_steps_per_year = float(steps_per_year)
+    if not isfinite(resolved_steps_per_year) or resolved_steps_per_year <= 0.0:
+        raise ValueError("steps_per_year must be positive")
+    if n_steps is None:
+        resolved_steps = min(
+            upper_steps,
+            max(lower_steps, int(resolved_horizon * resolved_steps_per_year)),
+        )
+    else:
+        resolved_steps = _positive_integer(n_steps, name="n_steps")
+
+    return ResolvedShortRateLatticeInputs(
+        model_name=tree_model.name,
+        volatility_type=tree_model.vol_type,
+        horizon=resolved_horizon,
+        r0=resolved_r0,
+        mean_reversion=float(resolved_mean_reversion),
+        sigma=float(resolved_sigma),
+        n_steps=resolved_steps,
+    )
+
+
+__all__ = [
+    "DiscountCurveLike",
+    "ResolvedShortRateLatticeInputs",
+    "ShortRateLatticeMarketStateLike",
+    "VolSurfaceLike",
+    "resolve_short_rate_lattice_inputs",
+]

--- a/trellis/models/short_rate_lattice.py
+++ b/trellis/models/short_rate_lattice.py
@@ -2,15 +2,12 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from math import isfinite
 from operator import index as integer_index
-from typing import Protocol, SupportsIndex, cast
+from typing import Protocol, SupportsFloat, SupportsIndex, cast
 
-from trellis.models.hull_white_parameters import (
-    extract_hull_white_parameter_payload,
-    resolve_hull_white_parameters,
-)
 from trellis.models.trees.models import MODEL_REGISTRY
 
 
@@ -55,6 +52,84 @@ class ResolvedShortRateLatticeInputs:
     mean_reversion: float
     sigma: float
     n_steps: int
+
+
+_MODEL_FAMILY_ALIASES = {
+    "black_derman_toy": "bdt",
+    "blackdermantoy": "bdt",
+    "blackkarasinski": "black_karasinski",
+    "hullwhite": "hull_white",
+    "holee": "ho_lee",
+}
+
+
+def _normalize_model_family(value: object) -> str:
+    normalized = str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
+    for alias, canonical in _MODEL_FAMILY_ALIASES.items():
+        if normalized == alias or normalized.startswith(f"{alias}_"):
+            return f"{canonical}{normalized[len(alias):]}"
+    return normalized
+
+
+def _model_parameter_payload(
+    market_state: ShortRateLatticeMarketStateLike,
+    *,
+    model_key: str,
+) -> Mapping[str, object]:
+    """Return calibrated parameters associated with the selected tree model."""
+    candidates: list[tuple[str, Mapping[str, object]]] = []
+    direct = getattr(market_state, "model_parameters", None)
+    if isinstance(direct, Mapping):
+        nested = direct.get(model_key)
+        if isinstance(nested, Mapping):
+            candidates.append((model_key, nested))
+        candidates.append(("", direct))
+
+    parameter_sets = getattr(market_state, "model_parameter_sets", None)
+    if isinstance(parameter_sets, Mapping):
+        candidates.extend(
+            (str(name), payload)
+            for name, payload in parameter_sets.items()
+            if isinstance(payload, Mapping)
+        )
+
+    for _, payload in candidates:
+        family = _normalize_model_family(
+            payload.get("model_family") or payload.get("model_name") or payload.get("family")
+        )
+        if family == model_key:
+            return payload
+
+    for name, payload in candidates:
+        normalized_name = _normalize_model_family(name)
+        family = _normalize_model_family(
+            payload.get("model_family") or payload.get("model_name") or payload.get("family")
+        )
+        if not family and (
+            normalized_name == model_key or normalized_name.startswith(f"{model_key}_")
+        ):
+            return payload
+
+    for name, payload in candidates:
+        family = _normalize_model_family(
+            payload.get("model_family") or payload.get("model_name") or payload.get("family")
+        )
+        if not name and not family and (
+            payload.get("sigma") is not None or payload.get("mean_reversion") is not None
+        ):
+            return payload
+    return {}
+
+
+def _parameter_float(
+    payload: Mapping[str, object],
+    *names: str,
+) -> float | None:
+    for name in names:
+        value = payload.get(name)
+        if value is not None:
+            return float(cast(str | SupportsFloat | SupportsIndex, value))
+    return None
 
 
 def _positive_integer(value: object, *, name: str) -> int:
@@ -111,12 +186,19 @@ def resolve_short_rate_lattice_inputs(
     resolved_r0 = float(discount_curve.zero_rate(max(resolved_horizon / 2.0, 1e-6)))
     if not isfinite(resolved_r0):
         raise ValueError("short-rate lattice initial rate must be finite")
-    parameter_payload = extract_hull_white_parameter_payload(market_state)
-    has_parameter_sigma = (
-        parameter_payload is not None and parameter_payload.get("sigma") is not None
+    parameter_payload = _model_parameter_payload(market_state, model_key=model_key)
+    parameter_sigma = (
+        None
+        if sigma is not None
+        else _parameter_float(
+            parameter_payload,
+            "sigma",
+            "volatility",
+            "short_rate_vol",
+        )
     )
     fallback_sigma: float | None = None
-    if sigma is None and not has_parameter_sigma:
+    if sigma is None and parameter_sigma is None:
         vol_surface = market_state.vol_surface
         if vol_surface is None:
             raise ValueError(
@@ -148,13 +230,30 @@ def resolve_short_rate_lattice_inputs(
             else black_vol * max(abs(resolved_r0), 1e-6)
         )
 
-    resolved_mean_reversion, resolved_sigma = resolve_hull_white_parameters(
-        market_state,
-        mean_reversion=mean_reversion,
-        sigma=sigma,
-        default_mean_reversion=default_mean_reversion,
-        default_sigma=fallback_sigma,
+    parameter_mean_reversion = (
+        None
+        if mean_reversion is not None
+        else _parameter_float(
+            parameter_payload,
+            "mean_reversion",
+            "a",
+        )
     )
+    resolved_mean_reversion = (
+        float(mean_reversion)
+        if mean_reversion is not None
+        else parameter_mean_reversion
+        if parameter_mean_reversion is not None
+        else float(default_mean_reversion)
+    )
+    resolved_sigma = float(sigma) if sigma is not None else parameter_sigma
+    if resolved_sigma is None:
+        resolved_sigma = fallback_sigma
+    if resolved_sigma is None:
+        raise ValueError(
+            "short-rate lattice sigma must be provided explicitly, through model parameters, "
+            "or through market_state.vol_surface"
+        )
 
     if not isfinite(float(resolved_mean_reversion)):
         raise ValueError("short-rate lattice mean reversion must be finite")


### PR DESCRIPTION
## Summary
- add a product-neutral short-rate lattice market-input resolver
- migrate callable-bond and Bermudan-swaption lattice builders to the shared binding without changing payoff or rollback semantics
- expose raw lattice construction and binding APIs through the canonical API map and import registry
- document model-specific volatility units, precedence, and fail-closed behavior

## Validation
- NUMBA_CACHE_DIR=/tmp/trellis-numba make gate-pr
  - 4,761 passed in the main gate
  - 32 passed, 15 skipped in tier 2
  - hygiene passed against the existing findings inventory
- scoped model, API-map, import-registry, and knowledge tests: 191 passed
- scoped mypy: success
- strict offline replay of T02/T05/T17 made zero LLM calls and failed closed on missing target-contract evidence

## Scope notes
- no cookbook entries were added or promoted
- no live LLM execution was used
- the replay contract gap is tracked separately as QUA-1206
- LIMITATIONS.md is unchanged because this refactor does not expand the support contract

Linear: QUA-1204