### PR TITLE
FpML normalizer: extract swaption mapping

### DIFF
--- a/doc/plan/draft__fpml-interoperability-roadmap.md
+++ b/doc/plan/draft__fpml-interoperability-roadmap.md
@@ -188,7 +188,7 @@ normalization, package result cardinality, and support closeout.
 | `QUA-1226` | Done | shared parsing and stream-normalization boundary | `QUA-1207` |
 | `QUA-1227` | Done | fixed-float swap mapping extraction | `QUA-1226` |
 | `QUA-1229` | Done | cap/floor mapping extraction | `QUA-1226` |
-| `QUA-1228` | Backlog | swaption mapping extraction | `QUA-1226`, `QUA-1227` |
+| `QUA-1228` | In Progress | swaption mapping extraction | `QUA-1226`, `QUA-1227` |
 | `QUA-1230` | Backlog | facade and modularity closeout | `QUA-1227`, `QUA-1228`, `QUA-1229` |
 | `QUA-1222` | Backlog | reusable irregular-period static coupon execution | none |
 | `QUA-1223` | Backlog | bounded basis-swap normalization | `QUA-1220` |

--- a/docs/developer/fpml_import.rst
+++ b/docs/developer/fpml_import.rst
@@ -46,15 +46,19 @@ Internal Module Boundaries
 ``trellis.io.fpml.importer`` owns secure document inspection and
 ``trellis.io.fpml.contracts`` owns immutable body-free reports.
 ``trellis.io.fpml.normalizer`` remains the stable normalization facade and
-contains the admitted swaption mapping until its extraction ticket closes. The
-internal ``trellis.io.fpml._normalization_swap`` module owns fixed-float swap
-validation, semantic mapping, provenance, and the product-specific
+owns bounded document validation, product dispatch, and report construction.
+The internal ``trellis.io.fpml._normalization_swap`` module owns fixed-float
+swap validation, semantic mapping, provenance, and the product-specific
 historical-fixing rejection. The internal
 ``trellis.io.fpml._normalization_cap_floor`` module owns cap/floor validation,
 strike and option-side mapping, static-strip construction, and provenance. It
 normalizes the external ``capFloor`` label to source-neutral
 ``period_rate_option_strip`` semantics without selecting a pricing route. The
-internal
+internal ``trellis.io.fpml._normalization_swaption`` module owns physical
+European swaption exercise, buyer/seller, settlement, complete underlying-swap
+composition, semantic payoff construction, and provenance. It consumes the
+same fixed-float mapper as standalone swap normalization and preserves the
+complete underlying swap in canonical contract identity. The internal
 ``trellis.io.fpml._normalization_common`` module owns product-neutral XML
 access, exact blocker and provenance construction, calendars, date and
 frequency conventions, regular schedule validation, bounded stream parsing,

