### PR TITLE
Roadmap: mark QUA-1228 complete

### DIFF
--- a/doc/plan/draft__fpml-interoperability-roadmap.md
+++ b/doc/plan/draft__fpml-interoperability-roadmap.md
@@ -188,7 +188,7 @@ normalization, package result cardinality, and support closeout.
 | `QUA-1226` | Done | shared parsing and stream-normalization boundary | `QUA-1207` |
 | `QUA-1227` | Done | fixed-float swap mapping extraction | `QUA-1226` |
 | `QUA-1229` | Done | cap/floor mapping extraction | `QUA-1226` |
-| `QUA-1228` | In Progress | swaption mapping extraction | `QUA-1226`, `QUA-1227` |
+| `QUA-1228` | Done | swaption mapping extraction | `QUA-1226`, `QUA-1227` |
 | `QUA-1230` | Backlog | facade and modularity closeout | `QUA-1227`, `QUA-1228`, `QUA-1229` |
 | `QUA-1222` | Backlog | reusable irregular-period static coupon execution | none |
 | `QUA-1223` | Backlog | bounded basis-swap normalization | `QUA-1220` |


### PR DESCRIPTION
## Summary
- synchronize the FpML roadmap mirror after QUA-1228 was merged and marked Done in Linear

## Validation
- documentation-only one-line status update
- git diff --check passed

Linear: QUA-1228