### PR TITLE
QUA-1212: close roadmap mirror

### DIFF
--- a/doc/plan/draft__fpml-interoperability-roadmap.md
+++ b/doc/plan/draft__fpml-interoperability-roadmap.md
@@ -168,7 +168,7 @@ execution mirror and stays ordered by implementation dependency.
 | `QUA-1209` | Done | explicit FpML platform-request entry point | `QUA-1208` |
 | `QUA-1210` | Done | secure XML inspection and stable blocker contract | `QUA-1209` |
 | `QUA-1211` | Done | confirmation-view fixed-float swap normalization | `QUA-1210` |
-| `QUA-1212` | Backlog | European swaption normalization | `QUA-1210`, `QUA-1211` |
+| `QUA-1212` | Done | European swaption normalization | `QUA-1210`, `QUA-1211` |
 | `QUA-1213` | Backlog | scheduled cap/floor strip normalization | `QUA-1210`, `QUA-1211` |
 | `QUA-1214` | Backlog | paired FpML/native conformance task corpus | `QUA-1211`, `QUA-1212`, `QUA-1213` |
 | `QUA-1215` | Backlog | support matrix, maintenance review, and epic closeout | `QUA-1214` |


### PR DESCRIPTION
## Summary
- mark QUA-1212 Done in the FpML interoperability roadmap after Linear and PR #833 closeout

## Validation
- documentation-only status mirror
- git diff --check

TDD does not apply to this one-line tracking update.