### PR TITLE
QUA-1230: harden FpML modularity contract

### DIFF
--- a/doc/plan/draft__fpml-interoperability-roadmap.md
+++ b/doc/plan/draft__fpml-interoperability-roadmap.md
@@ -189,7 +189,7 @@ normalization, package result cardinality, and support closeout.
 | `QUA-1227` | Done | fixed-float swap mapping extraction | `QUA-1226` |
 | `QUA-1229` | Done | cap/floor mapping extraction | `QUA-1226` |
 | `QUA-1228` | Done | swaption mapping extraction | `QUA-1226`, `QUA-1227` |
-| `QUA-1230` | Backlog | facade and modularity closeout | `QUA-1227`, `QUA-1228`, `QUA-1229` |
+| `QUA-1230` | In Progress | facade and modularity closeout | `QUA-1227`, `QUA-1228`, `QUA-1229` |
 | `QUA-1222` | Backlog | reusable irregular-period static coupon execution | none |
 | `QUA-1223` | Backlog | bounded basis-swap normalization | `QUA-1220` |
 | `QUA-1224` | Backlog | bounded irregular schedule normalization | `QUA-1220`, `QUA-1222` |

--- a/docs/developer/fpml_import.rst
+++ b/docs/developer/fpml_import.rst
@@ -64,6 +64,40 @@ access, exact blocker and provenance construction, calendars, date and
 frequency conventions, regular schedule validation, bounded stream parsing,
 and option-premium metadata shared by cap/floor and swaption normalization.
 
+The internal dependency graph is deliberately small and enforced by tests:
+
+.. list-table:: FpML normalization ownership
+   :header-rows: 1
+   :widths: 30 45 25
+
+   * - Module
+     - Owns
+     - May depend on
+   * - ``normalizer``
+     - document validation, valuation context, product dispatch, economic
+       identity selection, and immutable report construction
+     - ``_normalization_common`` and every admitted product mapper
+   * - ``_normalization_common``
+     - product-neutral XML, blocker, provenance, convention, schedule, stream,
+       and shared premium parsing
+     - no product mapper
+   * - ``_normalization_swap``
+     - fixed-float swap semantics and swap-specific fixing rejection
+     - ``_normalization_common``
+   * - ``_normalization_cap_floor``
+     - scheduled cap/floor strip semantics
+     - ``_normalization_common``
+   * - ``_normalization_swaption``
+     - physical European swaption semantics and complete underlying-swap
+       composition
+     - ``_normalization_common`` and ``_normalization_swap``
+
+``tests/test_io/test_fpml_normalizer_boundaries.py`` fixes this graph, the two
+function facade surface, stable public exports, mapper identity, and exclusion
+from code-generation import authority. Shared and product modules may use
+semantic IR types, but cannot import the facade, pricing models, generated
+adapters, agent knowledge, task runtime, or route-selection authority.
+
 The public entry point remains ``normalize_fpml_document(...)``. The platform
 request compiler also uses the internal
 ``_normalize_inspected_fpml_document(...)`` seam so it can reconcile document
@@ -255,3 +289,19 @@ update. ``genericProduct``, ``nonSchemaProduct``, vendor extensions, or labels
 can advance only when their full economics have a separately approved Trellis
 semantic contract. An agent-authored adapter or cookbook entry cannot upgrade
 the public import support claim by itself.
+
+Place new XML access, convention, or schedule logic in
+``_normalization_common`` only when it is product-neutral and reused by more
+than one admitted mapper. Product-specific admission rules, blockers, semantic
+construction, and provenance belong in one product mapper. A product mapper
+may compose another mapper only when the nested product is part of canonical
+economic identity, as the admitted swaption composes the complete fixed-float
+swap. Such a dependency must be explicit in the boundary test and must not
+flow back from the nested mapper to its consumer.
+
+The facade may add a product name only after inspection admits it and an
+internal mapper exists. The facade remains responsible for orchestration and
+report cardinality; product validation must not move back into it. Internal
+normalization modules remain absent from the code-generation import registry,
+and neither a generated adapter nor learned cookbook can become import-support
+authority.

--- a/tests/test_io/test_fpml_normalizer_boundaries.py
+++ b/tests/test_io/test_fpml_normalizer_boundaries.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import ast
 from datetime import date
 import importlib
+from importlib.util import resolve_name
 import inspect
 from pathlib import Path
 
@@ -38,18 +39,57 @@ NORMALIZATION_MODULES = {
     "swaption": "trellis.io.fpml._normalization_swaption",
     "facade": "trellis.io.fpml.normalizer",
 }
+PUBLIC_FACADE_EXPORTS = {
+    "trellis.io.fpml.normalize_fpml_document": NORMALIZATION_MODULES["facade"],
+}
 
 
-def _imported_modules(module) -> tuple[str, ...]:
-    source = inspect.getsource(module)
+def _imported_modules_from_source(source: str, *, package: str) -> tuple[str, ...]:
     tree = ast.parse(source)
     imports: list[str] = []
+    internal_modules = set(NORMALIZATION_MODULES.values())
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             imports.extend(alias.name for alias in node.names)
-        elif isinstance(node, ast.ImportFrom) and node.module:
-            imports.append(node.module)
+        elif isinstance(node, ast.ImportFrom):
+            if node.level:
+                imported_module = resolve_name(
+                    f"{'.' * node.level}{node.module or ''}", package
+                )
+            else:
+                imported_module = node.module
+            if imported_module is None:
+                continue
+            imports.append(imported_module)
+            for alias in node.names:
+                imported_symbol = f"{imported_module}.{alias.name}"
+                if imported_symbol in internal_modules:
+                    imports.append(imported_symbol)
+                facade_module = PUBLIC_FACADE_EXPORTS.get(imported_symbol)
+                if facade_module is not None:
+                    imports.append(facade_module)
     return tuple(imports)
