### PR TITLE
docs: close QUA-1205 plan row

### DIFF
--- a/doc/plan/active__semantic-task-synthesis-helper-retirement.md
+++ b/doc/plan/active__semantic-task-synthesis-helper-retirement.md
@@ -66,7 +66,7 @@ Status mirror last synced: `2026-07-22`
 | `QUA-1203` | Semantic authority: classify scalar barrier formula as pricing kernel | Done |
 | `QUA-1204` | Short-rate lattice: reusable market calibration inputs | Done |
 | `QUA-1206` | Semantic comparison: bind callable fixed-income target variants | Done |
-| `QUA-1205` | Callable fixed income: raw lattice primitive assembly | Backlog |
+| `QUA-1205` | Callable fixed income: raw lattice primitive assembly | Done |
 | `QUA-1102` | Semantic target binding: typed comparison target contracts (related prerequisite) | Done |
 
 ## Current Sequence


### PR DESCRIPTION
## Summary
- mark QUA-1205 Done in the helper-retirement execution mirror after Linear closeout and PR #855 merge

## Validation
- documentation-only mirror update; TDD does not apply
- git diff --check passed

Linear: https://linear.app/quant-macro/issue/QUA-1205/callable-fixed-income-raw-lattice-primitive-assembly