### PR TITLE
QUA-1208: add immutable FpML trade envelope boundary

### DIFF
--- a/doc/plan/draft__fpml-interoperability-roadmap.md
+++ b/doc/plan/draft__fpml-interoperability-roadmap.md
@@ -2,13 +2,15 @@
 
 ## Status
 
-Draft. Cross-cutting roadmap for external interoperability. Not yet an
-execution mirror.
+Active execution mirror for the bounded first FpML interoperability cohort.
 
-No linked Linear umbrella exists yet. The `FPI.*` queue ids below are
-repo-local placeholders until the implementation program is filed.
+Linear umbrella: `QUA-1207` — Semantic FpML import: canonical trade
+interoperability.
 
-Status snapshot as of `2026-04-23`.
+The `FPI.*` labels below remain architectural cohort names. The live ticket
+queue for the first cohort is recorded under **First Cohort Execution Queue**.
+
+Status snapshot as of `2026-07-19`.
 
 ## Linked Context
 
@@ -154,6 +156,22 @@ of silently coercing it into a nearby product family.
 | `FPI.4` | Proposed | lifecycle-state and alternate-view normalization | `FPI.2`, `FPI.3` |
 | `FPI.5` | Proposed | dynamic and stateful imported exotics | `FPI.4` plus executable dynamic lowering inside Trellis |
 | `FPI.6` | Proposed | industrial interoperability closeout | `FPI.5` |
+
+## First Cohort Execution Queue
+
+Linear is the source of truth for ticket state. This table is the repository
+execution mirror and stays ordered by implementation dependency.
+
+| Ticket | Status | Objective | Hard prerequisites |
+| --- | --- | --- | --- |
+| `QUA-1208` | In Progress | immutable trade envelope and selection-invariance contract | none |
+| `QUA-1209` | Backlog | explicit FpML platform-request entry point | `QUA-1208` |
+| `QUA-1210` | Backlog | secure XML inspection and stable blocker contract | `QUA-1209` |
+| `QUA-1211` | Backlog | confirmation-view fixed-float swap normalization | `QUA-1210` |
+| `QUA-1212` | Backlog | European swaption normalization | `QUA-1210`, `QUA-1211` |
+| `QUA-1213` | Backlog | scheduled cap/floor strip normalization | `QUA-1210`, `QUA-1211` |
+| `QUA-1214` | Backlog | paired FpML/native conformance task corpus | `QUA-1211`, `QUA-1212`, `QUA-1213` |
+| `QUA-1215` | Backlog | support matrix, maintenance review, and epic closeout | `QUA-1214` |
 
 ## Cohort Details
 

--- a/doc/plan/draft__semantic-contract-target-and-trade-envelope.md
+++ b/doc/plan/draft__semantic-contract-target-and-trade-envelope.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-Draft. Cross-cutting design document. Not yet an execution mirror.
+Approved design boundary. The first implementation slice is tracked by
+`QUA-1208` under the FpML interoperability umbrella `QUA-1207`; later position
+and result-path work remains planning-only.
 
 ## Linked Context
 
@@ -222,6 +224,14 @@ Acceptance:
 - at least one workflow, such as bounded FpML confirmation import, can
   carry external ids or trade date separately from contract meaning
 - route-free selection remains invariant under envelope-only changes
+
+Implementation status:
+
+- `QUA-1208` implements the immutable, format-neutral trade-envelope value,
+  request propagation, stable diagnostic summary, and route/backend/validation
+  invariance tests.
+- FpML parsing and product normalization remain in downstream `QUA-1209`
+  through `QUA-1214`; the envelope alone is not an import-support claim.
 
 ### T3 — Position context and result-path alignment
 

