### PR TITLE
Mark QUA-1213 roadmap slice done

### DIFF
--- a/doc/plan/draft__fpml-interoperability-roadmap.md
+++ b/doc/plan/draft__fpml-interoperability-roadmap.md
@@ -169,7 +169,7 @@ execution mirror and stays ordered by implementation dependency.
 | `QUA-1210` | Done | secure XML inspection and stable blocker contract | `QUA-1209` |
 | `QUA-1211` | Done | confirmation-view fixed-float swap normalization | `QUA-1210` |
 | `QUA-1212` | Done | European swaption normalization | `QUA-1210`, `QUA-1211` |
-| `QUA-1213` | Backlog | scheduled cap/floor strip normalization | `QUA-1210`, `QUA-1211` |
+| `QUA-1213` | Done | scheduled cap/floor strip normalization | `QUA-1210`, `QUA-1211` |
 | `QUA-1214` | Backlog | paired FpML/native conformance task corpus | `QUA-1211`, `QUA-1212`, `QUA-1213` |
 | `QUA-1215` | Backlog | support matrix, maintenance review, and epic closeout | `QUA-1214` |
 


### PR DESCRIPTION
## Summary
- mark QUA-1213 Done in the FpML interoperability roadmap after PR #835 merged and the Linear issue closed

## Validation
- git diff --check clean
- documentation-only status mirror update