### PR TITLE
QUA-1208: sync completed FpML roadmap status

### DIFF
--- a/doc/plan/draft__fpml-interoperability-roadmap.md
+++ b/doc/plan/draft__fpml-interoperability-roadmap.md
@@ -164,7 +164,7 @@ execution mirror and stays ordered by implementation dependency.
 
 | Ticket | Status | Objective | Hard prerequisites |
 | --- | --- | --- | --- |
-| `QUA-1208` | In Progress | immutable trade envelope and selection-invariance contract | none |
+| `QUA-1208` | Done | immutable trade envelope and selection-invariance contract | none |
 | `QUA-1209` | Backlog | explicit FpML platform-request entry point | `QUA-1208` |
 | `QUA-1210` | Backlog | secure XML inspection and stable blocker contract | `QUA-1209` |
 | `QUA-1211` | Backlog | confirmation-view fixed-float swap normalization | `QUA-1210` |


### PR DESCRIPTION
## Summary
- mark QUA-1208 Done in the FpML interoperability execution mirror after Linear closeout and PR #825 merge

## Validation
- git diff --check

Docs-only status synchronization.