### PR TITLE
Docs: mark QUA-1227 complete

### DIFF
--- a/doc/plan/draft__fpml-interoperability-roadmap.md
+++ b/doc/plan/draft__fpml-interoperability-roadmap.md
@@ -186,7 +186,7 @@ normalization, package result cardinality, and support closeout.
 | `QUA-1217` | In Progress | FPI.2 rates and package umbrella | `QUA-1207` |
 | `QUA-1220` | In Progress | modular normalizer umbrella | `QUA-1207` |
 | `QUA-1226` | Done | shared parsing and stream-normalization boundary | `QUA-1207` |
-| `QUA-1227` | In Progress | fixed-float swap mapping extraction | `QUA-1226` |
+| `QUA-1227` | Done | fixed-float swap mapping extraction | `QUA-1226` |
 | `QUA-1229` | Backlog | cap/floor mapping extraction | `QUA-1226` |
 | `QUA-1228` | Backlog | swaption mapping extraction | `QUA-1226`, `QUA-1227` |
 | `QUA-1230` | Backlog | facade and modularity closeout | `QUA-1227`, `QUA-1228`, `QUA-1229` |


### PR DESCRIPTION
Updates the FPI.2 execution mirror after QUA-1227 was merged and marked Done in Linear.

Validation: git diff --check (pass).

No runtime or support-contract change.