--- a/docs/developer/overview.rst
+++ b/docs/developer/overview.rst
@@ -28,6 +28,32 @@ The canonical request/compiler layer lives in ``trellis.agent.platform_requests`
 It normalizes these surfaces into ``PlatformRequest`` and ``CompiledPlatformRequest``
 objects with execution plans, method selection, knowledge payloads, and blocker reports.
 
+Trade Envelope Boundary
+-----------------------
+
+``trellis.agent.trade_envelope.TradeEnvelope`` is the immutable home for
+operational identity and imported-document provenance surrounding one economic
+contract. It carries fields such as source format/view/version, document and
+trade ids, trade date, package id, parties, external identifiers, lifecycle
+state, and bounded metadata. ``TradeParty`` provides the corresponding
+external party-identity record, and ``trade_envelope_summary(...)`` emits a
+stable serializable diagnostic projection.
+
+The envelope is deliberately outside ``SemanticContract``, ``ContractIR``,
+``ProductIR``, valuation context, and market binding. It may identify and
+reconcile a request, but it cannot select a structural declaration, backend,
+validation bundle, or pricing model. ``PlatformRequest.trade_envelope`` carries
+the value through compilation, and ``CompiledPlatformRequest.trade_envelope``
+exposes the same request-owned value without duplicating it into semantic
+metadata. Tests compare materially different envelopes over the same contract
+and require identical semantic, pricing-plan, backend-binding, and validation
+artifacts.
+
+This boundary is format-neutral. FpML is the first planned importer, but the
+envelope itself does not parse XML and does not imply that an imported product
+is supported. Importers must normalize economics separately and fail closed
+when the internal semantic and executable support contract is incomplete.
+
 The plain fixed-income pricing path now also carries desk-readable bond
 reporting outputs. ``price_instrument(...)`` and the ``Session.price(...)``
 projection solve a coupon-frequency nominal ``ytm`` from the reported dirty

--- a/tests/test_agent/test_platform_requests.py
+++ b/tests/test_agent/test_platform_requests.py
@@ -1771,6 +1771,62 @@ def test_compile_build_request_ignores_non_semantic_wrapper_metadata_for_route_f
     assert compiled_b.validation_contract.route_id is None
 
 
+def test_compile_build_request_preserves_trade_envelope_without_selection_authority():
+    from trellis.agent.platform_requests import compile_build_request
+    from trellis.agent.trade_envelope import TradeEnvelope, TradeParty
+
+    description = "European call on AAPL strike 150 expiring 2025-11-15"
+    envelope_a = TradeEnvelope(
+        source_format="fpml",
+        source_view="confirmation",
+        source_version="5-13",
+        document_id="DOC-A",
+        trade_id="TRADE-A",
+        parties=(TradeParty(party_id="PARTY-A"),),
+        metadata={"desk": "equity-derivatives"},
+    )
+    envelope_b = TradeEnvelope(
+        source_format="trellis_contract",
+        source_view="native",
+        source_version="1",
+        document_id="DOC-Z",
+        trade_id="TRADE-Z",
+        parties=(TradeParty(party_id="PARTY-Z"),),
+        metadata={"desk": "manual-rebook"},
+    )
+
+    compiled_a = compile_build_request(
+        description,
+        instrument_type="european_option",
+        preferred_method="analytical",
+        trade_envelope=envelope_a,
+    )
+    compiled_b = compile_build_request(
+        description,
+        instrument_type="european_option",
+        preferred_method="analytical",
+        trade_envelope=envelope_b,
+    )
+
+    assert compiled_a.request.trade_envelope is envelope_a
+    assert compiled_a.trade_envelope is envelope_a
+    assert compiled_b.request.trade_envelope is envelope_b
+    assert compiled_b.trade_envelope is envelope_b
+    assert compiled_a.semantic_contract == compiled_b.semantic_contract
+    assert compiled_a.product_ir == compiled_b.product_ir
+    assert compiled_a.pricing_plan == compiled_b.pricing_plan
+    assert compiled_a.generation_plan.backend_binding_id == (
+        compiled_b.generation_plan.backend_binding_id
+    )
+    assert compiled_a.validation_contract == compiled_b.validation_contract
+    assert compiled_a.request.metadata["contract_ir_compiler"] == (
+        compiled_b.request.metadata["contract_ir_compiler"]
+    )
+    assert compiled_a.request.metadata["route_binding_authority"] == (
+        compiled_b.request.metadata["route_binding_authority"]
+    )
+
+
 def test_compile_build_request_ignores_non_semantic_wrapper_metadata_for_route_free_basket():
     from trellis.agent.platform_requests import compile_build_request
 

--- a/tests/test_agent/test_trade_envelope.py
+++ b/tests/test_agent/test_trade_envelope.py
@@ -124,3 +124,31 @@ def test_platform_request_requires_typed_trade_envelope():
             entry_point="executor",
             trade_envelope={"source_format": "fpml"},
         )
+
+
+def test_platform_request_preserves_legacy_positional_metadata_argument():
+    from trellis.agent.platform_requests import PlatformRequest
+
+    request = PlatformRequest(
+        "request-legacy",
+        "build",
+        "executor",
+        None,
+        None,
+        None,
+        None,
+        (),
+        (),
+        (),
+        {},
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        {"task_id": "E23"},
+    )
+
+    assert request.metadata == {"task_id": "E23"}
+    assert request.trade_envelope is None

--- a/tests/test_agent/test_trade_envelope.py
+++ b/tests/test_agent/test_trade_envelope.py
@@ -1,0 +1,126 @@
+"""Tests for external trade-envelope identity and provenance."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+
+def test_trade_envelope_is_deeply_immutable_and_has_stable_summary():
+    from trellis.agent.trade_envelope import (
+        TradeEnvelope,
+        TradeParty,
+        trade_envelope_summary,
+    )
+
+    identifiers = {"uti": "UTI-001", "book": "RATES-NY"}
+    metadata = {
+        "annotations": ["confirmed", {"channel": "electronic"}],
+        "source_sequence": 7,
+    }
+    envelope = TradeEnvelope(
+        source_format="fpml",
+        source_view="confirmation",
+        source_version="5-13",
+        document_id="DOC-001",
+        trade_id="TRADE-001",
+        package_id="PACKAGE-001",
+        trade_date=date(2026, 7, 1),
+        lifecycle_state="current",
+        parties=(
+            TradeParty(
+                party_id="PARTY-B",
+                role="counterparty",
+                identifiers={"lei": "LEI-B"},
+            ),
+            TradeParty(
+                party_id="PARTY-A",
+                role="reporting_party",
+                identifiers={"lei": "LEI-A"},
+            ),
+        ),
+        identifiers=identifiers,
+        metadata=metadata,
+    )
+
+    identifiers["uti"] = "MUTATED"
+    metadata["annotations"][1]["channel"] = "voice"
+
+    assert envelope.identifiers["uti"] == "UTI-001"
+    assert envelope.metadata["annotations"][1]["channel"] == "electronic"
+    assert tuple(party.party_id for party in envelope.parties) == (
+        "PARTY-A",
+        "PARTY-B",
+    )
+    with pytest.raises(TypeError):
+        envelope.identifiers["new"] = "value"
+    with pytest.raises(TypeError):
+        envelope.metadata["annotations"][1]["channel"] = "voice"
+
+    assert trade_envelope_summary(envelope) == {
+        "source_format": "fpml",
+        "source_view": "confirmation",
+        "source_version": "5-13",
+        "document_id": "DOC-001",
+        "trade_id": "TRADE-001",
+        "package_id": "PACKAGE-001",
+        "trade_date": "2026-07-01",
+        "lifecycle_state": "current",
+        "parties": [
+            {
+                "party_id": "PARTY-A",
+                "role": "reporting_party",
+                "name": None,
+                "identifiers": {"lei": "LEI-A"},
+            },
+            {
+                "party_id": "PARTY-B",
+                "role": "counterparty",
+                "name": None,
+                "identifiers": {"lei": "LEI-B"},
+            },
+        ],
+        "identifiers": {"book": "RATES-NY", "uti": "UTI-001"},
+        "metadata": {
+            "annotations": ["confirmed", {"channel": "electronic"}],
+            "source_sequence": 7,
+        },
+    }
+
+
+def test_trade_envelope_rejects_missing_source_identity_and_duplicate_parties():
+    from trellis.agent.trade_envelope import TradeEnvelope, TradeParty
+
+    with pytest.raises(ValueError, match="source_format"):
+        TradeEnvelope(source_format=" ")
+
+    with pytest.raises(ValueError, match="duplicate trade party ids"):
+        TradeEnvelope(
+            source_format="fpml",
+            parties=(
+                TradeParty(party_id="PARTY-A"),
+                TradeParty(party_id="PARTY-A"),
+            ),
+        )
+
+    with pytest.raises(ValueError, match="duplicate normalized key"):
+        TradeEnvelope(
+            source_format="fpml",
+            identifiers={"uti": "UTI-1", " uti ": "UTI-2"},
+        )
+
+    with pytest.raises(TypeError, match="source_format"):
+        TradeEnvelope(source_format=5)
+
+
+def test_platform_request_requires_typed_trade_envelope():
+    from trellis.agent.platform_requests import PlatformRequest
+
+    with pytest.raises(TypeError, match="trade_envelope"):
+        PlatformRequest(
+            request_id="request-1",
+            request_type="build",
+            entry_point="executor",
+            trade_envelope={"source_format": "fpml"},
+        )

--- a/trellis/agent/platform_requests.py
+++ b/trellis/agent/platform_requests.py
@@ -39,6 +39,7 @@ from trellis.agent.quant import (
     select_pricing_method_for_product_ir,
 )
 from trellis.agent.sensitivity_support import normalize_requested_outputs
+from trellis.agent.trade_envelope import TradeEnvelope
 from trellis.agent.valuation_context import (
     EngineModelSpec,
     PotentialSpec,
@@ -95,6 +96,7 @@ class PlatformRequest:
     comparison_spec: Any | None = None
     instrument: Any | None = None
     book: Any | None = None
+    trade_envelope: TradeEnvelope | None = None
     metadata: Mapping[str, object] = field(default_factory=dict)
 
     def __post_init__(self):
@@ -105,6 +107,11 @@ class PlatformRequest:
         object.__setattr__(self, "measures", normalized_measures)
         object.__setattr__(self, "measure_specs", _freeze_tuple(self.measure_specs))
         object.__setattr__(self, "measure_context", _freeze_mapping(self.measure_context))
+        if self.trade_envelope is not None and not isinstance(
+            self.trade_envelope,
+            TradeEnvelope,
+        ):
+            raise TypeError("trade_envelope must be a TradeEnvelope")
         object.__setattr__(self, "metadata", _freeze_mapping(self.metadata))
 
 
@@ -284,6 +291,11 @@ class CompiledPlatformRequest:
     def __post_init__(self):
         """Freeze knowledge summaries carried on the compiled request envelope."""
         object.__setattr__(self, "knowledge_summary", _freeze_mapping(self.knowledge_summary))
+
+    @property
+    def trade_envelope(self) -> TradeEnvelope | None:
+        """Expose request provenance without duplicating it into semantic state."""
+        return self.request.trade_envelope
 
 
 def make_term_sheet_request(
@@ -1792,6 +1804,7 @@ def compile_build_request(
     preferred_method: str | None = None,
     measures: list | None = None,
     knowledge_profile: str | None = None,
+    trade_envelope: TradeEnvelope | None = None,
     metadata: Mapping[str, object] | None = None,
     semantic_contract=None,
     knowledge_overlays: Any = None,
@@ -1821,6 +1834,7 @@ def compile_build_request(
         instrument_type=instrument_type,
         measures=_normalize_measures(measures),
         model=model,
+        trade_envelope=trade_envelope,
         metadata={
             **request_metadata,
             **(

--- a/trellis/agent/platform_requests.py
+++ b/trellis/agent/platform_requests.py
@@ -96,8 +96,8 @@ class PlatformRequest:
     comparison_spec: Any | None = None
     instrument: Any | None = None
     book: Any | None = None
-    trade_envelope: TradeEnvelope | None = None
     metadata: Mapping[str, object] = field(default_factory=dict)
+    trade_envelope: TradeEnvelope | None = None
 
     def __post_init__(self):
         """Freeze mutable metadata so requests remain hash- and trace-stable."""

--- a/trellis/agent/trade_envelope.py
+++ b/trellis/agent/trade_envelope.py
@@ -1,0 +1,224 @@
+"""Non-economic trade and source-document provenance.
+
+Trade-envelope fields are intentionally outside Trellis' semantic contract.
+They may identify, report, or reconcile a trade, but they are not pricing-route
+or solver-selection inputs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, datetime
+import math
+from types import MappingProxyType
+from typing import Any, Mapping
+
+
+def _optional_text(value: str | None, *, field_name: str) -> str | None:
+    if value is not None and not isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string")
+    text = (value or "").strip()
+    return text or None
+
+
+def _freeze_string_mapping(
+    value: Mapping[str, str] | None,
+    *,
+    field_name: str,
+) -> Mapping[str, str]:
+    items: dict[str, str] = {}
+    for key, item in (value or {}).items():
+        if not isinstance(key, str) or not key.strip():
+            raise TypeError(f"{field_name} keys must be non-empty strings")
+        if not isinstance(item, str) or not item.strip():
+            raise TypeError(f"{field_name} values must be non-empty strings")
+        normalized_key = key.strip()
+        if normalized_key in items:
+            raise ValueError(
+                f"{field_name} contains duplicate normalized key {normalized_key!r}"
+            )
+        items[normalized_key] = item.strip()
+    return MappingProxyType(dict(sorted(items.items())))
+
+
+def _freeze_metadata(value: object, *, path: str = "metadata") -> object:
+    if value is None or isinstance(value, (str, int, bool, date, datetime)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError(f"{path} contains a non-finite float")
+        return value
+    if isinstance(value, Mapping):
+        frozen: dict[str, object] = {}
+        for key, item in value.items():
+            if not isinstance(key, str) or not key.strip():
+                raise TypeError(f"{path} keys must be non-empty strings")
+            normalized_key = key.strip()
+            if normalized_key in frozen:
+                raise ValueError(f"{path} contains duplicate key {normalized_key!r}")
+            frozen[normalized_key] = _freeze_metadata(
+                item,
+                path=f"{path}.{normalized_key}",
+            )
+        return MappingProxyType(dict(sorted(frozen.items())))
+    if isinstance(value, (list, tuple)):
+        return tuple(
+            _freeze_metadata(item, path=f"{path}[{index}]")
+            for index, item in enumerate(value)
+        )
+    raise TypeError(
+        f"{path} must contain only mappings, sequences, scalar values, or dates"
+    )
+
+
+def _summary_value(value: object) -> Any:
+    if isinstance(value, Mapping):
+        return {key: _summary_value(item) for key, item in sorted(value.items())}
+    if isinstance(value, tuple):
+        return [_summary_value(item) for item in value]
+    if isinstance(value, (date, datetime)):
+        return value.isoformat()
+    return value
+
+
+@dataclass(frozen=True)
+class TradeParty:
+    """One externally identified party carried outside contract economics."""
+
+    party_id: str
+    role: str | None = None
+    name: str | None = None
+    identifiers: Mapping[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        party_id = str(self.party_id or "").strip()
+        if not party_id:
+            raise ValueError("trade party party_id is required")
+        object.__setattr__(self, "party_id", party_id)
+        object.__setattr__(
+            self,
+            "role",
+            _optional_text(self.role, field_name="trade party role"),
+        )
+        object.__setattr__(
+            self,
+            "name",
+            _optional_text(self.name, field_name="trade party name"),
+        )
+        object.__setattr__(
+            self,
+            "identifiers",
+            _freeze_string_mapping(
+                self.identifiers,
+                field_name="trade party identifiers",
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class TradeEnvelope:
+    """Immutable operational metadata surrounding one economic contract."""
+
+    source_format: str
+    source_view: str | None = None
+    source_version: str | None = None
+    document_id: str | None = None
+    trade_id: str | None = None
+    package_id: str | None = None
+    trade_date: date | None = None
+    lifecycle_state: str | None = None
+    parties: tuple[TradeParty, ...] = ()
+    identifiers: Mapping[str, str] = field(default_factory=dict)
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.source_format, str):
+            raise TypeError("trade envelope source_format must be a string")
+        source_format = self.source_format.strip().lower()
+        if not source_format:
+            raise ValueError("trade envelope source_format is required")
+        object.__setattr__(self, "source_format", source_format)
+        for field_name in (
+            "source_view",
+            "source_version",
+            "document_id",
+            "trade_id",
+            "package_id",
+            "lifecycle_state",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _optional_text(
+                    getattr(self, field_name),
+                    field_name=f"trade envelope {field_name}",
+                ),
+            )
+
+        if self.trade_date is not None and (
+            not isinstance(self.trade_date, date)
+            or isinstance(self.trade_date, datetime)
+        ):
+            raise TypeError("trade envelope trade_date must be a date")
+
+        parties = tuple(self.parties or ())
+        if any(not isinstance(party, TradeParty) for party in parties):
+            raise TypeError("trade envelope parties must contain TradeParty values")
+        party_ids = [party.party_id for party in parties]
+        duplicates = sorted(
+            party_id for party_id in set(party_ids) if party_ids.count(party_id) > 1
+        )
+        if duplicates:
+            raise ValueError(
+                "duplicate trade party ids: " + ", ".join(duplicates)
+            )
+        object.__setattr__(
+            self,
+            "parties",
+            tuple(sorted(parties, key=lambda party: (party.party_id, party.role or ""))),
+        )
+        object.__setattr__(
+            self,
+            "identifiers",
+            _freeze_string_mapping(
+                self.identifiers,
+                field_name="trade envelope identifiers",
+            ),
+        )
+        frozen_metadata = _freeze_metadata(self.metadata)
+        if not isinstance(frozen_metadata, Mapping):
+            raise TypeError("trade envelope metadata must be a mapping")
+        object.__setattr__(self, "metadata", frozen_metadata)
+
+
+def trade_envelope_summary(envelope: TradeEnvelope | None) -> dict[str, object] | None:
+    """Return a stable serializable provenance projection for diagnostics."""
+
+    if envelope is None:
+        return None
+    if not isinstance(envelope, TradeEnvelope):
+        raise TypeError("envelope must be a TradeEnvelope")
+    return {
+        "source_format": envelope.source_format,
+        "source_view": envelope.source_view,
+        "source_version": envelope.source_version,
+        "document_id": envelope.document_id,
+        "trade_id": envelope.trade_id,
+        "package_id": envelope.package_id,
+        "trade_date": envelope.trade_date.isoformat() if envelope.trade_date else None,
+        "lifecycle_state": envelope.lifecycle_state,
+        "parties": [
+            {
+                "party_id": party.party_id,
+                "role": party.role,
+                "name": party.name,
+                "identifiers": _summary_value(party.identifiers),
+            }
+            for party in envelope.parties
+        ],
+        "identifiers": _summary_value(envelope.identifiers),
+        "metadata": _summary_value(envelope.metadata),
+    }
+
+
+__all__ = ["TradeEnvelope", "TradeParty", "trade_envelope_summary"]


### PR DESCRIPTION
## Summary
- add frozen TradeParty and TradeEnvelope provenance values with deterministic summaries
- carry the envelope through PlatformRequest without semantic or route authority
- prove semantic, backend, and validation invariance under envelope-only changes
- activate the QUA-1207 FpML interoperability execution mirror

## Validation
- 81 targeted platform request tests passed
- make gate-pr passed with NUMBA_CACHE_DIR=/tmp/trellis-numba-cache: 4,768 main tests and 32 tier-two contract tests
- final focused post-cleanup run: 4 passed
- Sphinx processed the changed document, but repository-wide -W remains blocked by pre-existing warnings/errors and offline intersphinx inventories

## Boundaries
- no XML parser or FpML product mapping
- no pricing helper, route, backend binding, cookbook, or LLM change

Linear: QUA-1208