### PR TITLE
Semantic comparison: bind callable fixed-income target variants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ cover/
 
 # Local benchmark scratch reports
 benchmark_runs/
+/task_runs/comparison_target_artifacts/
 
 # Translations
 *.mo

--- a/TASKS_PROOF_LEGACY.yaml
+++ b/TASKS_PROOF_LEGACY.yaml
@@ -56,6 +56,29 @@ tasks:
     internal:
     - bdt_tree
     - hull_white_tree
+    target_contracts:
+      bdt_tree:
+        method: rate_tree
+        route_id: exercise_lattice
+        route_family: rate_lattice
+        backend_binding_id: trellis.models.callable_bond_tree.price_callable_bond_tree
+        variant_parameters: {lattice_model: bdt}
+        validation_bundle_id: rate_tree:callable_bond
+        payoff_family: callable_fixed_income
+        exercise_style: issuer_call
+        model_family: interest_rate
+        observation_style: exercise_schedule
+      hull_white_tree:
+        method: rate_tree
+        route_id: exercise_lattice
+        route_family: rate_lattice
+        backend_binding_id: trellis.models.callable_bond_tree.price_callable_bond_tree
+        variant_parameters: {lattice_model: hull_white}
+        validation_bundle_id: rate_tree:callable_bond
+        payoff_family: callable_fixed_income
+        exercise_style: issuer_call
+        model_family: interest_rate
+        observation_style: exercise_schedule
     external:
     - financepy
     - quantlib
@@ -88,13 +111,23 @@ tasks:
     - financepy
   status: done
 - id: T05
-  title: 'Puttable bond: exercise_fn=max and puttable-callable symmetry'
+  title: 'Puttable bond: holder exercise and straight-bond lower bound'
   construct: lattice
   new_component: null
   cross_validate:
     internal:
     - puttable_tree
-    - callable_tree_symmetry
+    target_contracts:
+      puttable_tree:
+        method: rate_tree
+        route_id: exercise_lattice
+        route_family: rate_lattice
+        backend_binding_id: trellis.models.callable_bond_tree.price_callable_bond_tree
+        validation_bundle_id: rate_tree:puttable_bond
+        payoff_family: puttable_fixed_income
+        exercise_style: holder_put
+        model_family: interest_rate
+        observation_style: exercise_schedule
     external:
     - quantlib
     - financepy
@@ -236,10 +269,44 @@ tasks:
   - pde
   - lattice
   new_component: hw_rate_pde_operator
+  comparison_regime:
+    family: short_rate
+    regime_name: t17_hull_white_comparison
+    flat_discount_rate: 0.05
+    flat_sigma: 0.01
+    hull_white_mean_reversion: 0.1
+    ho_lee_mean_reversion: 0.0
+    quote_family: black
+    quote_subject: discount_bond_option
+    quote_convention: flat
+    source_kind: task_comparison_regime
   cross_validate:
     internal:
     - hw_pde_psor
     - hw_rate_tree
+    target_contracts:
+      hw_pde_psor:
+        method: pde_solver
+        route_id: pde_theta_1d
+        route_family: pde_solver
+        backend_binding_id: trellis.models.callable_bond_pde.price_callable_bond_pde
+        variant_parameters: {pricing_method: pde_solver, solver: psor, model_parameter_set: 't17_hull_white_comparison:hull_white', mean_reversion: 0.1, sigma: 0.01}
+        validation_bundle_id: pde_solver:callable_bond
+        payoff_family: callable_fixed_income
+        exercise_style: issuer_call
+        model_family: interest_rate
+        observation_style: exercise_schedule
+      hw_rate_tree:
+        method: rate_tree
+        route_id: exercise_lattice
+        route_family: rate_lattice
+        backend_binding_id: trellis.models.callable_bond_tree.price_callable_bond_tree
+        variant_parameters: {pricing_method: rate_tree, lattice_model: hull_white, model_parameter_set: 't17_hull_white_comparison:hull_white', mean_reversion: 0.1, sigma: 0.01}
+        validation_bundle_id: rate_tree:callable_bond
+        payoff_family: callable_fixed_income
+        exercise_style: issuer_call
+        model_family: interest_rate
+        observation_style: exercise_schedule
     external:
     - quantlib
   status: pending

--- a/TASKS_PROOF_LEGACY.yaml
+++ b/TASKS_PROOF_LEGACY.yaml
@@ -264,7 +264,7 @@ tasks:
     - quantlib
   status: pending
 - id: T17
-  title: 'Callable bond: HW rate PDE (PSOR) vs HW tree'
+  title: 'Callable bond: HW event-aware theta PDE vs HW tree'
   construct:
   - pde
   - lattice
@@ -282,15 +282,15 @@ tasks:
     source_kind: task_comparison_regime
   cross_validate:
     internal:
-    - hw_pde_psor
+    - hw_pde_theta
     - hw_rate_tree
     target_contracts:
-      hw_pde_psor:
+      hw_pde_theta:
         method: pde_solver
         route_id: pde_theta_1d
         route_family: pde_solver
         backend_binding_id: trellis.models.callable_bond_pde.price_callable_bond_pde
-        variant_parameters: {pricing_method: pde_solver, solver: psor, model_parameter_set: 't17_hull_white_comparison:hull_white', mean_reversion: 0.1, sigma: 0.01}
+        variant_parameters: {pricing_method: pde_solver, theta: 0.5, model_parameter_set: 't17_hull_white_comparison:hull_white', mean_reversion: 0.1, sigma: 0.01}
         validation_bundle_id: pde_solver:callable_bond
         payoff_family: callable_fixed_income
         exercise_style: issuer_call

--- a/doc/plan/active__legacy-task-migration-map.md
+++ b/doc/plan/active__legacy-task-migration-map.md
@@ -11,10 +11,10 @@ rate payoff and schedule are specified.
 
 `QUA-1206` binds the retained callable fixed-income experiments explicitly.
 `T02` distinguishes BDT from Hull-White lattice execution, `T17` compares
-Hull-White PSOR PDE with the Hull-White lattice under one typed parameter set,
-and `T05` is narrowed to one honest puttable-lattice target plus its
-straight-bond lower-bound validation because the former callable "symmetry"
-label was not an independent implementation.
+Hull-White event-aware theta PDE with the Hull-White lattice under one typed
+parameter set, and `T05` is narrowed to one honest puttable-lattice target plus
+its straight-bond lower-bound validation because the former callable
+"symmetry" label was not an independent implementation.
 
 | Task | Bucket | Target | Title |
 | --- | --- | --- | --- |
@@ -34,7 +34,7 @@ label was not an independent implementation.
 | `T14` | `proof_only_hold` | `TASKS_PROOF_LEGACY.yaml` | American put: PSOR vs tree vs LSM three-way |
 | `T15` | `proof_only_hold` | `TASKS_PROOF_LEGACY.yaml` | CEV model: CEVOperator PDE vs CEV tree |
 | `T16` | `proof_only_hold` | `TASKS_PROOF_LEGACY.yaml` | Barrier call: PDE absorbing BC vs MC discrete monitoring |
-| `T17` | `proof_only_hold` | `TASKS_PROOF_LEGACY.yaml` | Callable bond: HW rate PDE (PSOR) vs HW tree |
+| `T17` | `proof_only_hold` | `TASKS_PROOF_LEGACY.yaml` | Callable bond: HW event-aware theta PDE vs HW tree |
 | `T18` | `certified_honest_block` | `TASKS_PROOF_LEGACY.yaml` | Log-space PDE for rate instruments (avoid negative rates) |
 | `T19` | `proof_only_hold` | `TASKS_PROOF_LEGACY.yaml` | Non-uniform grid (log-spaced) for PDE near-barrier accuracy |
 | `T20` | `proof_only_hold` | `TASKS_PROOF_LEGACY.yaml` | 2D PDE: Heston (S, V) via ADI splitting |

--- a/doc/plan/active__legacy-task-migration-map.md
+++ b/doc/plan/active__legacy-task-migration-map.md
@@ -9,13 +9,20 @@ proof rows that previously failed at `semantic_product_shape`. `T25`, `T26`,
 basis/tree comparison targets, and `T18` is a certified honest block until the
 rate payoff and schedule are specified.
 
+`QUA-1206` binds the retained callable fixed-income experiments explicitly.
+`T02` distinguishes BDT from Hull-White lattice execution, `T17` compares
+Hull-White PSOR PDE with the Hull-White lattice under one typed parameter set,
+and `T05` is narrowed to one honest puttable-lattice target plus its
+straight-bond lower-bound validation because the former callable "symmetry"
+label was not an independent implementation.
+
 | Task | Bucket | Target | Title |
 | --- | --- | --- | --- |
 | `T01` | `benchmark_rewrite_candidate` | `rewrite/new corpus` | ZCB option: Ho-Lee vs HW tree vs Jamshidian analytical |
 | `T02` | `benchmark_rewrite_candidate` | `rewrite/new corpus` | Callable bond: BDT lognormal vs HW normal tree |
 | `T03` | `market_or_research_hold` | `TASKS_PROOF_LEGACY.yaml` | Trinomial tree implementation and convergence |
 | `T04` | `benchmark_rewrite_candidate` | `rewrite/new corpus` | Bermudan swaption on HW tree |
-| `T05` | `benchmark_rewrite_candidate` | `rewrite/new corpus` | Puttable bond: exercise_fn=max and puttable-callable symmetry |
+| `T05` | `benchmark_rewrite_candidate` | `rewrite/new corpus` | Puttable bond: holder exercise and straight-bond lower bound |
 | `T06` | `proof_only_hold` | `TASKS_PROOF_LEGACY.yaml` | CIR++ rate tree: positive rates via shifted CIR |
 | `T07` | `proof_only_hold` | `TASKS_PROOF_LEGACY.yaml` | Two-factor Hull-White tree (2D lattice) |
 | `T08` | `proof_only_hold` | `TASKS_PROOF_LEGACY.yaml` | Convertible bond: equity + credit on tree |

--- a/doc/plan/done__binding-first-exotic-proof-cohort.md
+++ b/doc/plan/done__binding-first-exotic-proof-cohort.md
@@ -81,9 +81,14 @@ All proof slices must use the same measurement protocol.
 
 These tasks define the `QUA-808` proof surface.
 
+Correction (`QUA-1206`): the T17 callable-bond PDE lane uses the event-aware
+theta rollback (`pde_theta_1d`, theta `0.5`), not PSOR. The historical target
+label below was narrowed after executable target binding made that distinction
+observable.
+
 | Task | Expected outcome | Binding-first capability under test | Notes |
 | --- | --- | --- | --- |
