### PR TITLE
QUA-1209: Sync FpML roadmap status

### DIFF
--- a/doc/plan/draft__fpml-interoperability-roadmap.md
+++ b/doc/plan/draft__fpml-interoperability-roadmap.md
@@ -165,7 +165,7 @@ execution mirror and stays ordered by implementation dependency.
 | Ticket | Status | Objective | Hard prerequisites |
 | --- | --- | --- | --- |
 | `QUA-1208` | Done | immutable trade envelope and selection-invariance contract | none |
-| `QUA-1209` | In Progress | explicit FpML platform-request entry point | `QUA-1208` |
+| `QUA-1209` | Done | explicit FpML platform-request entry point | `QUA-1208` |
 | `QUA-1210` | Backlog | secure XML inspection and stable blocker contract | `QUA-1209` |
 | `QUA-1211` | Backlog | confirmation-view fixed-float swap normalization | `QUA-1210` |
 | `QUA-1212` | Backlog | European swaption normalization | `QUA-1210`, `QUA-1211` |


### PR DESCRIPTION
## Summary
- mark QUA-1209 Done in the repository FpML execution mirror after PR #827 merged and the Linear ticket closed

## Validation
- documentation-only one-line status update
- `git diff --check` passed

Linear: QUA-1209