### PR TITLE
Plan mirror: mark QUA-1232 done

### DIFF
--- a/doc/plan/active__semantic-task-synthesis-helper-retirement.md
+++ b/doc/plan/active__semantic-task-synthesis-helper-retirement.md
@@ -68,7 +68,7 @@ Status mirror last synced: `2026-07-23`
 | `QUA-1206` | Semantic comparison: bind callable fixed-income target variants | Done |
 | `QUA-1205` | Callable fixed income: raw lattice primitive assembly | Done |
 | `QUA-1231` | Semantic ranked-observation basket: primitive-composed Monte Carlo lane | Done |
-| `QUA-1232` | Terminal basket pricing: retire analytical, Monte Carlo, and transform helper authority | In Progress |
+| `QUA-1232` | Terminal basket pricing: retire analytical, Monte Carlo, and transform helper authority | Done |
 | `QUA-1102` | Semantic target binding: typed comparison target contracts (related prerequisite) | Done |
 
 ## Current Sequence


### PR DESCRIPTION
## What changed

Updates the helper-retirement plan mirror from `In Progress` to `Done` for QUA-1232.

## Why

The repository workflow requires Linear to be closed first and the local plan mirror to be updated afterward. QUA-1232 is Done and implementation PR #859 is merged.

## Validation

- documentation-only one-line status change
- `git diff --check` passed
- TDD and behavioral gates do not apply to this post-closeout mirror update