-| `T17` Callable bond: HW rate PDE (PSOR) vs HW tree | `proved` | same-day event schedule plus issuer control across PDE and lattice bindings | Tests event transforms, fixed-income schedule semantics, and explicit issuer control |
+| `T17` Callable bond: HW event-aware theta PDE vs HW tree | `proved` | same-day event schedule plus issuer control across PDE and lattice bindings | Tests event transforms, fixed-income schedule semantics, and explicit issuer control |
 | `T73` European swaption: Black76 vs HW tree vs HW MC | `proved` | rate-style schedule semantics and method-spanning helper bindings | Good check that schedule-aware analytical, lattice, and MC bindings share one semantic contract |
 | `E22` Cap/floor: Black caplet stack vs MC rate simulation | `proved` | rate cap/floor strip decomposition without route-local rescue logic | Confirms typed family lowering plus rate MC/analytical bindings |
 | `T105` Quanto option: quanto-adjusted BS vs MC cross-currency | `proved` | cross-currency market binding plus analytical/MC parity | Keeps the proof program honest about multi-currency exact bindings |

--- a/docs/benchmarks/binding_first_exotic_proof_closeout.md
+++ b/docs/benchmarks/binding_first_exotic_proof_closeout.md
@@ -112,7 +112,13 @@
 - Retry taxonomy: `none`
 - Latest diagnosis dossier: `T126.md`
 
-### T17 - Callable bond: HW rate PDE (PSOR) vs HW tree
+### T17 - Callable bond: HW event-aware theta PDE vs HW tree
+
+Correction (`QUA-1206`): this lane executes the event-aware theta rollback
+(`pde_theta_1d`, theta `0.5`), not PSOR. The underlying historical result paths
+are retained as recorded evidence; only the unsupported solver claim is
+corrected here.
+
 - Cohort: `event_control_schedule`
 - Expected outcome: `proved`
 - Gate passed: `True`

--- a/docs/developer/task_and_eval_loops.rst
+++ b/docs/developer/task_and_eval_loops.rst
@@ -122,6 +122,13 @@ fallback, but that fallback records ``explicit=false`` and
 ``resolution_source=legacy_target_inference`` rather than pretending that an
 inferred target has exact route or variant authority.
 
+An explicit one-target row is still a target-contract task even though no
+two-price tolerance comparison is possible. The runtime carries that target's
+full contract into construction and applies artifact coherence before the row
+can pass. This is useful for a bounded validation claim such as a puttable
+bond's holder-exercise and straight-bond lower-bound checks, but it must not be
+described as an independent cross-method comparison.
+
 The requested contract follows one target through harness planning,
 platform-request compilation, and builder request metadata. Build results keep
 that request in ``requested_comparison_target_contract`` and separately retain
@@ -133,6 +140,15 @@ fresh generation: an old class is not restamped with the current request.
 Standard and thorough cached comparison builds re-execute a required validation
 bundle before returning the class. Fast validation does not claim that evidence
 and therefore cannot make a target requiring a bundle coherent.
+
+If a cached adapter has no compatible declaration for the requested target,
+the executor bypasses it and deterministically rematerializes the checked
+binding into an isolated run artifact under
+``task_runs/comparison_target_artifacts/``. It does not overwrite or promote
+the admitted adapter. The request remains a request; only the declaration on
+the rematerialized artifact can become comparison evidence. This fallback is
+for exact checked bindings, not permission to add a task- or product-shaped
+helper.
 
 ``comparison_binding_evidence_source`` and
 ``validation_binding_evidence_source`` state where the evidence came from.

--- a/docs/developer/task_diagnostics.rst
+++ b/docs/developer/task_diagnostics.rst
@@ -107,6 +107,14 @@ so pricing and tolerance checks were suppressed. The corrective action is to
 repair target binding or the missing reusable composition surface, not to widen
 the tolerance or accept matching numbers.
 
+This evidence rule also applies to an explicit single-target task. Such a row
+has no cross-method tolerance result, but its result still includes an
+``artifact_binding`` report and fails when the executable cannot prove the
+declared target contract. A stale cached adapter with a missing or incompatible
+target declaration is bypassed; the diagnosis should identify the isolated
+rematerialized artifact rather than presenting the cached source as newly
+bound evidence.
+
 Computational problem evidence
 ------------------------------
 

--- a/docs/quant/pricing_stack.rst
+++ b/docs/quant/pricing_stack.rst
@@ -1024,8 +1024,8 @@ already owns that work.
 
 The retained callable fixed-income proof rows bind their numerical experiments
 explicitly. ``T02`` selects BDT and Hull-White variants of the checked lattice
-binding; ``T17`` selects the Hull-White PSOR PDE and Hull-White lattice
-bindings. Both ``T17`` lanes consume the same typed Hull-White parameter set
+binding; ``T17`` selects the Hull-White event-aware theta PDE and Hull-White
+lattice bindings. Both ``T17`` lanes consume the same typed Hull-White parameter set
 from the task comparison regime. Model selection and calibration coordinates
 belong to the valuation target and market parameter set, not to derivative spec
 overrides. Hull-White parameter resolution therefore prefers typed

--- a/docs/quant/pricing_stack.rst
+++ b/docs/quant/pricing_stack.rst
@@ -108,6 +108,13 @@ thorough cached comparison builds re-execute that deterministic bundle rather
 than relying on historical validation; fast cache reuse cannot satisfy a
 target that requires bundle evidence.
 
+An explicit single target follows the same rule even though it cannot produce
+a two-method tolerance check. Its validation bundle can prove bounded product
+invariants, but the task passes only when the executable artifact also proves
+the full target contract. A cached adapter without that declaration is not
+silently relabeled: the checked binding is rematerialized into an isolated run
+artifact, leaving the admitted source untouched.
+
 Variant names are not evidence. Direct numerical coordinates such as
 ``tree_steps=2000`` are proven by exact spec instantiation. Behavioral choices
 that are not spec fields, such as selecting a polynomial rather than Laguerre
@@ -1014,6 +1021,22 @@ routes into a single pattern-keyed route ``short_rate_bond_option`` whose
 lattice helper. The route card still carries no lattice-construction or
 short-rate-input assembly instructions because the checked helper surface
 already owns that work.
+
+The retained callable fixed-income proof rows bind their numerical experiments
+explicitly. ``T02`` selects BDT and Hull-White variants of the checked lattice
+binding; ``T17`` selects the Hull-White PSOR PDE and Hull-White lattice
+bindings. Both ``T17`` lanes consume the same typed Hull-White parameter set
+from the task comparison regime. Model selection and calibration coordinates
+belong to the valuation target and market parameter set, not to derivative spec
+overrides. Hull-White parameter resolution therefore prefers typed
+``model_family="hull_white"`` payloads (or explicitly named Hull-White sets)
+and ignores unrelated named parameter sets that merely contain a generic
+``sigma`` field.
+
+``T05`` is intentionally narrower: the former callable-tree "symmetry" target
+was not an independent implementation. The row now proves one explicitly bound
+puttable-lattice artifact plus the holder-exercise/straight-bond lower-bound
+validation contract; it does not claim cross-method evidence.
 
 Plain zero-coupon bond comparison tasks under Vasicek or CIR use a separate
 ``short_rate_zero_coupon_bond`` route. That route narrows the product to

--- a/tests/evals/binding_first_exotic_proof.yaml
+++ b/tests/evals/binding_first_exotic_proof.yaml
@@ -2,7 +2,7 @@ T17:
   cohort: event_control_schedule
   outcome_class: proved
   comparison_targets:
-    - hw_pde_psor
+    - hw_pde_theta
     - hw_rate_tree
   requires_binding_ids: true
 

--- a/tests/test_agent/test_comparison_target_contracts.py
+++ b/tests/test_agent/test_comparison_target_contracts.py
@@ -94,6 +94,103 @@ def test_declared_basket_comparison_targets_preserve_method_and_sampling_identit
     assert t126["fft_spread_2d"].method == "fft_pricing"
 
 
+def test_callable_fixed_income_targets_have_explicit_executable_contracts():
+    tasks = _proof_tasks()
+
+    t02 = _contracts_for("T02")
+    assert set(t02) == {"bdt_tree", "hull_white_tree"}
+    assert t02["bdt_tree"].explicit is True
+    assert t02["bdt_tree"].route_id == "exercise_lattice"
+    assert t02["bdt_tree"].route_family == "rate_lattice"
+    assert t02["bdt_tree"].backend_binding_id == (
+        "trellis.models.callable_bond_tree.price_callable_bond_tree"
+    )
+    assert t02["bdt_tree"].validation_bundle_id == "rate_tree:callable_bond"
+    assert t02["bdt_tree"].variant_parameters == {"lattice_model": "bdt"}
+    assert t02["bdt_tree"].spec_overrides == {}
+    assert t02["hull_white_tree"].variant_parameters == {
+        "lattice_model": "hull_white"
+    }
+    assert t02["hull_white_tree"].exercise_style == "issuer_call"
+    assert t02["hull_white_tree"].observation_style == "exercise_schedule"
+
+    # The old callable-tree "symmetry" label was not an independent
+    # implementation.  T05 is narrowed to the puttable target whose standard
+    # validation bundle proves the meaningful straight-bond lower bound.
+    assert tasks["T05"]["cross_validate"]["internal"] == ["puttable_tree"]
+    t05 = _contracts_for("T05")
+    assert set(t05) == {"puttable_tree"}
+    assert t05["puttable_tree"].explicit is True
+    assert t05["puttable_tree"].route_id == "exercise_lattice"
+    assert t05["puttable_tree"].validation_bundle_id == "rate_tree:puttable_bond"
+    assert t05["puttable_tree"].payoff_family == "puttable_fixed_income"
+    assert t05["puttable_tree"].exercise_style == "holder_put"
+
+    t17 = _contracts_for("T17")
+    assert set(t17) == {"hw_pde_psor", "hw_rate_tree"}
+    assert t17["hw_pde_psor"].method == "pde_solver"
+    assert t17["hw_pde_psor"].route_id == "pde_theta_1d"
+    assert t17["hw_pde_psor"].route_family == "pde_solver"
+    assert t17["hw_pde_psor"].backend_binding_id == (
+        "trellis.models.callable_bond_pde.price_callable_bond_pde"
+    )
+    assert t17["hw_pde_psor"].validation_bundle_id == (
+        "pde_solver:callable_bond"
+    )
+    assert t17["hw_pde_psor"].variant_parameters == {
+        "pricing_method": "pde_solver",
+        "solver": "psor",
+        "model_parameter_set": "t17_hull_white_comparison:hull_white",
+        "mean_reversion": 0.1,
+        "sigma": 0.01,
+    }
+    assert t17["hw_rate_tree"].method == "rate_tree"
+    assert t17["hw_rate_tree"].variant_parameters == {
+        "pricing_method": "rate_tree",
+        "lattice_model": "hull_white",
+        "model_parameter_set": "t17_hull_white_comparison:hull_white",
+        "mean_reversion": 0.1,
+        "sigma": 0.01,
+    }
+
+
+def test_comparison_execution_binding_uses_validation_contract_axis_fallbacks():
+    from trellis.agent.executor import _comparison_execution_binding_metadata
+
+    binding = _comparison_execution_binding_metadata(
+        pricing_plan=SimpleNamespace(method="pde_solver"),
+        generation_plan=SimpleNamespace(
+            lowering_route_id="pde_theta_1d",
+            backend_route_family="",
+            backend_binding_id="callable-pde-binding",
+            validation_bundle_id="",
+            primitive_plan=None,
+        ),
+        product_ir=SimpleNamespace(
+            payoff_family="callable_fixed_income",
+            exercise_style="issuer_call",
+            model_family="interest_rate",
+            schedule_dependence=True,
+            state_dependence="terminal_markov",
+            underlying_asset_class="rate",
+            option_type="call",
+        ),
+        request_metadata={},
+        validation_contract=SimpleNamespace(
+            route_id="pde_theta_1d",
+            route_family="pde_solver",
+            backend_binding_id="callable-pde-binding",
+            bundle_id="pde_solver:callable_bond",
+        ),
+    )
+
+    assert binding["selected_route_family"] == "pde_solver"
+    assert binding["selected_validation_bundle_id"] == "pde_solver:callable_bond"
+    assert binding["selected_semantic_axes"]["observation_style"] == (
+        "exercise_schedule"
+    )
+
+
 def test_legacy_comparison_target_fallback_is_typed_and_explicitly_unresolved():
     from trellis.agent.assembly_tools import build_comparison_harness_plan
 