+
+
+def _imported_modules(module) -> tuple[str, ...]:
+    return _imported_modules_from_source(
+        inspect.getsource(module), package=module.__package__
+    )
+
+
+def test_import_parser_normalizes_facade_bypass_forms():
+    for source in (
+        "from .normalizer import _normalize_inspected_fpml_document",
+        "from trellis.io.fpml import normalize_fpml_document",
+    ):
+        imports = set(
+            _imported_modules_from_source(
+                source,
+                package="trellis.io.fpml",
+            )
+        )
+
+        assert NORMALIZATION_MODULES["facade"] in imports
 
 
 def test_normalizer_facade_defines_only_bounded_orchestration():

--- a/tests/test_io/test_fpml_normalizer_boundaries.py
+++ b/tests/test_io/test_fpml_normalizer_boundaries.py
@@ -31,6 +31,13 @@ FORBIDDEN_SHARED_IMPORT_PREFIXES = (
     "trellis.instruments",
     "trellis.models",
 )
+NORMALIZATION_MODULES = {
+    "common": "trellis.io.fpml._normalization_common",
+    "swap": "trellis.io.fpml._normalization_swap",
+    "cap_floor": "trellis.io.fpml._normalization_cap_floor",
+    "swaption": "trellis.io.fpml._normalization_swaption",
+    "facade": "trellis.io.fpml.normalizer",
+}
 
 
 def _imported_modules(module) -> tuple[str, ...]:
@@ -43,6 +50,77 @@ def _imported_modules(module) -> tuple[str, ...]:
         elif isinstance(node, ast.ImportFrom) and node.module:
             imports.append(node.module)
     return tuple(imports)
+
+
+def test_normalizer_facade_defines_only_bounded_orchestration():
+    normalizer = importlib.import_module(NORMALIZATION_MODULES["facade"])
+    tree = ast.parse(inspect.getsource(normalizer))
+
+    functions = tuple(
+        node.name for node in tree.body if isinstance(node, ast.FunctionDef)
+    )
+    normalization_imports = {
+        imported
+        for imported in _imported_modules(normalizer)
+        if imported in set(NORMALIZATION_MODULES.values())
+    }
+
+    assert functions == (
+        "normalize_fpml_document",
+        "_normalize_inspected_fpml_document",
+    )
+    assert normalization_imports == {
+        NORMALIZATION_MODULES["common"],
+        NORMALIZATION_MODULES["swap"],
+        NORMALIZATION_MODULES["cap_floor"],
+        NORMALIZATION_MODULES["swaption"],
+    }
+
+
+def test_internal_normalization_dependency_graph_is_explicit_and_acyclic():
+    expected_dependencies = {
+        "common": set(),
+        "swap": {NORMALIZATION_MODULES["common"]},
+        "cap_floor": {NORMALIZATION_MODULES["common"]},
+        "swaption": {
+            NORMALIZATION_MODULES["common"],
+            NORMALIZATION_MODULES["swap"],
+        },
+    }
+    internal_module_names = set(NORMALIZATION_MODULES.values())
+
+    for module_name, expected in expected_dependencies.items():
+        module = importlib.import_module(NORMALIZATION_MODULES[module_name])
+        dependencies = {
+            imported
+            for imported in _imported_modules(module)
+            if imported in internal_module_names
+        }
+        assert dependencies == expected
+
+
+def test_public_fpml_exports_keep_the_stable_normalization_facade():
+    fpml = importlib.import_module("trellis.io.fpml")
+    normalizer = importlib.import_module(NORMALIZATION_MODULES["facade"])
+
+    assert fpml.__all__ == [
+        "DEFAULT_FPML_INSPECTION_LIMITS",
+        "FPML_5_13_CONFIRMATION",
+        "SUPPORTED_FPML_PROFILES",
+        "FpMLClarification",
+        "FpMLDocumentIdentity",
+        "FpMLFieldProvenance",
+        "FpMLImportBlocker",
+        "FpMLImportReport",
+        "FpMLInspectionLimits",
+        "FpMLPremiumMetadata",
+        "FpMLProfile",
+        "FpMLTradeIdentity",
+        "fpml_import_report_summary",
+        "inspect_fpml_document",
+        "normalize_fpml_document",
+    ]
+    assert fpml.normalize_fpml_document is normalizer.normalize_fpml_document
 
 
 def test_shared_normalization_module_owns_product_neutral_helpers():


### PR DESCRIPTION
## Summary
- codify the bounded FpML normalizer facade and internal mapper dependency graph
- defend stable public exports and mapper identity with executable boundary tests
- document module ownership and extension rules without adding pricing or agent authority

## Validation
- focused FpML/import suites: 351 passed
- Ruff: passed
- Sphinx: passed with 96 pre-existing warnings
- `NUMBA_CACHE_DIR=/tmp/trellis-numba-cache make gate-release`: passed
  - primary: 4,980 passed, 5 deselected
  - tier 2: 32 passed, 15 skipped, 7 deselected
  - cross-validation/verification/tasks: 487 passed, 2 skipped
  - cassette freshness: 2 passed
  - T13 deterministic replay passed with 0 LLM attempts; drift comparison skipped because no checkpoint exists
  - T38 cassette replay unsupported/skipped; no checkpoint exists

Linear: QUA-1230