--- a/tests/test_io/test_fpml_normalizer_boundaries.py
+++ b/tests/test_io/test_fpml_normalizer_boundaries.py
@@ -17,6 +17,11 @@ FIXTURE = (
 CAP_FLOOR_FIXTURE = (
     Path(__file__).with_name("fixtures") / "fpml" / "confirmation_5_13_cap_floor.xml"
 )
+SWAPTION_FIXTURE = (
+    Path(__file__).with_name("fixtures")
+    / "fpml"
+    / "confirmation_5_13_european_swaption.xml"
+)
 
 FORBIDDEN_SHARED_IMPORT_PREFIXES = (
     "trellis.agent.executor",
@@ -59,7 +64,6 @@ def test_shared_normalization_module_owns_product_neutral_helpers():
     for facade_helper_name in (
         "_blocked_from",
         "_blocker",
-        "_normalize_option_premiums",
         "_validate_document_metadata",
     ):
         shared_helper = getattr(shared, facade_helper_name)
@@ -127,6 +131,28 @@ def test_cap_floor_normalization_module_owns_strip_mapping():
         assert not hasattr(cap_floor_mapper, other_product_mapper_name)
 
 
+def test_swaption_normalization_module_owns_european_mapping():
+    normalizer = importlib.import_module("trellis.io.fpml.normalizer")
+    swaption_mapper = importlib.import_module(
+        "trellis.io.fpml._normalization_swaption"
+    )
+
+    mapper = swaption_mapper._normalize_european_swaption
+    assert mapper.__module__ == swaption_mapper.__name__
+    assert normalizer._normalize_european_swaption is mapper
+
+    shared_premium_mapper = importlib.import_module(
+        "trellis.io.fpml._normalization_common"
+    )._normalize_option_premiums
+    swap_mapper = importlib.import_module(
+        "trellis.io.fpml._normalization_swap"
+    )._normalize_fixed_float_swap
+    assert mapper.__globals__["_normalize_option_premiums"] is shared_premium_mapper
+    assert mapper.__globals__["_normalize_fixed_float_swap"] is swap_mapper
+
+    assert not hasattr(swaption_mapper, "_normalize_cap_floor")
+
+
 def test_shared_normalization_module_has_no_pricing_or_route_authority_imports():
     shared = importlib.import_module("trellis.io.fpml._normalization_common")
 
@@ -165,6 +191,20 @@ def test_cap_floor_module_has_no_pricing_or_route_authority_imports():
     assert violations == ()
 
 
+def test_swaption_module_has_no_pricing_or_route_authority_imports():
+    swaption_mapper = importlib.import_module(
+        "trellis.io.fpml._normalization_swaption"
+    )
+
+    violations = tuple(
+        imported
+        for imported in _imported_modules(swaption_mapper)
+        if imported.startswith(FORBIDDEN_SHARED_IMPORT_PREFIXES)
+    )
+
+    assert violations == ()
+
+
 def test_internal_normalization_module_is_not_codegen_import_authority():
     from trellis.agent.knowledge.import_registry import get_import_registry
 
@@ -173,6 +213,7 @@ def test_internal_normalization_module_is_not_codegen_import_authority():
     assert "trellis.io.fpml._normalization_common" not in registry
     assert "trellis.io.fpml._normalization_cap_floor" not in registry
     assert "trellis.io.fpml._normalization_swap" not in registry
+    assert "trellis.io.fpml._normalization_swaption" not in registry
 
 
 def test_public_and_inspected_document_facades_remain_field_compatible():
@@ -297,3 +338,54 @@ def test_direct_cap_floor_mapper_matches_source_neutral_public_facade():
     assert provenance == report.mapping_provenance
     assert premium_metadata == report.premium_metadata
     assert contract.metadata["semantic_family"] == "period_rate_option_strip"
+
+
+def test_direct_swaption_mapper_matches_public_facade_and_preserves_underlying():
+    from trellis.io.fpml import inspect_fpml_document, normalize_fpml_document
+    from trellis.io.fpml.contracts import DEFAULT_FPML_INSPECTION_LIMITS
+    from trellis.io.fpml.importer import (
+        _bounded_parse,
+        _content_bytes,
+        _direct_children,
+        _first_direct_child,
+    )
+
+    swaption_mapper = importlib.import_module(
+        "trellis.io.fpml._normalization_swaption"
+    )
+    xml = SWAPTION_FIXTURE.read_bytes()
+    inspected = inspect_fpml_document(
+        xml,
+        declared_view="confirmation",
+        declared_version="5-13",
+    )
+    root = _bounded_parse(
+        _content_bytes(xml),
+        limits=DEFAULT_FPML_INSPECTION_LIMITS,
+    )
+    namespace = inspected.document.namespace
+    trade = _direct_children(root, "trade", namespace=namespace)[0]
+    swaption = _first_direct_child(trade, "swaption", namespace=namespace)
+
+    contract, provenance, premium_metadata = (
+        swaption_mapper._normalize_european_swaption(
+            swaption,
+            namespace=namespace,
+            valuation_party_id="PARTY-A",
+            valuation_date=date(2025, 1, 15),
+            known_party_ids=inspected.trade.party_ids,
+        )
+    )
+    report = normalize_fpml_document(
+        xml,
+        declared_view="confirmation",
+        declared_version="5-13",
+        valuation_party_id="PARTY-A",
+        valuation_date=date(2025, 1, 15),
+    )
+
+    assert contract == report.normalized_contract
+    assert provenance == report.mapping_provenance
+    assert premium_metadata == report.premium_metadata
+    assert contract.underlying_contract is not None
+    assert contract.underlying_contract == report.normalized_contract.underlying_contract

--- a/trellis/io/fpml/_normalization_swaption.py
+++ b/trellis/io/fpml/_normalization_swaption.py
@@ -1,0 +1,330 @@
+"""Physical European swaption FpML normalization into semantic IR."""
+
+from __future__ import annotations
+
+from datetime import date
+
+from trellis.agent.contract_ir import (
+    Annuity,
+    Constant,
+    ContractIR,
+    Exercise,
+    FiniteSchedule,
+    ForwardRate,
+    Max,
+    Observation,
+    Scaled,
+    Singleton,
+    Strike,
+    Sub,
+    SwapRate,
+    Underlying,
+)
+from trellis.agent.static_leg_contract import (
+    CouponLeg,
+    FixedCouponFormula,
+    SettlementRule,
+    static_leg_economic_identity,
+)
+from trellis.io.fpml._normalization_common import (
+    _ALLOWED_LEAF_CHILDREN,
+    _adjustable_date,
+    _fail,
+    _normalize_option_premiums,
+    _provenance,
+    _reject_nested_metadata_children,
+    _reject_unadmitted_direct_children,
+    _required_child,
+    _required_href,
+)
+from trellis.io.fpml._normalization_swap import _normalize_fixed_float_swap
+from trellis.io.fpml.contracts import FpMLFieldProvenance, FpMLPremiumMetadata
+from trellis.io.fpml.importer import _direct_children, _optional_text, _split_tag
+
+
+_ALLOWED_SWAPTION_CHILDREN = {
+    "assetClass",
+    "buyerPartyReference",
+    "cashSettlement",
+    "europeanExercise",
+    "physicalSettlement",
+    "premium",
+    "primaryAssetClass",
+    "productId",
+    "productType",
+    "secondaryAssetClass",
+    "sellerPartyReference",
+    "swap",
+    "swaptionStraddle",
+}
+_SWAPTION_METADATA_CHILDREN = {
+    "assetClass",
+    "primaryAssetClass",
+    "productId",
+    "productType",
+    "secondaryAssetClass",
+}
+_ALLOWED_EUROPEAN_EXERCISE_CHILDREN = {"expirationDate"}
+
+
+def _normalize_european_swaption(
+    swaption,
+    *,
+    namespace: str | None,
+    valuation_party_id: str,
+    valuation_date: date | None,
+    known_party_ids: tuple[str, ...],
+) -> tuple[
+    ContractIR,
+    tuple[FpMLFieldProvenance, ...],
+    tuple[FpMLPremiumMetadata, ...],
+]:
+    """Normalize the bounded physical European fixed-float swaption cohort."""
+
+    exercise_styles = tuple(
+        local_name
+        for child in tuple(swaption)
+        for child_namespace, local_name in (_split_tag(child.tag),)
+        if child_namespace == namespace
+        and local_name in {"americanExercise", "bermudaExercise", "europeanExercise"}
+    )
+    if not exercise_styles:
+        _fail(
+            "missing_contract_field:fpml_swaption_exercise",
+            "contract_gap",
+            "A swaption requires an explicit exercise declaration.",
+            missing_fields=("exercise",),
+        )
+    if exercise_styles != ("europeanExercise",):
+        _fail(
+            "external_import:fpml_swaption_exercise_style_unsupported",
+            "unsupported_contract",
+            "The admitted swaption cohort requires exactly one European exercise.",
+        )
+    if _direct_children(swaption, "cashSettlement", namespace=namespace):
+        _fail(
+            "external_import:fpml_swaption_cash_settlement_unsupported",
+            "unsupported_contract",
+            "Cash-settled swaptions require settlement-method semantics outside "
+            "the admitted physical cohort.",
+        )
+    _reject_unadmitted_direct_children(
+        swaption,
+        allowed=_ALLOWED_SWAPTION_CHILDREN,
+        scope="swaption",
+        namespace=namespace,
+    )
+    _reject_nested_metadata_children(
+        swaption,
+        names=_SWAPTION_METADATA_CHILDREN,
+        namespace=namespace,
+    )
+
+    buyer = _required_href(
+        swaption,
+        "buyerPartyReference",
+        namespace=namespace,
+        missing_field="buyer_party_reference",
+    )
+    seller = _required_href(
+        swaption,
+        "sellerPartyReference",
+        namespace=namespace,
+        missing_field="seller_party_reference",
+    )
+    if buyer == seller:
+        _fail(
+            "contract_conflict:fpml_swaption_parties",
+            "contract_conflict",
+            "Swaption buyer and seller must differ.",
+        )
+    if not {buyer, seller}.issubset(set(known_party_ids)):
+        _fail(
+            "contract_conflict:fpml_swaption_party_reference",
+            "contract_conflict",
+            "The swaption references a party not identified by the FpML document.",
+        )
+    if valuation_party_id not in {buyer, seller}:
+        _fail(
+            "contract_conflict:fpml_valuation_party_id",
+            "contract_conflict",
+            "The valuation party is neither buyer nor seller of the swaption.",
+        )
+
+    physical = _required_child(
+        swaption,
+        "physicalSettlement",
+        namespace=namespace,
+        missing_field="physical_settlement",
+    )
+    _reject_unadmitted_direct_children(
+        physical,
+        allowed=_ALLOWED_LEAF_CHILDREN,
+        scope="physical_settlement",
+        namespace=namespace,
+    )
+    straddle_elements = _direct_children(
+        swaption,
+        "swaptionStraddle",
+        namespace=namespace,
+    )
+    if len(straddle_elements) > 1:
+        _fail(
+            "contract_ambiguity:fpml_swaption_straddle",
+            "contract_ambiguity",
+            "FpML normalization found multiple swaptionStraddle declarations.",
+            ambiguous_fields=("swaption_straddle",),
+        )
+    straddle = (
+        _optional_text(straddle_elements[0].text).lower()
+        if straddle_elements and _optional_text(straddle_elements[0].text)
+        else "false"
+    )
+    if straddle not in {"true", "false", "1", "0"}:
+        _fail(
+            "external_import:fpml_malformed_swaption_straddle",
+            "malformed_document",
+            "FpML swaptionStraddle must use XML boolean syntax.",
+        )
+    if straddle in {"true", "1"}:
+        _fail(
+            "external_import:fpml_swaption_straddle_unsupported",
+            "unsupported_contract",
+            "Swaption straddles are outside the admitted payer/receiver cohort.",
+        )
+
+    exercise = _required_child(
+        swaption,
+        "europeanExercise",
+        namespace=namespace,
+        missing_field="european_exercise",
+    )
+    _reject_unadmitted_direct_children(
+        exercise,
+        allowed=_ALLOWED_EUROPEAN_EXERCISE_CHILDREN,
+        scope="european_exercise",
+        namespace=namespace,
+    )
+    _, expiry = _adjustable_date(
+        exercise,
+        "expirationDate",
+        namespace=namespace,
+    )
+    if valuation_date is not None and valuation_date >= expiry:
+        _fail(
+            "external_import:fpml_expired_swaption_unsupported",
+            "unsupported_contract",
+            "The admitted swaption pricing cohort requires valuation before expiry.",
+        )
+
+    swaps = _direct_children(swaption, "swap", namespace=namespace)
+    if len(swaps) != 1:
+        _fail(
+            "missing_contract_field:fpml_swaption_underlying_swap"
+            if not swaps
+            else "contract_ambiguity:fpml_swaption_underlying_swap",
+            "contract_gap" if not swaps else "contract_ambiguity",
+            "A European swaption requires exactly one complete underlying swap.",
+            missing_fields=("underlying_swap",) if not swaps else (),
+            ambiguous_fields=("underlying_swap",) if len(swaps) > 1 else (),
+        )
+    underlying_contract, raw_underlying_provenance = _normalize_fixed_float_swap(
+        swaps[0],
+        namespace=namespace,
+        valuation_party_id=buyer,
+        known_party_ids=known_party_ids,
+        required_party_pair=frozenset((buyer, seller)),
+        xml_base_path="/dataDocument/trade/swaption/swap",
+    )
+    underlying_provenance = tuple(
+        FpMLFieldProvenance(
+            xml_path=item.xml_path,
+            semantic_field=f"underlying_contract.{item.semantic_field}",
+            normalized_value=item.normalized_value,
+        )
+        for item in raw_underlying_provenance
+        if item.semantic_field != "valuation_party_id"
+    )
+    fixed_signed_leg = next(
+        (
+            item
+            for item in underlying_contract.legs
+            if isinstance(item.leg, CouponLeg)
+            and isinstance(item.leg.coupon_formula, FixedCouponFormula)
+        ),
+        None,
+    )
+    if fixed_signed_leg is None:
+        raise AssertionError("normalized fixed-float swap has no fixed leg")
+    fixed_leg = fixed_signed_leg.leg
+    notional_step = fixed_leg.notional_schedule.steps[0]
+    if expiry >= notional_step.start_date:
+        _fail(
+            "contract_conflict:fpml_swaption_expiry_underlying_start",
+            "contract_conflict",
+            "Swaption expiry must precede the underlying swap effective date.",
+        )
+    payment_schedule = FiniteSchedule(
+        tuple(period.payment_date for period in fixed_leg.coupon_periods)
+    )
+    underlier_id = (
+        f"{fixed_leg.currency}-IRS-"
+        f"{notional_step.start_date:%Y%m%d}-{notional_step.end_date:%Y%m%d}"
+    )
+    rate = fixed_leg.coupon_formula.rate
+    intrinsic = (
+        Sub(SwapRate(underlier_id, payment_schedule), Strike(rate))
+        if fixed_signed_leg.direction == "pay"
+        else Sub(Strike(rate), SwapRate(underlier_id, payment_schedule))
+    )
+    expiry_schedule = Singleton(expiry)
+    contract = ContractIR(
+        payoff=Scaled(
+            Annuity(underlier_id, payment_schedule),
+            Max((intrinsic, Constant(0.0))),
+        ),
+        exercise=Exercise("european", expiry_schedule),
+        observation=Observation("terminal", expiry_schedule),
+        underlying=Underlying(ForwardRate(underlier_id, "lognormal_forward")),
+        position="long" if valuation_party_id == buyer else "short",
+        settlement=SettlementRule(
+            settlement_kind="physical",
+            payout_currency=fixed_leg.currency,
+        ),
+        underlying_contract=underlying_contract,
+    )
+    premium_metadata = _normalize_option_premiums(
+        swaption,
+        namespace=namespace,
+        valuation_date=valuation_date,
+        known_party_ids=known_party_ids,
+        option_party_ids=(buyer, seller),
+        product_scope="swaption",
+        product_label="Swaption",
+    )
+    provenance = (
+        _provenance("", "valuation_party_id", valuation_party_id),
+        _provenance(
+            "/dataDocument/trade/swaption/buyerPartyReference/@href",
+            "position",
+            contract.position,
+        ),
+        _provenance(
+            "/dataDocument/trade/swaption/europeanExercise/expirationDate/"
+            "unadjustedDate",
+            "exercise.schedule.t",
+            expiry,
+        ),
+        _provenance(
+            "/dataDocument/trade/swaption/physicalSettlement",
+            "settlement.settlement_kind",
+            "physical",
+        ),
+        _provenance(
+            "/dataDocument/trade/swaption/swap",
+            "underlying_contract",
+            static_leg_economic_identity(underlying_contract),
+        ),
+        *underlying_provenance,
+    )
+    return contract, provenance, premium_metadata

--- a/trellis/io/fpml/normalizer.py
+++ b/trellis/io/fpml/normalizer.py
@@ -5,33 +5,11 @@ from __future__ import annotations
 from datetime import date
 import hashlib
 
-from trellis.agent.contract_ir import (
-    Annuity,
-    Constant,
-    ContractIR,
-    Exercise,
-    FiniteSchedule,
-    ForwardRate,
-    Max,
-    Observation,
-    Scaled,
-    Singleton,
-    Strike,
-    Sub,
-    SwapRate,
-    Underlying,
-    contract_ir_economic_identity,
-)
-from trellis.agent.static_leg_contract import (
-    CouponLeg,
-    FixedCouponFormula,
-    SettlementRule,
-    static_leg_economic_identity,
-)
+from trellis.agent.contract_ir import contract_ir_economic_identity
+from trellis.agent.static_leg_contract import static_leg_economic_identity
 from trellis.io.fpml.contracts import (
     DEFAULT_FPML_INSPECTION_LIMITS,
     FpMLClarification,
-    FpMLFieldProvenance,
     FpMLImportReport,
     FpMLInspectionLimits,
     FpMLPremiumMetadata,
@@ -42,23 +20,15 @@ from trellis.io.fpml.importer import (
     _direct_children,
     _first_direct_child,
     _optional_text,
-    _split_tag,
     inspect_fpml_document,
 )
 from trellis.io.fpml._normalization_common import (
-    _ALLOWED_LEAF_CHILDREN,
     _NormalizationBlocked,
-    _adjustable_date,
     _blocked_from,
     _blocker,
     _fail,
     _has_unresolved_historical_fixing,
-    _normalize_option_premiums,
-    _provenance,
-    _reject_nested_metadata_children,
     _reject_unadmitted_direct_children,
-    _required_child,
-    _required_href,
     _validate_document_metadata,
 )
 from trellis.io.fpml._normalization_cap_floor import _normalize_cap_floor
@@ -66,33 +36,11 @@ from trellis.io.fpml._normalization_swap import (
     _normalize_fixed_float_swap,
     _reject_unresolved_swap_historical_fixings,
 )
+from trellis.io.fpml._normalization_swaption import _normalize_european_swaption
 
 
 _ALLOWED_DOCUMENT_CHILDREN = {"party", "trade"}
 _ALLOWED_TRADE_CHILDREN = {"capFloor", "swap", "swaption", "tradeHeader"}
-_ALLOWED_SWAPTION_CHILDREN = {
-    "assetClass",
-    "buyerPartyReference",
-    "cashSettlement",
-    "europeanExercise",
-    "physicalSettlement",
-    "premium",
-    "primaryAssetClass",
-    "productId",
-    "productType",
-    "secondaryAssetClass",
-    "sellerPartyReference",
-    "swap",
-    "swaptionStraddle",
-}
-_SWAPTION_METADATA_CHILDREN = {
-    "assetClass",
-    "primaryAssetClass",
-    "productId",
-    "productType",
-    "secondaryAssetClass",
-}
-_ALLOWED_EUROPEAN_EXERCISE_CHILDREN = {"expirationDate"}
 
 
 def normalize_fpml_document(
@@ -301,266 +249,3 @@ def _normalize_inspected_fpml_document(
         mapping_provenance=provenance,
         premium_metadata=premium_metadata,
     )
-
-
-def _normalize_european_swaption(
-    swaption,
-    *,
-    namespace: str | None,
-    valuation_party_id: str,
-    valuation_date: date | None,
-    known_party_ids: tuple[str, ...],
-) -> tuple[
-    ContractIR,
-    tuple[FpMLFieldProvenance, ...],
-    tuple[FpMLPremiumMetadata, ...],
-]:
-    """Normalize the bounded physical European fixed-float swaption cohort."""
-
-    exercise_styles = tuple(
-        local_name
-        for child in tuple(swaption)
-        for child_namespace, local_name in (_split_tag(child.tag),)
-        if child_namespace == namespace
-        and local_name in {"americanExercise", "bermudaExercise", "europeanExercise"}
-    )
-    if not exercise_styles:
-        _fail(
-            "missing_contract_field:fpml_swaption_exercise",
-            "contract_gap",
-            "A swaption requires an explicit exercise declaration.",
-            missing_fields=("exercise",),
-        )
-    if exercise_styles != ("europeanExercise",):
-        _fail(
-            "external_import:fpml_swaption_exercise_style_unsupported",
-            "unsupported_contract",
-            "The admitted swaption cohort requires exactly one European exercise.",
-        )
-    if _direct_children(swaption, "cashSettlement", namespace=namespace):
-        _fail(
-            "external_import:fpml_swaption_cash_settlement_unsupported",
-            "unsupported_contract",
-            "Cash-settled swaptions require settlement-method semantics outside "
-            "the admitted physical cohort.",
-        )
-    _reject_unadmitted_direct_children(
-        swaption,
-        allowed=_ALLOWED_SWAPTION_CHILDREN,
-        scope="swaption",
-        namespace=namespace,
-    )
-    _reject_nested_metadata_children(
-        swaption,
-        names=_SWAPTION_METADATA_CHILDREN,
-        namespace=namespace,
-    )
-
-    buyer = _required_href(
-        swaption,
-        "buyerPartyReference",
-        namespace=namespace,
-        missing_field="buyer_party_reference",
-    )
-    seller = _required_href(
-        swaption,
-        "sellerPartyReference",
-        namespace=namespace,
-        missing_field="seller_party_reference",
-    )
-    if buyer == seller:
-        _fail(
-            "contract_conflict:fpml_swaption_parties",
-            "contract_conflict",
-            "Swaption buyer and seller must differ.",
-        )
-    if not {buyer, seller}.issubset(set(known_party_ids)):
-        _fail(
-            "contract_conflict:fpml_swaption_party_reference",
-            "contract_conflict",
-            "The swaption references a party not identified by the FpML document.",
-        )
-    if valuation_party_id not in {buyer, seller}:
-        _fail(
-            "contract_conflict:fpml_valuation_party_id",
-            "contract_conflict",
-            "The valuation party is neither buyer nor seller of the swaption.",
-        )
-
-    physical = _required_child(
-        swaption,
-        "physicalSettlement",
-        namespace=namespace,
-        missing_field="physical_settlement",
-    )
-    _reject_unadmitted_direct_children(
-        physical,
-        allowed=_ALLOWED_LEAF_CHILDREN,
-        scope="physical_settlement",
-        namespace=namespace,
-    )
-    straddle_elements = _direct_children(
-        swaption,
-        "swaptionStraddle",
-        namespace=namespace,
-    )
-    if len(straddle_elements) > 1:
-        _fail(
-            "contract_ambiguity:fpml_swaption_straddle",
-            "contract_ambiguity",
-            "FpML normalization found multiple swaptionStraddle declarations.",
-            ambiguous_fields=("swaption_straddle",),
-        )
-    straddle = (
-        _optional_text(straddle_elements[0].text).lower()
-        if straddle_elements and _optional_text(straddle_elements[0].text)
-        else "false"
-    )
-    if straddle not in {"true", "false", "1", "0"}:
-        _fail(
-            "external_import:fpml_malformed_swaption_straddle",
-            "malformed_document",
-            "FpML swaptionStraddle must use XML boolean syntax.",
-        )
-    if straddle in {"true", "1"}:
-        _fail(
-            "external_import:fpml_swaption_straddle_unsupported",
-            "unsupported_contract",
-            "Swaption straddles are outside the admitted payer/receiver cohort.",
-        )
-
-    exercise = _required_child(
-        swaption,
-        "europeanExercise",
-        namespace=namespace,
-        missing_field="european_exercise",
-    )
-    _reject_unadmitted_direct_children(
-        exercise,
-        allowed=_ALLOWED_EUROPEAN_EXERCISE_CHILDREN,
-        scope="european_exercise",
-        namespace=namespace,
-    )
-    _, expiry = _adjustable_date(
-        exercise,
-        "expirationDate",
-        namespace=namespace,
-    )
-    if valuation_date is not None and valuation_date >= expiry:
-        _fail(
-            "external_import:fpml_expired_swaption_unsupported",
-            "unsupported_contract",
-            "The admitted swaption pricing cohort requires valuation before expiry.",
-        )
-
-    swaps = _direct_children(swaption, "swap", namespace=namespace)
-    if len(swaps) != 1:
-        _fail(
-            "missing_contract_field:fpml_swaption_underlying_swap"
-            if not swaps
-            else "contract_ambiguity:fpml_swaption_underlying_swap",
-            "contract_gap" if not swaps else "contract_ambiguity",
-            "A European swaption requires exactly one complete underlying swap.",
-            missing_fields=("underlying_swap",) if not swaps else (),
-            ambiguous_fields=("underlying_swap",) if len(swaps) > 1 else (),
-        )
-    underlying_contract, raw_underlying_provenance = _normalize_fixed_float_swap(
-        swaps[0],
-        namespace=namespace,
-        valuation_party_id=buyer,
-        known_party_ids=known_party_ids,
-        required_party_pair=frozenset((buyer, seller)),
-        xml_base_path="/dataDocument/trade/swaption/swap",
-    )
-    underlying_provenance = tuple(
-        FpMLFieldProvenance(
-            xml_path=item.xml_path,
-            semantic_field=f"underlying_contract.{item.semantic_field}",
-            normalized_value=item.normalized_value,
-        )
-        for item in raw_underlying_provenance
-        if item.semantic_field != "valuation_party_id"
-    )
-    fixed_signed_leg = next(
-        (
-            item
-            for item in underlying_contract.legs
-            if isinstance(item.leg, CouponLeg)
-            and isinstance(item.leg.coupon_formula, FixedCouponFormula)
-        ),
-        None,
-    )
-    if fixed_signed_leg is None:
-        raise AssertionError("normalized fixed-float swap has no fixed leg")
-    fixed_leg = fixed_signed_leg.leg
-    notional_step = fixed_leg.notional_schedule.steps[0]
-    if expiry >= notional_step.start_date:
-        _fail(
-            "contract_conflict:fpml_swaption_expiry_underlying_start",
-            "contract_conflict",
-            "Swaption expiry must precede the underlying swap effective date.",
-        )
-    payment_schedule = FiniteSchedule(
-        tuple(period.payment_date for period in fixed_leg.coupon_periods)
-    )
-    underlier_id = (
-        f"{fixed_leg.currency}-IRS-"
-        f"{notional_step.start_date:%Y%m%d}-{notional_step.end_date:%Y%m%d}"
-    )
-    rate = fixed_leg.coupon_formula.rate
-    intrinsic = (
-        Sub(SwapRate(underlier_id, payment_schedule), Strike(rate))
-        if fixed_signed_leg.direction == "pay"
-        else Sub(Strike(rate), SwapRate(underlier_id, payment_schedule))
-    )
-    expiry_schedule = Singleton(expiry)
-    contract = ContractIR(
-        payoff=Scaled(
-            Annuity(underlier_id, payment_schedule),
-            Max((intrinsic, Constant(0.0))),
-        ),
-        exercise=Exercise("european", expiry_schedule),
-        observation=Observation("terminal", expiry_schedule),
-        underlying=Underlying(ForwardRate(underlier_id, "lognormal_forward")),
-        position="long" if valuation_party_id == buyer else "short",
-        settlement=SettlementRule(
-            settlement_kind="physical",
-            payout_currency=fixed_leg.currency,
-        ),
-        underlying_contract=underlying_contract,
-    )
-    premium_metadata = _normalize_option_premiums(
-        swaption,
-        namespace=namespace,
-        valuation_date=valuation_date,
-        known_party_ids=known_party_ids,
-        option_party_ids=(buyer, seller),
-        product_scope="swaption",
-        product_label="Swaption",
-    )
-    provenance = (
-        _provenance("", "valuation_party_id", valuation_party_id),
-        _provenance(
-            "/dataDocument/trade/swaption/buyerPartyReference/@href",
-            "position",
-            contract.position,
-        ),
-        _provenance(
-            "/dataDocument/trade/swaption/europeanExercise/expirationDate/"
-            "unadjustedDate",
-            "exercise.schedule.t",
-            expiry,
-        ),
-        _provenance(
-            "/dataDocument/trade/swaption/physicalSettlement",
-            "settlement.settlement_kind",
-            "physical",
-        ),
-        _provenance(
-            "/dataDocument/trade/swaption/swap",
-            "underlying_contract",
-            static_leg_economic_identity(underlying_contract),
-        ),
-        *underlying_provenance,
-    )
-    return contract, provenance, premium_metadata


### PR DESCRIPTION
## Summary
- extract physical European swaption normalization into a product-owned internal module
- reuse the exact shared premium parser and extracted fixed-float swap mapper
- preserve complete underlying-swap identity and the stable facade

## Validation
- 149 FpML tests passed
- 120 imported-document/platform/conformance tests passed
- 63 import/helper-authority tests passed
- make gate-pr: 4,977 primary tests and 32 tier-2 contract tests passed
- Sphinx build passed with pre-existing warnings

Linear: QUA-1228