### PR TITLE
docs(plan): mark QUA-1210 done

### DIFF
--- a/doc/plan/draft__fpml-interoperability-roadmap.md
+++ b/doc/plan/draft__fpml-interoperability-roadmap.md
@@ -166,7 +166,7 @@ execution mirror and stays ordered by implementation dependency.
 | --- | --- | --- | --- |
 | `QUA-1208` | Done | immutable trade envelope and selection-invariance contract | none |
 | `QUA-1209` | Done | explicit FpML platform-request entry point | `QUA-1208` |
-| `QUA-1210` | In Progress | secure XML inspection and stable blocker contract | `QUA-1209` |
+| `QUA-1210` | Done | secure XML inspection and stable blocker contract | `QUA-1209` |
 | `QUA-1211` | Backlog | confirmation-view fixed-float swap normalization | `QUA-1210` |
 | `QUA-1212` | Backlog | European swaption normalization | `QUA-1210`, `QUA-1211` |
 | `QUA-1213` | Backlog | scheduled cap/floor strip normalization | `QUA-1210`, `QUA-1211` |


### PR DESCRIPTION
## Summary
- mark QUA-1210 Done in the FpML interoperability roadmap after PR #829 merged and the Linear issue closed

## Validation
- plan-only change; TDD does not apply
- 

Linear: QUA-1210