### PR TITLE
Mark QUA-1233 complete in plan mirror

### DIFF
--- a/doc/plan/active__semantic-task-synthesis-helper-retirement.md
+++ b/doc/plan/active__semantic-task-synthesis-helper-retirement.md
@@ -69,7 +69,7 @@ Status mirror last synced: `2026-07-23`
 | `QUA-1205` | Callable fixed income: raw lattice primitive assembly | Done |
 | `QUA-1231` | Semantic ranked-observation basket: primitive-composed Monte Carlo lane | Done |
 | `QUA-1232` | Terminal basket pricing: retire analytical, Monte Carlo, and transform helper authority | Done |
-| `QUA-1233` | Semantic ZCB option: raw Jamshidian and partial-horizon lattice composition | In Progress |
+| `QUA-1233` | Semantic ZCB option: raw Jamshidian and partial-horizon lattice composition | Done |
 | `QUA-1102` | Semantic target binding: typed comparison target contracts (related prerequisite) | Done |
 
 ## Current Sequence


### PR DESCRIPTION
## Summary

- update the helper-retirement plan mirror to mark QUA-1233 Done after Linear closeout

## Context

PR #861 is merged, its CI is green, the implementation handoff and final closeout are recorded, and QUA-1233 is Done in Linear. This follow-up preserves Linear as the source of truth while syncing the repository execution mirror afterward, as required by the ticket workflow.

## Validation

- documentation-only one-line status change; TDD/runtime tests do not apply
- `git diff --check` passed

## Tracking

- Linear: QUA-1233
- Implementation: PR #861