--- a/tests/test_agent/test_comparison_target_contracts.py
+++ b/tests/test_agent/test_comparison_target_contracts.py
@@ -127,19 +127,19 @@ def test_callable_fixed_income_targets_have_explicit_executable_contracts():
     assert t05["puttable_tree"].exercise_style == "holder_put"
 
     t17 = _contracts_for("T17")
-    assert set(t17) == {"hw_pde_psor", "hw_rate_tree"}
-    assert t17["hw_pde_psor"].method == "pde_solver"
-    assert t17["hw_pde_psor"].route_id == "pde_theta_1d"
-    assert t17["hw_pde_psor"].route_family == "pde_solver"
-    assert t17["hw_pde_psor"].backend_binding_id == (
+    assert set(t17) == {"hw_pde_theta", "hw_rate_tree"}
+    assert t17["hw_pde_theta"].method == "pde_solver"
+    assert t17["hw_pde_theta"].route_id == "pde_theta_1d"
+    assert t17["hw_pde_theta"].route_family == "pde_solver"
+    assert t17["hw_pde_theta"].backend_binding_id == (
         "trellis.models.callable_bond_pde.price_callable_bond_pde"
     )
-    assert t17["hw_pde_psor"].validation_bundle_id == (
+    assert t17["hw_pde_theta"].validation_bundle_id == (
         "pde_solver:callable_bond"
     )
-    assert t17["hw_pde_psor"].variant_parameters == {
+    assert t17["hw_pde_theta"].variant_parameters == {
         "pricing_method": "pde_solver",
-        "solver": "psor",
+        "theta": 0.5,
         "model_parameter_set": "t17_hull_white_comparison:hull_white",
         "mean_reversion": 0.1,
         "sigma": 0.01,

--- a/tests/test_agent/test_executor.py
+++ b/tests/test_agent/test_executor.py
@@ -337,6 +337,9 @@ def test_build_payoff_reuse_branch_attaches_analytical_trace(monkeypatch, tmp_pa
         target_id="black_scholes",
         method="analytical",
     ).to_payload()
+    existing.__trellis_comparison_bindings__ = {
+        "black_scholes": {"target_contract": target_contract}
+    }
     trace_id = "executor_build_cached_123"
     emitted_kwargs: dict[str, object] = {}
 
@@ -384,10 +387,12 @@ def test_build_payoff_reuse_branch_attaches_analytical_trace(monkeypatch, tmp_pa
     assert emitted_kwargs["context"]["selected_curve_names"] == {
         "discount_curve": "usd_ois",
     }
-    assert build_meta["comparison_target_contract"] == {}
-    assert build_meta["execution_binding"]["comparison_target_contract"] == {}
+    assert build_meta["comparison_target_contract"] == target_contract
+    assert build_meta["execution_binding"]["comparison_target_contract"] == (
+        target_contract
+    )
     assert build_meta["comparison_binding_evidence_source"] == (
-        "cached_artifact_declaration_missing"
+        "cached_artifact_declaration"
     )
 
 
@@ -1587,6 +1592,121 @@ def test_deterministic_exact_binding_module_materializes_callable_bond_tree_wrap
     assert generated is not None
     assert 'return price_callable_bond_tree(market_state, spec, model="hull_white")' in generated.code
     assert EVALUATE_SENTINEL not in generated.code
+
+
+def test_deterministic_callable_bond_tree_wrapper_binds_declared_lattice_model():
+    from trellis.agent.comparison_target_contracts import ComparisonTargetContract
+    from trellis.agent.executor import (
+        _generate_skeleton,
+        _materialize_deterministic_exact_binding_module,
+    )
+    from trellis.agent.planner import STATIC_SPECS
+
+    contract = ComparisonTargetContract(
+        target_id="bdt_tree",
+        method="rate_tree",
+        variant_parameters={"lattice_model": "bdt"},
+    )
+    generation_plan = SimpleNamespace(
+        lane_exact_binding_refs=(
+            "trellis.models.callable_bond_tree.price_callable_bond_tree",
+        ),
+        primitive_plan=None,
+        method="rate_tree",
+        instrument_type="callable_bond",
+    )
+    skeleton = _generate_skeleton(
+        STATIC_SPECS["callable_bond"],
+        "Callable bond BDT target",
+        generation_plan=generation_plan,
+    )
+
+    generated = _materialize_deterministic_exact_binding_module(
+        skeleton,
+        generation_plan,
+        request_metadata={
+            "comparison_target_contract": contract.to_payload(),
+        },
+        comparison_target="bdt_tree",
+    )
+
+    assert generated is not None
+    assert 'return price_callable_bond_tree(market_state, spec, model="bdt")' in (
+        generated.code
+    )
+
+
+@pytest.mark.parametrize(
+    ("method", "binding_ref", "target_id", "variants", "expected_call"),
+    [
+        (
+            "pde_solver",
+            "trellis.models.callable_bond_pde.price_callable_bond_pde",
+            "hw_pde_psor",
+            {
+                "pricing_method": "pde_solver",
+                "solver": "psor",
+                "mean_reversion": 0.1,
+                "sigma": 0.01,
+            },
+            "return price_callable_bond_pde(market_state, spec)",
+        ),
+        (
+            "rate_tree",
+            "trellis.models.callable_bond_tree.price_callable_bond_tree",
+            "hw_rate_tree",
+            {
+                "pricing_method": "rate_tree",
+                "lattice_model": "hull_white",
+                "mean_reversion": 0.1,
+                "sigma": 0.01,
+            },
+            'return price_callable_bond_tree(market_state, spec, model="hull_white")',
+        ),
+    ],
+)
+def test_deterministic_callable_bond_targets_bind_shared_hull_white_parameters(
+    method,
+    binding_ref,
+    target_id,
+    variants,
+    expected_call,
+):
+    from trellis.agent.comparison_target_contracts import ComparisonTargetContract
+    from trellis.agent.executor import (
+        _generate_skeleton,
+        _materialize_deterministic_exact_binding_module,
+    )
+    from trellis.agent.planner import STATIC_SPECS
+
+    contract = ComparisonTargetContract(
+        target_id=target_id,
+        method=method,
+        variant_parameters=variants,
+    )
+    generation_plan = SimpleNamespace(
+        lane_exact_binding_refs=(binding_ref,),
+        primitive_plan=None,
+        method=method,
+        instrument_type="callable_bond",
+    )
+    skeleton = _generate_skeleton(
+        STATIC_SPECS["callable_bond"],
+        f"Callable bond {target_id}",
+        generation_plan=generation_plan,
+    )
+
+    generated = _materialize_deterministic_exact_binding_module(
+        skeleton,
+        generation_plan,
+        request_metadata={
+            "comparison_target_contract": contract.to_payload(),
+        },
+        comparison_target=target_id,
+    )
+
+    assert generated is not None
+    assert expected_call in generated.code
 
 
 def test_deterministic_exact_binding_module_materializes_callable_bond_pde_wrapper():
@@ -7113,6 +7233,57 @@ def test_resolve_output_target_uses_benchmark_generated_root_for_financepy_tasks
     ).replace("\\", "/")
     assert output_module_path == "task_runs/financepy_benchmarks/generated/f009/analytical/barrieroption.py"
     assert module_name == "trellis_benchmarks._fresh.f009.analytical.barrieroption"
+
+
+def test_resolve_output_target_isolates_rematerialized_comparison_artifact():
+    from trellis.agent.executor import _resolve_output_target
+
+    output_file_path, output_module_path, module_name = _resolve_output_target(
+        "instruments/_agent/callablebond.py",
+        fresh_build=False,
+        isolate_comparison_target=True,
+        request_metadata={
+            "task_id": "T02",
+            "comparison_target": "bdt_tree",
+        },
+    )
+
+    assert output_module_path == (
+        "task_runs/comparison_target_artifacts/t02/bdt_tree/callablebond.py"
+    )
+    assert str(output_file_path).replace("\\", "/").endswith(output_module_path)
+    assert module_name == "trellis_task_targets.t02.bdt_tree.callablebond"
+
+
+def test_cached_comparison_artifact_requires_compatible_target_declaration():
+    from trellis.agent.comparison_target_contracts import ComparisonTargetContract
+    from trellis.agent.executor import (
+        _cached_artifact_declares_requested_comparison_target,
+    )
+
+    requested = ComparisonTargetContract(
+        target_id="bdt_tree",
+        method="rate_tree",
+        variant_parameters={"lattice_model": "bdt"},
+    )
+
+    class UndeclaredPayoff:
+        pass
+
+    class DeclaredPayoff:
+        __trellis_comparison_bindings__ = {
+            requested.target_id: {"target_contract": requested.to_payload()}
+        }
+
+    metadata = {"comparison_target_contract": requested.to_payload()}
+    assert not _cached_artifact_declares_requested_comparison_target(
+        UndeclaredPayoff,
+        metadata,
+    )
+    assert _cached_artifact_declares_requested_comparison_target(
+        DeclaredPayoff,
+        metadata,
+    )
 
 
 def test_resolve_output_target_sanitizes_agent_prompt_filename():

--- a/tests/test_agent/test_executor.py
+++ b/tests/test_agent/test_executor.py
@@ -1763,7 +1763,10 @@ def test_deterministic_exact_binding_module_materializes_callable_bond_pde_wrapp
     )
 
     assert generated is not None
-    assert "return price_callable_bond_pde(market_state, spec)" in generated.code
+    assert (
+        "return price_callable_bond_pde(market_state, spec, theta=0.5)"
+        in generated.code
+    )
     assert EVALUATE_SENTINEL not in generated.code
 
 

--- a/tests/test_agent/test_executor.py
+++ b/tests/test_agent/test_executor.py
@@ -1636,6 +1636,34 @@ def test_deterministic_callable_bond_tree_wrapper_binds_declared_lattice_model()
     )
 
 
+def test_deterministic_callable_bond_tree_rejects_unsupported_lattice_model():
+    from trellis.agent.comparison_target_contracts import ComparisonTargetContract
+    from trellis.agent.executor import _deterministic_exact_binding_evaluate_body
+
+    contract = ComparisonTargetContract(
+        target_id="misspelled_tree",
+        method="rate_tree",
+        variant_parameters={"lattice_model": "hull_wite"},
+    )
+    generation_plan = SimpleNamespace(
+        lane_exact_binding_refs=(
+            "trellis.models.callable_bond_tree.price_callable_bond_tree",
+        ),
+        primitive_plan=None,
+        method="rate_tree",
+        instrument_type="callable_bond",
+    )
+
+    with pytest.raises(ValueError, match="lattice_model must be one of"):
+        _deterministic_exact_binding_evaluate_body(
+            generation_plan,
+            request_metadata={
+                "comparison_target_contract": contract.to_payload(),
+            },
+            comparison_target="misspelled_tree",
+        )
+
+
 @pytest.mark.parametrize(
     ("method", "binding_ref", "target_id", "variants", "expected_call"),
     [

--- a/tests/test_agent/test_executor.py
+++ b/tests/test_agent/test_executor.py
@@ -1642,14 +1642,14 @@ def test_deterministic_callable_bond_tree_wrapper_binds_declared_lattice_model()
         (
             "pde_solver",
             "trellis.models.callable_bond_pde.price_callable_bond_pde",
-            "hw_pde_psor",
+            "hw_pde_theta",
             {
                 "pricing_method": "pde_solver",
-                "solver": "psor",
+                "theta": 0.5,
                 "mean_reversion": 0.1,
                 "sigma": 0.01,
             },
-            "return price_callable_bond_pde(market_state, spec)",
+            "return price_callable_bond_pde(market_state, spec, theta=0.5)",
         ),
         (
             "rate_tree",
@@ -1707,6 +1707,34 @@ def test_deterministic_callable_bond_targets_bind_shared_hull_white_parameters(
 
     assert generated is not None
     assert expected_call in generated.code
+
+
+def test_deterministic_callable_bond_pde_rejects_invalid_theta_variant():
+    from trellis.agent.comparison_target_contracts import ComparisonTargetContract
+    from trellis.agent.executor import _deterministic_exact_binding_evaluate_body
+
+    contract = ComparisonTargetContract(
+        target_id="hw_pde_theta",
+        method="pde_solver",
+        variant_parameters={"theta": "psor"},
+    )
+    generation_plan = SimpleNamespace(
+        lane_exact_binding_refs=(
+            "trellis.models.callable_bond_pde.price_callable_bond_pde",
+        ),
+        primitive_plan=None,
+        method="pde_solver",
+        instrument_type="callable_bond",
+    )
+
+    with pytest.raises(ValueError, match="theta must be a number between 0 and 1"):
+        _deterministic_exact_binding_evaluate_body(
+            generation_plan,
+            request_metadata={
+                "comparison_target_contract": contract.to_payload(),
+            },
+            comparison_target="hw_pde_theta",
+        )
 
 
 def test_deterministic_exact_binding_module_materializes_callable_bond_pde_wrapper():

--- a/tests/test_agent/test_executor.py
+++ b/tests/test_agent/test_executor.py
@@ -1677,7 +1677,8 @@ def test_deterministic_callable_bond_tree_rejects_unsupported_lattice_model():
                 "mean_reversion": 0.1,
                 "sigma": 0.01,
             },
-            "return price_callable_bond_pde(market_state, spec, theta=0.5)",
+            "return price_callable_bond_pde(market_state, spec, "
+            "mean_reversion=0.1, sigma=0.01, theta=0.5)",
         ),
         (
             "rate_tree",
@@ -1689,7 +1690,8 @@ def test_deterministic_callable_bond_tree_rejects_unsupported_lattice_model():
                 "mean_reversion": 0.1,
                 "sigma": 0.01,
             },
-            'return price_callable_bond_tree(market_state, spec, model="hull_white")',
+            'return price_callable_bond_tree(market_state, spec, model="hull_white", '
+            "mean_reversion=0.1, sigma=0.01)",
         ),
     ],
 )
@@ -1735,6 +1737,37 @@ def test_deterministic_callable_bond_targets_bind_shared_hull_white_parameters(
 
     assert generated is not None
     assert expected_call in generated.code
+
+
+def test_deterministic_callable_bond_target_rejects_unbound_named_parameter_set():
+    from trellis.agent.comparison_target_contracts import ComparisonTargetContract
+    from trellis.agent.executor import _deterministic_exact_binding_evaluate_body
+
+    contract = ComparisonTargetContract(
+        target_id="named_hw_pde",
+        method="pde_solver",
+        variant_parameters={"model_parameter_set": "comparison:hull_white"},
+    )
+    generation_plan = SimpleNamespace(
+        lane_exact_binding_refs=(
+            "trellis.models.callable_bond_pde.price_callable_bond_pde",
+        ),
+        primitive_plan=None,
+        method="pde_solver",
+        instrument_type="callable_bond",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="model_parameter_set requires explicit mean_reversion and sigma",
+    ):
+        _deterministic_exact_binding_evaluate_body(
+            generation_plan,
+            request_metadata={
+                "comparison_target_contract": contract.to_payload(),
+            },
+            comparison_target="named_hw_pde",
+        )
 
 
 def test_deterministic_callable_bond_pde_rejects_invalid_theta_variant():

--- a/tests/test_agent/test_lite_review.py
+++ b/tests/test_agent/test_lite_review.py
@@ -414,6 +414,64 @@ def price(spec, market_state):
     assert "lite.hardcoded_black_vol_surface" not in issue_codes
 
 
+def test_lite_review_allows_callable_calibration_only_when_it_matches_target_contract():
+    from trellis.agent.lite_review import review_generated_code
+    from trellis.agent.quant import PricingPlan
+
+    source = """\
+from trellis.models.callable_bond_pde import price_callable_bond_pde
+
+def price(spec, market_state):
+    return price_callable_bond_pde(
+        market_state,
+        spec,
+        mean_reversion=0.1,
+        sigma=0.01,
+        theta=0.5,
+    )
+"""
+    pricing_plan = PricingPlan(
+        method="pde_solver",
+        method_modules=["trellis.models.callable_bond_pde"],
+        required_market_data={"discount_curve", "black_vol_surface"},
+        model_to_build="callable_bond",
+        reasoning="test",
+    )
+    generation_plan = SimpleNamespace(primitive_plan=None)
+    matching_contract = {
+        "variant_parameters": {
+            "model_parameter_set": "comparison:hull_white",
+            "mean_reversion": 0.1,
+            "sigma": 0.01,
+        }
+    }
+
+    matching_report = review_generated_code(
+        source,
+        pricing_plan=pricing_plan,
+        generation_plan=generation_plan,
+        comparison_target_contract=matching_contract,
+    )
+    mismatched_report = review_generated_code(
+        source,
+        pricing_plan=pricing_plan,
+        generation_plan=generation_plan,
+        comparison_target_contract={
+            "variant_parameters": {
+                "mean_reversion": 0.1,
+                "sigma": 0.02,
+            }
+        },
+    )
+
+    assert "lite.hardcoded_black_vol_surface" not in {
+        issue.code for issue in matching_report.issues
+    }
+    assert "lite.hardcoded_black_vol_surface" in {
+        issue.code for issue in mismatched_report.issues
+    }
+
+
 def test_lite_review_rejects_garman_kohlhagen_without_foreign_curve_access():
     from trellis.agent.codegen_guardrails import GenerationPlan, PrimitivePlan
     from trellis.agent.lite_review import review_generated_code

--- a/tests/test_agent/test_platform_requests.py
+++ b/tests/test_agent/test_platform_requests.py
@@ -1966,9 +1966,9 @@ def test_compile_build_request_uses_exact_callable_bond_pde_binding_for_bootstra
     description = _effective_task_description(
         {
             "id": "T17",
-            "title": "Callable bond: HW rate PDE (PSOR) vs HW tree",
+            "title": "Callable bond: HW event-aware theta PDE vs HW tree",
             "construct": ["pde", "lattice"],
-            "cross_validate": {"internal": ["hw_pde_psor", "hw_rate_tree"]},
+            "cross_validate": {"internal": ["hw_pde_theta", "hw_rate_tree"]},
         }
     )
     compiled = compile_build_request(

--- a/tests/test_agent/test_platform_traces.py
+++ b/tests/test_agent/test_platform_traces.py
@@ -667,13 +667,13 @@ def test_platform_trace_summarizes_event_aware_pde_family_ir(tmp_path):
 
     compiled = compile_build_request(
         (
-            "Build a pricer for: Callable bond: HW rate PDE (PSOR) vs HW tree\n\n"
+            "Build a pricer for: Callable bond: HW event-aware theta PDE vs HW tree\n\n"
             "Price a 10-year callable bond paying a 5% semi-annual coupon, par $100,\n"
             "callable at par on any coupon date after year 3.\n"
             "Use the USD OIS discount curve from the market snapshot (as_of 2024-11-15).\n"
             "Hull-White model: mean reversion a=0.05, short-rate vol sigma=0.01.\n"
-            "Method 1: solve the HW rate PDE backward in time using PSOR to\n"
-            "enforce the call constraint (issuer calls when continuation value > par)."
+            "Method 1: solve the HW rate PDE with an event-aware theta=0.5 rollback\n"
+            "and project the issuer call constraint on scheduled call dates."
         ),
         instrument_type="callable_bond",
         preferred_method="pde_solver",

--- a/tests/test_agent/test_task_runtime.py
+++ b/tests/test_agent/test_task_runtime.py
@@ -1369,6 +1369,12 @@ def test_build_market_state_for_task_materializes_short_rate_comparison_regime(m
     assert regime.regime_name == "t01_short_rate_comparison"
     assert regime.hull_white_mean_reversion == pytest.approx(0.1)
     assert regime.ho_lee_mean_reversion == pytest.approx(0.0)
+    hull_white_parameters = market_state.model_parameter_sets[
+        "t01_short_rate_comparison:hull_white"
+    ]
+    assert hull_white_parameters["model_family"] == "hull_white"
+    assert hull_white_parameters["mean_reversion"] == pytest.approx(0.1)
+    assert hull_white_parameters["sigma"] == pytest.approx(0.01)
     assert market_context["provenance"]["comparison_regime"]["regime_family"] == "short_rate"
     assert market_context["provenance"]["comparison_regime"]["flat_sigma"] == pytest.approx(0.01)
 
@@ -1809,6 +1815,119 @@ def test_run_task_uses_single_construct_as_preferred_method():
     assert result["comparison_task"] is False
     assert result["preferred_method"] == "pde_solver"
     assert result["success"] is True
+
+
+def test_run_task_propagates_and_enforces_single_explicit_target_contract(tmp_path):
+    from trellis.agent.comparison_target_contracts import ComparisonTargetContract
+    from trellis.agent.task_runtime import run_task
+
+    contract = ComparisonTargetContract(
+        target_id="puttable_tree",
+        method="rate_tree",
+        route_id="exercise_lattice",
+        route_family="rate_lattice",
+        backend_binding_id=(
+            "trellis.models.callable_bond_tree.price_callable_bond_tree"
+        ),
+        validation_bundle_id="rate_tree:puttable_bond",
+        payoff_family="puttable_fixed_income",
+        exercise_style="holder_put",
+        model_family="interest_rate",
+        observation_style="exercise_schedule",
+    )
+    task = {
+        "id": "SINGLE-TARGET",
+        "title": "Puttable bond holder exercise",
+        "construct": "lattice",
+        "cross_validate": {
+            "internal": ["puttable_tree"],
+            "target_contracts": {
+                "puttable_tree": {
+                    key: value
+                    for key, value in contract.to_payload().items()
+                    if key
+                    not in {
+                        "schema_version",
+                        "contract_id",
+                        "target_id",
+                        "resolution_source",
+                        "explicit",
+                    }
+                }
+            },
+        },
+    }
+    calls = []
+    binding_mode = {"declared": True}
+
+    def fake_build(**kwargs):
+        calls.append(kwargs)
+        requested_payload = kwargs["request_metadata"][
+            "comparison_target_contract"
+        ]
+
+        class BoundPuttablePayoff:
+            __trellis_comparison_bindings__ = (
+                {"puttable_tree": {"target_contract": requested_payload}}
+                if binding_mode["declared"]
+                else {}
+            )
+
+        return SimpleNamespace(
+            success=True,
+            attempts=0,
+            gap_confidence=1.0,
+            knowledge_gaps=[],
+            payoff_cls=BoundPuttablePayoff,
+            failures=[],
+            reflection={},
+            comparison_target_contract=requested_payload,
+            execution_binding={},
+            comparison_binding_evidence_source="fresh_artifact_declaration",
+            validation_binding_evidence_source="executed_validation_bundle",
+            selected_method="rate_tree",
+            selected_route_id="exercise_lattice",
+            selected_route_family="rate_lattice",
+            selected_backend_binding_id=(
+                "trellis.models.callable_bond_tree.price_callable_bond_tree"
+            ),
+            selected_validation_bundle_id="rate_tree:puttable_bond",
+            selected_semantic_axes={
+                "payoff_family": "puttable_fixed_income",
+                "exercise_style": "holder_put",
+                "model_family": "interest_rate",
+                "observation_style": "exercise_schedule",
+            },
+        )
+
+    result = run_task(
+        task,
+        market_state=object(),
+        build_fn=fake_build,
+        task_run_storage_root=tmp_path,
+        task_run_storage_layout="isolated",
+    )
+
+    assert calls[0]["comparison_target"] == "puttable_tree"
+    assert calls[0]["preferred_method"] == "rate_tree"
+    assert calls[0]["request_metadata"]["comparison_target_contract"][
+        "target_id"
+    ] == "puttable_tree"
+    assert result["success"] is True
+    assert result["artifact_binding"]["status"] == "bound_unique_artifact"
+
+    binding_mode["declared"] = False
+    unbound_result = run_task(
+        task,
+        market_state=object(),
+        build_fn=fake_build,
+        task_run_storage_root=tmp_path,
+        task_run_storage_layout="isolated",
+    )
+
+    assert unbound_result["success"] is False
+    assert unbound_result["artifact_binding"]["status"] == "unbound_artifact"
+    assert "missing_artifact_target_declaration" in unbound_result["failures"][0]
 
 
 def test_run_task_builds_each_construct_method_for_comparison_task():

--- a/tests/test_agent/test_task_runtime.py
+++ b/tests/test_agent/test_task_runtime.py
@@ -4642,15 +4642,15 @@ def test_effective_task_description_bootstraps_title_only_callable_bond_tasks():
     description = _effective_task_description(
         {
             "id": "T17",
-            "title": "Callable bond: HW rate PDE (PSOR) vs HW tree",
+            "title": "Callable bond: HW event-aware theta PDE vs HW tree",
             "construct": ["pde", "lattice"],
-            "cross_validate": {"internal": ["hw_pde_psor", "hw_rate_tree"]},
+            "cross_validate": {"internal": ["hw_pde_theta", "hw_rate_tree"]},
         }
     )
 
     assert "issuer call dates 2028-01-15, 2030-01-15, and 2032-01-15" in description
     assert "5% semi-annual coupon" in description
-    assert "Comparison targets: hw_pde_psor (pde_solver), hw_rate_tree (rate_tree)" in description
+    assert "Comparison targets: hw_pde_theta (pde_solver), hw_rate_tree (rate_tree)" in description
 
 
 def test_prepare_existing_task_infers_schema_for_matching_generic_module(monkeypatch):

--- a/tests/test_agent/test_validation_bundles.py
+++ b/tests/test_agent/test_validation_bundles.py
@@ -546,6 +546,83 @@ def test_execute_validation_bundle_skips_generic_vol_checks_for_model_parameter_
     assert calls == ["check_non_negativity", "check_price_sanity"]
 
 
+def test_execute_validation_bundle_skips_flat_vol_for_bound_callable_calibration(
+    monkeypatch,
+):
+    from trellis.agent.validation_bundles import ValidationBundle, execute_validation_bundle
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        "trellis.agent.invariants.check_non_negativity",
+        lambda payoff, market_state: calls.append("check_non_negativity") or [],
+    )
+    monkeypatch.setattr(
+        "trellis.agent.invariants.check_price_sanity",
+        lambda payoff, market_state: calls.append("check_price_sanity") or [],
+    )
+    monkeypatch.setattr(
+        "trellis.agent.invariants.check_vol_sensitivity",
+        lambda payoff_factory, market_state_factory: calls.append(
+            "check_vol_sensitivity"
+        )
+        or [],
+    )
+    monkeypatch.setattr(
+        "trellis.agent.invariants.check_vol_monotonicity",
+        lambda payoff_factory, market_state_factory, expected_direction=None: calls.append(
+            "check_vol_monotonicity"
+        )
+        or [],
+    )
+
+    test_payoff = SimpleNamespace(
+        requirements={"discount_curve", "black_vol_surface"},
+        __trellis_comparison_bindings__={
+            "hw_pde_theta": {
+                "target_contract": {
+                    "backend_binding_id": (
+                        "trellis.models.callable_bond_pde.price_callable_bond_pde"
+                    ),
+                    "variant_parameters": {
+                        "model_parameter_set": "comparison:hull_white",
+                        "mean_reversion": 0.1,
+                        "sigma": 0.01,
+                    },
+                }
+            }
+        },
+    )
+    bundle = ValidationBundle(
+        bundle_id="pde_solver:callable_bond",
+        instrument_type="callable_bond",
+        method="pde_solver",
+        checks=(
+            "check_non_negativity",
+            "check_price_sanity",
+            "check_vol_sensitivity",
+            "check_vol_monotonicity",
+        ),
+        categories={
+            "universal": ("check_non_negativity", "check_price_sanity"),
+            "no_arbitrage": ("check_vol_sensitivity", "check_vol_monotonicity"),
+        },
+    )
+
+    execution = execute_validation_bundle(
+        bundle,
+        validation_level="standard",
+        test_payoff=test_payoff,
+        market_state=object(),
+        payoff_factory=lambda: test_payoff,
+        market_state_factory=lambda **kwargs: object(),
+    )
+
+    assert execution.failures == ()
+    assert execution.executed_checks == ("check_non_negativity", "check_price_sanity")
+    assert execution.skipped_checks == ("check_vol_sensitivity", "check_vol_monotonicity")
+    assert calls == ["check_non_negativity", "check_price_sanity"]
+
+
 def test_execute_validation_bundle_returns_structured_failure_details(monkeypatch):
     from trellis.agent.invariants import InvariantFailure
     from trellis.agent.validation_bundles import ValidationBundle, execute_validation_bundle

--- a/tests/test_models/test_hull_white_parameters.py
+++ b/tests/test_models/test_hull_white_parameters.py
@@ -1,0 +1,58 @@
+"""Tests for typed Hull-White model-parameter selection."""
+
+from types import SimpleNamespace
+
+
+def test_hull_white_parameter_selection_preserves_direct_legacy_payload():
+    from trellis.models.hull_white_parameters import resolve_hull_white_parameters
+
+    market_state = SimpleNamespace(
+        model_parameters={"mean_reversion": 0.07, "sigma": 0.012},
+        model_parameter_sets={},
+    )
+
+    assert resolve_hull_white_parameters(market_state) == (0.07, 0.012)
+
+
+def test_hull_white_parameter_selection_accepts_explicitly_named_set():
+    from trellis.models.hull_white_parameters import resolve_hull_white_parameters
+
+    market_state = SimpleNamespace(
+        model_parameters=None,
+        model_parameter_sets={
+            "desk_hull_white_fit": {"mean_reversion": 0.08, "sigma": 0.011}
+        },
+    )
+
+    assert resolve_hull_white_parameters(market_state) == (0.08, 0.011)
+
+
+def test_hull_white_parameter_selection_skips_unrelated_sigma_payloads():
+    from trellis.models.hull_white_parameters import (
+        extract_hull_white_parameter_payload,
+        resolve_hull_white_parameters,
+    )
+
+    market_state = SimpleNamespace(
+        model_parameters={
+            "model_family": "heston",
+            "sigma": 0.30,
+        },
+        model_parameter_sets={
+            "variance_gamma_equity": {
+                "family": "variance_gamma",
+                "sigma": 0.21,
+            },
+            "t17_hull_white_comparison:hull_white": {
+                "model_family": "hull_white",
+                "mean_reversion": 0.1,
+                "sigma": 0.01,
+            },
+        },
+    )
+
+    payload = extract_hull_white_parameter_payload(market_state)
+
+    assert payload is not None
+    assert payload["model_family"] == "hull_white"
+    assert resolve_hull_white_parameters(market_state) == (0.1, 0.01)

--- a/tests/test_tasks/test_t05_puttable_bond.py
+++ b/tests/test_tasks/test_t05_puttable_bond.py
@@ -1,10 +1,10 @@
-"""T05: Puttable bond pricing — exercise_fn=max, verify puttable >= straight,
-compare callable-puttable symmetry.
+"""T05: Puttable bond pricing — holder exercise and straight-bond lower bound.
 
-Cross-validates:
+Validates:
   1. Puttable bond pricing via HW tree with exercise_fn=max
   2. Puttable >= straight bond at all rate levels (3%, 5%, 7%)
-  3. Callable vs puttable symmetry: puttable >= straight >= callable
+  3. Callable/straight/puttable ordering as a local invariant, not an
+     independent comparison target
   4. Puttable OAS: negative OAS for puttable trading above straight
   5. QuantLib cross-validation via CallableFixedRateBond with put schedule
   6. FinancePy cross-validation via BondEmbeddedOption with put dates

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -5683,6 +5683,18 @@ def _deterministic_exact_binding_evaluate_body(
     ).strip().lower()
     if callable_bond_lattice_model not in {"bdt", "hull_white"}:
         callable_bond_lattice_model = "hull_white"
+    callable_bond_pde_theta = 0.5
+    if "trellis.models.callable_bond_pde.price_callable_bond_pde" in refs:
+        try:
+            callable_bond_pde_theta = float(target_variants.get("theta", 0.5))
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                "Callable-bond PDE theta must be a number between 0 and 1"
+            ) from exc
+        if not 0.0 <= callable_bond_pde_theta <= 1.0:
+            raise ValueError(
+                "Callable-bond PDE theta must be a number between 0 and 1"
+            )
     is_american_equity_option = instrument_type in {"american_put", "american_option"}
     black_scholes_vanilla_exact_binding = _is_black_scholes_vanilla_exact_binding(
         generation_plan,
@@ -6707,7 +6719,8 @@ def _deterministic_exact_binding_evaluate_body(
             "return price_fx_barrier_option_monte_carlo(market_state, spec)"
         ),
         "trellis.models.callable_bond_pde.price_callable_bond_pde": (
-            "return price_callable_bond_pde(market_state, spec)"
+            "return price_callable_bond_pde("
+            f"market_state, spec, theta={callable_bond_pde_theta!r})"
         ),
         "trellis.models.callable_bond_tree.price_callable_bond_tree": (
             "return price_callable_bond_tree("

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -13,6 +13,7 @@ import time
 from dataclasses import MISSING, asdict, dataclass, fields, is_dataclass, replace as replace_dataclass
 from datetime import date, datetime
 from importlib import import_module
+from math import isfinite
 from pathlib import Path
 from typing import Any, Callable, Mapping, Sequence, get_args, get_origin
 from types import SimpleNamespace
@@ -2216,6 +2217,9 @@ def build_payoff(
             pricing_plan=pricing_plan,
             product_ir=product_ir,
             generation_plan=generation_plan,
+            comparison_target_contract=(request_metadata or {}).get(
+                "comparison_target_contract"
+            ),
         )
         _record_platform_event(
             compiled_request,
@@ -5678,6 +5682,41 @@ def _deterministic_exact_binding_evaluate_body(
         if isinstance(raw_target_contract, Mapping)
         else {}
     )
+    callable_bond_binding_refs = {
+        "trellis.models.callable_bond_pde.price_callable_bond_pde",
+        "trellis.models.callable_bond_tree.price_callable_bond_tree",
+    }
+    has_callable_bond_exact_binding = bool(refs & callable_bond_binding_refs)
+    callable_bond_calibration_kwargs: list[str] = []
+    if has_callable_bond_exact_binding:
+        for variant_name in ("mean_reversion", "sigma"):
+            if variant_name not in target_variants:
+                continue
+            try:
+                variant_value = float(target_variants[variant_name])
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"Callable-bond {variant_name} must be a finite number"
+                ) from exc
+            if not isfinite(variant_value):
+                raise ValueError(
+                    f"Callable-bond {variant_name} must be a finite number"
+                )
+            callable_bond_calibration_kwargs.append(
+                f"{variant_name}={variant_value!r}"
+            )
+    declared_callable_bond_parameter_set = str(
+        target_variants.get("model_parameter_set") or ""
+    ).strip()
+    if (
+        has_callable_bond_exact_binding
+        and declared_callable_bond_parameter_set
+        and not {"mean_reversion", "sigma"}.issubset(target_variants)
+    ):
+        raise ValueError(
+            "Callable-bond model_parameter_set requires explicit "
+            "mean_reversion and sigma variants"
+        )
     raw_callable_bond_lattice_model = target_variants.get("lattice_model")
     callable_bond_lattice_model = str(
         raw_callable_bond_lattice_model
@@ -6728,11 +6767,25 @@ def _deterministic_exact_binding_evaluate_body(
         ),
         "trellis.models.callable_bond_pde.price_callable_bond_pde": (
             "return price_callable_bond_pde("
-            f"market_state, spec, theta={callable_bond_pde_theta!r})"
+            "market_state, spec, "
+            + ", ".join(
+                (
+                    *callable_bond_calibration_kwargs,
+                    f"theta={callable_bond_pde_theta!r}",
+                )
+            )
+            + ")"
         ),
         "trellis.models.callable_bond_tree.price_callable_bond_tree": (
             "return price_callable_bond_tree("
-            f'market_state, spec, model="{callable_bond_lattice_model}")'
+            "market_state, spec, "
+            + ", ".join(
+                (
+                    f'model="{callable_bond_lattice_model}"',
+                    *callable_bond_calibration_kwargs,
+                )
+            )
+            + ")"
         ),
         "trellis.models.rate_style_swaption.price_swaption_black76_raw": (
             "resolved = resolve_swaption_black76_inputs(market_state, spec"

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -5678,11 +5678,19 @@ def _deterministic_exact_binding_evaluate_body(
         if isinstance(raw_target_contract, Mapping)
         else {}
     )
+    raw_callable_bond_lattice_model = target_variants.get("lattice_model")
     callable_bond_lattice_model = str(
-        target_variants.get("lattice_model") or "hull_white"
+        raw_callable_bond_lattice_model
+        if raw_callable_bond_lattice_model is not None
+        else "hull_white"
     ).strip().lower()
-    if callable_bond_lattice_model not in {"bdt", "hull_white"}:
-        callable_bond_lattice_model = "hull_white"
+    if (
+        "trellis.models.callable_bond_tree.price_callable_bond_tree" in refs
+        and callable_bond_lattice_model not in {"bdt", "hull_white"}
+    ):
+        raise ValueError(
+            "Callable-bond lattice_model must be one of: bdt, hull_white"
+        )
     callable_bond_pde_theta = 0.5
     if "trellis.models.callable_bond_pde.price_callable_bond_pde" in refs:
         try:

--- a/trellis/agent/executor.py
+++ b/trellis/agent/executor.py
@@ -191,16 +191,19 @@ def _comparison_execution_binding_metadata(
     route_id = str(
         getattr(generation_plan, "lowering_route_id", "")
         or getattr(primitive_plan, "route", "")
+        or getattr(validation_contract, "route_id", "")
         or ""
     ).strip()
     route_family = str(
         getattr(generation_plan, "backend_route_family", "")
         or getattr(primitive_plan, "route_family", "")
+        or getattr(validation_contract, "route_family", "")
         or ""
     ).strip()
     backend_binding_id = str(
         getattr(generation_plan, "backend_binding_id", "")
         or getattr(primitive_plan, "backend_binding_id", "")
+        or getattr(validation_contract, "backend_binding_id", "")
         or ""
     ).strip()
 
@@ -211,7 +214,7 @@ def _comparison_execution_binding_metadata(
     state_dependence = str(
         getattr(product_ir, "state_dependence", "") or ""
     ).strip()
-    if exercise_style in {"american", "bermudan"}:
+    if exercise_style in {"american", "bermudan", "issuer_call", "holder_put"}:
         observation_style = "exercise_schedule"
     elif schedule_dependence:
         observation_style = "fixed_schedule"
@@ -360,6 +363,34 @@ def _record_reused_comparison_binding(
         requested_contract=requested_contract,
         artifact_kind="cached",
         compiled_request=compiled_request,
+    )
+
+
+def _cached_artifact_declares_requested_comparison_target(
+    payoff_cls: type,
+    request_metadata: Mapping[str, object] | None,
+) -> bool:
+    """Return whether cached source proves the requested target identity."""
+    from trellis.agent.comparison_target_contracts import (
+        ComparisonTargetContract,
+        comparison_target_contracts_compatible,
+        declared_comparison_target_contract,
+    )
+
+    raw_contract = (request_metadata or {}).get("comparison_target_contract")
+    if not isinstance(raw_contract, Mapping):
+        return True
+    try:
+        expected = ComparisonTargetContract.from_payload(raw_contract)
+    except (TypeError, ValueError):
+        return False
+    declared = declared_comparison_target_contract(
+        getattr(payoff_cls, "__trellis_comparison_bindings__", None),
+        expected.target_id,
+    )
+    return declared is not None and comparison_target_contracts_compatible(
+        expected,
+        declared,
     )
 
 
@@ -1508,8 +1539,24 @@ def build_payoff(
 
     # Step 3b: Reuse supported deterministic adapters and explicit cached builds.
     existing = _try_import_existing(plan)
+    cached_target_binding_valid = (
+        existing is None
+        or _cached_artifact_declares_requested_comparison_target(
+            existing,
+            request_metadata,
+        )
+    )
+    target_bound_rematerialization = bool(
+        existing is not None
+        and not fresh_build
+        and not cached_target_binding_valid
+        and isinstance(
+            (request_metadata or {}).get("comparison_target_contract"),
+            Mapping,
+        )
+    )
     reuse_reason = None
-    if existing is not None and not fresh_build:
+    if existing is not None and not fresh_build and cached_target_binding_valid:
         if _is_deterministic_supported_route(plan):
             reuse_reason = "deterministic_supported_route"
         elif not force_rebuild:
@@ -1606,7 +1653,7 @@ def build_payoff(
             market_state=market_state,
         )
         return existing
-    if existing is not None and fresh_build:
+    if existing is not None and (fresh_build or target_bound_rematerialization):
         _record_platform_event(
             compiled_request,
             "existing_generated_module_bypassed",
@@ -1614,7 +1661,11 @@ def build_payoff(
             details={
                 "module_path": plan.steps[0].module_path if plan.steps else "",
                 "class_name": getattr(existing, "__name__", type(existing).__name__),
-                "reason": "fresh_build",
+                "reason": (
+                    "fresh_build"
+                    if fresh_build
+                    else "cached_comparison_target_binding_missing_or_incompatible"
+                ),
             },
         )
 
@@ -1841,6 +1892,7 @@ def build_payoff(
     output_file_path, output_module_path, module_name = _resolve_output_target(
         step.module_path,
         fresh_build=fresh_build,
+        isolate_comparison_target=target_bound_rematerialization,
         request_metadata=request_metadata,
     )
     if build_meta is not None:
@@ -5620,6 +5672,17 @@ def _deterministic_exact_binding_evaluate_body(
     normalized_target = str(
         comparison_target or metadata.get("comparison_target") or ""
     ).strip().lower().replace("-", "_")
+    raw_target_contract = metadata.get("comparison_target_contract")
+    target_variants = (
+        dict(raw_target_contract.get("variant_parameters") or {})
+        if isinstance(raw_target_contract, Mapping)
+        else {}
+    )
+    callable_bond_lattice_model = str(
+        target_variants.get("lattice_model") or "hull_white"
+    ).strip().lower()
+    if callable_bond_lattice_model not in {"bdt", "hull_white"}:
+        callable_bond_lattice_model = "hull_white"
     is_american_equity_option = instrument_type in {"american_put", "american_option"}
     black_scholes_vanilla_exact_binding = _is_black_scholes_vanilla_exact_binding(
         generation_plan,
@@ -6647,7 +6710,8 @@ def _deterministic_exact_binding_evaluate_body(
             "return price_callable_bond_pde(market_state, spec)"
         ),
         "trellis.models.callable_bond_tree.price_callable_bond_tree": (
-            'return price_callable_bond_tree(market_state, spec, model="hull_white")'
+            "return price_callable_bond_tree("
+            f'market_state, spec, model="{callable_bond_lattice_model}")'
         ),
         "trellis.models.rate_style_swaption.price_swaption_black76_raw": (
             "resolved = resolve_swaption_black76_inputs(market_state, spec"
@@ -8084,6 +8148,7 @@ def _resolve_output_target(
     module_path: str,
     *,
     fresh_build: bool,
+    isolate_comparison_target: bool = False,
     request_metadata: Mapping[str, object] | None,
 ) -> tuple[Path, str, str]:
     """Resolve the output file path, module path, and import name for one build.
@@ -8099,6 +8164,30 @@ def _resolve_output_target(
         normalized_module_path,
         request_metadata=request_metadata,
     )
+    if isolate_comparison_target and _is_agent_module_path(normalized_module_path):
+        metadata = dict(request_metadata or {})
+        task_id = _normalize_fresh_build_token(metadata.get("task_id")) or "task"
+        target = (
+            _normalize_fresh_build_token(metadata.get("comparison_target"))
+            or "target"
+        )
+        filename = Path(normalized_module_path).name
+        output_file_path = (
+            REPO_ROOT
+            / "task_runs"
+            / "comparison_target_artifacts"
+            / task_id
+            / target
+            / filename
+        )
+        output_module_path = str(output_file_path.relative_to(REPO_ROOT)).replace(
+            "\\", "/"
+        )
+        stem = _normalize_fresh_build_token(Path(filename).stem) or "module"
+        module_name = (
+            f"trellis_task_targets.{task_id}.{target}.{stem}"
+        )
+        return output_file_path, output_module_path, module_name
     if fresh_build and _is_agent_module_path(normalized_module_path):
         benchmark_root = _benchmark_fresh_build_root(request_metadata)
         if benchmark_root is not None:

--- a/trellis/agent/lite_review.py
+++ b/trellis/agent/lite_review.py
@@ -9,7 +9,9 @@ through to later LLM-backed review.
 from __future__ import annotations
 
 import ast
+from collections.abc import Mapping
 from dataclasses import dataclass
+from math import isfinite
 
 
 _CAPABILITY_ATTR_PREFIXES = {
@@ -36,6 +38,10 @@ _CHECKED_ROUTE_HELPER_SYMBOLS = frozenset({
 _CHECKED_MARKET_BINDING_OWNER_SYMBOLS = frozenset({
     "price_single_state_terminal_claim_monte_carlo_result",
 })
+_CALLABLE_CALIBRATION_BINDING_SYMBOLS = frozenset({
+    "price_callable_bond_pde",
+    "price_callable_bond_tree",
+})
 
 # Legacy _ROUTE_REQUIRED_ACCESSES and _ROUTE_ACCESS_ERROR_CODES removed.
 # Market-data access requirements are now sourced from the route registry
@@ -59,6 +65,9 @@ class LiteReviewSignals:
     literal_assignments: tuple[str, ...]
     wall_clock_calls: tuple[str, ...]
     api_misuses: tuple[str, ...] = ()
+    literal_call_arguments: tuple[
+        tuple[str, tuple[tuple[str, str], ...]], ...
+    ] = ()
 
 
 @dataclass(frozen=True)
@@ -84,6 +93,9 @@ class _LiteReviewVisitor(ast.NodeVisitor):
         self.market_state_accesses: set[str] = set()
         self.call_names: set[str] = set()
         self.literal_assignments: list[str] = []
+        self.literal_call_arguments: list[
+            tuple[str, tuple[tuple[str, str], ...]]
+        ] = []
         self.wall_clock_calls: set[str] = set()
         self.api_misuses: set[str] = set()
 
@@ -117,12 +129,18 @@ class _LiteReviewVisitor(ast.NodeVisitor):
             bad_spot_keywords = {"spot", "s0", "initial_spot", "initial_value"}
             if any(keyword.arg in bad_spot_keywords for keyword in node.keywords if keyword.arg):
                 self.api_misuses.add("gbm_spot_constructor_keyword")
+        literal_call_arguments: list[tuple[str, str]] = []
         for keyword in node.keywords:
             if keyword.arg is None:
                 continue
             value = _numeric_literal(keyword.value)
             if value is not None:
                 self.literal_assignments.append(f"{keyword.arg}={value}")
+                literal_call_arguments.append((keyword.arg, value))
+        if call_name and literal_call_arguments:
+            self.literal_call_arguments.append(
+                (call_name, tuple(literal_call_arguments))
+            )
         self.generic_visit(node)
 
 
@@ -132,6 +150,7 @@ def review_generated_code(
     pricing_plan=None,
     product_ir=None,
     generation_plan=None,
+    comparison_target_contract: Mapping[str, object] | None = None,
 ) -> LiteReviewReport:
     """Run a cheap deterministic review for high-confidence anti-patterns."""
     try:
@@ -160,6 +179,7 @@ def review_generated_code(
         literal_assignments=tuple(visitor.literal_assignments),
         wall_clock_calls=tuple(sorted(visitor.wall_clock_calls)),
         api_misuses=tuple(sorted(visitor.api_misuses)),
+        literal_call_arguments=tuple(visitor.literal_call_arguments),
     )
 
     required_market_data = set()
@@ -174,6 +194,7 @@ def review_generated_code(
             capability,
             signals,
             generation_plan=generation_plan,
+            comparison_target_contract=comparison_target_contract,
         )
         if issue is not None:
             issues.append(issue)
@@ -216,11 +237,13 @@ def _capability_literal_issue(
     signals: LiteReviewSignals,
     *,
     generation_plan=None,
+    comparison_target_contract: Mapping[str, object] | None = None,
 ) -> LiteReviewIssue | None:
     if _capability_literal_is_subsumed_by_route_binding(
         capability,
         signals,
         generation_plan=generation_plan,
+        comparison_target_contract=comparison_target_contract,
     ):
         return None
 
@@ -264,10 +287,16 @@ def _capability_literal_is_subsumed_by_route_binding(
     signals: LiteReviewSignals,
     *,
     generation_plan=None,
+    comparison_target_contract: Mapping[str, object] | None = None,
 ) -> bool:
     """Return whether an admitted route binding legitimately owns the literal."""
     if capability != "black_vol_surface":
         return False
+    if _callable_calibration_matches_target_contract(
+        signals,
+        comparison_target_contract,
+    ):
+        return True
     primitive_plan = getattr(generation_plan, "primitive_plan", None)
     if primitive_plan is None:
         return False
@@ -284,6 +313,42 @@ def _capability_literal_is_subsumed_by_route_binding(
         any(item.startswith("mean_reversion=") for item in signals.literal_assignments)
         and any(item.startswith("sigma=") for item in signals.literal_assignments)
     )
+
+
+def _callable_calibration_matches_target_contract(
+    signals: LiteReviewSignals,
+    comparison_target_contract: Mapping[str, object] | None,
+) -> bool:
+    """Return whether one callable helper call binds the declared calibration."""
+    if not isinstance(comparison_target_contract, Mapping):
+        return False
+    raw_variants = comparison_target_contract.get("variant_parameters")
+    if not isinstance(raw_variants, Mapping):
+        return False
+    try:
+        expected = {
+            name: float(raw_variants[name])
+            for name in ("mean_reversion", "sigma")
+        }
+    except (KeyError, TypeError, ValueError):
+        return False
+    if not all(isfinite(value) for value in expected.values()):
+        return False
+
+    for call_name, literal_arguments in signals.literal_call_arguments:
+        if call_name.rsplit(".", 1)[-1] not in _CALLABLE_CALIBRATION_BINDING_SYMBOLS:
+            continue
+        bound_arguments = dict(literal_arguments)
+        try:
+            actual = {
+                name: float(bound_arguments[name])
+                for name in ("mean_reversion", "sigma")
+            }
+        except (KeyError, TypeError, ValueError):
+            continue
+        if actual == expected:
+            return True
+    return False
 
 
 def _resolve_attribute_chain(node: ast.AST) -> str:

--- a/trellis/agent/task_runtime.py
+++ b/trellis/agent/task_runtime.py
@@ -1077,6 +1077,13 @@ def _materialize_task_comparison_regime(task: dict, market_state):
         "ho_lee_mean_reversion": float(regime.ho_lee_mean_reversion),
         "source_kind": regime.source_kind,
     }
+    model_parameter_sets[f"{regime.regime_name}:hull_white"] = {
+        "model_family": "hull_white",
+        "mean_reversion": float(regime.hull_white_mean_reversion),
+        "sigma": float(regime.flat_sigma),
+        "parameter_set_name": f"{regime.regime_name}:hull_white",
+        "source_kind": regime.source_kind,
+    }
     base_discount = getattr(market_state, "discount", None)
     max_tenor = getattr(base_discount, "max_tenor", None)
     if max_tenor is None:
@@ -2384,12 +2391,33 @@ def run_task(
             )
             result_data["failures"] = _aggregate_failures(result_data)
         else:
-            preferred_method = construct_methods[0] if construct_methods else None
+            single_declared_target = (
+                comparison_targets[0]
+                if len(comparison_targets) == 1
+                and comparison_targets[0].contract.explicit
+                else None
+            )
+            preferred_method = (
+                single_declared_target.preferred_method
+                if single_declared_target is not None
+                else (construct_methods[0] if construct_methods else None)
+            )
+            single_target_metadata = (
+                {
+                    "comparison_target": single_declared_target.target_id,
+                    "comparison_target_contract": (
+                        single_declared_target.contract.to_payload()
+                    ),
+                }
+                if single_declared_target is not None
+                else {}
+            )
             build_kwargs = {
                 "description": description,
                 "instrument_type": instrument_type,
                 "request_metadata": {
                     **base_request_metadata,
+                    **single_target_metadata,
                     **(
                         {"preferred_method": preferred_method}
                         if preferred_method is not None
@@ -2420,6 +2448,11 @@ def run_task(
             payload = _build_result_payload(
                 result,
                 preferred_method=preferred_method,
+                comparison_target_contract=(
+                    single_declared_target.contract
+                    if single_declared_target is not None
+                    else None
+                ),
                 generation_policy=generation_policy_value,
             )
             target_id = (
@@ -2438,9 +2471,35 @@ def run_task(
                 task_kind="pricing",
                 instrument_type=instrument_type,
                 recovery_mode=recovery_mode_value,
+                comparison_target_contract=(
+                    single_declared_target.contract
+                    if single_declared_target is not None
+                    else None
+                ),
             )
             if recovery_record is not None:
                 result_data.setdefault("recovery_attempts", []).append(recovery_record)
+            if (
+                single_declared_target is not None
+                and getattr(result, "success", False)
+                and getattr(result, "payoff_cls", None) is not None
+            ):
+                artifact_binding = _comparison_target_binding_report(
+                    single_declared_target,
+                    result,
+                )
+                payload["artifact_binding"] = artifact_binding
+                if artifact_binding["status"] not in _BOUND_ARTIFACT_STATUSES:
+                    payload["success"] = False
+                    binding_codes = [
+                        str(failure.get("code") or "target_binding_mismatch")
+                        for failure in artifact_binding.get("failures") or ()
+                    ]
+                    payload.setdefault("failures", []).insert(
+                        0,
+                        "Explicit comparison target artifact mismatch: "
+                        + ", ".join(binding_codes),
+                    )
             elapsed = timer() - t0
             runtime_contract_result = dict(runtime_contract)
             runtime_contract_result["trace_identifier"] = getattr(result, "platform_request_id", None)

--- a/trellis/agent/validation_bundles.py
+++ b/trellis/agent/validation_bundles.py
@@ -8,6 +8,7 @@ and executes them. Checks that lack required inputs are skipped gracefully.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from math import isfinite
 from typing import Any, Callable, Mapping
 
 from trellis.agent.assembly_tools import normalize_comparison_relation, select_invariant_pack
@@ -385,6 +386,9 @@ def _uses_model_parameter_volatility_route(
     ):
         return True
 
+    if _has_explicit_callable_comparison_calibration(test_payoff):
+        return True
+
     spec = getattr(test_payoff, "spec", None)
     requirements = set(getattr(test_payoff, "requirements", set()) or set())
     if "model_parameters" in requirements and not (
@@ -407,6 +411,38 @@ def _uses_model_parameter_volatility_route(
                 "levy_parameter_set",
             )
         )
+    return False
+
+
+def _has_explicit_callable_comparison_calibration(test_payoff: Any | None) -> bool:
+    """Return whether the artifact fixes an explicit callable-model calibration."""
+    bindings = getattr(test_payoff, "__trellis_comparison_bindings__", None)
+    if not isinstance(bindings, Mapping):
+        return False
+    callable_backends = {
+        "trellis.models.callable_bond_pde.price_callable_bond_pde",
+        "trellis.models.callable_bond_tree.price_callable_bond_tree",
+    }
+    for raw_binding in bindings.values():
+        if not isinstance(raw_binding, Mapping):
+            continue
+        target_contract = raw_binding.get("target_contract")
+        if not isinstance(target_contract, Mapping):
+            continue
+        if target_contract.get("backend_binding_id") not in callable_backends:
+            continue
+        variants = target_contract.get("variant_parameters")
+        if not isinstance(variants, Mapping):
+            continue
+        try:
+            calibration = (
+                float(variants["mean_reversion"]),
+                float(variants["sigma"]),
+            )
+        except (KeyError, TypeError, ValueError):
+            continue
+        if all(isfinite(value) for value in calibration):
+            return True
     return False
 
 

--- a/trellis/models/hull_white_parameters.py
+++ b/trellis/models/hull_white_parameters.py
@@ -28,17 +28,47 @@ def build_hull_white_parameter_payload(
 
 def extract_hull_white_parameter_payload(market_state) -> dict[str, object] | None:
     """Return the first Hull-White parameter payload attached to ``market_state``."""
-    candidates = []
+    candidates: list[tuple[str, Mapping[str, object], bool]] = []
     direct = getattr(market_state, "model_parameters", None)
     if isinstance(direct, Mapping):
-        candidates.append(direct)
-    for payload in dict(getattr(market_state, "model_parameter_sets", None) or {}).values():
+        nested = direct.get("hull_white")
+        if isinstance(nested, Mapping):
+            candidates.append(("hull_white", nested, False))
+        candidates.append(("", direct, True))
+    for name, payload in dict(
+        getattr(market_state, "model_parameter_sets", None) or {}
+    ).items():
         if isinstance(payload, Mapping):
-            candidates.append(payload)
+            candidates.append((str(name), payload, False))
 
-    for payload in candidates:
-        model_family = str(payload.get("model_family", "")).strip().lower()
-        if model_family not in {"", "hull_white"}:
+    def _family(payload: Mapping[str, object]) -> str:
+        return str(
+            payload.get("model_family")
+            or payload.get("model_name")
+            or payload.get("family")
+            or ""
+        ).strip().lower().replace("-", "_").replace(" ", "_")
+
+    for _, payload, _ in candidates:
+        model_family = _family(payload)
+        if model_family in {"hull_white", "hullwhite"} and (
+            "mean_reversion" in payload or "sigma" in payload
+        ):
+            return dict(payload)
+
+    for name, payload, _ in candidates:
+        normalized_name = name.strip().lower().replace("-", "_").replace(" ", "_")
+        if (
+            not _family(payload)
+            and "hull_white" in normalized_name
+            and ("mean_reversion" in payload or "sigma" in payload)
+        ):
+            return dict(payload)
+
+    # Preserve the legacy direct, untyped payload form without letting an
+    # unrelated named parameter set with a generic ``sigma`` field win.
+    for _, payload, is_direct in candidates:
+        if not is_direct or _family(payload):
             continue
         if "mean_reversion" in payload or "sigma" in payload:
             return dict(payload)


### PR DESCRIPTION
## Summary

- add explicit executable target contracts for the retained T02, T05, and T17 callable fixed-income proof rows
- make single explicit targets artifact-coherent and bypass stale cached adapters that cannot prove the requested target
- isolate deterministic target rematerialization from admitted adapters
- materialize one typed Hull-White comparison parameter set and prevent unrelated named sigma payloads from being selected
- narrow T05 to its honest puttable-lattice/lower-bound claim
- update agent-facing task, diagnostics, quant, and migration documentation

No new helper, cookbook entry, or knowledge-promotion authority is added. QUA-1205 remains the follow-on that retires callable/puttable wrapper authority.

## Root cause

The legacy green rows named method/model variants but their cached adapters did not carry executable target declarations. T05 also named a callable “symmetry” comparator that was not independent. During T17 validation, the broad market parameter map exposed a second reusable bug: an unrelated named model payload with a generic `sigma` could be selected as Hull-White input.

## Validation

- strict offline replay: T02, T05, T17 all passed, with zero LLM calls and every target `bound_unique_artifact`
- T17 PDE/tree: 96.8557422911 vs 96.8252972854
- focused agent/model/manifest suites: 429 passed; FinancePy T05 cross-check passed separately with writable Numba cache
- `NUMBA_CACHE_DIR=/tmp/trellis-numba-cache make gate-pr`: 5,003 core tests passed; 32 tier-2 contract tests passed
- `scripts/remediate.py --analyze-only`: no T02/T05/T17 remediation pattern

Linear: QUA-1206